### PR TITLE
loader: Fix vkSubmitDebugUtilsMessageEXT

### DIFF
--- a/loader/debug_utils.c
+++ b/loader/debug_utils.c
@@ -87,14 +87,16 @@ VkBool32 util_SubmitDebugUtilsMessageEXT(const struct loader_instance *inst, VkD
                                          const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData) {
     VkBool32 bail = false;
 
-    if (NULL != pCallbackData && NULL != pCallbackData->pObjects && 0 < pCallbackData->objectCount) {
+    if (NULL != pCallbackData) {
         VkLayerDbgFunctionNode *pTrav = inst->DbgFunctionHead;
-        VkDebugReportObjectTypeEXT object_type;
+        VkDebugReportObjectTypeEXT object_type = VK_OBJECT_TYPE_UNKNOWN;
         VkDebugReportFlagsEXT object_flags = 0;
-        uint64_t object_handle;
+        uint64_t object_handle = 0;
 
         debug_utils_AnnotFlagsToReportFlags(messageSeverity, messageTypes, &object_flags);
-        debug_utils_AnnotObjectToDebugReportObject(pCallbackData->pObjects, &object_type, &object_handle);
+        if (0 < pCallbackData->objectCount) {
+            debug_utils_AnnotObjectToDebugReportObject(pCallbackData->pObjects, &object_type, &object_handle);
+        }
 
         while (pTrav) {
             if (pTrav->is_messenger && (pTrav->messenger.messageSeverity & messageSeverity) &&


### PR DESCRIPTION
If the object count was 0, then no message was reported by the loader.

Change-Id: Ia809d193fb117e85742af0db9856f896be0b2ea3