### PR TITLE
loader: Fix VK_EXT_debug_utils termination

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -847,9 +847,9 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice phy
     loader_init_dispatch_dev_ext(inst, dev);
 
     // Initialize WSI device extensions as part of core dispatch since loader
-    // has dedicated trampoline code for these*/
-    loader_init_device_extension_dispatch_table(&dev->loader_dispatch, dev->loader_dispatch.core_dispatch.GetDeviceProcAddr,
-                                                *pDevice);
+    // has dedicated trampoline code for these
+    loader_init_device_extension_dispatch_table(&dev->loader_dispatch, inst->disp->layer_inst_disp.GetInstanceProcAddr,
+                                                dev->loader_dispatch.core_dispatch.GetDeviceProcAddr, (VkInstance)inst, *pDevice);
 
 out:
 


### PR DESCRIPTION
Some of the commands aren't needed in the loader, but this would
cause command chains to crash when they hit the NULL.
Also, the ICDs expect the commands to come through vkGetInstantProcAddr
not vkGetDeviceProcAddr.  So, we need to redirect them when generating
the ICD dispatch table because the device commands in the instance
extension exist in the device dispatch table but need to call into
the ICD using the instance queries.

Change-Id: I24cd0ea4f3e5058b1137881452df75bf1ff7487a