### PR TITLE
loader: Support VK_EXT_full_screen_exclusive ext

### DIFF
--- a/loader/extension_manual.h
+++ b/loader/extension_manual.h
@@ -80,3 +80,27 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(VkPhysicalDevice physica
 VKAPI_ATTR VkResult VKAPI_CALL terminator_GetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, RROutput rrOutput,
                                                                    VkDisplayKHR* pDisplay);
 #endif  // VK_USE_PLATFORM_XLIB_XRANDR_EXT
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModes2EXT(
+    VkPhysicalDevice                            physicalDevice,
+    const VkPhysicalDeviceSurfaceInfo2KHR*      pSurfaceInfo,
+    uint32_t*                                   pPresentModeCount,
+    VkPresentModeKHR*                           pPresentModes);
+
+VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfacePresentModes2EXT(
+    VkPhysicalDevice                            physicalDevice,
+    const VkPhysicalDeviceSurfaceInfo2KHR*      pSurfaceInfo,
+    uint32_t*                                   pPresentModeCount,
+    VkPresentModeKHR*                           pPresentModes);
+#endif // VK_USE_PLATFORM_WIN32_KHR
+
+VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModes2EXT(
+    VkDevice                                    device,
+    const VkPhysicalDeviceSurfaceInfo2KHR*      pSurfaceInfo,
+    VkDeviceGroupPresentModeFlagsKHR*           pModes);
+
+VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDeviceGroupSurfacePresentModes2EXT(
+    VkDevice                                    device,
+    const VkPhysicalDeviceSurfaceInfo2KHR*      pSurfaceInfo,
+    VkDeviceGroupPresentModeFlagsKHR*           pModes);

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -923,7 +923,9 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                                'vkGetPhysicalDeviceDisplayProperties2KHR',
                                'vkGetPhysicalDeviceDisplayPlaneProperties2KHR',
                                'vkGetDisplayModeProperties2KHR',
-                               'vkGetDisplayPlaneCapabilities2KHR']
+                               'vkGetDisplayPlaneCapabilities2KHR',
+                               'vkGetPhysicalDeviceSurfacePresentModes2EXT',
+                               'vkGetDeviceGroupSurfacePresentModes2EXT']
 
         for ext_cmd in self.ext_commands:
             if (ext_cmd.ext_name in WSI_EXT_NAMES or


### PR DESCRIPTION
This change adds manual handing for new APIs which need to unwrap an
ICD surface handle before calling down to the ICD.

Change-Id: Id64c8021a3d36800af9a59cafe52577a4d5d69ff