### PR TITLE
Set enable_testing in cmake file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment ve
 
 project(Vulkan-Loader)
 
+enable_testing()
+
 add_definitions(-DAPI_NAME="Vulkan")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,8 @@
 # ~~~
 
 add_executable(vk_loader_validation_tests loader_validation_tests.cpp)
+add_test(NAME vk_loader_validation_tests COMMAND vk_loader_validation_tests)
+
 set_target_properties(vk_loader_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
 if(UNIX)
     set_target_properties(vk_loader_validation_tests PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")


### PR DESCRIPTION
This CL adds the enable_testing() cmake call and registers
vk_loader_validation_tests as a test in cmake.

This allows the test to be run when `ctest` is executed.