### PR TITLE
build: Update known-good for 1.1.108 header

### DIFF
--- a/loader/extension_manual.c
+++ b/loader/extension_manual.c
@@ -398,7 +398,6 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfacePresentModes2E
     }
     return icd_term->dispatch.GetPhysicalDeviceSurfacePresentModes2EXT(phys_dev_term->phys_dev, pSurfaceInfo, pPresentModeCount, pPresentModes);
 }
-#endif // VK_USE_PLATFORM_WIN32_KHR
 
 VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModes2EXT(
     VkDevice                                    device,
@@ -429,3 +428,5 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDeviceGroupSurfacePresentModes2EXT(
     }
     return VK_SUCCESS;
 }
+
+#endif  // VK_USE_PLATFORM_WIN32_KHR

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "Vulkan-Headers",
       "build_dir" : "Vulkan-Headers/build",
       "install_dir" : "Vulkan-Headers/build/install",
-      "commit" : "v1.1.107"
+      "commit" : "v1.1.108"
     }
   ],
   "install_names" : {


### PR DESCRIPTION
Additionally, moved platform guards to surround
`GetPhysicalDeviceSurfacePresentModes2EXT`

Platform guards did not surround opening and closing curly braces in
`loader_extension_generator.py`