### PR TITLE
loader: Remove duplicate search paths on posix

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3860,15 +3860,16 @@ static VkResult ReadDataFilesInSearchPaths(const struct loader_instance *inst, e
 
     // Remove duplicate paths, or it would result in duplicate extensions, duplicate devices, etc.
     // This uses minimal memory, but is O(N^2) on the number of paths. Expect only a few paths.
-    char path_sep_str[2] = { PATH_SEPARATOR, '\0' };
+    char path_sep_str[2] = {PATH_SEPARATOR, '\0'};
     size_t search_path_updated_size = strlen(search_path);
-    for (size_t first = 0; first < search_path_updated_size - 1; ) {
+    for (size_t first = 0; first < search_path_updated_size - 1;) {
         size_t first_end = first + 1;
         first_end += strcspn(&search_path[first_end], path_sep_str);
-        for (size_t second = first_end + 1; second < search_path_updated_size; ) {
+        for (size_t second = first_end + 1; second < search_path_updated_size;) {
             size_t second_end = second + 1;
             second_end += strcspn(&search_path[second_end], path_sep_str);
-            if (first_end - first == second_end - second && !strncmp(&search_path[first], &search_path[second], second_end - second)) {
+            if (first_end - first == second_end - second &&
+                !strncmp(&search_path[first], &search_path[second], second_end - second)) {
                 // Found duplicate. Include PATH_SEPARATOR in second_end, then erase it from search_path.
                 if (search_path[second_end] == PATH_SEPARATOR) {
                     second_end++;

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3862,7 +3862,14 @@ static VkResult ReadDataFilesInSearchPaths(const struct loader_instance *inst, e
     // This uses minimal memory, but is O(N^2) on the number of paths. Expect only a few paths.
     char path_sep_str[2] = {PATH_SEPARATOR, '\0'};
     size_t search_path_updated_size = strlen(search_path);
-    for (size_t first = 0; first < search_path_updated_size - 1;) {
+    for (size_t first = 0; first < search_path_updated_size;) {
+        // If this is an empty path, erase it
+        if (search_path[first] == PATH_SEPARATOR) {
+            memmove(&search_path[first], &search_path[first + 1], search_path_updated_size - first + 1);
+            search_path_updated_size -= 1;
+            continue;
+        }
+
         size_t first_end = first + 1;
         first_end += strcspn(&search_path[first_end], path_sep_str);
         for (size_t second = first_end + 1; second < search_path_updated_size;) {

--- a/tests/run_loader_tests.sh
+++ b/tests/run_loader_tests.sh
@@ -45,9 +45,9 @@ RunEnvironmentVariablePathsTest()
        echo "Environment Variable Path test FAILED - Implicit layer path incorrect" >&2
        exit 1
     fi
-    # Sadly, the loader does not clean up this path and just stumbles through it.
-    # So just make sure it is the same.
-    right_path="${vk_layer_path}"
+    # The loader cleans up this path to remove the empty paths, so we need to clean up the right path, too
+    right_path="${vk_layer_path//:::::/:}"
+    right_path="${right_path//::::/:}"
     echo "$output" | grep -q "$right_path"
     ec=$?
     if [ $ec -eq 1 ]


### PR DESCRIPTION
Fixes issue #124

Windows platforms remove duplicate search paths due to registry keys
that are not device-specific but need to be searched. For the most
part, mac and linux do not need to do that. But if duplicate paths
crop up on a posix platform, it can cause the same device showing up
twice in the vkEnumeratePhysicalDevices results. There may be other
places it causes unexpected results as well.

VkPhysicalDeviceIDProperties.deviceUUID can be used later to tell that
the two entries are actually the same device and not a multi-GPU
system, but finding the root cause at that point is going to be very
difficult.