### PR TITLE
Possibility to run loader_genvk.py in Python 2

### DIFF
--- a/scripts/loader_genvk.py
+++ b/scripts/loader_genvk.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright (c) 2013-2018 The Khronos Group Inc.
+# Copyright (c) 2013-2019 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,12 +21,13 @@ startTime = None
 
 def startTimer(timeit):
     global startTime
-    startTime = time.process_time()
+    if timeit:
+        startTime = time.process_time()
 
 def endTimer(timeit, msg):
     global startTime
-    endTime = time.process_time()
-    if (timeit):
+    if timeit:
+        endTime = time.process_time()
         write(msg, endTime - startTime, file=sys.stderr)
         startTime = None
 


### PR DESCRIPTION
This would limit the script to not accept the `time` argument, but otherwise allow it to run on Python 2.

Needed for ANGLE.