### PR TITLE
Add loader support for VK_KHR_get_display_properties2

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -315,6 +315,7 @@ struct loader_instance {
     bool wsi_ios_surface_enabled;
 #endif
     bool wsi_display_enabled;
+    bool wsi_display_props2_enabled;
 };
 
 // VkPhysicalDevice requires special treatment by loader.  Firstly, terminator

--- a/loader/vulkan-1.def
+++ b/loader/vulkan-1.def
@@ -211,3 +211,8 @@ EXPORTS
    vkCreateDescriptorUpdateTemplate
    vkDestroyDescriptorUpdateTemplate
    vkUpdateDescriptorSetWithTemplate
+
+   vkGetPhysicalDeviceDisplayProperties2KHR
+   vkGetPhysicalDeviceDisplayPlaneProperties2KHR
+   vkGetDisplayModeProperties2KHR
+   vkGetDisplayPlaneCapabilities2KHR

--- a/loader/wsi.h
+++ b/loader/wsi.h
@@ -163,4 +163,20 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDevicePresentRectanglesKHR(
                                                                                 uint32_t* pRectCount,
                                                                                 VkRect2D* pRects);
 
+VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceDisplayProperties2KHR(VkPhysicalDevice physicalDevice,
+                                                                                 uint32_t *pPropertyCount,
+                                                                                 VkDisplayProperties2KHR *pProperties);
+
+VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceDisplayPlaneProperties2KHR(VkPhysicalDevice physicalDevice,
+                                                                                      uint32_t *pPropertyCount,
+                                                                                      VkDisplayPlaneProperties2KHR *pProperties);
+
+VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayModeProperties2KHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
+                                                                       uint32_t *pPropertyCount,
+                                                                       VkDisplayModeProperties2KHR *pProperties);
+
+VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayPlaneCapabilities2KHR(VkPhysicalDevice physicalDevice,
+                                                                          const VkDisplayPlaneInfo2KHR *pDisplayPlaneInfo,
+                                                                          VkDisplayPlaneCapabilities2KHR *pCapabilities);
+
 #endif // WSI_H

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -38,7 +38,8 @@ WSI_EXT_NAMES = ['VK_KHR_surface',
                  'VK_MVK_macos_surface',
                  'VK_MVK_ios_surface',
                  'VK_KHR_swapchain',
-                 'VK_KHR_display_swapchain']
+                 'VK_KHR_display_swapchain',
+                 'VK_KHR_get_display_properties2']
 
 ADD_INST_CMDS = ['vkCreateInstance',
                  'vkEnumerateInstanceExtensionProperties',
@@ -59,7 +60,7 @@ DEVICE_CMDS_NEED_TERM = ['vkGetDeviceProcAddr',
                          'vkDebugMarkerSetObjectNameEXT',
                          'vkSetDebugUtilsObjectNameEXT',
                          'vkSetDebugUtilsObjectTagEXT']
-                         
+
 ALIASED_CMDS = {
     'vkEnumeratePhysicalDeviceGroupsKHR':                   'vkEnumeratePhysicalDeviceGroups',
     'vkGetPhysicalDeviceFeatures2KHR':                      'vkGetPhysicalDeviceFeatures2',
@@ -890,7 +891,11 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                                'vkGetRandROutputDisplayEXT',
                                'vkGetPhysicalDeviceExternalBufferPropertiesKHR',
                                'vkGetPhysicalDeviceExternalSemaphorePropertiesKHR',
-                               'vkGetPhysicalDeviceExternalFencePropertiesKHR']
+                               'vkGetPhysicalDeviceExternalFencePropertiesKHR',
+                               'vkGetPhysicalDeviceDisplayProperties2KHR',
+                               'vkGetPhysicalDeviceDisplayPlaneProperties2KHR',
+                               'vkGetDisplayModeProperties2KHR',
+                               'vkGetDisplayPlaneCapabilities2KHR']
 
         for ext_cmd in self.ext_commands:
             if (ext_cmd.ext_name in WSI_EXT_NAMES or


### PR DESCRIPTION
The 1.0.76 header introduced a new instance extension, `VK_KHR_get_display_properties2`. Since this is an instance extension, it requires loader support to function properly. This PR adds that support. Note that this requires a 1.0.76 header to build.