### PR TITLE
cmake: Clean up macOS install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,6 @@ endif()
 if(APPLE)
     # CMake versions 3 or later need CMAKE_MACOSX_RPATH defined. This avoids the CMP0042 policy message.
     set(CMAKE_MACOSX_RPATH 1)
-    # The "install" target for MacOS fixes up bundles in place.
-    set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR})
 endif()
 
 # Enable IDE GUI folders


### PR DESCRIPTION
Stop hardcoding CMAKE_INSTALL_PREFIX to CMAKE_BINARY_DIR