### PR TITLE
docs: Add Vulkan Logo

### DIFF
--- a/loader/LoaderAndLayerInterface.md
+++ b/loader/LoaderAndLayerInterface.md
@@ -1,5 +1,14 @@
-# Architecture of the Vulkan Loader Interfaces
+<!-- markdownlint-disable MD041 -->
+[![Khronos Vulkan][1]][2]
 
+[1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
+[2]: https://www.khronos.org/vulkan/
+
+# Architecture of the Vulkan Loader Interfaces
+[![Creative Commons][3]][4]
+
+[3]: https://i.creativecommons.org/l/by-nd/4.0/88x31.png "Creative Commons License"
+[4]: https://creativecommons.org/licenses/by-nd/4.0/
 ## Table of Contents
   * [Overview](#overview)
     * [Who Should Read This Document](#who-should-read-this-document)


### PR DESCRIPTION
Adding Vulkan Logo for consistency across Vulkan SDK documentation.
Adding creative commons license (because there was no license on the documentation)