### PR TITLE
Fix for MinGW compiler

### DIFF
--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -334,7 +334,23 @@ static char *loader_platform_get_proc_address_error(const char *name) {
 
 // Threads:
 typedef HANDLE loader_platform_thread;
+
+// __declspec(thread) is not supported by MinGW compiler (ignored with warning or
+//                    cause erorr depending on compiler switches)
+//
+// __thread should be used instead
+//
+// __MINGW32__ defined for both 32 and 64 bit MinGW compilers, so it is enough to
+// detect any (32 or 64) flawor of MinGW compiler.
+//
+// @note __GNUC__ could be used as a more generic way to detect _any_
+//       GCC[-compitible] compiler on Windows, but this fix was tested
+//       only with MinGW, so keep it explicit at the moment.
+#if defined(__MINGW32__)
+#define THREAD_LOCAL_DECL __thread
+#else
 #define THREAD_LOCAL_DECL __declspec(thread)
+#endif
 
 // The once init functionality is not used when building a DLL on Windows. This is because there is no way to clean up the
 // resources allocated by anything allocated by once init. This isn't a problem for static libraries, but it is for dynamic


### PR DESCRIPTION
This should fix compilation with MinGW compiler on Windows platform.

**The problem:**

- Original code use `__declspec(thread)` declaration for Thread Local variables on Windows platform
- MinGW compiler on Windows platform doesn't support  `__declspec(thread)` declaration. In worst case incorrect binary could be generated (warning emitted but compilation complete with no actual TLS support)

**Solution:**

- Detect MinGW compiler via predefined `__MINGW32__` preprocessor definition and use GCC specific `__thread` declaration instead of `__declspec(thread)`

**Note:**

- It is possible to detect virtually _any_ GCC or GCC-compatible compiler via `__GNUC__` preprocessor definition but I have tested only with MinGW, so decided to keep it clear at the moment and check explicitly for MinGW only.