### PR TITLE
doc: Update minimum cmake version for windows

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -185,7 +185,7 @@ CMake to generate the native platform files.
     - [2017](https://www.visualstudio.com/vs/downloads/)
   - The Community Edition of each of the above versions is sufficient, as
     well as any more capable edition.
-- [CMake](http://www.cmake.org/download/) (Version 2.8.11 or better)
+- [CMake](http://www.cmake.org/download/) (Version 3.11 or better)
   - Use the installer option to add CMake to the system PATH
 - Git Client Support
   - [Git for Windows](http://git-scm.com/download/win) is a popular solution


### PR DESCRIPTION
Recent commit 41e6a81 uses COMPILE_LANGUAGE generator expression which isn't supported by the Visual Studio generator until version 3.11: https://cmake.org/cmake/help/v3.11/release/3.11.html

I had 3.9.4 on my system and could not build on windows until I updated.