### PR TITLE
build: use CMAKE_DL_LIBS instead of -ldl

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -247,7 +247,7 @@ else()
                                      "1"
                                      VERSION
                                      "${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}")
-    target_link_libraries(vulkan -ldl -lpthread -lm)
+    target_link_libraries(vulkan ${CMAKE_DL_LIBS} -lpthread -lm)
     target_link_libraries(vulkan Vulkan::Headers)
 
     if(APPLE)


### PR DESCRIPTION
e.g. FreeBSD does not use an extra library for dynamic loading, everything is in libc.

CMake provides the [CMAKE_DL_LIBS](https://cmake.org/cmake/help/latest/variable/CMAKE_DL_LIBS.html) variable to handle this. Use it.