### PR TITLE
Remove unnecessary call from extension_prop loop.

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5565,14 +5565,7 @@ VkResult loader_validate_instance_extensions(struct loader_instance *inst, const
         extension_prop = NULL;
 
         // Not in global list, search layer extension lists
-        struct loader_layer_properties *layer_prop = NULL;
         for (uint32_t j = 0; NULL == extension_prop && j < expanded_layers.count; ++j) {
-            layer_prop = loaderFindLayerProperty(pCreateInfo->ppEnabledLayerNames[j], instance_layers);
-            if (NULL == layer_prop) {
-                // Should NOT get here, loaderValidateLayers should have already filtered this case out.
-                continue;
-            }
-
             extension_prop =
                 get_extension_property(pCreateInfo->ppEnabledExtensionNames[i], &expanded_layers.list[j].instance_extension_list);
             if (extension_prop) {


### PR DESCRIPTION
This causes a segmentation fault when expanded_layers.count is greater
than the number of explicitly enabled layers (for example, when an
instance extension is exported by an implicitly enabled layer but
requested by the application).

The check does nothing meaningful for the loop anyways; as the comment
states, the condition it checks for should not occur.