### PR TITLE
loader: Destroy debug callbacks/messengers properly

### DIFF
--- a/loader/debug_utils.c
+++ b/loader/debug_utils.c
@@ -271,8 +271,6 @@ static VKAPI_ATTR void VKAPI_CALL debug_utils_DestroyDebugUtilsMessengerEXT(VkIn
 
     inst->disp->layer_inst_disp.DestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
 
-    util_DestroyDebugUtilsMessenger(inst, messenger, pAllocator);
-
     loader_platform_thread_unlock_mutex(&loader_lock);
 }
 
@@ -412,6 +410,8 @@ VKAPI_ATTR void VKAPI_CALL terminator_DestroyDebugUtilsMessengerEXT(VkInstance i
         }
         storage_idx++;
     }
+
+    util_DestroyDebugUtilsMessenger(inst, messenger, pAllocator);
 
 #if (DEBUG_DISABLE_APP_ALLOCATORS == 1)
     {
@@ -670,8 +670,6 @@ static VKAPI_ATTR void VKAPI_CALL debug_utils_DestroyDebugReportCallbackEXT(VkIn
 
     inst->disp->layer_inst_disp.DestroyDebugReportCallbackEXT(instance, callback, pAllocator);
 
-    util_DestroyDebugReportCallback(inst, callback, pAllocator);
-
     loader_platform_thread_unlock_mutex(&loader_lock);
 }
 
@@ -820,6 +818,8 @@ VKAPI_ATTR void VKAPI_CALL terminator_DestroyDebugReportCallbackEXT(VkInstance i
         }
         storage_idx++;
     }
+
+    util_DestroyDebugReportCallback(inst, callback, pAllocator);
 
 #if (DEBUG_DISABLE_APP_ALLOCATORS == 1)
     {


### PR DESCRIPTION
When creating debug callbacks or messengers, each of them is added to a
linked list from the terminator, with the handle provided by the ICD.

When enabling some validation layers, this handle is renamed as part of
the chain and the application gets a different one.

In the removal process, the application usually receives one of these
function pointers using vkGetInstanceProcAddr:

  - debug_utils_DestroyDebugReportCallbackEXT
  - debug_utils_DestroyDebugUtilsMessengerEXT

Those trigger the chain calls but then try to remove the callback or
messenger from the linked list using the application-level handle, which
is not found because it doesn't match the one from the ICD.

The linked list should be accessed from the destruction terminators,
when the handle has already been unwrapped by the layers.

This fixes  #149.