### PR TITLE
CMake: Unset linker flags before testing ASM compilation

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -153,7 +153,12 @@ else(UNIX AND NOT APPLE) # i.e.: Linux
 
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/asm_test.asm
                ".intel_syntax noprefix\n.text\n.global sample\nsample:\nmov ecx, [eax + 16]\n")
+    # try_compile uses the C/C++ linker flags even for ASM,
+    # while they're not valid for ASM and making linking fail.
+    set(TMP_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
+    set(CMAKE_EXE_LINKER_FLAGS "")
     try_compile(ASSEMBLER_WORKS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/asm_test.asm)
+    set(CMAKE_EXE_LINKER_FLAGS ${TMP_EXE_LINKER_FLAGS})
     file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/asm_test.asm)
     if(ASSEMBLER_WORKS)
         set(CMAKE_ASM-ATT_FLAGS "$ENV{ASFLAGS} -I\"${CMAKE_CURRENT_BINARY_DIR}\"")


### PR DESCRIPTION
Otherwise compilation would fail (at least on Linux with GCC) if the `LDFLAGS` environment variable, or `CMAKE_EXE_LINKER_FLAGS`, are set to any value that isn't supported by `ld` for ASM, which means most C/C++ linker flags.

It's not a pretty hack, but I couldn't find a better fix. If an experience CMake user has a better idea, I'm interested :) (I tried to set `CMAKE_FLAGS -DCMAKE_EXE_LINKER_FLAGS=""` in the `try_compile` call [as per the docs](https://cmake.org/cmake/help/latest/command/try_compile.html), but to no avail.)

-----

Context on why this fix is needed: on Linux distros like Fedora or Mageia (I'm packaging Vulkan-Loader for the latter), we set predefined linker flags in `LDFLAGS` when calling CMake, to prevent underlinking and various other things. On Mageia for example, the `%cmake` macro calls before running `cmake`:
```
LDFLAGS="${LDFLAGS:- -Wl,--as-needed -Wl,--no-undefined -Wl,-z,relro -Wl,-O1 -Wl,--build-id -Wl,--enable-new-dtags}" ; export LDFLAGS
```

This works great for C/C++ with GCC or Clang, but the test compilation of an ASM file fails with this cryptic error:
```
CMake Warning at loader/CMakeLists.txt:177 (message):
  Could not find working x86 GAS assembler

  The build will fall back on building with C code

  Note that this may be unsafe, as the C code requires tail-call
  optimizations to remove the stack frame for certain calls.  If the compiler
  does not do this, then unknown device extensions will suffer from a
  corrupted stack.
```
[Same issue on Fedora](https://kojipkgs.fedoraproject.org/work/tasks/8271/31248271/build.log) (cc maintainer @airlied)

Saving and printing the output of the `try_compile` command, we can see the culprit:
```

Run Build Command:"/usr/bin/gmake" "cmTC_422a0/fast"
/usr/bin/gmake -f CMakeFiles/cmTC_422a0.dir/build.make CMakeFiles/cmTC_422a0.dir/build
gmake[1] : on entre dans le répertoire « /home/akien/Mageia/Sandbox/_rpm/BUILD/Vulkan-Loader-sdk-1.1.92.0/build/loader/CMakeFiles/CMakeTmp »
Building ASM-ATT object CMakeFiles/cmTC_422a0.dir/asm_test.asm.o
/usr/bin/as   -o CMakeFiles/cmTC_422a0.dir/asm_test.asm.o /home/akien/Mageia/Sandbox/_rpm/BUILD/Vulkan-Loader-sdk-1.1.92.0/build/loader/asm_test.asm
Linking ASM-ATT executable cmTC_422a0
/usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_422a0.dir/link.txt --verbose=1
/usr/bin/ld    -Wl,--as-needed -Wl,--no-undefined -Wl,-z,relro -Wl,-O1 -Wl,--build-id -Wl,--enable-new-dtags  CMakeFiles/cmTC_422a0.dir/asm_test.asm.o  -o cmTC_422a0 
/usr/bin/ld : option « -Wl,--as-needed » non reconnue
/usr/bin/ld: use the --help option for usage information
gmake[1]: *** [CMakeFiles/cmTC_422a0.dir/build.make:79: cmTC_422a0] Error 1
gmake[1] : on quitte le répertoire « /home/akien/Mageia/Sandbox/_rpm/BUILD/Vulkan-Loader-sdk-1.1.92.0/build/loader/CMakeFiles/CMakeTmp »
gmake: *** [Makefile:121: cmTC_422a0/fast] Error 2
```
(Some stuff in French but basically it's "unknown option '-Wl,--as-needed'".)

The same error happens with *any* value in `LDFLAGS` that I could try.