### PR TITLE
enhance wrapped objects test

### DIFF
--- a/tests/loader_validation_tests.cpp
+++ b/tests/loader_validation_tests.cpp
@@ -460,6 +460,36 @@ TEST(CreateInstance, LayerPresent) {
     instance = VK_NULL_HANDLE;
     result = vkCreateInstance(info2, VK_NULL_HANDLE, &instance);
     ASSERT_EQ(result, VK_SUCCESS);
+
+    uint32_t deviceCount;
+    vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
+    std::vector<VkPhysicalDevice> devs(deviceCount);
+    vkEnumeratePhysicalDevices(instance, &deviceCount, devs.data());
+    auto device_create_info = VkDeviceCreateInfo{
+              VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,  // sType
+              nullptr,                               // pNext
+              0,                                     // flags
+              0,                                     // queueCreateInfoCount
+              nullptr,                               // pQueueCreateInfos
+              0,                                     // enabledLayerCount
+              nullptr,                               // ppEnabledLayerNames
+              0,                                     // enabledExtensionCount
+              nullptr,                               // ppEnabledExtensionNames
+              nullptr                                // pEnabledFeatures
+    };
+    auto deviceQueue = VkDeviceQueueCreateInfo{};
+    deviceQueue.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    float prios = 1;
+    deviceQueue.queueFamilyIndex = 0;
+    deviceQueue.queueCount = 1;
+    deviceQueue.pQueuePriorities = &prios;
+    device_create_info.pQueueCreateInfos = &deviceQueue;
+    device_create_info.queueCreateInfoCount = 1;
+    VkDevice dev;
+    vkCreateDevice(devs[0], &device_create_info, nullptr, &dev);
+
+    vkDestroyDevice(dev, nullptr);
+
     vkDestroyInstance(instance, nullptr);
 }
 


### PR DESCRIPTION
This PR adds a (failing) test that shows a problem with wrapped `VkPhysicalDevice`s: An application cannot call `vkCreateDevice` with a wrapped `VkPhysicalDevice`. To my knowledge the usage of creating a device shown in this PR is valid Vulkan usage. However this test segfaults when invoked (as configured) with the wrapping objects layer. The offending line is probably this one here:
https://github.com/KhronosGroup/Vulkan-Loader/blob/5cdde103accaecaf6cc4a67243dd504da48b95f7/loader/trampoline.c#L776
Here the wrapping objects layer gets bypassed and a lower layer gets the wrapped object and cannot handle it properly.