### PR TITLE
loader: Call through layers for device extensions

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -6756,11 +6756,56 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateDeviceExtensionProperties(VkP
     struct loader_extension_list all_exts = {0};
     struct loader_extension_list icd_exts = {0};
 
-    assert(pLayerName == NULL || strlen(pLayerName) == 0);
-
     // Any layer or trampoline wrapping should be removed at this point in time can just cast to the expected
     // type for VkPhysicalDevice.
     phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
+
+    // if we got here with a non-empty pLayerName, look up the extensions
+    // from the json
+    if (pLayerName != NULL && strlen(pLayerName) > 0) {
+        uint32_t count;
+        uint32_t copy_size;
+        const struct loader_instance *inst = phys_dev_term->this_icd_term->this_instance;
+        struct loader_device_extension_list *dev_ext_list = NULL;
+        struct loader_device_extension_list local_ext_list;
+        memset(&local_ext_list, 0, sizeof(local_ext_list));
+        if (vk_string_validate(MaxLoaderStringLength, pLayerName) == VK_STRING_ERROR_NONE) {
+            for (uint32_t i = 0; i < inst->instance_layer_list.count; i++) {
+                struct loader_layer_properties *props = &inst->instance_layer_list.list[i];
+                if (strcmp(props->info.layerName, pLayerName) == 0) {
+                    dev_ext_list = &props->device_extension_list;
+                }
+            }
+
+            count = (dev_ext_list == NULL) ? 0 : dev_ext_list->count;
+            if (pProperties == NULL) {
+                *pPropertyCount = count;
+                loader_destroy_generic_list(inst, (struct loader_generic_list *)&local_ext_list);
+                loader_platform_thread_unlock_mutex(&loader_lock);
+                return VK_SUCCESS;
+            }
+
+            copy_size = *pPropertyCount < count ? *pPropertyCount : count;
+            for (uint32_t i = 0; i < copy_size; i++) {
+                memcpy(&pProperties[i], &dev_ext_list->list[i].props, sizeof(VkExtensionProperties));
+            }
+            *pPropertyCount = copy_size;
+
+            loader_destroy_generic_list(inst, (struct loader_generic_list *)&local_ext_list);
+            if (copy_size < count) {
+                loader_platform_thread_unlock_mutex(&loader_lock);
+                return VK_INCOMPLETE;
+            }
+        } else {
+            loader_log(inst, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                       "vkEnumerateDeviceExtensionProperties:  pLayerName "
+                       "is too long or is badly formed");
+            loader_platform_thread_unlock_mutex(&loader_lock);
+            return VK_ERROR_EXTENSION_NOT_PRESENT;
+        }
+
+        return VK_SUCCESS;
+    }
 
     // This case is during the call down the instance chain with pLayerName == NULL
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -778,61 +778,17 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionPropertie
                                                                                   VkExtensionProperties *pProperties) {
     VkResult res = VK_SUCCESS;
     struct loader_physical_device_tramp *phys_dev;
+    const VkLayerInstanceDispatchTable *disp;
     phys_dev = (struct loader_physical_device_tramp *)physicalDevice;
 
     loader_platform_thread_lock_mutex(&loader_lock);
 
-    // If pLayerName == NULL, then querying ICD extensions, pass this call
-    // down the instance chain which will terminate in the ICD. This allows
-    // layers to filter the extensions coming back up the chain.
-    // If pLayerName != NULL then get layer extensions from manifest file.
-    if (pLayerName == NULL || strlen(pLayerName) == 0) {
-        const VkLayerInstanceDispatchTable *disp;
-
-        disp = loader_get_instance_layer_dispatch(physicalDevice);
-        res = disp->EnumerateDeviceExtensionProperties(phys_dev->phys_dev, NULL, pPropertyCount, pProperties);
-    } else {
-        uint32_t count;
-        uint32_t copy_size;
-        const struct loader_instance *inst = phys_dev->this_instance;
-        struct loader_device_extension_list *dev_ext_list = NULL;
-        struct loader_device_extension_list local_ext_list;
-        memset(&local_ext_list, 0, sizeof(local_ext_list));
-        if (vk_string_validate(MaxLoaderStringLength, pLayerName) == VK_STRING_ERROR_NONE) {
-            for (uint32_t i = 0; i < inst->instance_layer_list.count; i++) {
-                struct loader_layer_properties *props = &inst->instance_layer_list.list[i];
-                if (strcmp(props->info.layerName, pLayerName) == 0) {
-                    dev_ext_list = &props->device_extension_list;
-                }
-            }
-
-            count = (dev_ext_list == NULL) ? 0 : dev_ext_list->count;
-            if (pProperties == NULL) {
-                *pPropertyCount = count;
-                loader_destroy_generic_list(inst, (struct loader_generic_list *)&local_ext_list);
-                loader_platform_thread_unlock_mutex(&loader_lock);
-                return VK_SUCCESS;
-            }
-
-            copy_size = *pPropertyCount < count ? *pPropertyCount : count;
-            for (uint32_t i = 0; i < copy_size; i++) {
-                memcpy(&pProperties[i], &dev_ext_list->list[i].props, sizeof(VkExtensionProperties));
-            }
-            *pPropertyCount = copy_size;
-
-            loader_destroy_generic_list(inst, (struct loader_generic_list *)&local_ext_list);
-            if (copy_size < count) {
-                loader_platform_thread_unlock_mutex(&loader_lock);
-                return VK_INCOMPLETE;
-            }
-        } else {
-            loader_log(inst, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
-                       "vkEnumerateDeviceExtensionProperties:  pLayerName "
-                       "is too long or is badly formed");
-            loader_platform_thread_unlock_mutex(&loader_lock);
-            return VK_ERROR_EXTENSION_NOT_PRESENT;
-        }
-    }
+    // always pass this call down the instance chain which will terminate
+    // in the ICD. This allows layers to filter the extensions coming back
+    // up the chain. In the terminator we look up layer extensions from the
+    // manifest file if it wasn't provided by the layer itself.
+    disp = loader_get_instance_layer_dispatch(physicalDevice);
+    res = disp->EnumerateDeviceExtensionProperties(phys_dev->phys_dev, pLayerName, pPropertyCount, pProperties);
 
     loader_platform_thread_unlock_mutex(&loader_lock);
     return res;


### PR DESCRIPTION
At the moment for `pLayerName==NULL` in `vkEnumerateDeviceExtensionProperties` the loader calls down the layer chain to allow layers to optionally filter the results before it gets to the application. However this doesn't happen for other values of `pLayerName` and the loader looks up the JSON directly to return the results.

This PR changes that so that it always calls down the layer chain and does the JSON lookup logic in the terminator instead. That way layers are always included in the enumeration process and have the ability to filter extensions provided by layers.