### PR TITLE
Remove Google Test submodule

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,6 +42,8 @@ before_build:
   - cmake -DCMAKE_INSTALL_PREFIX=%TEMP%\headers\install ..
   - cmake --build . --target install
   - ps: popd
+  # Get Google Test
+  - git clone https://github.com/google/googletest.git external/googletest
   # Generate build files using CMake for the build step.
   - echo Generating CMake files for %GENERATOR%
   - cd %TOP_DIR%

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ VKConfig.h
 build
 build32
 dbuild
-external
+external/googletest
 *.so
 *.so.*
 *.pyc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tests/googletest"]
-	path = tests/googletest
-	url = https://github.com/google/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ before_install:
       cmake . -DCMAKE_INSTALL_PREFIX=/tmp/headers/install
       cmake --build . --target install
       popd
+      # Get Google Test
+      git clone https://github.com/google/googletest.git external/googletest
     fi
   - |
     if [[ "$CHECK_FORMAT" == "ON" && "$TRAVIS_PULL_REQUEST" != "false" ]]; then

--- a/BUILD.md
+++ b/BUILD.md
@@ -29,13 +29,7 @@ graphics hardware vendor and install it properly.
 
 To create your local git repository:
 
-    git clone --recurse-submodules https://github.com/KhronosGroup/Vulkan-Loader
-
-The `--recurse-submodules` option is required because this repository contains
-submodules.
-If you forget to specify this option, you can later run:
-
-    git submodule update --init --recursive
+    git clone https://github.com/KhronosGroup/Vulkan-Loader
 
 ## Building On Windows
 
@@ -60,6 +54,10 @@ Windows 7+ with the following software packages:
   - Tell the installer to treat line endings "as is" (i.e. both DOS and Unix-style line endings).
   - Install both the 32-bit and 64-bit versions, as the 64-bit installer does not install the
     32-bit libraries and tools.
+- [Google Test](https://github.com/google/googletest) (Tests only)
+  - To build the loader tests, clone google test into the "external" directory like:
+        git clone https://github.com/google/googletest external/googletest
+  - If you do not include Google Test, the repo will still build, but the tests will be omitted
 
 ### Windows Build - Microsoft Visual Studio
 
@@ -212,6 +210,13 @@ It should be straightforward to adapt this repository to other Linux distributio
 In addition to this, the [Vulkan-Headers](https://github.com/KhronosGroup/Vulkan-Headers) repo should be
 built and installed to the directory of your choosing. This can be done by setting `CMAKE_INSTALL_PREFIX`
 and running the "install" target from within the Vulkan-Headers repository.
+
+In addition to this, the loader tests require that a copy of Google Test be present in the "external" directory.
+The loader will still build if Google Test is not provided, but the tests will be skipped.
+To get a copy of Google Test, run:
+
+    git clone https://github.com/google/googletest external/googletest
+
 
 ### Linux Build
 
@@ -384,6 +389,12 @@ Setup Homebrew and components
       built and installed to the directory of your choosing. This can be done by setting `CMAKE_INSTALL_PREFIX`
       and running the "install" target from within the Vulkan-Headers repository.
 
+- The loader tests require that a copy of Google Test be present in the "external" directory.
+  The loader will still build if Google Test is not provided, but the tests will be skipped.
+  To get a copy of Google Test, run:
+
+      git clone https://github.com/google/googletest external/googletest
+
 ### MacOS build
 
 #### CMake Generators
@@ -487,7 +498,7 @@ The following is a table of all on/off options currently supported by this repos
 | Option | Platform | Default | Description |
 | ------ | -------- | ------- | ----------- |
 | BUILD_LOADER | All | `ON` | Controls whether or not the loader is built. Setting this to `OFF` will allow building the tests against a loader that is installed to the system. |
-| BUILD_TESTS | All | `ON` | Controls whether or not the loader tests are built. |
+| BUILD_TESTS | All | `ON` | Controls whether or not the loader tests are built. This option is only available when a copy of Google Test is available in the "external" directory. |
 | BUILD_WSI_XCB_SUPPORT | Linux | `ON` | Build the loader with the XCB entry points enabled. Without this, the XCB headers should not be needed, but the extension `VK_KHR_xcb_surface` won't be available. |
 | BUILD_WSI_XLIB_SUPPORT | Linux | `ON` | Build the loader with the Xlib entry points enabled. Without this, the X11 headers should not be needed, but the extension `VK_KHR_xlib_surface` won't be available. |
 | BUILD_WSI_WAYLAND_SUPPORT | Linux | `ON` | Build the loader with the Wayland entry points enabled. Without this, the Wayland headers should not be needed, but the extension `VK_KHR_wayland_surface` won't be available. |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,6 @@ if(WIN32)
 endif()
 
 option(BUILD_LOADER "Build loader" ON)
-option(BUILD_TESTS "Build tests" ON)
 
 set (PYTHON_CMD ${PYTHON_EXECUTABLE})
 
@@ -180,6 +179,8 @@ add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 
 add_definitions(-DAPI_NAME="Vulkan")
+
+add_subdirectory(external)
 
 if(BUILD_LOADER)
     add_subdirectory(loader)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Add all optional dependencies
+# Currently, the only optional project is googletest
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/googletest")
+    option(BUILD_TESTS "Build tests" ON)
+endif()
+
+if(BUILD_TESTS)
+    message(STATUS "Building gtest from ${CMAKE_CURRENT_SOURCE_DIR}/googletest")
+    set(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
+    set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
+    set(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically")
+    set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
+    # EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/googletest" EXCLUDE_FROM_ALL)
+endif()

--- a/external/README.md
+++ b/external/README.md
@@ -1,0 +1,9 @@
+# External dependencies
+
+This directory provides a location where external projects can be cloned that are used by the loader.
+Currently, the only project that can be used by the loader is Google Test.
+It can be enabled by cloning it here like:
+
+```
+git clone https://github.com/google/googletest.git
+```

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,8 +59,8 @@ endif()
 set (LIBGLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libs)
 
 include_directories(
-    ${PROJECT_SOURCE_DIR}/tests
-    ${PROJECT_SOURCE_DIR}/tests/googletest/googletest/include
+    ${PROJECT_SOURCE_DIR}/external
+    ${GTEST_SOURCE_DIR}/googletest/include
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_BINARY_DIR}
     ${PROJECT_BINARY_DIR}
@@ -118,23 +118,15 @@ if(WIN32)
     file(COPY vk_loader_validation_tests.vcxproj.user DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 
-SET(GTEST_RELATIVE_LOCATION googletest)
-SET(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
-SET(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
-SET(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically")
-SET(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
-# EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
-add_subdirectory(${GTEST_RELATIVE_LOCATION} ${CMAKE_CURRENT_BINARY_DIR}/googletest EXCLUDE_FROM_ALL)
-
 # Copy googletest (gtest) libs to test dir so the test executable can find them.
 if(WIN32)
     if (CMAKE_GENERATOR MATCHES "^Visual Studio.*")
-        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${GTEST_RELATIVE_LOCATION}/googletest/$<CONFIG>/gtest_main$<$<CONFIG:Debug>:d>.dll GTEST_COPY_SRC1)
-        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${GTEST_RELATIVE_LOCATION}/googletest/$<CONFIG>/gtest$<$<CONFIG:Debug>:d>.dll GTEST_COPY_SRC2)
+        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIG>/gtest_main$<$<CONFIG:Debug>:d>.dll GTEST_COPY_SRC1)
+        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIG>/gtest$<$<CONFIG:Debug>:d>.dll GTEST_COPY_SRC2)
         file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG> GTEST_COPY_DEST)
     else()
-        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${GTEST_RELATIVE_LOCATION}/googletest/gtest_main.dll GTEST_COPY_SRC1)
-        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${GTEST_RELATIVE_LOCATION}/googletest/gtest.dll GTEST_COPY_SRC2)
+        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googeltest/gtest_main.dll GTEST_COPY_SRC1)
+        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/gtest.dll GTEST_COPY_SRC2)
         file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR} GTEST_COPY_DEST)
     endif()
     add_custom_command(TARGET vk_loader_validation_tests POST_BUILD


### PR DESCRIPTION
This changes removes the Google Test submodule and changes the build system to make Google Test optional. Tests will not be built when Google Test is not present, but cloning it into the "external" directory will cause tests to be built by default.

This PR also updates CI and documentation to match the build system changes.