### PR TITLE
loader: Update FindVulkanHeaders CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,15 +210,6 @@ endif()
 
 add_definitions(-DAPI_NAME="Vulkan")
 
-# Fetch header version from vulkan_core.h
-file(STRINGS "${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_core.h" lines REGEX "^#define VK_HEADER_VERSION [0-9]+")
-list(LENGTH lines len)
-if(${len} EQUAL 1)
-    string(REGEX MATCHALL "[0-9]+" vk_header_version ${lines})
-else()
-    message(FATAL_ERROR "Unable to fetch version from vulkan.h")
-endif()
-
 if(BUILD_LOADER)
     add_subdirectory(loader)
 endif()

--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -32,6 +32,13 @@
 #   VulkanRegistry_FOUND         - True if VulkanRegistry was found
 #   VulkanRegistry_DIRS          - directories for VulkanRegistry
 #
+#   VulkanHeaders_VERSION_MAJOR  - The Major API version of the latest version
+#                                  contained in the Vulkan header
+#   VulkanHeaders_VERSION_MINOR  - The Minor API version of the latest version
+#                                  contained in the Vulkan header
+#   VulkanHeaders_VERSION_PATCH  - The Patch API version of the latest version
+#                                  contained in the Vulkan header
+#
 # The module will also define two cache variables::
 #
 #   VulkanHeaders_INCLUDE_DIR    - the VulkanHeaders include directory
@@ -67,3 +74,57 @@ find_package_handle_standard_args(VulkanRegistry
     VulkanRegistry_DIR)
 
 mark_as_advanced(VulkanHeaders_INCLUDE_DIR VulkanRegistry_DIR)
+
+# Determine the major/minor/patch version from the vulkan header
+set(VulkanHeaders_VERSION_MAJOR "0")
+set(VulkanHeaders_VERSION_MINOR "0")
+set(VulkanHeaders_VERSION_PATCH "0")
+
+# First, determine which header we need to grab the version information from.
+# Starting with Vulkan 1.1, we should use vulkan_core.h, but prior to that,
+# the information was in vulkan.h.
+if (EXISTS "${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_core.h")
+    set(VulkanHeaders_main_header ${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_core.h)
+else()
+    set(VulkanHeaders_main_header ${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan.h)
+endif()
+
+# Find all lines in the header file that contain any version we may be interested in
+#  NOTE: They start with #define and then have other keywords
+file(STRINGS
+        ${VulkanHeaders_main_header}
+        VulkanHeaders_lines
+        REGEX "^#define (VK_API_VERSION.*VK_MAKE_VERSION|VK_HEADER_VERSION)")
+
+foreach(VulkanHeaders_line ${VulkanHeaders_lines})
+
+    # First, handle the case where we have a major/minor version
+    #   Format is:
+    #        #define VK_API_VERSION_X_Y VK_MAKE_VERSION(X, Y, 0)
+    #   We grab the major version (X) and minor version (Y) out of the parentheses
+    string(REGEX MATCH "VK_MAKE_VERSION\\(.*\\)" VulkanHeaders_out ${VulkanHeaders_line})
+    string(REGEX MATCHALL "[0-9]+" VulkanHeaders_MAJOR_MINOR "${VulkanHeaders_out}")
+    if (VulkanHeaders_MAJOR_MINOR)
+        list (GET VulkanHeaders_MAJOR_MINOR 0 VulkanHeaders_cur_major)
+        list (GET VulkanHeaders_MAJOR_MINOR 1 VulkanHeaders_cur_minor)
+        if (${VulkanHeaders_cur_major} GREATER ${VulkanHeaders_VERSION_MAJOR})
+            set(VulkanHeaders_VERSION_MAJOR ${VulkanHeaders_cur_major})
+            set(VulkanHeaders_VERSION_MINOR ${VulkanHeaders_cur_minor})
+        endif()
+        if (${VulkanHeaders_cur_major} EQUAL ${VulkanHeaders_VERSION_MAJOR} AND
+            ${VulkanHeaders_cur_minor} GREATER ${VulkanHeaders_VERSION_MINOR})
+            set(VulkanHeaders_VERSION_MINOR ${VulkanHeaders_cur_minor})
+        endif()
+    endif()
+
+    # Second, handle the case where we have the patch version
+    #   Format is:
+    #      #define VK_HEADER_VERSION Z
+    #   Where Z is the patch version which we just grab off the end
+    string(REGEX MATCH "define.*VK_HEADER_VERSION.*" VulkanHeaders_out ${VulkanHeaders_line})
+    list(LENGTH VulkanHeaders_out VulkanHeaders_len)
+    if (VulkanHeaders_len)
+        string(REGEX MATCHALL "[0-9]+" VulkanHeaders_VERSION_PATCH "${VulkanHeaders_out}")
+    endif()
+
+endforeach()

--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -121,10 +121,14 @@ foreach(VulkanHeaders_line ${VulkanHeaders_lines})
     #   Format is:
     #      #define VK_HEADER_VERSION Z
     #   Where Z is the patch version which we just grab off the end
-    string(REGEX MATCH "define.*VK_HEADER_VERSION.*" VulkanHeaders_out ${VulkanHeaders_line})
+    string(REGEX MATCH "define.*VK_HEADER_VERSION.*[0-9]+" VulkanHeaders_out ${VulkanHeaders_line})
     list(LENGTH VulkanHeaders_out VulkanHeaders_len)
     if (VulkanHeaders_len)
-        string(REGEX MATCHALL "[0-9]+" VulkanHeaders_VERSION_PATCH "${VulkanHeaders_out}")
+        string(REGEX MATCH "[0-9]+" VulkanHeaders_VERSION_PATCH "${VulkanHeaders_out}")
     endif()
 
 endforeach()
+MESSAGE(STATUS
+        "Detected Vulkan Version ${VulkanHeaders_VERSION_MAJOR}."
+        "${VulkanHeaders_VERSION_MINOR}."
+        "${VulkanHeaders_VERSION_PATCH}")

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -222,7 +222,7 @@ else()
     add_library(vulkan SHARED ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS})
     add_dependencies(vulkan generate_helper_files loader_gen_files loader_asm_gen_files)
     target_compile_definitions(vulkan PUBLIC -DLOADER_DYNAMIC_LIB)
-    set_target_properties(vulkan PROPERTIES SOVERSION "1" VERSION "1.1.${vk_header_version}")
+    set_target_properties(vulkan PROPERTIES SOVERSION "1" VERSION "${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}")
     target_link_libraries(vulkan -ldl -lpthread -lm)
 
     if(APPLE)
@@ -263,7 +263,7 @@ else()
             OUTPUT_NAME vulkan
             FRAMEWORK TRUE
             FRAMEWORK_VERSION A
-            VERSION "1.1.${vk_header_version}"       # "current version"
+            VERSION "${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}" # "current version"
             SOVERSION "1.0.0"                        # "compatibility version"
             MACOSX_FRAMEWORK_IDENTIFIER com.lunarg.vulkanFramework
             PUBLIC_HEADER "${FRAMEWORK_HEADERS}"
@@ -279,7 +279,7 @@ else()
         # Generate pkg-config file.
         include(FindPkgConfig QUIET)
         if(PKG_CONFIG_FOUND)
-            set(VK_API_VERSION "1.1.${vk_header_version}")
+            set(VK_API_VERSION "${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}")
             foreach(LIB ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES} ${PLATFORM_LIBS})
                 set(PRIVATE_LIBS "${PRIVATE_LIBS} -l${LIB}")
             endforeach()

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -81,7 +81,7 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake" "configure_file(\"\${IN
 foreach(TARGET_NAME ${TARGET_NAMES})
     set(CONFIG_DEFINES
         -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in"
-        -DVK_VERSION=1.1.${vk_header_version}
+        -DVK_VERSION="${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}"
     )
     # If this json file is not a metalayer, get the needed properties from that target
     if(TARGET ${TARGET_NAME})


### PR DESCRIPTION
Update the FindVulkaHeaders.cmake file to determine the Vulkan
header latest Major/Minor/Patch version.

Now, when you use FindVulkanHeaders.cmake, it creates 3 new variables that it generates from the vulkan header file (either vulkan_core.h or vulkan.h):
 * VulkanHeaders_VERSION_MAJOR
 * VulkanHeaders_VERSION_MINOR
 * VulkanHeaders_VERSION_PATCH

These are the latest API versions for the header and can be used anywhere we currently hard-code a version.

Change-Id: Ia2a2df56d6ca6687ccb904f6c286c82553586695