### PR TITLE
cmake: Use CMake 3.10.2 for CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,15 +17,16 @@ os:
 environment:
   PYTHON_PATH: "C:/Python35"
   PYTHON_PACKAGE_PATH: "C:/Python35/Scripts"
+  CMAKE_URL: "http://cmake.org/files/v3.10/cmake-3.10.2-win64-x64.zip"
 
 branches:
   only:
     - master
 
-# Install desired CMake version 3.10.2 before any other building
 install:
-  - choco upgrade cmake --version 3.10.2
-  - set path=C:\Program Files\CMake\bin;%path%
+  - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
+  - 7z x cmake.zip -oC:\cmake > nul
+  - set path=C:\cmake\bin;%path%
   - cmake --version
 
 before_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,12 @@ branches:
   only:
     - master
 
+# Install desired CMake version 3.10.2 before any other building
+install:
+  - choco upgrade cmake --version 3.10.2
+  - set path=C:\Program Files\CMake\bin;%path%
+  - cmake --version
+
 before_build:
   - "SET PATH=C:\\Python35;C:\\Python35\\Scripts;%PATH%"
   - echo.

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,18 @@ cache: ccache
 
 before_install:
   - set -e
+  - CMAKE_VERSION=3.10.2
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      # Upgrade to the desired version of CMake
+      CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+      echo CMAKE_URL=${CMAKE_URL}
+      mkdir cmake-${CMAKE_VERSION} && travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake-${CMAKE_VERSION}
+      export PATH=${PWD}/cmake-${CMAKE_VERSION}/bin:${PATH}
+    else
+      brew install cmake || brew upgrade cmake
+    fi
+    cmake --version
   - unset -f cd pushd popd
   - |
     if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,6 @@ script:
 notifications:
   email:
     recipients:
-      - karl@lunarg.com
       - lenny@lunarg.com
     on_success: change
     on_failure: always


### PR DESCRIPTION
These changes ensure that the Travis and AppVeyor
builds use a known version of CMake.