### PR TITLE
build: Fix ninja on windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,18 +144,18 @@ endif()
 
 if(MSVC)
     # Treat warnings as errors
-    add_compile_options("/WX")
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:/WX>)
     # Disable RTTI
-    add_compile_options("/GR-")
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:/GR->)
     # Warn about nested declarations
-    add_compile_options("/w34456")
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:/w34456>)
     # Warn about potentially uninitialized variables
-    add_compile_options("/w34701")
-    add_compile_options("/w34703")
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:/w34701>)
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:/w34703>)
     # Warn about different indirection types.
-    add_compile_options("/w34057")
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:/w34057>)
     # Warn about signed/unsigned mismatch.
-    add_compile_options("/w34245")
+    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:/w34245>)
 endif()
 
 # Define a macro to generate source code from vk.xml

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -28,7 +28,7 @@ if(WIN32)
     if(MSVC AND NOT MSVC_VERSION LESS 1900)
         # Enable control flow guard
         message(STATUS "Building loader with control flow guard")
-        add_compile_options("/guard:cf")
+	add_compile_options($<$<COMPILE_LANGUAGE:C>:/guard:cf>)
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf")
     endif()
@@ -176,11 +176,11 @@ if(WIN32)
 
     add_library(loader-norm OBJECT ${NORMAL_LOADER_SRCS} dirent_on_windows.c)
     add_dependencies(loader-norm generate_helper_files loader_gen_files)
-    target_compile_options(loader-norm PUBLIC "$<$<CONFIG:DEBUG>:${LOCAL_C_FLAGS_DBG}>")
+    target_compile_options(loader-norm PUBLIC "$<$<AND:$<CONFIG:DEBUG>,$<COMPILE_LANGUAGE:C>>:${LOCAL_C_FLAGS_DBG}>")
 
     add_library(loader-opt OBJECT ${OPT_LOADER_SRCS})
     add_dependencies(loader-opt generate_helper_files loader_gen_files loader_asm_gen_files)
-    target_compile_options(loader-opt PUBLIC "$<$<CONFIG:DEBUG>:${LOCAL_C_FLAGS_REL}>")
+    target_compile_options(loader-opt PUBLIC "$<$<AND:$<CONFIG:DEBUG>,$<COMPILE_LANGUAGE:C>>:${LOCAL_C_FLAGS_REL}>")
 
     if(NOT ENABLE_STATIC_LOADER)
         target_compile_definitions(loader-norm PUBLIC LOADER_DYNAMIC_LIB)


### PR DESCRIPTION
Fix  #79

The ninja generator was passing flags from `(add|target)_compile_options` to MASM. This commit uses generator expressions to persuade all generators to only apply the options to C/CXX.

Change-Id: Ie15d8a47636d228732950fb5b3462a2819d5b2af