### PR TITLE
Expand layer test

### DIFF
--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -78,7 +78,7 @@ string(REPLACE "\\"
 # TARGET_FILE_DIR, specifically)
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake" "configure_file(\"\${INPUT_FILE}\" \"\${OUTPUT_FILE}\")")
 
-foreach(TARGET_NAME VkLayer_wrap_objects VkLayer_test VkLayer_meta)
+foreach(TARGET_NAME VkLayer_wrap_objects VkLayer_test VkLayer_meta VkLayer_meta_rev)
     set(CONFIG_DEFINES -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/json/${TARGET_NAME}.json.in"
         -DVK_VERSION="${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}")
 

--- a/tests/layers/VkLayer_test.def
+++ b/tests/layers/VkLayer_test.def
@@ -27,6 +27,5 @@
 LIBRARY VkLayer_test
 EXPORTS
 vkGetInstanceProcAddr
-vkGetDeviceProcAddr
 vkEnumerateInstanceLayerProperties
 vkEnumerateInstanceExtensionProperties

--- a/tests/layers/json/VkLayer_meta_rev.json.in
+++ b/tests/layers/json/VkLayer_meta_rev.json.in
@@ -1,0 +1,14 @@
+{
+    "file_format_version" : "1.1.1",
+    "layer" : {
+        "name": "VK_LAYER_LUNARG_meta_rev",
+        "type": "GLOBAL",
+        "api_version": "@VK_VERSION@",
+        "implementation_version": "1",
+        "description": "LunarG Test Metalayer (Reversed)",
+        "component_layers": [
+            "VK_LAYER_LUNARG_test",
+            "VK_LAYER_LUNARG_wrap_objects"
+        ]
+    }
+}

--- a/tests/layers/test.cpp
+++ b/tests/layers/test.cpp
@@ -138,11 +138,6 @@ VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(V
     return test::GetInstanceProcAddr(instance, funcName);
 }
 
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice device, const char *funcName)
-{
-    return nullptr;
-}
-
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount, VkExtensionProperties *pProperties)
 {
     return VK_ERROR_LAYER_NOT_PRESENT;
@@ -164,7 +159,6 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
     // Fill in the function pointers if our version is at least capable of having the structure contain them.
     if (pVersionStruct->loaderLayerInterfaceVersion >= 2) {
         pVersionStruct->pfnGetInstanceProcAddr = vkGetInstanceProcAddr;
-        pVersionStruct->pfnGetDeviceProcAddr = vkGetDeviceProcAddr;
         pVersionStruct->pfnGetPhysicalDeviceProcAddr = vk_layerGetPhysicalDeviceProcAddr;
     }
 

--- a/tests/layers/wrap_objects.cpp
+++ b/tests/layers/wrap_objects.cpp
@@ -170,7 +170,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, c
     VkLayerDeviceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
     PFN_vkGetInstanceProcAddr fpGetInstanceProcAddr = chain_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
     PFN_vkGetDeviceProcAddr fpGetDeviceProcAddr = chain_info->u.pLayerInfo->pfnNextGetDeviceProcAddr;
-    PFN_vkCreateDevice fpCreateDevice = (PFN_vkCreateDevice) fpGetInstanceProcAddr(phys_dev->inst->obj, "vkCreateDevice");
+    PFN_vkCreateDevice fpCreateDevice = (PFN_vkCreateDevice)fpGetInstanceProcAddr(phys_dev->inst->obj, "vkCreateDevice");
     if (fpCreateDevice == NULL) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }

--- a/tests/layers/wrap_objects.cpp
+++ b/tests/layers/wrap_objects.cpp
@@ -170,7 +170,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, c
     VkLayerDeviceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
     PFN_vkGetInstanceProcAddr fpGetInstanceProcAddr = chain_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
     PFN_vkGetDeviceProcAddr fpGetDeviceProcAddr = chain_info->u.pLayerInfo->pfnNextGetDeviceProcAddr;
-    PFN_vkCreateDevice fpCreateDevice = (PFN_vkCreateDevice) fpGetInstanceProcAddr(NULL, "vkCreateDevice");
+    PFN_vkCreateDevice fpCreateDevice = (PFN_vkCreateDevice) fpGetInstanceProcAddr(phys_dev->inst->obj, "vkCreateDevice");
     if (fpCreateDevice == NULL) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }

--- a/tests/loader_validation_tests.cpp
+++ b/tests/loader_validation_tests.cpp
@@ -460,6 +460,36 @@ TEST(CreateInstance, LayerPresent) {
     instance = VK_NULL_HANDLE;
     result = vkCreateInstance(info2, VK_NULL_HANDLE, &instance);
     ASSERT_EQ(result, VK_SUCCESS);
+
+    uint32_t deviceCount;
+    vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
+    std::vector<VkPhysicalDevice> devs(deviceCount);
+    vkEnumeratePhysicalDevices(instance, &deviceCount, devs.data());
+    auto device_create_info = VkDeviceCreateInfo{
+              VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,  // sType
+              nullptr,                               // pNext
+              0,                                     // flags
+              0,                                     // queueCreateInfoCount
+              nullptr,                               // pQueueCreateInfos
+              0,                                     // enabledLayerCount
+              nullptr,                               // ppEnabledLayerNames
+              0,                                     // enabledExtensionCount
+              nullptr,                               // ppEnabledExtensionNames
+              nullptr                                // pEnabledFeatures
+    };
+    auto deviceQueue = VkDeviceQueueCreateInfo{};
+    deviceQueue.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    float prios = 1;
+    deviceQueue.queueFamilyIndex = 0;
+    deviceQueue.queueCount = 1;
+    deviceQueue.pQueuePriorities = &prios;
+    device_create_info.pQueueCreateInfos = &deviceQueue;
+    device_create_info.queueCreateInfoCount = 1;
+    VkDevice dev;
+    vkCreateDevice(devs[0], &device_create_info, nullptr, &dev);
+
+    vkDestroyDevice(dev, nullptr);
+
     vkDestroyInstance(instance, nullptr);
 }
 

--- a/tests/loader_validation_tests.cpp
+++ b/tests/loader_validation_tests.cpp
@@ -405,36 +405,34 @@ VKAPI_ATTR void *VKAPI_CALL ReallocCallbackFunc(void *pUserData, void *pOriginal
     }
 }
 
-void test_create_device(VkPhysicalDevice physical){
-  uint32_t familyCount = 0;
-  VkResult result;
-  vkGetPhysicalDeviceQueueFamilyProperties(physical, &familyCount, nullptr);
-  ASSERT_GT(familyCount, 0u);
+void test_create_device(VkPhysicalDevice physical) {
+    uint32_t familyCount = 0;
+    VkResult result;
+    vkGetPhysicalDeviceQueueFamilyProperties(physical, &familyCount, nullptr);
+    ASSERT_GT(familyCount, 0u);
 
-  std::unique_ptr<VkQueueFamilyProperties[]> family(new VkQueueFamilyProperties[familyCount]);
-  vkGetPhysicalDeviceQueueFamilyProperties(physical, &familyCount, family.get());
-  ASSERT_GT(familyCount, 0u);
+    std::unique_ptr<VkQueueFamilyProperties[]> family(new VkQueueFamilyProperties[familyCount]);
+    vkGetPhysicalDeviceQueueFamilyProperties(physical, &familyCount, family.get());
+    ASSERT_GT(familyCount, 0u);
 
-  for (uint32_t q = 0; q < familyCount; ++q) {
-    if (~family[q].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
-      continue;
+    for (uint32_t q = 0; q < familyCount; ++q) {
+        if (~family[q].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+            continue;
+        }
+
+        float const priorities[] = {0.0f};  // Temporary required due to MSVC bug.
+        VkDeviceQueueCreateInfo const queueInfo[1]{
+            VK::DeviceQueueCreateInfo().queueFamilyIndex(q).queueCount(1).pQueuePriorities(priorities)};
+
+        auto const deviceInfo = VK::DeviceCreateInfo().queueCreateInfoCount(1).pQueueCreateInfos(queueInfo);
+
+        VkDevice device;
+        result = vkCreateDevice(physical, deviceInfo, nullptr, &device);
+        ASSERT_EQ(result, VK_SUCCESS);
+
+        vkDestroyDevice(device, nullptr);
     }
-
-    float const priorities[] = {0.0f};  // Temporary required due to MSVC bug.
-    VkDeviceQueueCreateInfo const queueInfo[1]{
-      VK::DeviceQueueCreateInfo().queueFamilyIndex(q).queueCount(1).pQueuePriorities(priorities)};
-
-    auto const deviceInfo = VK::DeviceCreateInfo().queueCreateInfoCount(1).pQueueCreateInfos(queueInfo);
-
-    VkDevice device;
-    result = vkCreateDevice(physical, deviceInfo, nullptr, &device);
-    ASSERT_EQ(result, VK_SUCCESS);
-
-    vkDestroyDevice(device, nullptr);
-  }
 }
-
-
 
 // Test groups:
 // LX = lunar exchange
@@ -481,26 +479,26 @@ TEST(CreateInstance, LayerNotPresent) {
 TEST(CreateInstance, LayerPresent) {
     char const *const names1[] = {"VK_LAYER_LUNARG_test"};  // Temporary required due to MSVC bug.
     char const *const names2[] = {"VK_LAYER_LUNARG_meta"};  // Temporary required due to MSVC bug.
-    char const *const names3[] = {"VK_LAYER_LUNARG_meta_rev"}; // Temporary required due to MSVC bug.
+    char const *const names3[] = {"VK_LAYER_LUNARG_meta_rev"};  // Temporary required due to MSVC bug.
     auto const info1 = VK::InstanceCreateInfo().enabledLayerCount(1).ppEnabledLayerNames(names1);
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vkCreateInstance(info1, VK_NULL_HANDLE, &instance);
     ASSERT_EQ(result, VK_SUCCESS);
     vkDestroyInstance(instance, nullptr);
 
-    for(auto names : {names2, names3}){
-      auto const info2 = VK::InstanceCreateInfo().enabledLayerCount(1).ppEnabledLayerNames(names);
-      instance = VK_NULL_HANDLE;
-      result = vkCreateInstance(info2, VK_NULL_HANDLE, &instance);
-      ASSERT_EQ(result, VK_SUCCESS);
+    for (auto names : {names2, names3}) {
+        auto const info2 = VK::InstanceCreateInfo().enabledLayerCount(1).ppEnabledLayerNames(names);
+        instance = VK_NULL_HANDLE;
+        result = vkCreateInstance(info2, VK_NULL_HANDLE, &instance);
+        ASSERT_EQ(result, VK_SUCCESS);
 
-      uint32_t deviceCount;
-      vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
-      std::vector<VkPhysicalDevice> devs(deviceCount);
-      vkEnumeratePhysicalDevices(instance, &deviceCount, devs.data());
-      test_create_device(devs[0]);
+        uint32_t deviceCount;
+        vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
+        std::vector<VkPhysicalDevice> devs(deviceCount);
+        vkEnumeratePhysicalDevices(instance, &deviceCount, devs.data());
+        test_create_device(devs[0]);
 
-      vkDestroyInstance(instance, nullptr);
+        vkDestroyInstance(instance, nullptr);
     }
 }
 
@@ -1039,7 +1037,7 @@ TEST(WrapObjects, Insert) {
     ASSERT_GT(physicalCount, 0u);
 
     for (uint32_t p = 0; p < physicalCount; ++p) {
-      test_create_device(physical[p]);
+        test_create_device(physical[p]);
     }
 
     vkDestroyInstance(instance, nullptr);

--- a/tests/loader_validation_tests.cpp
+++ b/tests/loader_validation_tests.cpp
@@ -405,6 +405,37 @@ VKAPI_ATTR void *VKAPI_CALL ReallocCallbackFunc(void *pUserData, void *pOriginal
     }
 }
 
+void test_create_device(VkPhysicalDevice physical){
+  uint32_t familyCount = 0;
+  VkResult result;
+  vkGetPhysicalDeviceQueueFamilyProperties(physical, &familyCount, nullptr);
+  ASSERT_GT(familyCount, 0u);
+
+  std::unique_ptr<VkQueueFamilyProperties[]> family(new VkQueueFamilyProperties[familyCount]);
+  vkGetPhysicalDeviceQueueFamilyProperties(physical, &familyCount, family.get());
+  ASSERT_GT(familyCount, 0u);
+
+  for (uint32_t q = 0; q < familyCount; ++q) {
+    if (~family[q].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+      continue;
+    }
+
+    float const priorities[] = {0.0f};  // Temporary required due to MSVC bug.
+    VkDeviceQueueCreateInfo const queueInfo[1]{
+      VK::DeviceQueueCreateInfo().queueFamilyIndex(q).queueCount(1).pQueuePriorities(priorities)};
+
+    auto const deviceInfo = VK::DeviceCreateInfo().queueCreateInfoCount(1).pQueueCreateInfos(queueInfo);
+
+    VkDevice device;
+    result = vkCreateDevice(physical, deviceInfo, nullptr, &device);
+    ASSERT_EQ(result, VK_SUCCESS);
+
+    vkDestroyDevice(device, nullptr);
+  }
+}
+
+
+
 // Test groups:
 // LX = lunar exchange
 // LVLGH = loader and validation github
@@ -450,47 +481,27 @@ TEST(CreateInstance, LayerNotPresent) {
 TEST(CreateInstance, LayerPresent) {
     char const *const names1[] = {"VK_LAYER_LUNARG_test"};  // Temporary required due to MSVC bug.
     char const *const names2[] = {"VK_LAYER_LUNARG_meta"};  // Temporary required due to MSVC bug.
+    char const *const names3[] = {"VK_LAYER_LUNARG_meta_rev"}; // Temporary required due to MSVC bug.
     auto const info1 = VK::InstanceCreateInfo().enabledLayerCount(1).ppEnabledLayerNames(names1);
     VkInstance instance = VK_NULL_HANDLE;
     VkResult result = vkCreateInstance(info1, VK_NULL_HANDLE, &instance);
     ASSERT_EQ(result, VK_SUCCESS);
     vkDestroyInstance(instance, nullptr);
 
-    auto const info2 = VK::InstanceCreateInfo().enabledLayerCount(1).ppEnabledLayerNames(names2);
-    instance = VK_NULL_HANDLE;
-    result = vkCreateInstance(info2, VK_NULL_HANDLE, &instance);
-    ASSERT_EQ(result, VK_SUCCESS);
+    for(auto names : {names2, names3}){
+      auto const info2 = VK::InstanceCreateInfo().enabledLayerCount(1).ppEnabledLayerNames(names);
+      instance = VK_NULL_HANDLE;
+      result = vkCreateInstance(info2, VK_NULL_HANDLE, &instance);
+      ASSERT_EQ(result, VK_SUCCESS);
 
-    uint32_t deviceCount;
-    vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
-    std::vector<VkPhysicalDevice> devs(deviceCount);
-    vkEnumeratePhysicalDevices(instance, &deviceCount, devs.data());
-    auto device_create_info = VkDeviceCreateInfo{
-              VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,  // sType
-              nullptr,                               // pNext
-              0,                                     // flags
-              0,                                     // queueCreateInfoCount
-              nullptr,                               // pQueueCreateInfos
-              0,                                     // enabledLayerCount
-              nullptr,                               // ppEnabledLayerNames
-              0,                                     // enabledExtensionCount
-              nullptr,                               // ppEnabledExtensionNames
-              nullptr                                // pEnabledFeatures
-    };
-    auto deviceQueue = VkDeviceQueueCreateInfo{};
-    deviceQueue.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-    float prios = 1;
-    deviceQueue.queueFamilyIndex = 0;
-    deviceQueue.queueCount = 1;
-    deviceQueue.pQueuePriorities = &prios;
-    device_create_info.pQueueCreateInfos = &deviceQueue;
-    device_create_info.queueCreateInfoCount = 1;
-    VkDevice dev;
-    vkCreateDevice(devs[0], &device_create_info, nullptr, &dev);
+      uint32_t deviceCount;
+      vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
+      std::vector<VkPhysicalDevice> devs(deviceCount);
+      vkEnumeratePhysicalDevices(instance, &deviceCount, devs.data());
+      test_create_device(devs[0]);
 
-    vkDestroyDevice(dev, nullptr);
-
-    vkDestroyInstance(instance, nullptr);
+      vkDestroyInstance(instance, nullptr);
+    }
 }
 
 // Used by run_loader_tests.sh to test that calling vkEnumeratePhysicalDevices without first querying
@@ -1028,33 +1039,7 @@ TEST(WrapObjects, Insert) {
     ASSERT_GT(physicalCount, 0u);
 
     for (uint32_t p = 0; p < physicalCount; ++p) {
-        uint32_t familyCount = 0;
-        vkGetPhysicalDeviceQueueFamilyProperties(physical[p], &familyCount, nullptr);
-        ASSERT_EQ(result, VK_SUCCESS);
-        ASSERT_GT(familyCount, 0u);
-
-        std::unique_ptr<VkQueueFamilyProperties[]> family(new VkQueueFamilyProperties[familyCount]);
-        vkGetPhysicalDeviceQueueFamilyProperties(physical[p], &familyCount, family.get());
-        ASSERT_EQ(result, VK_SUCCESS);
-        ASSERT_GT(familyCount, 0u);
-
-        for (uint32_t q = 0; q < familyCount; ++q) {
-            if (~family[q].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
-                continue;
-            }
-
-            float const priorities[] = {0.0f};  // Temporary required due to MSVC bug.
-            VkDeviceQueueCreateInfo const queueInfo[1]{
-                VK::DeviceQueueCreateInfo().queueFamilyIndex(q).queueCount(1).pQueuePriorities(priorities)};
-
-            auto const deviceInfo = VK::DeviceCreateInfo().queueCreateInfoCount(1).pQueueCreateInfos(queueInfo);
-
-            VkDevice device;
-            result = vkCreateDevice(physical[p], deviceInfo, nullptr, &device);
-            ASSERT_EQ(result, VK_SUCCESS);
-
-            vkDestroyDevice(device, nullptr);
-        }
+      test_create_device(physical[p]);
     }
 
     vkDestroyInstance(instance, nullptr);


### PR DESCRIPTION
The test layers were not able to handle vkCreate/DestroyDevice properly. I fixed them and extended the test case. I also extended the test case to have the two test layers tested in both orders.