### PR TITLE
loader: Fix python3 warning

### DIFF
--- a/scripts/loader_genvk.py
+++ b/scripts/loader_genvk.py
@@ -21,11 +21,11 @@ startTime = None
 
 def startTimer(timeit):
     global startTime
-    startTime = time.clock()
+    startTime = time.process_time()
 
 def endTimer(timeit, msg):
     global startTime
-    endTime = time.clock()
+    endTime = time.process_time()
     if (timeit):
         write(msg, endTime - startTime, file=sys.stderr)
         startTime = None


### PR DESCRIPTION
Python 3.8 will remove time.clock() and the warnings suggest that
time.process_time() or time.perf_counter() should be used instead.
So, move the script to using time.process_time().

@lenny-lunarg, I'm not entirely sure this is exactly what you want, but I think it will work.  Please look it over.

Change-Id: I982da1560adec4aab49f42936334e520456647c1