### PR TITLE
Rework include dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,8 +201,6 @@ if(NOT WIN32)
     endif()
 endif()
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/vk_layer_dispatch_table.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/vulkan")
-
 # uninstall target
 if(NOT TARGET uninstall)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -34,6 +34,7 @@
 #include <vulkan/vk_layer.h>
 #include <vulkan/vk_icd.h>
 #include <assert.h>
+#include "vk_layer_dispatch_table.h"
 #include "vk_loader_extensions.h"
 
 #if defined(__GNUC__) && __GNUC__ >= 4

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -113,6 +113,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
         preamble += '#include <vulkan/vulkan.h>\n'
         preamble += '#include <vulkan/vk_layer.h>\n'
         preamble += '#include <string.h>\n'
+        preamble += '#include "vk_layer_dispatch_table.h"\n'
 
         write(copyright, file=self.outFile)
         write(preamble, file=self.outFile)


### PR DESCRIPTION
This change removes the assumption that `vk_layer.h` will include `vk_layer_dispatch_table.h`, since that include should be removed in the near future. The change to remove the extra include is KhronosGroup/Vulkan-Headers#11.

This changes also fixes #43 (which is what motivated this change). The problem there is that `vk_layer_dispatch_table.h` was being installed, which it really shouldn't be. It was installed because `vk_layer.h` depends on it, but there's no good reason for that dependency to exist.