### PR TITLE
Replace Vulkan-Headers submodule

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,12 +33,21 @@ before_build:
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" (set VK_VERSION=15 2017)
   - if %PLATFORM% == Win32 (set GENERATOR="Visual Studio %VS_VERSION%")
   - if %PLATFORM% == x64 (set GENERATOR="Visual Studio %VS_VERSION% Win64")
+  # Install Vulkan-Headers
+  - mkdir %TEMP%\headers
+  - git clone https://github.com/KhronosGroup/Vulkan-Headers.git %TEMP%\headers\repo
+  - ps: pushd $ENV:TEMP\headers\repo
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_INSTALL_PREFIX=%TEMP%\headers\install ..
+  - cmake --build . --target install
+  - ps: popd
   # Generate build files using CMake for the build step.
   - echo Generating CMake files for %GENERATOR%
   - cd %TOP_DIR%
   - mkdir build
   - cd build
-  - cmake -G %GENERATOR% ..
+  - cmake -G %GENERATOR% -DVULKAN_HEADERS_INSTALL_DIR=%TEMP%\headers\install ..
   - echo Building platform=%PLATFORM% configuration=%CONFIGURATION%
 
 platform:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Vulkan-Headers"]
-	path = Vulkan-Headers
-	url = https://github.com/KhronosGroup/Vulkan-Headers.git
 [submodule "tests/googletest"]
 	path = tests/googletest
 	url = https://github.com/google/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ cache: ccache
 
 before_install:
   - set -e
+  - unset -f cd pushd popd
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       # Install the appropriate Linux packages.
@@ -48,6 +49,16 @@ before_install:
     if [[ "$VULKAN_BUILD_TARGET" == "MACOS" ]]; then
       # Install the appropriate MacOS packages
       brew upgrade python3
+    fi
+  - |
+    if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]] || [[ "$VULKAN_BUILD_TARGET" == "MACOS" ]]; then
+      # Install Vulkan-Headers
+      mkdir /tmp/headers
+      git clone https://github.com/KhronosGroup/Vulkan-Headers.git /tmp/headers/repo
+      pushd /tmp/headers/repo
+      cmake . -DCMAKE_INSTALL_PREFIX=/tmp/headers/install
+      cmake --build . --target install
+      popd
     fi
   - |
     if [[ "$CHECK_FORMAT" == "ON" && "$TRAVIS_PULL_REQUEST" != "false" ]]; then
@@ -63,13 +74,12 @@ before_install:
 
 script:
   - set -e
-  - unset -f cd
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]] || [[ "$VULKAN_BUILD_TARGET" == "MACOS" ]]; then
       # Build Vulkan-Loader
       mkdir build
       cd build
-      cmake -DCMAKE_BUILD_TYPE=Debug ..
+      cmake -DCMAKE_BUILD_TYPE=Debug -DVULKAN_HEADERS_INSTALL_DIR=/tmp/headers/install ..
       make -j $core_count
       cd ..
     fi

--- a/BUILD.md
+++ b/BUILD.md
@@ -44,6 +44,9 @@ If you forget to specify this option, you can later run:
 Windows 7+ with the following software packages:
 
 - Microsoft Visual Studio 2013 Update 4 Professional, VS2015 (any version), or VS2017 (any version).
+- [Vulkan-Headers](https://github.com/KhronosGroup/Vulkan-Headers)
+  - Vulkan headers should be built with the "install" target. Generally, you will want to use the
+    `CMAKE_INSTALL_PREFIX` and remember where you set this to.
 - [CMake](http://www.cmake.org/download/)
   - Tell the installer to "Add CMake to the system PATH" environment variable.
 - [Python 3](https://www.python.org/downloads)
@@ -72,12 +75,17 @@ PowerShell, MINGW, CygWin, etc.
 #### Use `cmake` to create the VS project files
 
 Switch to the top of the cloned repository directory,
-create a build directory and generate the VS project files:
+create a build directory and generate the VS project files.
+When generating the project files, the location to a Vulkan-Headers install
+directory must be provided. This can be done by setting the environment variable
+`VULKAN_HEADERS_INSTALL_DIR` or by setting it as a CMake flag.
+In either case, the variable should point to the installation directory of the
+Vulkan-Headers repo:
 
     cd Vulkan-Loader
     mkdir build
     cd build
-    cmake ..
+    cmake -DVULKAN_HEADERS_INSTALL_DIR=C:\SampleDir ..
 
 As it starts generating the project files, `cmake` responds with something like:
 
@@ -89,7 +97,7 @@ If this is not what you want, you can supply one of the
 [specific generators](#cmake-visual-studio-generators).
 For example:
 
-    cmake -G "Visual Studio 14 2015 Win64" ..
+    cmake -DVULKAN_HEADERS_INSTALL_DIR=C:\SampleDir -G "Visual Studio 14 2015 Win64" ..
 
 This creates a Windows 64-bit solution file named `Vulkan-Loader.sln`
 in the build directory for Visual Studio 2015.
@@ -201,18 +209,27 @@ It should be straightforward to adapt this repository to other Linux distributio
 
     sudo apt-get install git cmake build-essential libx11-xcb-dev libxkbcommon-dev libmirclient-dev libwayland-dev libxrandr-dev
 
+In addition to this, the [Vulkan-Headers](https://github.com/KhronosGroup/Vulkan-Headers) repo should be
+built and installed to the directory of your choosing. This can be done by setting `CMAKE_INSTALL_PREFIX`
+and running the "install" target from within the Vulkan-Headers repository.
+
 ### Linux Build
 
 Example debug build (Note that the update\_external\_sources script used below builds external tools into predefined locations.
 See **Loader and Validation Layer Dependencies** for more information and other options):
 
 Switch to the top of the cloned repository directory,
-create a build directory and generate the make files:
+create a build directory and generate the make files.
+When generating the project files, the location to a Vulkan-Headers install
+directory must be provided. This can be done by setting the environment variable
+`VULKAN_HEADERS_INSTALL_DIR` or by setting it as a CMake flag.
+In either case, the variable should point to the installation directory of the
+Vulkan-Headers repo:
 
     cd Vulkan-Loader
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=Debug ..
+    cmake -DVULKAN_HEADERS_INSTALL_DIR=/sample/dir -DCMAKE_BUILD_TYPE=Debug ..
 
 Run `make -j8` to begin the build.
 
@@ -363,6 +380,10 @@ Setup Homebrew and components
 
       brew install cmake python python3 git
 
+      In addition to this, the [Vulkan-Headers](https://github.com/KhronosGroup/Vulkan-Headers) repo should be
+      built and installed to the directory of your choosing. This can be done by setting `CMAKE_INSTALL_PREFIX`
+      and running the "install" target from within the Vulkan-Headers repository.
+
 ### MacOS build
 
 #### CMake Generators
@@ -376,12 +397,16 @@ The CMake generators explicitly supported in this repository are:
 
 #### Building with the Unix Makefiles Generator
 
-This generator is the default generator, so all that is needed for a debug
-build is:
+This generator is the default generator.
+However, when generating the project files, the location to a Vulkan-Headers install
+directory must be provided. This can be done by setting the environment variable
+`VULKAN_HEADERS_INSTALL_DIR` or by setting it as a CMake flag.
+In either case, the variable should point to the installation directory of the
+Vulkan-Headers repo:
 
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug ..
+        cmake -DVULKAN_HEADERS_INSTALL_DIR=/sample/dir -DCMAKE_BUILD_TYPE=Debug ..
         make
 
 To speed up the build on a multi-core machine, use the `-j` option for `make`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ set (CMAKE_VERBOSE_MAKEFILE 0)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(PythonInterp 3 REQUIRED)
 
+find_package(VulkanHeaders)
+if (NOT ${VulkanHeaders_FOUND})
+    message(FATAL_ERROR "Could not find Vulkan headers path. This can be fixed by setting VULKAN_HEADERS_INSTALL_DIR to an "
+        "installation of the Vulkan-Headers repository.")
+endif()
+
 option(USE_CCACHE "Use ccache" OFF)
 if (USE_CCACHE)
     find_program(CCACHE_FOUND ccache)
@@ -74,16 +80,9 @@ if(WIN32)
 endif()
 
 set(SCRIPTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
-set(HEADERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers")
-
-# Output warning if vulkan headers submodule contents are not present
-if (NOT EXISTS "${HEADERS_DIR}/include/vulkan/vulkan_core.h")
-    message(FATAL_ERROR "Please run 'git submodule update --init' before running cmake")
-endif()
 
 # Add location of Vulkan header files to include search path
-set(vulkan_include_dir "${HEADERS_DIR}/include")
-include_directories(${vulkan_include_dir})
+include_directories(${VulkanHeaders_INCLUDE_DIRS})
 
 if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers")
@@ -131,8 +130,8 @@ set (PYTHON_CMD ${PYTHON_EXECUTABLE})
 # Define macro used for building vkxml generated files
 macro(run_vk_xml_generate dependency output)
     add_custom_command(OUTPUT ${output}
-    COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${HEADERS_DIR}/registry/vk.xml ${output}
-    DEPENDS ${HEADERS_DIR}/registry/vk.xml ${HEADERS_DIR}/registry/generator.py ${SCRIPTS_DIR}/${dependency} ${SCRIPTS_DIR}/lvl_genvk.py ${HEADERS_DIR}/registry/reg.py
+    COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/loader_genvk.py -registry ${VulkanRegistry_DIR}/vk.xml -scripts ${VulkanRegistry_DIR} ${output}
+    DEPENDS ${VulkanRegistry_DIR}/vk.xml ${VulkanRegistry_DIR}/generator.py ${SCRIPTS_DIR}/${dependency} ${SCRIPTS_DIR}/loader_genvk.py ${VulkanRegistry_DIR}/reg.py
     )
 endmacro()
 

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(NOT ${VulkanRegistry_FOUND})
+    message(FATAL_ERROR "Could not find Vulkan registry path. This can be fixed by setting VULKAN_HEADERS_INSTALL_DIR to an "
+        "installation of the Vulkan-Headers repository.")
+endif()
+
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
@@ -12,7 +17,7 @@ CHECK_FUNCTION_EXISTS(__secure_getenv HAVE___SECURE_GETENV)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/loader_cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/loader_cmake_config.h)
 
 # Fetch header version from vulkan_core.h
-file(STRINGS "${vulkan_include_dir}/vulkan/vulkan_core.h" lines REGEX "^#define VK_HEADER_VERSION [0-9]+")
+file(STRINGS "${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_core.h" lines REGEX "^#define VK_HEADER_VERSION [0-9]+")
 list(LENGTH lines len)
 if(${len} EQUAL 1)
     string(REGEX MATCHALL "[0-9]+" vk_header_version ${lines})
@@ -225,23 +230,23 @@ else()
 
         # Build vulkan.framework
         set(FRAMEWORK_HEADERS
-            ${HEADERS_DIR}/include/vulkan/vk_icd.h
-            ${HEADERS_DIR}/include/vulkan/vk_layer.h
-            ${HEADERS_DIR}/include/vulkan/vk_platform.h
-            ${HEADERS_DIR}/include/vulkan/vk_sdk_platform.h
-            ${HEADERS_DIR}/include/vulkan/vulkan_android.h
-            ${HEADERS_DIR}/include/vulkan/vulkan_core.h
-            ${HEADERS_DIR}/include/vulkan/vulkan_ios.h
-            ${HEADERS_DIR}/include/vulkan/vulkan_macos.h
-            ${HEADERS_DIR}/include/vulkan/vulkan_mir.h
-            ${HEADERS_DIR}/include/vulkan/vulkan_vi.h
-            ${HEADERS_DIR}/include/vulkan/vulkan_wayland.h
-            ${HEADERS_DIR}/include/vulkan/vulkan_win32.h
-            ${HEADERS_DIR}/include/vulkan/vulkan_xcb.h
-            ${HEADERS_DIR}/include/vulkan/vulkan_xlib.h
-            ${HEADERS_DIR}/include/vulkan/vulkan_xlib_xrandr.h
-            ${HEADERS_DIR}/include/vulkan/vulkan.h
-            ${HEADERS_DIR}/include/vulkan/vulkan.hpp
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_icd.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_layer.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_platform.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_sdk_platform.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_android.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_core.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_ios.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_macos.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_mir.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_vi.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_wayland.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_win32.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xcb.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xlib.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xlib_xrandr.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan.hpp
         )
         add_library(vulkan-framework SHARED ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS} ${FRAMEWORK_HEADERS})
         add_dependencies(vulkan-framework generate_helper_files loader_gen_files loader_asm_gen_files)
@@ -286,5 +291,5 @@ endif()
 
 install(TARGETS vulkan
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} 
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/scripts/loader_genvk.py
+++ b/scripts/loader_genvk.py
@@ -16,18 +16,6 @@
 
 import argparse, cProfile, pdb, string, sys, time, os
 
-scripts_dir = os.path.dirname(os.path.abspath(__file__))
-registry_dir = os.path.join(scripts_dir, '../Vulkan-Headers/registry')
-sys.path.insert(0, registry_dir)
-
-from reg import *
-from generator import write
-from cgenerator import CGeneratorOptions, COutputGenerator
-# Loader Generator Modifications
-from dispatch_table_helper_generator import DispatchTableHelperOutputGenerator, DispatchTableHelperOutputGeneratorOptions
-from helper_file_generator import HelperFileOutputGenerator, HelperFileOutputGeneratorOptions
-from loader_extension_generator import LoaderExtensionOutputGenerator, LoaderExtensionGeneratorOptions
-
 # Simple timer functions
 startTime = None
 
@@ -445,7 +433,24 @@ if __name__ == '__main__':
     parser.add_argument('-verbose', action='store_false', dest='quiet', default=True,
                         help='Enable script output during normal execution.')
 
+    # This argument tells us where to load the script from the Vulkan-Headers registry
+    parser.add_argument('-scripts', action='store',
+                        help='Find additional scripts in this directory')
+
     args = parser.parse_args()
+
+    scripts_dir = os.path.dirname(os.path.abspath(__file__))
+    registry_dir = os.path.join(scripts_dir, args.scripts)
+    sys.path.insert(0, registry_dir)
+
+    # The imports need to be done here so that they can be picked up from Vulkan-Headers
+    from reg import *
+    from generator import write
+    from cgenerator import CGeneratorOptions, COutputGenerator
+
+    from dispatch_table_helper_generator import DispatchTableHelperOutputGenerator, DispatchTableHelperOutputGeneratorOptions
+    from helper_file_generator import HelperFileOutputGenerator, HelperFileOutputGeneratorOptions
+    from loader_extension_generator import LoaderExtensionOutputGenerator, LoaderExtensionGeneratorOptions
 
     # This splits arguments which are space-separated lists
     args.feature = [name for arg in args.feature for name in arg.split()]


### PR DESCRIPTION
This fixes #22. This PR removes the Vulkan-Headers submodule, and instead uses a CMake Fine Module. Building the repo now requires setting `-DVULKAN_HEADERS_INSTALL_DIR` so that the loader can find the headers and registry file from Vulkan-Headers.