### PR TITLE
cmake: Move loader copy to test dir

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -196,18 +196,6 @@ if (WIN32)
 
     add_dependencies(vulkan generate_helper_files loader_gen_files loader_asm_gen_files)
 
-    if(BUILD_TESTS AND NOT ENABLE_STATIC_LOADER)
-        if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
-            file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/vulkan-1.dll COPY_SRC_PATH)
-            file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../tests/$<CONFIGURATION>/ COPY_DST_TEST_PATH)
-        else()
-            file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/vulkan-1.dll COPY_SRC_PATH)
-            file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../tests/ COPY_DST_TEST_PATH)
-        endif()
-        add_custom_command(TARGET vulkan POST_BUILD
-            COMMAND xcopy /Y /I ${COPY_SRC_PATH} ${COPY_DST_TEST_PATH})
-    endif()
-
 else()
     # Linux and MacOS
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,7 +119,7 @@ if(TARGET gtest_main)
         file(COPY vk_loader_validation_tests.vcxproj.user DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
     endif()
 
-    # Copy googletest (gtest) libs to test dir so the test executable can find them.
+    # Copy loader and googletest (gtest) libs to test dir so the test executable can find them.
     if(WIN32)
         if (CMAKE_GENERATOR MATCHES "^Visual Studio.*")
             file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIG>/gtest_main$<$<CONFIG:Debug>:d>.dll GTEST_COPY_SRC1)
@@ -134,6 +134,11 @@ if(TARGET gtest_main)
             COMMAND xcopy /Y /I ${GTEST_COPY_SRC1} ${GTEST_COPY_DEST}
             COMMAND xcopy /Y /I ${GTEST_COPY_SRC2} ${GTEST_COPY_DEST}
         )
+        # Copy the loader shared lib (if built) to the test application directory so the test app finds it.
+        if((NOT ENABLE_STATIC_LOADER) AND TARGET vulkan)
+            add_custom_command(TARGET vk_loader_validation_tests POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:vulkan> $<TARGET_FILE_DIR:vk_loader_validation_tests>)
+        endif()
     endif()
 
     add_subdirectory(layers)


### PR DESCRIPTION
- Move the CMake code to copy the loader DLL from the loader target
  definition to the test target definition.  The test should be
  taking responsibility for copying this DLL and it avoids doing the
  copy if BUILD_TESTS is on and gtest is not present.
- Use better CMake code to perform the copy.