### PR TITLE
Revert "build: Update cmake_minimum_required(VERSION 3.11.3)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 3.11.3)
+cmake_minimum_required(VERSION 3.4)
 
 # Apple: Must be set before enable_language() or project() as it may influence configuration of the toolchain and flags.
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment version")


### PR DESCRIPTION
This reverts PR https://github.com/KhronosGroup/Vulkan-Loader/pull/184 and its commit 
 124130ec3b181b2bb8a3c1cb0abe6d7259f995e2 which was push prematurely.
