### PR TITLE
Add MacOS build capability

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -234,24 +234,25 @@ else()
         target_link_libraries(${API_LOWERCASE} "-framework CoreFoundation")
 
         # Build vulkan.framework
+        set(VULKAN_HEADERS_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/Vulkan-Headers/include/vulkan)
         set(FRAMEWORK_HEADERS
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vk_icd.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vk_layer.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vk_platform.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vk_sdk_platform.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_android.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_core.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_ios.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_macos.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_mir.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_vi.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_wayland.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_win32.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_xcb.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_xlib.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_xlib_xrandr.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan.h
-            ${PROJECT_SOURCE_DIR}/include/vulkan/vulkan.hpp
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vk_icd.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vk_layer.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vk_platform.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vk_sdk_platform.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan_android.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan_core.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan_ios.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan_macos.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan_mir.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan_vi.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan_wayland.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan_win32.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan_xcb.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan_xlib.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan_xlib_xrandr.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan.h
+            ${VULKAN_HEADERS_INCLUDE_DIR}/vulkan.hpp
         )
         add_library(vulkan-framework SHARED ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS} ${FRAMEWORK_HEADERS})
         add_dependencies(vulkan-framework generate_helper_files loader_gen_files loader_asm_gen_files)


### PR DESCRIPTION
Updated the CMakeList.txt file to look in the Vulkan-Headers submodule for header files.
Updated the BUILD.md file to reflect the change in workflow required to build and test the Vulkan-Loader repository.