### PR TITLE
update_deps: make --clean-repo switch work in all cases

### DIFF
--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -343,7 +343,7 @@ class GoodRepo(object):
     def Checkout(self):
         print('Checking out {n} in {d}'.format(n=self.name, d=self.repo_dir))
         if self._args.do_clean_repo:
-            shutil.rmtree(self.repo_dir)
+            shutil.rmtree(self.repo_dir, ignore_errors=True)
         if not os.path.exists(os.path.join(self.repo_dir, '.git')):
             self.Clone()
         self.Fetch()


### PR DESCRIPTION
--clean-repo right now will raise an exception if the repository
directory was not present.  This makes it work in all cases.