### PR TITLE
Remove test dependency on validation layers

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,9 @@ target_link_libraries(vk_loader_validation_tests "${LOADER_LIB}" gtest gtest_mai
 if(BUILD_LOADER AND ENABLE_STATIC_LOADER)
     set_target_properties(vk_loader_validation_tests PROPERTIES LINK_FLAGS "/ignore:4098")
 endif()
+if(WIN32)
+    file(COPY vk_loader_validation_tests.vcxproj.user DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+endif()
 
 SET(GTEST_RELATIVE_LOCATION googletest)
 SET(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,14 @@
+
+# Loader Tests
+
+This directory contains a test suite for the Vulkan loader.
+These tests are not exhaustive &mdash; they are expected to be supplemented with other tests, such as CTS.
+
+## Running Tests
+
+To run the tests, your environment needs to be configured so that the test layers will be found.
+This can be done by setting the `VK_LAYER_PATH` environment variable to point at the built layers.
+Depending on the platform build tool you use, this location will either be `${CMAKE_BINARY_DIR}/tests/layers` or `${CMAKE_BINARY_DIR}/tests/layers/${CONFIGURATION}`.
+When using Visual Studio, a the generated project will already be set up to set the environment as needed.
+Running the tests through the `run_loader_tests.sh` script on Linux will also set up the environment properly.
+With any other toolchain, the user will have to set up the environment manually.

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -3,13 +3,15 @@ cmake_minimum_required (VERSION 2.8.11)
 set(LAYER_JSON_FILES
     VkLayer_wrap_objects
     VkLayer_test
-    )
+    VkLayer_meta
+)
 
 set(VK_LAYER_RPATH /usr/lib/x86_64-linux-gnu/vulkan/layer:/usr/lib/i386-linux-gnu/vulkan/layer)
 set(CMAKE_INSTALL_RPATH ${VK_LAYER_RPATH})
 
 if (WIN32)
     if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
+        add_custom_target(mk_test_layer_config_dir ALL COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
         foreach (config_file ${LAYER_JSON_FILES})
             FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/windows/${config_file}.json src_json)
             if (CMAKE_GENERATOR MATCHES "^Visual Studio.*")
@@ -21,7 +23,7 @@ if (WIN32)
                 COMMAND copy ${src_json} ${dst_json}
                 VERBATIM
                 )
-            add_dependencies(${config_file}-json ${config_file})
+            add_dependencies(${config_file}-json mk_test_layer_config_dir)
             set_target_properties(${config_file}-json PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
         endforeach(config_file)
     endif()

--- a/tests/layers/linux/VkLayer_meta.json
+++ b/tests/layers/linux/VkLayer_meta.json
@@ -1,0 +1,14 @@
+{
+    "file_format_version" : "1.1.1",
+    "layer" : {
+        "name": "VK_LAYER_LUNARG_meta",
+        "type": "GLOBAL",
+        "api_version": "1.1.74",
+        "implementation_version": "1",
+        "description": "LunarG Test Metalayer",
+        "component_layers": [
+            "VK_LAYER_LUNARG_wrap_objects",
+            "VK_LAYER_LUNARG_test"
+        ]
+    }
+}

--- a/tests/layers/macos/VkLayer_meta.json
+++ b/tests/layers/macos/VkLayer_meta.json
@@ -1,0 +1,14 @@
+{
+    "file_format_version" : "1.1.1",
+    "layer" : {
+        "name": "VK_LAYER_LUNARG_meta",
+        "type": "GLOBAL",
+        "api_version": "1.1.74",
+        "implementation_version": "1",
+        "description": "LunarG Test Metalayer",
+        "component_layers": [
+            "VK_LAYER_LUNARG_wrap_objects",
+            "VK_LAYER_LUNARG_test"
+        ]
+    }
+}

--- a/tests/layers/windows/VkLayer_meta.json
+++ b/tests/layers/windows/VkLayer_meta.json
@@ -1,0 +1,14 @@
+{
+    "file_format_version" : "1.1.1",
+    "layer" : {
+        "name": "VK_LAYER_LUNARG_meta",
+        "type": "GLOBAL",
+        "api_version": "1.1.74",
+        "implementation_version": "1",
+        "description": "LunarG Test Metalayer",
+        "component_layers": [
+            "VK_LAYER_LUNARG_wrap_objects",
+            "VK_LAYER_LUNARG_test"
+        ]
+    }
+}

--- a/tests/loader_validation_tests.cpp
+++ b/tests/loader_validation_tests.cpp
@@ -448,8 +448,8 @@ TEST(CreateInstance, LayerNotPresent) {
 
 // Used by run_loader_tests.sh to test for layer insertion.
 TEST(CreateInstance, LayerPresent) {
-    char const *const names1[] = {"VK_LAYER_LUNARG_parameter_validation"};  // Temporary required due to MSVC bug.
-    char const *const names2[] = {"VK_LAYER_LUNARG_standard_validation"};   // Temporary required due to MSVC bug.
+    char const *const names1[] = {"VK_LAYER_LUNARG_test"};  // Temporary required due to MSVC bug.
+    char const *const names2[] = {"VK_LAYER_LUNARG_meta"};  // Temporary required due to MSVC bug.
     auto const info1 = VK::InstanceCreateInfo().enabledLayerCount(1).ppEnabledLayerNames(names1);
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vkCreateInstance(info1, VK_NULL_HANDLE, &instance);
@@ -556,9 +556,8 @@ TEST(EnumeratePhysicalDevices, TwoCallIncomplete) {
 
 // Test to make sure that layers enabled in the instance show up in the list of device layers.
 TEST(EnumerateDeviceLayers, LayersMatch) {
-    char const *const names1[] = {"VK_LAYER_LUNARG_standard_validation"};
-    char const *const names2[3] = {"VK_LAYER_LUNARG_parameter_validation", "VK_LAYER_LUNARG_core_validation",
-                                   "VK_LAYER_LUNARG_object_tracker"};
+    char const *const names1[] = {"VK_LAYER_LUNARG_meta"};
+    char const *const names2[2] = {"VK_LAYER_LUNARG_test", "VK_LAYER_LUNARG_wrap_objects"};
     auto const info1 = VK::InstanceCreateInfo().enabledLayerCount(1).ppEnabledLayerNames(names1);
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vkCreateInstance(info1, VK_NULL_HANDLE, &instance);
@@ -590,7 +589,7 @@ TEST(EnumerateDeviceLayers, LayersMatch) {
 
     vkDestroyInstance(instance, nullptr);
 
-    auto const info2 = VK::InstanceCreateInfo().enabledLayerCount(3).ppEnabledLayerNames(names2);
+    auto const info2 = VK::InstanceCreateInfo().enabledLayerCount(2).ppEnabledLayerNames(names2);
     instance = VK_NULL_HANDLE;
     result = vkCreateInstance(info2, VK_NULL_HANDLE, &instance);
     ASSERT_EQ(result, VK_SUCCESS);
@@ -607,8 +606,8 @@ TEST(EnumerateDeviceLayers, LayersMatch) {
 
     count = 24;
     vkEnumerateDeviceLayerProperties(physical2[0], &count, layer_props);
-    ASSERT_GE(count, 3u);
-    for (uint32_t jjj = 0; jjj < 3; jjj++) {
+    ASSERT_GE(count, 2u);
+    for (uint32_t jjj = 0; jjj < 2; jjj++) {
         found = false;
         for (uint32_t iii = 0; iii < count; iii++) {
             if (!strcmp(layer_props[iii].layerName, names2[jjj])) {

--- a/tests/run_loader_tests.sh
+++ b/tests/run_loader_tests.sh
@@ -22,7 +22,7 @@ RunEnvironmentVariablePathsTest()
        GTEST_FILTER=CreateInstance.LayerPresent \
        ./vk_loader_validation_tests 2>&1)
 
-    # Here is a path we expect to find.  The loader constructs these from the XDG* env vars. 
+    # Here is a path we expect to find.  The loader constructs these from the XDG* env vars.
     right_path="/tmp/goober/vulkan/icd.d:/tmp/goober2/vulkan/icd.d:/tmp/goober3/with spaces/vulkan/icd.d"
     # There are other paths that come from SYSCONFIG settings established at build time.
     # So we can't really guess at what those are here.
@@ -65,12 +65,12 @@ RunCreateInstanceTest()
        GTEST_FILTER=CreateInstance.LayerPresent \
        ./vk_loader_validation_tests 2>&1)
 
-    echo "$output" | grep -q "Insert instance layer VK_LAYER_LUNARG_parameter_validation"
+    echo "$output" | grep -q "Insert instance layer VK_LAYER_LUNARG_test"
     ec=$?
 
     if [ $ec -eq 1 ]
     then
-       echo "CreateInstance insertion test FAILED - parameter-validation not detected in instance layers" >&2
+       echo "CreateInstance insertion test FAILED - test layer not detected in instance layers" >&2
        exit 1
     fi
     echo "CreateInstance Insertion test PASSED"
@@ -132,6 +132,7 @@ RunEnumerateInstanceExtensionPropertiesTest()
     echo "EnumerateInstanceExtensionProperties OnePass vs TwoPass test PASSED"
 }
 
+VK_LAYER_PATH="$PWD/layers"
 ./vk_loader_validation_tests
 
 RunEnvironmentVariablePathsTest

--- a/tests/vk_loader_validation_tests.vcxproj.user
+++ b/tests/vk_loader_validation_tests.vcxproj.user
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">
+    <LocalDebuggerEnvironment>VK_LAYER_PATH=$(ProjectDir)\layers\$(Configuration)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerEnvironment>VK_LAYER_PATH=$(ProjectDir)\layers\$(Configuration)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LocalDebuggerEnvironment>VK_LAYER_PATH=$(ProjectDir)\layers\$(Configuration)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">
+    <LocalDebuggerEnvironment>VK_LAYER_PATH=$(ProjectDir)\layers\$(Configuration)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|Win32'">
+    <LocalDebuggerEnvironment>VK_LAYER_PATH=$(ProjectDir)\layers\$(Configuration)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerEnvironment>VK_LAYER_PATH=$(ProjectDir)\layers\$(Configuration)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|Win32'">
+    <LocalDebuggerEnvironment>VK_LAYER_PATH=$(ProjectDir)\layers\$(Configuration)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LocalDebuggerEnvironment>VK_LAYER_PATH=$(ProjectDir)\layers\$(Configuration)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This fixes #13 by using the existing test layers instead of validation layers in the tests. It also adds a metalayer for testing, and adds a brief readme to describe how to run the tests.