### PR TITLE
scripts: Update known-good for 1.1.106 header

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -6141,11 +6141,23 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
             dev->extensions.khr_swapchain_enabled = true;
         } else if (!strcmp(localCreateInfo.ppEnabledExtensionNames[i], VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME)) {
             dev->extensions.khr_display_swapchain_enabled = true;
+        } else if (!strcmp(localCreateInfo.ppEnabledExtensionNames[i], VK_KHR_DEVICE_GROUP_EXTENSION_NAME)) {
+            dev->extensions.khr_device_group_enabled = true;
         } else if (!strcmp(localCreateInfo.ppEnabledExtensionNames[i], VK_EXT_DEBUG_MARKER_EXTENSION_NAME)) {
             dev->extensions.ext_debug_marker_enabled = true;
+        } else if (!strcmp(localCreateInfo.ppEnabledExtensionNames[i], "VK_EXT_full_screen_exclusive")) {
+            dev->extensions.ext_full_screen_exclusive_enabled = true;
         }
     }
     dev->extensions.ext_debug_utils_enabled = icd_term->this_instance->enabled_known_extensions.ext_debug_utils;
+
+    if (!dev->extensions.khr_device_group_enabled) {
+        VkPhysicalDeviceProperties properties;
+        icd_term->dispatch.GetPhysicalDeviceProperties(phys_dev_term->phys_dev, &properties);
+        if (properties.apiVersion >= VK_MAKE_VERSION(1, 1, 0)) {
+            dev->extensions.khr_device_group_enabled = true;
+        }
+    }
 
     res = fpCreateDevice(phys_dev_term->phys_dev, &localCreateInfo, pAllocator, &dev->icd_device);
     if (res != VK_SUCCESS) {

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -209,8 +209,10 @@ struct loader_device {
     struct {
         bool khr_swapchain_enabled;
         bool khr_display_swapchain_enabled;
+        bool khr_device_group_enabled;
         bool ext_debug_marker_enabled;
         bool ext_debug_utils_enabled;
+        bool ext_full_screen_exclusive_enabled;
     } extensions;
 
     struct loader_device *next;

--- a/scripts/common_codegen.py
+++ b/scripts/common_codegen.py
@@ -50,6 +50,7 @@ prefixStrings = [
 platform_dict = {
     'android' : 'VK_USE_PLATFORM_ANDROID_KHR',
     'fuchsia' : 'VK_USE_PLATFORM_FUCHSIA',
+    'ggp': 'VK_USE_PLATFORM_GGP',
     'ios' : 'VK_USE_PLATFORM_IOS_MVK',
     'macos' : 'VK_USE_PLATFORM_MACOS_MVK',
     'metal' : 'VK_USE_PLATFORM_METAL_EXT',

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -29,6 +29,7 @@ from common_codegen import *
 # DispatchTableHelperOutputGeneratorOptions - subclass of GeneratorOptions.
 class DispatchTableHelperOutputGeneratorOptions(GeneratorOptions):
     def __init__(self,
+                 conventions = None,
                  filename = None,
                  directory = '.',
                  apiname = None,
@@ -47,7 +48,7 @@ class DispatchTableHelperOutputGeneratorOptions(GeneratorOptions):
                  apientryp = '',
                  alignFuncParam = 0,
                  expandEnumerants = True):
-        GeneratorOptions.__init__(self, filename, directory, apiname, profile,
+        GeneratorOptions.__init__(self, conventions, filename, directory, apiname, profile,
                                   versions, emitversions, defaultExtensions,
                                   addExtensions, removeExtensions, emitExtensions, sortProcedure)
         self.prefixText      = prefixText

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -31,6 +31,7 @@ from common_codegen import *
 # HelperFileOutputGeneratorOptions - subclass of GeneratorOptions.
 class HelperFileOutputGeneratorOptions(GeneratorOptions):
     def __init__(self,
+                 conventions = None,
                  filename = None,
                  directory = '.',
                  apiname = None,
@@ -53,7 +54,7 @@ class HelperFileOutputGeneratorOptions(GeneratorOptions):
                  library_name = '',
                  expandEnumerants = True,
                  helper_file_type = ''):
-        GeneratorOptions.__init__(self, filename, directory, apiname, profile,
+        GeneratorOptions.__init__(self, conventions, filename, directory, apiname, profile,
                                   versions, emitversions, defaultExtensions,
                                   addExtensions, removeExtensions, emitExtensions, sortProcedure)
         self.prefixText       = prefixText

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "Vulkan-Headers",
       "build_dir" : "Vulkan-Headers/build",
       "install_dir" : "Vulkan-Headers/build/install",
-      "commit" : "v1.1.102"
+      "commit" : "v1.1.106"
     }
   ],
   "install_names" : {

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -60,7 +60,8 @@ DEVICE_CMDS_NEED_TERM = ['vkGetDeviceProcAddr',
                          'vkDebugMarkerSetObjectTagEXT',
                          'vkDebugMarkerSetObjectNameEXT',
                          'vkSetDebugUtilsObjectNameEXT',
-                         'vkSetDebugUtilsObjectTagEXT']
+                         'vkSetDebugUtilsObjectTagEXT',
+                         'vkGetDeviceGroupSurfacePresentModes2EXT']
 
 ALIASED_CMDS = {
     'vkEnumeratePhysicalDeviceGroupsKHR':                   'vkEnumeratePhysicalDeviceGroups',
@@ -84,6 +85,7 @@ PRE_INSTANCE_FUNCTIONS = ['vkEnumerateInstanceExtensionProperties',
 # LoaderExtensionGeneratorOptions - subclass of GeneratorOptions.
 class LoaderExtensionGeneratorOptions(GeneratorOptions):
     def __init__(self,
+                 conventions = None,
                  filename = None,
                  directory = '.',
                  apiname = None,
@@ -106,7 +108,7 @@ class LoaderExtensionGeneratorOptions(GeneratorOptions):
                  indentFuncPointer = False,
                  alignFuncParam = 0,
                  expandEnumerants = True):
-        GeneratorOptions.__init__(self, filename, directory, apiname, profile,
+        GeneratorOptions.__init__(self, conventions, filename, directory, apiname, profile,
                                   versions, emitversions, defaultExtensions,
                                   addExtensions, removeExtensions, emitExtensions, sortProcedure)
         self.prefixText      = prefixText
@@ -134,7 +136,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
         self.core_commands = []               # List of CommandData records for core Vulkan commands
         self.ext_commands = []                # List of CommandData records for extension Vulkan commands
         self.CommandParam = namedtuple('CommandParam', ['type', 'name', 'cdecl'])
-        self.CommandData = namedtuple('CommandData', ['name', 'ext_name', 'ext_type', 'protect', 'return_type', 'handle_type', 'params', 'cdecl'])
+        self.CommandData = namedtuple('CommandData', ['name', 'ext_name', 'ext_type', 'require', 'protect', 'return_type', 'handle_type', 'params', 'cdecl'])
         self.instanceExtensions = []
         self.ExtensionData = namedtuple('ExtensionData', ['name', 'type', 'protect', 'define', 'num_commands'])
 
@@ -306,6 +308,12 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
         if (return_type is not None and return_type.text == 'void'):
            return_type = None
 
+        require = None
+        if name == 'vkGetDeviceGroupSurfacePresentModes2EXT':
+            require_node = self.registry.tree.find("./extensions/extension[@name='{}']/require/command[@name='{}']/..".format(extension_name, name))
+            if 'extension' in require_node.attrib:
+                require = require_node.attrib['extension']
+
         cmd_params = []
 
         # Generate a list of commands for use in printing the necessary
@@ -332,6 +340,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 self.core_commands.append(
                     self.CommandData(name=name, ext_name=extension_name,
                                      ext_type='device',
+                                     require=require,
                                      protect=self.featureExtraProtect,
                                      return_type = return_type,
                                      handle_type = handle_type,
@@ -342,6 +351,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 self.ext_commands.append(
                     self.CommandData(name=name, ext_name=extension_name,
                                      ext_type=extension_type,
+                                     require=require,
                                      protect=self.featureExtraProtect,
                                      return_type = return_type,
                                      handle_type = handle_type,
@@ -354,6 +364,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 self.core_commands.append(
                     self.CommandData(name=name, ext_name=extension_name,
                                      ext_type='instance',
+                                     require=require,
                                      protect=self.featureExtraProtect,
                                      return_type = return_type,
                                      handle_type = handle_type,
@@ -365,6 +376,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 self.ext_commands.append(
                     self.CommandData(name=name, ext_name=extension_name,
                                      ext_type=extension_type,
+                                     require=require,
                                      protect=self.featureExtraProtect,
                                      return_type = return_type,
                                      handle_type = handle_type,
@@ -1442,7 +1454,10 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                         term_func += '\n    // ---- Core %s commands\n' % ext_cmd.ext_name[11:]
                     else:
                         term_func += '\n    // ---- %s extension commands\n' % ext_cmd.ext_name
-                        term_func += '    if (dev->extensions.%s_enabled) {\n' % ext_cmd.ext_name[3:].lower()
+                        if ext_cmd.require:
+                            term_func += '    if (dev->extensions.%s_enabled && dev->extensions.%s_enabled) {\n' % (ext_cmd.ext_name[3:].lower(), ext_cmd.require[3:].lower())
+                        else:
+                            term_func += '    if (dev->extensions.%s_enabled) {\n' % ext_cmd.ext_name[3:].lower()
                         is_extension = True
                     cur_extension_name = ext_cmd.ext_name
 

--- a/scripts/loader_genvk.py
+++ b/scripts/loader_genvk.py
@@ -111,11 +111,15 @@ def makeGenOpts(args):
     # Defaults for generating re-inclusion protection wrappers (or not)
     protectFeature = protect
 
+    # An API style conventions object
+    conventions = VulkanConventions()
+
     # Loader Generators
     # Options for dispatch table helper generator
     genOpts['vk_dispatch_table_helper.h'] = [
           DispatchTableHelperOutputGenerator,
           DispatchTableHelperOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_dispatch_table_helper.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -138,6 +142,7 @@ def makeGenOpts(args):
     genOpts['vk_layer_dispatch_table.h'] = [
           LoaderExtensionOutputGenerator,
           LoaderExtensionGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_layer_dispatch_table.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -160,6 +165,7 @@ def makeGenOpts(args):
     genOpts['vk_loader_extensions.h'] = [
           LoaderExtensionOutputGenerator,
           LoaderExtensionGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_loader_extensions.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -182,6 +188,7 @@ def makeGenOpts(args):
     genOpts['vk_loader_extensions.c'] = [
           LoaderExtensionOutputGenerator,
           LoaderExtensionGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_loader_extensions.c',
             directory         = directory,
             apiname           = 'vulkan',
@@ -204,6 +211,7 @@ def makeGenOpts(args):
     genOpts['vk_enum_string_helper.h'] = [
           HelperFileOutputGenerator,
           HelperFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_enum_string_helper.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -227,6 +235,7 @@ def makeGenOpts(args):
     genOpts['vk_safe_struct.h'] = [
           HelperFileOutputGenerator,
           HelperFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_safe_struct.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -250,6 +259,7 @@ def makeGenOpts(args):
     genOpts['vk_safe_struct.cpp'] = [
           HelperFileOutputGenerator,
           HelperFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_safe_struct.cpp',
             directory         = directory,
             apiname           = 'vulkan',
@@ -273,6 +283,7 @@ def makeGenOpts(args):
     genOpts['vk_object_types.h'] = [
           HelperFileOutputGenerator,
           HelperFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_object_types.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -296,6 +307,7 @@ def makeGenOpts(args):
     genOpts['vk_extension_helper.h'] = [
           HelperFileOutputGenerator,
           HelperFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_extension_helper.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -319,6 +331,7 @@ def makeGenOpts(args):
     genOpts['vk_typemap_helper.h'] = [
           HelperFileOutputGenerator,
           HelperFileOutputGeneratorOptions(
+            conventions       = conventions,
             filename          = 'vk_typemap_helper.h',
             directory         = directory,
             apiname           = 'vulkan',
@@ -452,6 +465,7 @@ if __name__ == '__main__':
     from dispatch_table_helper_generator import DispatchTableHelperOutputGenerator, DispatchTableHelperOutputGeneratorOptions
     from helper_file_generator import HelperFileOutputGenerator, HelperFileOutputGeneratorOptions
     from loader_extension_generator import LoaderExtensionOutputGenerator, LoaderExtensionGeneratorOptions
+    from vkconventions import VulkanConventions
 
     # This splits arguments which are space-separated lists
     args.feature = [name for arg in args.feature for name in arg.split()]


### PR DESCRIPTION
Changes:
- Integrate upstream script changes: We have to plumb-through the new
conventions object to continue using the makeCParamDecl utility function
- Add GGP to available platforms
- Add handling for extension dependencies: Previously, the codegen for
loader trampolines could not handle an extension command that depends on
more than one extension being present. This removes that limitation
- Add checks for device extensions: This adds a check for two functions
at device creation time:
 * VK_KHR_device_group
 * VK_EXT_full_screen_exclusive
The loader needs to know about these extensions for proper handling
of the vkGetDeviceGroupSurfacePresentModes2EXT terminator

Updated:
- `loader/loader.c`
- `loader/loader.h`
- `scripts/common_codegen.py`
- `scripts/dispatch_table_helper_generator.py`
- `scripts/helper_file_generator.py`
- `scripts/known_good.json`
- `scripts/loader_extension_generator.py`
- `scripts/loader_genvk.py`

Change-Id: I9f0828a8eee0e8e95b479e1b8feb31acaa10040d