### PR TITLE
Port GN build from ANGLE and add CI

### DIFF
--- a/.gn
+++ b/.gn
@@ -1,0 +1,22 @@
+# Copyright (C) 2019 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+buildconfig = "//build/config/BUILDCONFIG.gn"
+secondary_source = "//build-gn/secondary/"
+
+default_args = {
+    clang_use_chrome_plugins = false
+    use_custom_libcxx = false
+}
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: CHECK_COMMIT_FORMAT=ON
+    - env: VULKAN_BUILD_TARGET=GN
   include:
     # Linux GCC debug build.
     - os: linux
@@ -19,6 +20,9 @@ matrix:
     - os: linux
       compiler: clang
       env: VULKAN_BUILD_TARGET=LINUX
+    # Linux GN debug build
+    - os: linux
+      env: VULKAN_BUILD_TARGET=GN
     # MacOS clang debug build.
     - os: osx
       compiler: clang
@@ -45,10 +49,11 @@ before_install:
         UPDATE_DEPS_EXTRA_OPTIONS="--ref=master"
     fi
   - |
-    if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
+    if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]] || [[ "$VULKAN_BUILD_TARGET" == "GN" ]]; then
       # Install the appropriate Linux packages.
       sudo apt-get -qq update
-      sudo apt-get -y install libxkbcommon-dev libwayland-dev libxrandr-dev libx11-xcb-dev
+      sudo apt-get -y install libxkbcommon-dev libwayland-dev libxrandr-dev libx11-xcb-dev \
+                              python-pathlib
     fi
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]] || [[ "$VULKAN_BUILD_TARGET" == "MACOS" ]]; then
@@ -82,6 +87,14 @@ script:
       cmake -DCMAKE_BUILD_TYPE=Debug -C../external/helper.cmake ..
       make -j $core_count
       cd ..
+    fi
+  - |
+    if [[ "$VULKAN_BUILD_TARGET" == "GN" ]]; then
+      git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git depot_tools
+      export PATH=$PATH:$PWD/depot_tools
+      ./build-gn/update_deps.sh
+      gn gen out/Debug
+      ninja -C out/Debug
     fi
   - |
     if [[ "$CHECK_FORMAT" == "ON" ]]; then

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,256 @@
+# Copyright (C) 2018-2019 The ANGLE Project Authors.
+# Copyright (C) 2019 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/vulkan_loader.gni")
+
+vulkan_registry_script_files = [
+  "$vulkan_headers_dir/registry/cgenerator.py",
+  "$vulkan_headers_dir/registry/conventions.py",
+  "$vulkan_headers_dir/registry/generator.py",
+  "$vulkan_headers_dir/registry/reg.py",
+  "$vulkan_headers_dir/registry/vkconventions.py",
+  "$vulkan_headers_dir/registry/vk.xml",
+]
+
+# Fuchsia has non-upstream changes to the vulkan loader, so we don't want
+# to build it from upstream sources.
+assert(!is_fuchsia)
+
+if (!is_android) {
+  vulkan_undefine_configs = []
+}
+if (is_win) {
+  vulkan_undefine_configs += [
+    "//build/config/win:nominmax",
+    "//build/config/win:unicode",
+  ]
+}
+
+vulkan_gen_dir = "$target_gen_dir/$vulkan_gen_subdir"
+raw_vulkan_gen_dir = rebase_path(vulkan_gen_dir, root_build_dir)
+
+# Vulkan helper scripts
+# ---------------------
+
+helper_script_and_deps = [
+  [
+    "vulkan_gen_dispatch_table_helper_h",
+    "vk_dispatch_table_helper.h",
+    "dispatch_table_helper_generator.py",
+  ],
+  [
+    "vulkan_gen_enum_string_helper",
+    "vk_enum_string_helper.h",
+    "helper_file_generator.py",
+  ],
+  [
+    "vulkan_gen_extension_helper",
+    "vk_extension_helper.h",
+    "helper_file_generator.py",
+  ],
+  [
+    "vulkan_gen_layer_dispatch_table_h",
+    "vk_layer_dispatch_table.h",
+    "loader_extension_generator.py",
+  ],
+  [
+    "vulkan_gen_loader_extensions_c",
+    "vk_loader_extensions.c",
+    "loader_extension_generator.py",
+  ],
+  [
+    "vulkan_gen_loader_extensions_h",
+    "vk_loader_extensions.h",
+    "loader_extension_generator.py",
+  ],
+  [
+    "vulkan_gen_object_types_h",
+    "vk_object_types.h",
+    "helper_file_generator.py",
+  ],
+  [
+    "vulkan_gen_safe_struct_cpp",
+    "vk_safe_struct.cpp",
+    "helper_file_generator.py",
+  ],
+  [
+    "vulkan_gen_safe_struct_h",
+    "vk_safe_struct.h",
+    "helper_file_generator.py",
+  ],
+  [
+    "vulkan_gen_typemap_helper",
+    "vk_typemap_helper.h",
+    "helper_file_generator.py",
+  ],
+]
+
+# Python scripts needed for codegen, copy them to a temp dir
+# so that all dependencies are together. The reg.py script from
+# the headers repo is required input to loader_genvk.py.
+copy("python_gen_deps") {
+  sources = vulkan_registry_script_files + [
+              "scripts/common_codegen.py",
+              "scripts/dispatch_table_helper_generator.py",
+              "scripts/helper_file_generator.py",
+              "scripts/loader_extension_generator.py",
+              "scripts/loader_genvk.py",
+            ]
+  outputs = [
+    "$vulkan_gen_dir/{{source_file_part}}",
+  ]
+}
+
+foreach(script_and_dep, helper_script_and_deps) {
+  target_name = script_and_dep[0]
+  file = script_and_dep[1]
+  dep = script_and_dep[2]
+  target("action", target_name) {
+    public_deps = [
+      ":python_gen_deps",
+    ]
+    script = "$vulkan_gen_dir/loader_genvk.py"
+    inputs = [
+      "$vulkan_gen_dir/$dep",
+      "$vulkan_gen_dir/common_codegen.py",
+    ]
+    outputs = [
+      "$vulkan_gen_dir/$file",
+    ]
+    args = [
+      "-o",
+      raw_vulkan_gen_dir,
+      "-registry",
+      "$raw_vulkan_gen_dir/vk.xml",
+      "-scripts",
+      raw_vulkan_gen_dir,
+      "$file",
+      "-quiet",
+    ]
+  }
+}
+
+config("vulkan_generated_files_config") {
+  include_dirs = [ vulkan_gen_dir ]
+}
+
+group("vulkan_generate_helper_files") {
+  public_deps = [
+    "$vulkan_headers_dir:vulkan_headers",
+  ]
+  public_configs = [ ":vulkan_generated_files_config" ]
+  foreach(script_and_dep, helper_script_and_deps) {
+    target_name = script_and_dep[0]
+    public_deps += [ ":$target_name" ]
+  }
+}
+
+config("vulkan_internal_config") {
+  defines = [ "VULKAN_NON_CMAKE_BUILD" ]
+  if (is_clang || !is_win) {
+    cflags = [ "-Wno-unused-function" ]
+  }
+  if (is_linux) {
+    defines += [
+      "SYSCONFDIR=\"/etc\"",
+      "FALLBACK_CONFIG_DIRS=\"/etc/xdg\"",
+      "FALLBACK_DATA_DIRS=\"/usr/local/share:/usr/share\"",
+    ]
+  }
+}
+
+# Vulkan loader
+# -------------
+
+config("vulkan_loader_config") {
+  include_dirs = [
+    vulkan_gen_dir,
+    "loader",
+  ]
+  defines = [ "API_NAME=\"Vulkan\"" ] + vulkan_loader_extra_defines
+
+  if (is_win) {
+    cflags = [ "/wd4201" ]
+  }
+  if (is_linux) {
+    # assume secure_getenv() is available
+    defines += [ "HAVE_SECURE_GETENV" ]
+  }
+}
+
+if (!is_android) {
+  if (vulkan_loader_shared) {
+    library_type = "shared_library"
+  } else {
+    library_type = "static_library"
+  }
+
+  target(library_type, "libvulkan") {
+    sources = [
+      "loader/asm_offset.c",
+      "loader/cJSON.c",
+      "loader/cJSON.h",
+      "loader/debug_utils.c",
+      "loader/debug_utils.h",
+      "loader/dev_ext_trampoline.c",
+      "loader/extension_manual.c",
+      "loader/extension_manual.h",
+      "loader/gpa_helper.h",
+      "loader/loader.c",
+      "loader/loader.h",
+      "loader/murmurhash.c",
+      "loader/murmurhash.h",
+      "loader/phys_dev_ext.c",
+      "loader/trampoline.c",
+
+      # TODO(jmadill): Use assembler where available.
+      "loader/unknown_ext_chain.c",
+      "loader/vk_loader_platform.h",
+      "loader/wsi.c",
+      "loader/wsi.h",
+    ]
+    if (is_win) {
+      sources += [
+        "loader/dirent_on_windows.c",
+        "loader/dirent_on_windows.h",
+      ]
+      if (!is_clang) {
+        cflags = [
+          "/wd4054",  # Type cast from function pointer
+          "/wd4055",  # Type cast from data pointer
+          "/wd4100",  # Unreferenced formal parameter
+          "/wd4152",  # Nonstandard extension used (pointer conversion)
+          "/wd4201",  # Nonstandard extension used: nameless struct/union
+          "/wd4214",  # Nonstandard extension used: bit field types other than int
+          "/wd4232",  # Nonstandard extension used: address of dllimport is not static
+          "/wd4305",  # Type cast truncation
+          "/wd4706",  # Assignment within conditional expression
+          "/wd4996",  # Unsafe stdlib function
+        ]
+      }
+    }
+    deps = [
+      ":vulkan_generate_helper_files",
+    ]
+    public_deps = [
+      "$vulkan_headers_dir:vulkan_headers",
+    ]
+    configs -= [ "//build/config/compiler:chromium_code" ]
+    configs += [ "//build/config/compiler:no_chromium_code" ]
+    configs += [ ":vulkan_internal_config" ]
+    public_configs = [ ":vulkan_loader_config" ]
+    configs -= vulkan_undefine_configs
+  }
+}

--- a/build-gn/DEPS
+++ b/build-gn/DEPS
@@ -1,0 +1,57 @@
+vars = {
+  'chromium_git': 'https://chromium.googlesource.com',
+}
+
+deps = {
+
+  './build': {
+    'url': '{chromium_git}/chromium/src/build.git@a660b0b9174e3a808f620222017566e8d1b2669b',
+  },
+
+  './buildtools': {
+    'url': '{chromium_git}/chromium/src/buildtools.git@459baaf66bee809f6eb288e0215cf524f4d2429a',
+  },
+
+  './testing': {
+    'url': '{chromium_git}/chromium/src/testing@083d633e752e7a57cbe62a468a06e51e28c49ee9',
+  },
+
+  './tools/clang': {
+    'url': '{chromium_git}/chromium/src/tools/clang.git@3114fbc11f9644c54dd0a4cdbfa867bac50ff983',
+  },
+
+}
+
+hooks = [
+  # Pull clang-format binaries using checked-in hashes.
+  {
+    'name': 'clang_format_linux',
+    'pattern': '.',
+    'condition': 'host_os == "linux"',
+    'action': [ 'download_from_google_storage',
+                '--no_resume',
+                '--platform=linux*',
+                '--no_auth',
+                '--bucket', 'chromium-clang-format',
+                '-s', './buildtools/linux64/clang-format.sha1',
+    ],
+  },
+  {
+    'name': 'sysroot_x64',
+    'pattern': '.',
+    'condition': 'checkout_linux and checkout_x64',
+    'action': ['python', './build/linux/sysroot_scripts/install-sysroot.py',
+               '--arch=x64'],
+  },
+  {
+    # Note: On Win, this should run after win_toolchain, as it may use it.
+    'name': 'clang',
+    'pattern': '.',
+    'action': ['python', './tools/clang/scripts/update.py'],
+  },
+]
+
+recursedeps = [
+  # buildtools provides clang_format.
+  './buildtools',
+]

--- a/build-gn/secondary/build_overrides/build.gni
+++ b/build-gn/secondary/build_overrides/build.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2019 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_with_chromium = false
+ignore_elf32_limitations = true
+linux_use_bundled_binutils_override = false
+use_system_xcode = true

--- a/build-gn/secondary/build_overrides/vulkan_loader.gni
+++ b/build-gn/secondary/build_overrides/vulkan_loader.gni
@@ -1,0 +1,24 @@
+# Copyright (c) 2019 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Paths to loader dependencies
+vulkan_headers_dir = "//external/Vulkan-Headers"
+
+# Subdirectories for generated files
+vulkan_gen_subdir = "" 
+
+# Vulkan loader build options
+vulkan_loader_extra_defines = []
+vulkan_loader_shared = true
+

--- a/build-gn/update_deps.sh
+++ b/build-gn/update_deps.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Copyright (c) 2019 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Execute at repo root
+cd "$(dirname $0)/.."
+
+# Use update_deps.py to update source dependencies from /scripts/known_good.json
+scripts/update_deps.py --dir="external" --no-build
+
+# Use gclient to update toolchain dependencies from /build-gn/DEPS (from chromium)
+cat << EOF >> .gclient
+solutions = [
+  { "name"        : ".",
+    "url"         : "https://github.com/KhronosGroup/Vulkan-Loader",
+    "deps_file"   : "build-gn/DEPS",
+    "managed"     : False,
+    "custom_deps" : {
+    },
+    "custom_vars": {},
+  },
+]
+EOF
+gclient sync
+

--- a/scripts/loader_genvk.py
+++ b/scripts/loader_genvk.py
@@ -465,6 +465,8 @@ if __name__ == '__main__':
     from dispatch_table_helper_generator import DispatchTableHelperOutputGenerator, DispatchTableHelperOutputGeneratorOptions
     from helper_file_generator import HelperFileOutputGenerator, HelperFileOutputGeneratorOptions
     from loader_extension_generator import LoaderExtensionOutputGenerator, LoaderExtensionGeneratorOptions
+    # Temporary workaround for vkconventions python2 compatibility
+    import abc; abc.ABC = abc.ABCMeta('ABC', (object,), {})
     from vkconventions import VulkanConventions
 
     # This splits arguments which are space-separated lists


### PR DESCRIPTION
Add support for GN, Google's meta-build system for Ninja: https://gn.googlesource.com/gn/
- Pull GN build into the repo to ease update process for consumers of Vulkan-Loader who use GN.
- Add a non-blocking Travis CI job to monitor for breakages