### PR TITLE
CMake cleanup, part 1

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,4 +1,4 @@
-# Configuration for cmake-format (v0.3.6, circa Apr 2018)
+# Configuration for cmake-format (v0.4.1, circa Jul 2018)
 # https://github.com/cheshirekow/cmake_format
 
 # How wide to allow formatted cmake files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,14 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.4)
 
-# This must come before the project command.
+# Apple: Must be set before enable_language() or project() as it may influence configuration of the toolchain and flags.
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment version")
 
 project(Vulkan-Loader)
-set(CMAKE_VERBOSE_MAKEFILE 0)
+
+add_definitions(-DAPI_NAME="Vulkan")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(PythonInterp 3 REQUIRED)
@@ -31,20 +32,23 @@ if(NOT ${VulkanHeaders_FOUND})
     message(FATAL_ERROR "Could not find Vulkan headers path. This can be fixed by setting VULKAN_HEADERS_INSTALL_DIR to an "
                         "installation of the Vulkan-Headers repository.")
 endif()
+if(NOT ${VulkanRegistry_FOUND})
+    message(FATAL_ERROR "Could not find Vulkan registry path. This can be fixed by setting VULKAN_HEADERS_INSTALL_DIR to an "
+                        "installation of the Vulkan-Headers repository.")
+endif()
 
 option(USE_CCACHE "Use ccache" OFF)
 if(USE_CCACHE)
     find_program(CCACHE_FOUND ccache)
     if(CCACHE_FOUND)
         set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-    endif(CCACHE_FOUND)
+    endif()
 endif()
 
 include(GNUInstallDirs)
-# Set a better default install location for Windows only if the user did not provide one.
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND WIN32)
-    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "default install path" FORCE)
+
+if(UNIX AND NOT APPLE) # i.e.: Linux
+    include(FindPkgConfig)
 endif()
 
 if(APPLE)
@@ -52,12 +56,16 @@ if(APPLE)
     set(CMAKE_MACOSX_RPATH 1)
 endif()
 
-# Enable IDE GUI folders
+if(WIN32 AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    # Windows: if install locations not set by user, set install prefix to "<build_dir>\install".
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "default install path" FORCE)
+endif()
+
+# Enable IDE GUI folders.  "Helper targets" that don't have interesting source code should set their FOLDER property to this
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-# "Helper" targets that don't have interesting source code should set their FOLDER property to this
 set(LOADER_HELPER_FOLDER "Helper Targets")
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if(UNIX)
     set(
         FALLBACK_CONFIG_DIRS "/etc/xdg"
         CACHE
@@ -72,8 +80,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         )
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    include(FindPkgConfig)
+if(UNIX AND NOT APPLE) # i.e.: Linux
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
     option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
     option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
@@ -102,7 +109,13 @@ if(WIN32)
     option(ENABLE_STATIC_LOADER "Build the loader as a static library" OFF)
 endif()
 
-set(SCRIPTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
+option(BUILD_LOADER "Build loader" ON)
+
+if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest)
+    option(BUILD_TESTS "Build Tests" ON)
+else()
+    option(BUILD_TESTS "Build Tests" OFF)
+endif()
 
 # Add location of Vulkan header files to include search path
 include_directories(${VulkanHeaders_INCLUDE_DIRS})
@@ -129,44 +142,46 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     endif()
 endif()
 
-if(WIN32)
+if(MSVC)
     # Treat warnings as errors
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/WX>")
+    add_compile_options("/WX")
     # Disable RTTI
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/GR->")
+    add_compile_options("/GR-")
     # Warn about nested declarations
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34456>")
+    add_compile_options("/w34456")
     # Warn about potentially uninitialized variables
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34701>")
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34703>")
+    add_compile_options("/w34701")
+    add_compile_options("/w34703")
     # Warn about different indirection types.
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34057>")
+    add_compile_options("/w34057")
     # Warn about signed/unsigned mismatch.
-    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34245>")
+    add_compile_options("/w34245")
 endif()
 
-option(BUILD_LOADER "Build loader" ON)
-if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest)
-    option(BUILD_TESTS "Build Tests" ON)
-else()
-    option(BUILD_TESTS "Build Tests" OFF)
-endif()
-
-set(PYTHON_CMD ${PYTHON_EXECUTABLE})
-
-# Define macro used for building vkxml generated files
-macro(run_vk_xml_generate dependency output)
+# Define a macro to generate source code from vk.xml
+set(SCRIPTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
+macro(GenerateFromVkXml output dependency)
     add_custom_command(OUTPUT ${output}
-                       COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/loader_genvk.py -registry ${VulkanRegistry_DIR}/vk.xml -scripts
+                       COMMAND ${PYTHON_EXECUTABLE} ${SCRIPTS_DIR}/loader_genvk.py -registry ${VulkanRegistry_DIR}/vk.xml -scripts
                                ${VulkanRegistry_DIR} ${output}
-                       DEPENDS ${VulkanRegistry_DIR}/vk.xml
-                               ${VulkanRegistry_DIR}/generator.py
-                               ${SCRIPTS_DIR}/${dependency}
+                       DEPENDS ${SCRIPTS_DIR}/${dependency}
                                ${SCRIPTS_DIR}/loader_genvk.py
+                               ${VulkanRegistry_DIR}/vk.xml
+                               ${VulkanRegistry_DIR}/generator.py
                                ${VulkanRegistry_DIR}/reg.py)
 endmacro()
 
-# Custom target for generated vulkan helper file dependencies
+# Use the macro to generate the source files.
+GenerateFromVkXml(vk_layer_dispatch_table.h loader_extension_generator.py)
+GenerateFromVkXml(vk_dispatch_table_helper.h dispatch_table_helper_generator.py)
+GenerateFromVkXml(vk_safe_struct.h helper_file_generator.py)
+GenerateFromVkXml(vk_safe_struct.cpp helper_file_generator.py)
+GenerateFromVkXml(vk_enum_string_helper.h helper_file_generator.py)
+GenerateFromVkXml(vk_object_types.h helper_file_generator.py)
+GenerateFromVkXml(vk_extension_helper.h helper_file_generator.py)
+GenerateFromVkXml(vk_typemap_helper.h helper_file_generator.py)
+
+# Use a custom target to cause the source files to be generated.
 add_custom_target(generate_helper_files
                   DEPENDS vk_enum_string_helper.h
                           vk_safe_struct.h
@@ -176,19 +191,10 @@ add_custom_target(generate_helper_files
                           vk_dispatch_table_helper.h
                           vk_extension_helper.h
                           vk_typemap_helper.h)
+
 set_target_properties(generate_helper_files PROPERTIES FOLDER ${LOADER_HELPER_FOLDER})
 
-# Rules to build generated helper files
-run_vk_xml_generate(loader_extension_generator.py vk_layer_dispatch_table.h)
-run_vk_xml_generate(dispatch_table_helper_generator.py vk_dispatch_table_helper.h)
-run_vk_xml_generate(helper_file_generator.py vk_safe_struct.h)
-run_vk_xml_generate(helper_file_generator.py vk_safe_struct.cpp)
-run_vk_xml_generate(helper_file_generator.py vk_enum_string_helper.h)
-run_vk_xml_generate(helper_file_generator.py vk_object_types.h)
-run_vk_xml_generate(helper_file_generator.py vk_extension_helper.h)
-run_vk_xml_generate(helper_file_generator.py vk_typemap_helper.h)
-
-if(NOT WIN32)
+if(UNIX)
     add_definitions(-DFALLBACK_CONFIG_DIRS="${FALLBACK_CONFIG_DIRS}")
     add_definitions(-DFALLBACK_DATA_DIRS="${FALLBACK_DATA_DIRS}")
     add_definitions(-DSYSCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}")
@@ -201,14 +207,13 @@ endif()
 
 # uninstall target
 if(NOT TARGET uninstall)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
                    IMMEDIATE
                    @ONLY)
     add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
     set_target_properties(uninstall PROPERTIES FOLDER ${LOADER_HELPER_FOLDER})
 endif()
-
-add_definitions(-DAPI_NAME="Vulkan")
 
 if(BUILD_LOADER)
     add_subdirectory(loader)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -15,16 +15,17 @@
 # limitations under the License.
 # ~~~
 
-# Add all optional dependencies. Currently, the only optional project is googletest.
+# Add your optional dependencies in this "external" directory.
 
+# googletest is an optional external dependency for this repo.
 if(BUILD_TESTS)
-    # googletest is an external dependency for the tests in the ValidationLayers repo. Add googletest to the project if present and
-    # not already defined.
+    # Attempt to enable if it is available.
     if(TARGET gtest_main)
-        # It is possible that a project enclosing this one has defined the gtest target
-        message(STATUS "Vulkan-Loader/external: " "Google Test (googletest) already configured - use it")
+        # Already enabled as a target (perhaps by a project enclosing this one)
+        message(STATUS "Vulkan-Loader/external: " "googletest already configured - using it")
     elseif(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/googletest")
-        message(STATUS "Vulkan-Loader/external: " "googletests found - configuring it for tests")
+        # The googletest directory exists, so enable it as a target.
+        message(STATUS "Vulkan-Loader/external: " "googletest found - configuring it for tests")
         set(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
         set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
         set(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically")
@@ -32,7 +33,7 @@ if(BUILD_TESTS)
         # EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
         add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/googletest" EXCLUDE_FROM_ALL)
     else()
-        message(SEND_ERROR "Vulkan-Loader/external: Google Test was not found.  "
+        message(SEND_ERROR "Vulkan-Loader/external: " "Google Test was not found.  "
                            "Provide Google Test in external/googletest or set BUILD_TESTS=OFF")
     endif()
 endif()

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -15,11 +15,6 @@
 # limitations under the License.
 # ~~~
 
-if(NOT ${VulkanRegistry_FOUND})
-    message(FATAL_ERROR "Could not find Vulkan registry path. This can be fixed by setting VULKAN_HEADERS_INSTALL_DIR to an "
-                        "installation of the Vulkan-Headers repository.")
-endif()
-
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${PROJECT_BINARY_DIR} ${CMAKE_BINARY_DIR})
 
 # Check for the existance of the secure_getenv or __secure_getenv commands
@@ -28,19 +23,20 @@ check_function_exists(secure_getenv HAVE_SECURE_GETENV)
 check_function_exists(__secure_getenv HAVE___SECURE_GETENV)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/loader_cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/loader_cmake_config.h)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if(WIN32)
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
-    set(DisplayServer Win32)
-    if(NOT MSVC_VERSION LESS 1900)
+    if(MSVC AND NOT MSVC_VERSION LESS 1900)
         # Enable control flow guard
         message(STATUS "Building loader with control flow guard")
-        add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/guard:cf>")
+        add_compile_options("/guard:cf")
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf")
     endif()
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
+elseif(ANDROID)
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+elseif(APPLE)
+    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
+elseif(UNIX AND NOT APPLE) # i.e.: Linux
     if(BUILD_WSI_XCB_SUPPORT)
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
     endif()
@@ -57,8 +53,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         add_definitions(-DVK_USE_PLATFORM_MIR_KHR)
         include_directories(${MIR_INCLUDE_DIR})
     endif()
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
 else()
     message(FATAL_ERROR "Unsupported Platform!")
 endif()
@@ -109,12 +103,12 @@ if(WIN32)
         set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain.c)
         add_custom_target(loader_asm_gen_files)
     endif()
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+elseif(APPLE)
     # For MacOS, use the C code and force the compiler's tail-call optimization instead of using assembly code.
     set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain.c)
     set_source_files_properties(${OPT_LOADER_SRCS} PROPERTIES COMPILE_FLAGS -O)
     add_custom_target(loader_asm_gen_files) # This causes no assembly files to be generated.
-else()
+else(UNIX AND NOT APPLE) # i.e.: Linux
     enable_language(ASM-ATT)
     set(CMAKE_ASM-ATT_COMPILE_FLAGS "${CMAKE_ASM-ATT_COMPILE_FLAGS} $ENV{ASFLAGS}")
     set(CMAKE_ASM-ATT_COMPILE_FLAGS "${CMAKE_ASM-ATT_COMPILE_FLAGS} -I\"${CMAKE_CURRENT_BINARY_DIR}\"")
@@ -137,8 +131,8 @@ else()
     endif()
 endif()
 
-run_vk_xml_generate(loader_extension_generator.py vk_loader_extensions.h)
-run_vk_xml_generate(loader_extension_generator.py vk_loader_extensions.c)
+GenerateFromVkXml(vk_loader_extensions.h loader_extension_generator.py)
+GenerateFromVkXml(vk_loader_extensions.c loader_extension_generator.py)
 add_custom_target(loader_gen_files DEPENDS vk_loader_extensions.h vk_loader_extensions.c)
 set_target_properties(loader_gen_files PROPERTIES FOLDER ${LOADER_HELPER_FOLDER})
 
@@ -155,7 +149,11 @@ if(WIN32)
             CMAKE_CXX_FLAGS_RELEASE
             CMAKE_CXX_FLAGS_RELWITHDEBINFO)
         if(${configuration} MATCHES "/MD")
-            string(REGEX REPLACE "/MD" "/MT" ${configuration} "${${configuration}}")
+            string(REGEX
+                   REPLACE "/MD"
+                           "/MT"
+                           ${configuration}
+                           "${${configuration}}")
         endif()
     endforeach()
 
@@ -194,7 +192,11 @@ if(WIN32)
                     $<TARGET_OBJECTS:loader-norm>
                     ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-1.def
                     ${CMAKE_CURRENT_SOURCE_DIR}/loader.rc)
-        set_target_properties(vulkan PROPERTIES LINK_FLAGS_DEBUG "/ignore:4098" OUTPUT_NAME vulkan-1)
+        set_target_properties(vulkan
+                              PROPERTIES LINK_FLAGS_DEBUG
+                                         "/ignore:4098"
+                                         OUTPUT_NAME
+                                         vulkan-1)
     else()
         add_library(vulkan STATIC $<TARGET_OBJECTS:loader-opt> $<TARGET_OBJECTS:loader-norm>)
         set_target_properties(vulkan PROPERTIES OUTPUT_NAME VKstatic.1)
@@ -222,7 +224,11 @@ else()
     add_library(vulkan SHARED ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS})
     add_dependencies(vulkan generate_helper_files loader_gen_files loader_asm_gen_files)
     target_compile_definitions(vulkan PUBLIC -DLOADER_DYNAMIC_LIB)
-    set_target_properties(vulkan PROPERTIES SOVERSION "1" VERSION "${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}")
+    set_target_properties(vulkan
+                          PROPERTIES SOVERSION
+                                     "1"
+                                     VERSION
+                                     "${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}")
     target_link_libraries(vulkan -ldl -lpthread -lm)
 
     if(APPLE)
@@ -273,7 +279,7 @@ else()
             FRAMEWORK DESTINATION loader
         )
 # cmake-format: on
-    endif(APPLE)
+    endif()
 
     if(NOT APPLE)
         # Generate pkg-config file.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,14 +15,21 @@
 # limitations under the License.
 # ~~~
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+add_executable(vk_loader_validation_tests loader_validation_tests.cpp)
+set_target_properties(vk_loader_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
+if(UNIX)
+    set_target_properties(vk_loader_validation_tests PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
+endif()
+
+if(WIN32)
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
     # Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
     add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
-    set(DisplayServer Win32)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
+elseif(ANDROID)
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+elseif(APPLE)
+    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
+elseif(UNIX AND NOT APPLE) # i.e.: Linux
     if(BUILD_WSI_XCB_SUPPORT)
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
     endif()
@@ -39,24 +46,9 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         add_definitions(-DVK_USE_PLATFORM_MIR_KHR)
         include_directories(${MIR_INCLUDE_DIR})
     endif()
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
 else()
     message(FATAL_ERROR "Unsupported Platform!")
 endif()
-
-# On Windows, we must pair Debug and Release appropriately
-if(WIN32)
-    # For Windows, since 32-bit and 64-bit items can co-exist, we build each in its own build directory. 32-bit target data goes in
-    # build32, and 64-bit target data goes into build.  So, include/link the appropriate data at build time.
-    if(CMAKE_CL_64)
-        set(BUILDTGT_DIR build)
-    else()
-        set(BUILDTGT_DIR build32)
-    endif()
-endif()
-
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
@@ -78,14 +70,17 @@ include_directories(${PROJECT_SOURCE_DIR}/external
                     ${CMAKE_BINARY_DIR}
                     ${PROJECT_BINARY_DIR})
 
-if(NOT WIN32)
+if(UNIX)
     # extra setup for out-of-tree builds
     if(NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
         add_custom_target(binary-dir-symlinks ALL
-                          COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/run_wrap_objects_tests.sh
-                          COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/run_loader_tests.sh
-                          COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/run_extra_loader_tests.sh
-                          COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/run_all_tests.sh
+                          COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/run_wrap_objects_tests.sh
+                                  run_wrap_objects_tests.sh
+                          COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/run_loader_tests.sh
+                                  run_loader_tests.sh
+                          COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/run_extra_loader_tests.sh
+                                  run_extra_loader_tests.sh
+                          COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/run_all_tests.sh run_all_tests.sh
                           VERBATIM)
     endif()
 else()
@@ -96,12 +91,6 @@ else()
                           VERBATIM)
         set_target_properties(binary-dir-symlinks PROPERTIES FOLDER ${LOADER_HELPER_FOLDER})
     endif()
-endif()
-
-add_executable(vk_loader_validation_tests loader_validation_tests.cpp)
-set_target_properties(vk_loader_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
-if(NOT WIN32)
-    set_target_properties(vk_loader_validation_tests PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
 endif()
 
 if(TARGET vulkan)
@@ -120,12 +109,10 @@ target_link_libraries(vk_loader_validation_tests "${LOADER_LIB}" gtest gtest_mai
 if(BUILD_LOADER AND ENABLE_STATIC_LOADER)
     set_target_properties(vk_loader_validation_tests PROPERTIES LINK_FLAGS "/ignore:4098")
 endif()
-if(WIN32)
-    file(COPY vk_loader_validation_tests.vcxproj.user DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
-endif()
 
 # Copy loader and googletest (gtest) libs to test dir so the test executable can find them.
 if(WIN32)
+    file(COPY vk_loader_validation_tests.vcxproj.user DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
     if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
         file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIG>/gtest_main$<$<CONFIG:Debug>:d>.dll
                             GTEST_COPY_SRC1)

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -15,15 +15,10 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 2.8.11)
-
-set(TARGET_NAMES VkLayer_wrap_objects VkLayer_test VkLayer_meta)
-
-set(VK_LAYER_RPATH /usr/lib/x86_64-linux-gnu/vulkan/layer:/usr/lib/i386-linux-gnu/vulkan/layer)
-set(CMAKE_INSTALL_RPATH ${VK_LAYER_RPATH})
+set(CMAKE_INSTALL_RPATH /usr/lib/x86_64-linux-gnu/vulkan/layer:/usr/lib/i386-linux-gnu/vulkan/layer)
 
 if(WIN32)
-    macro(add_vk_layer target)
+    macro(AddVkLayer target)
         file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_${target}.def DEF_FILE)
         add_custom_target(copy-${target}-def-file ALL
                           COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DEF_FILE} VkLayer_${target}.def
@@ -33,13 +28,13 @@ if(WIN32)
         add_dependencies(VkLayer_${target} generate_helper_files)
     endmacro()
 elseif(APPLE)
-    macro(add_vk_layer target)
+    macro(AddVkLayer target)
         add_library(VkLayer_${target} SHARED ${ARGN})
         add_dependencies(VkLayer_${target} generate_helper_files)
         set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl")
     endmacro()
-else()
-    macro(add_vk_layer target)
+else(UNIX AND NOT APPLE) # i.e.: Linux
+    macro(AddVkLayer target)
         add_library(VkLayer_${target} SHARED ${ARGN})
         add_dependencies(VkLayer_${target} generate_helper_files)
         set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl,-Bsymbolic")
@@ -63,37 +58,41 @@ else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Wno-unused-function")
 endif()
 
-set(WRAP_SRCS wrap_objects.cpp vk_layer_table.cpp vk_layer_extension_utils.cpp)
-add_vk_layer(wrap_objects ${WRAP_SRCS})
+AddVkLayer(wrap_objects wrap_objects.cpp vk_layer_table.cpp vk_layer_extension_utils.cpp)
 
-set(TEST_SRCS test.cpp vk_layer_table.cpp vk_layer_extension_utils.cpp)
-add_vk_layer(test ${TEST_SRCS})
+AddVkLayer(test test.cpp vk_layer_table.cpp vk_layer_extension_utils.cpp)
 
-# The output file needs Unix "/" separators or Windows "\" separators
-# On top of that, Windows separators actually need to be doubled because the json format uses backslash escapes
+# --------------------------------------------------------------------------------------------------------------------------------
+
+# The output file needs Unix "/" separators or Windows "\" separators On top of that, Windows separators actually need to be doubled
+# because the json format uses backslash escapes
 file(TO_NATIVE_PATH "./" RELATIVE_PATH_PREFIX)
-string(REPLACE "\\" "\\\\" RELATIVE_PATH_PREFIX "${RELATIVE_PATH_PREFIX}")
+string(REPLACE "\\"
+               "\\\\"
+               RELATIVE_PATH_PREFIX
+               "${RELATIVE_PATH_PREFIX}")
 
-# Run each .json.in file through the generator
-# We need to create the generator.cmake script so that the generator can be run at compile time, instead of configure time
-# Running at compile time lets us use cmake generator expressions (TARGET_FILE_NAME and TARGET_FILE_DIR, specifically)
+# Run each .json.in file through the generator We need to create the generator.cmake script so that the generator can be run at
+# compile time, instead of configure time Running at compile time lets us use cmake generator expressions (TARGET_FILE_NAME and
+# TARGET_FILE_DIR, specifically)
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake" "configure_file(\"\${INPUT_FILE}\" \"\${OUTPUT_FILE}\")")
-foreach(TARGET_NAME ${TARGET_NAMES})
-    set(CONFIG_DEFINES
-        -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in"
-        -DVK_VERSION="${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}"
-    )
-    # If this json file is not a metalayer, get the needed properties from that target
+
+foreach(TARGET_NAME VkLayer_wrap_objects VkLayer_test VkLayer_meta)
+    set(CONFIG_DEFINES -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in"
+        -DVK_VERSION="${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}")
+
+    # Append further config parameters, depending on which layer.
     if(TARGET ${TARGET_NAME})
-        set(CONFIG_DEFINES ${CONFIG_DEFINES}
+        # This json file corresponds to an actual target (not a metalayer); query properties from that target.
+        set(CONFIG_DEFINES
+            ${CONFIG_DEFINES}
             -DOUTPUT_FILE="$<TARGET_FILE_DIR:${TARGET_NAME}>/${TARGET_NAME}.json"
-            -DRELATIVE_LAYER_BINARY="${RELATIVE_PATH_PREFIX}$<TARGET_FILE_NAME:${TARGET_NAME}>"
-        )
-    # If this json file is a metalayer, make the output path match the test layer, and there is no layer binary file
+            -DRELATIVE_LAYER_BINARY="${RELATIVE_PATH_PREFIX}$<TARGET_FILE_NAME:${TARGET_NAME}>")
     else()
-        set(CONFIG_DEFINES ${CONFIG_DEFINES}
-            -DOUTPUT_FILE="$<TARGET_FILE_DIR:VkLayer_test>/${TARGET_NAME}.json"
-        )
+        # This json file is a metalayer.  Query properties from the VkLayer_test layer; there is no layer binary file.
+        set(CONFIG_DEFINES ${CONFIG_DEFINES} -DOUTPUT_FILE="$<TARGET_FILE_DIR:VkLayer_test>/${TARGET_NAME}.json")
     endif()
-    add_custom_target(${TARGET_NAME}-json ALL COMMAND ${CMAKE_COMMAND} ${CONFIG_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
+
+    add_custom_target(${TARGET_NAME}-json ALL
+                      COMMAND ${CMAKE_COMMAND} ${CONFIG_DEFINES} -P "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake")
 endforeach()


### PR DESCRIPTION
This is the first PR cleaning up CMake files in the Vulkan-Loader repo. It consists primarily of cleanup, dead code/variable removal, and simplification.

This PR (in its current form of many separate commits) meant to make it easier to review; it will be squashed to a single commit before pushing to VL master.