### PR TITLE
loader: Fix Vk instance given to layer

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -849,7 +849,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice phy
     // Initialize WSI device extensions as part of core dispatch since loader
     // has dedicated trampoline code for these
     loader_init_device_extension_dispatch_table(&dev->loader_dispatch, inst->disp->layer_inst_disp.GetInstanceProcAddr,
-                                                dev->loader_dispatch.core_dispatch.GetDeviceProcAddr, (VkInstance)inst, *pDevice);
+                                                dev->loader_dispatch.core_dispatch.GetDeviceProcAddr, inst->instance, *pDevice);
 
 out:
 


### PR DESCRIPTION
The instance give to the layer entry points appears to be an internal
loader structure. While running with RenderDoc, I would hit a crash
where Renderdoc doesn't get the right pointer to find its own private
structures :

```
 #0  VK_LAYER_RENDERDOC_CaptureGetInstanceProcAddr (instance=0x7fffe4006d00, pName=0x7ffff56dc2bb "vkSetDebugUtilsObjectNameEXT") at /home/djdeath/src/mesa-src/renderdoc/renderdoc/driver/vulkan/vk_layer.cpp:376
 #1  0x00007ffff56a8dbb in loader_init_device_extension_dispatch_table (dev_table=0x7fffe42ea6a0, gipa=0x7ffff73ca734 <VK_LAYER_RENDERDOC_CaptureGetInstanceProcAddr(VkInstance, char const*)>, gdpa=0x7ffff73c7d70 <VK_LAYER_RENDERDOC_CaptureGetDeviceProcAddr(VkDevice, char const*)>, inst=0x7fffe4006d00,
     dev=0x7ffff3bd8fe0) at /home/djdeath/src/mesa-src/Vulkan-Loader/build/loader/vk_loader_extensions.c:572
 #2  0x00007ffff56c62cc in vkCreateDevice (physicalDevice=0x7fffe42c31b0, pCreateInfo=0x7ffff1324670, pAllocator=0x0, pDevice=0x7fffe4005c80) at /home/djdeath/src/mesa-src/Vulkan-Loader/loader/trampoline.c:851
 #3  0x00000000007fc6b0 in ?? ()
```