### PR TITLE
Find ICDs via WDK queries

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ version: "{build}"
 max_jobs: 4
 
 os:
-  - Visual Studio 2013
+  - Visual Studio 2017
 
 environment:
   PYTHON_PATH: "C:/Python35"
@@ -31,6 +31,11 @@ install:
 
 before_build:
   - "SET PATH=C:\\Python35;C:\\Python35\\Scripts;%PATH%"
+  # vcvars32.bat will override the platform ennvar, so we need to reset it or else appveyor dies
+  - "SET APPVEYOR_PLATFORM=%PLATFORM%"
+  - if %APPVEYOR_PLATFORM% == x64 (call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat")
+  - if %APPVEYOR_PLATFORM% == Win32 (call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat")
+  - "SET PLATFORM=%APPVEYOR_PLATFORM%"
   - echo.
   - echo Starting build for %APPVEYOR_REPO_NAME%
   # Install dependencies

--- a/BUILD.md
+++ b/BUILD.md
@@ -71,6 +71,15 @@ contains the Vulkan API definition files (registry) that are required to build
 the loader. You must also take note of the headers install directory and pass
 it on the CMake command line for building this repository, as described below.
 
+#### Windows Driver Kit (WDK)
+
+On Windows builds, the loader needs to have a WDK installed. Microsoft provides
+[WDK releases](https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk),
+including several old releases. The installed WDK must be at least version 1709.
+Take note of the fact that the latest WDK release generally requires the latest
+version of Visual Studio. It may be necessary to use an older WDK with an older
+Visual Studio.
+
 #### Google Test
 
 The loader tests depend on the [Google Test](https://github.com/google/googletest)
@@ -179,11 +188,12 @@ CMake to generate the native platform files.
   - Any Personal Computer version supported by Microsoft
 - Microsoft [Visual Studio](https://www.visualstudio.com/)
   - Versions
-    - [2013 (update 4)](https://www.visualstudio.com/vs/older-downloads/)
     - [2015](https://www.visualstudio.com/vs/older-downloads/)
-    - [2017](https://www.visualstudio.com/vs/downloads/)
+    - [2017](https://www.visualstudio.com/vs/older-downloads/)
+    - [2019](https://www.visualstudio.com/vs/downloads/)
   - The Community Edition of each of the above versions is sufficient, as
     well as any more capable edition.
+- [Windows Driver Kit](https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk) 1803 or later
 - CMake: Continuous integration tools use [CMake 3.12.2](https://github.com/Kitware/CMake/releases/tag/v3.12.2) for Windows
   - Use the installer option to add CMake to the system PATH
 - Git Client Support
@@ -202,6 +212,8 @@ work with the solution interactively.
 
 #### Windows Quick Start
 
+Open a developer command prompt and enter:
+
     cd Vulkan-Loader
     mkdir build
     cd build
@@ -212,6 +224,13 @@ The above commands instruct CMake to find and use the default Visual Studio
 installation to generate a Visual Studio solution and projects for the x64
 architecture. The second CMake command builds the Debug (default)
 configuration of the solution.
+
+Note that if you do not wish to use a developer command prompt, you may either
+run either `vcvars64.bat` or `vcvars32.bat` to set the required environment
+variables. You may also define a `WDK_FULL_PATH` variable when first invoking CMake
+like:
+
+    cmake -A x64 --DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir -DWDK_BASE="C:/Program Files (x86)/Windows Kits/10/Include/10.0.17763.0" ..
 
 See below for the details.
 
@@ -324,9 +343,12 @@ include:
 
 | Build Platform               | 64-bit Generator              | 32-bit Generator        |
 |------------------------------|-------------------------------|-------------------------|
-| Microsoft Visual Studio 2013 | "Visual Studio 12 2013 Win64" | "Visual Studio 12 2013" |
 | Microsoft Visual Studio 2015 | "Visual Studio 14 2015 Win64" | "Visual Studio 14 2015" |
 | Microsoft Visual Studio 2017 | "Visual Studio 15 2017 Win64" | "Visual Studio 15 2017" |
+| Microsoft Visual Studio 2019 | "Visual Studio 16 2019"       | "Visual Studio 16 2019" |
+
+Note that with Visual Studio 2019, the architecture will need to be specified with the `-A`
+flag for 64-bit builds.
 
 #### Using The Vulkan Loader Library in this Repository on Windows
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ if(UNIX AND NOT APPLE) # i.e.: Linux
 endif()
 
 if(WIN32)
+    find_package(WDK REQUIRED)
     option(ENABLE_WIN10_ONECORE "Link the loader with OneCore umbrella libraries" OFF)
     option(ENABLE_STATIC_LOADER "Build the loader as a static library" OFF)
 endif()

--- a/cmake/FindWDK.cmake
+++ b/cmake/FindWDK.cmake
@@ -1,0 +1,65 @@
+
+#.rst:
+# FindWDK
+# -----------------
+#
+# Try to find headers in the Windows Driver Kit
+#
+# This module is intended to be used by the Vulkan loader to locate
+# the required headers from the Windows Driver Kit. This should not
+# be considered feature complete for other uses, as it is only
+# intended for the Vulkan loader.
+#
+# By default, this module uses environment variables to try to find an
+# installed WDK. These environment variables are present in a developer
+# command prompt, or can be set by running vcvarsall.bat (which comes
+# with a Visual Studio installation.
+#
+# If a user wants to override the default behavior, or not set the
+# needed environment variables, they may also specify one or more of
+# the following CMake variables:
+#
+#   WDK_FULL_PATH       - Attempts to find a WDK in the given path. No
+#                         other environment or CMake variable will have
+#                         any effect if this is set.
+#   WDK_BASE            - Sets the base path for the Windows Kit to use.
+#                         This should be the path one level up from the
+#                         "Include" directory.
+#   WDK_VERSION         - Sets the version of the Windows Kit to use.
+#
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines no IMPORTED targets
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following variables::
+#
+#   WDK_FOUND                    - True if the WDK was found
+#   WDK_INCLUDE_DIRS             - include directories for the WDK
+#
+
+if(NOT DEFINED WDK_FULL_PATH)
+    if(NOT DEFINED WDK_BASE)
+        set(WDK_BASE "$ENV{UniversalCRTSdkDir}")
+    endif()
+    if(NOT DEFINED WDK_VERSION)
+        set(WDK_VERSION "$ENV{UCRTVersion}")
+        string(REPLACE \\ "" WDK_VERSION "${WDK_VERSION}")
+    endif()
+    set(WDK_FULL_PATH "${WDK_BASE}/Include/${WDK_VERSION}")
+endif()
+
+find_path(WDK_VERSION_INCLUDE_DIR
+    NAMES km/d3dkmthk.h shared/d3dkmdt.h
+    PATHS "${WDK_FULL_PATH}"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WDK DEFAULT_MSG WDK_VERSION_INCLUDE_DIR)
+
+if(WDK_FOUND)
+    set(WDK_INCLUDE_DIRS "${WDK_VERSION_INCLUDE_DIR}/km" "${WDK_VERSION_INCLUDE_DIR}/shared")
+endif()

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -187,6 +187,7 @@ if(WIN32)
     target_compile_options(loader-norm PUBLIC "$<$<CONFIG:DEBUG>:${LOCAL_C_FLAGS_DBG}>")
     target_compile_options(loader-norm PUBLIC ${MSVC_LOADER_COMPILE_OPTIONS})
     target_include_directories(loader-norm PRIVATE "$<TARGET_PROPERTY:Vulkan::Headers,INTERFACE_INCLUDE_DIRECTORIES>")
+    target_include_directories(loader-norm PRIVATE "${WDK_INCLUDE_DIRS}")
 
     add_library(loader-opt OBJECT ${OPT_LOADER_SRCS})
     add_dependencies(loader-opt generate_helper_files loader_gen_files loader_asm_gen_files)

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -207,7 +207,12 @@ static inline void loader_platform_thread_cond_broadcast(loader_platform_thread_
 static inline const char *LoaderPnpDriverRegistry() {
     BOOL is_wow;
     IsWow64Process(GetCurrentProcess(), &is_wow);
-    return is_wow ? (API_NAME "DriverNameWow") : (API_NAME "DriverName");
+    return is_wow ? "VulkanDriverNameWow" : "VulkanDriverName";
+}
+static inline const wchar_t *LoaderPnpDriverRegistryWide() {
+    BOOL is_wow;
+    IsWow64Process(GetCurrentProcess(), &is_wow);
+    return is_wow ? L"VulkanDriverNameWow" : L"VulkanDriverName";
 }
 
 // Get the key for the plug 'n play explicit layer registry
@@ -215,15 +220,25 @@ static inline const char *LoaderPnpDriverRegistry() {
 static inline const char *LoaderPnpELayerRegistry() {
     BOOL is_wow;
     IsWow64Process(GetCurrentProcess(), &is_wow);
-    return is_wow ? (API_NAME "ExplicitLayersWow") : (API_NAME "ExplicitLayers");
+    return is_wow ? "VulkanExplicitLayersWow" : "VulkanExplicitLayers";
 }
+static inline const wchar_t *LoaderPnpELayerRegistryWide() {
+    BOOL is_wow;
+    IsWow64Process(GetCurrentProcess(), &is_wow);
+    return is_wow ? L"VulkanExplicitLayersWow" : L"VulkanExplicitLayers";
+}
+
 // Get the key for the plug 'n play implicit layer registry
 // The string returned by this function should NOT be freed
-
 static inline const char *LoaderPnpILayerRegistry() {
     BOOL is_wow;
     IsWow64Process(GetCurrentProcess(), &is_wow);
-    return is_wow ? (API_NAME "ImplicitLayersWow") : (API_NAME "ImplicitLayers");
+    return is_wow ? "VulkanImplicitLayersWow" : "VulkanImplicitLayers";
+}
+static inline const wchar_t *LoaderPnpILayerRegistryWide() {
+    BOOL is_wow;
+    IsWow64Process(GetCurrentProcess(), &is_wow);
+    return is_wow ? L"VulkanImplicitLayersWow" : L"VulkanImplicitLayers";
 }
 #endif
 


### PR DESCRIPTION
This PR adds a new mechanism for finding drivers on Windows. The loader will now try to enumerate adapters via the `D3DKMTEnumAdapters2` method, and then find the driver's JSON manifest through `D3DKMTQueryAdapterInfo` method.

Because those queries are defined in the Windows Driver Kit (WDK), this PR also adds a loader dependency on the WDK (for Windows builds, only). The current mechanism for finding the mechanism requires a developer command prompt to find the WDK automatically. I didn't see any mechanism to find the WDK (or Windows SDK) location without a developer command prompt, but if @jjulianoatnv or someone else knows of a better mechanism, please let me know.