### PR TITLE
loader: Fix VK_KHR_surface_protected_capabilities

### DIFF
--- a/loader/extension_manual.c
+++ b/loader/extension_manual.c
@@ -58,6 +58,17 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2K
     uint8_t icd_index = phys_dev_term->icd_index;
 
     if (icd_term->dispatch.GetPhysicalDeviceSurfaceCapabilities2KHR != NULL) {
+        VkBaseOutStructure *pNext = (VkBaseOutStructure *)pSurfaceCapabilities->pNext;
+        while (pNext != NULL) {
+            if ((int)pNext->sType == VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR) {
+                // Not all ICDs may be supporting VK_KHR_surface_protected_capabilities
+                // Initialize VkSurfaceProtectedCapabilitiesKHR.supportsProtected to false and
+                // if an ICD supports protected surfaces, it will reset it to true accordingly.
+                ((VkSurfaceProtectedCapabilitiesKHR *)pNext)->supportsProtected = VK_FALSE;
+            }
+            pNext = (VkBaseOutStructure *)pNext->pNext;
+        }
+
         // Pass the call to the driver, possibly unwrapping the ICD surface
         if (icd_surface->real_icd_surfaces != NULL && (void *)icd_surface->real_icd_surfaces[icd_index] != NULL) {
             VkPhysicalDeviceSurfaceInfo2KHR info_copy = *pSurfaceInfo;


### PR DESCRIPTION
Loader is exposing VK_KHR_surface_protected_capabilities instance
extension support if one of the ICDs supports it.

An ICD, not supporting this extension, will not know about
VkSurfaceProtectedCapabilitiesKHR being passed as additional structure
to VkPhysicalDeviceSurfaceInfo2KHR in vulkan API
vkGetPhysicalDeviceSurfaceCapabilities2KHR().

Reset VkSurfaceProtectedCapabilitiesKHR.supportsProtected to false
always before calling vkGetPhysicalDeviceSurfaceCapabilities2KHR(). If
a particular ICD supports protected surfaces then it will set it
true.

An application will always receive either 1/0 in supportsProtected as
expected.

The issue got exposed through below CTS test failure on a Optimus windows
system with different ICDs versions, one supporting this extension and
another not supporting it.

- dEQP-VK.wsi.win32.surface.query_protected_capabilities