### PR TITLE
build: Revert known-good to 1.1.97 header

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "Vulkan-Headers",
       "build_dir" : "Vulkan-Headers/build",
       "install_dir" : "Vulkan-Headers/build/install",
-      "commit" : "v1.1.99"
+      "commit" : "v1.1.97"
     }
   ],
   "install_names" : {


### PR DESCRIPTION
This commit consists of reverting known-good files to 'v1.1.97' tags due to a spec bug introduced in the 1.1.99 header and a Vulkan-Hpp failure with the 1.1.100 header.

Note - I ran this through Gerrit and it passed.