### PR TITLE
loader: GH54: Fix setfault with VK_EXT_debug_utils

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5582,8 +5582,8 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
         } else if (!strcmp(localCreateInfo.ppEnabledExtensionNames[i], VK_EXT_DEBUG_MARKER_EXTENSION_NAME)) {
             dev->extensions.ext_debug_marker_enabled = true;
         }
-        dev->extensions.ext_debug_utils_enabled = icd_term->this_instance->enabled_known_extensions.ext_debug_utils;
     }
+    dev->extensions.ext_debug_utils_enabled = icd_term->this_instance->enabled_known_extensions.ext_debug_utils;
 
     res = fpCreateDevice(phys_dev_term->phys_dev, &localCreateInfo, pAllocator, &dev->icd_device);
     if (res != VK_SUCCESS) {


### PR DESCRIPTION
The loader was not setting the device flag indicating that the
VK_EXT_debug_utils extension had been set in the instance unless
one or more device extensions had been added to the list.

This fixes the bug caught by nikitablack on StackOverflow internally known as issue #54.

Change-Id: I23c24ee059ab5a66b9dbfdb9fa9ddab009fb2118
