### PR TITLE
Discard duplicate json files scanned by the loader

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -492,6 +492,12 @@ static bool loaderAddJsonEntry(const struct loader_instance *inst,
                                LPSTR json_path,    // JSON string to add to the list reg_data
                                DWORD json_size,    // size in bytes of json_path
                                VkResult *result) {
+
+    // Check for and ignore duplicates.
+    if (*reg_data && strstr(*reg_data, json_path)) {
+        return true;
+    }
+
     if (NULL == *reg_data) {
         *reg_data = loader_instance_heap_alloc(inst, *total_size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
         if (NULL == *reg_data) {

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -495,6 +495,7 @@ static bool loaderAddJsonEntry(const struct loader_instance *inst,
 
     // Check for and ignore duplicates.
     if (*reg_data && strstr(*reg_data, json_path)) {
+        // Success. The json_path is already in the list.
         return true;
     }
 


### PR DESCRIPTION
I'm seeing an issue on multi-GPU systems where the same ICD, or implicit layer DLL, are being loaded more than once. This causes the loader to enumerate duplicate physical devices since it adds together the physical devices exposed by each ICD.

The reason this happens is because on multi-GPU systems there is a DriverStore entry for each adapter. The loader scans all the DriverStore locations and appends each VulkanDriverName entry to its internal list of json files to process. On these systems the VulkanDriverName for each adapter is going to point to the same json file and ICD.

The solution is to simply discard duplicate json entries when building the list of json files to scan.
