### PR TITLE
Always define VulkanHeaders_INCLUDE_DIRS property under OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(PythonInterp 3 QUIET)
 
 if (TARGET Vulkan::Headers)
     message(STATUS "Using Vulkan headers from Vulkan::Headers target")
+    get_target_property(VulkanHeaders_INCLUDE_DIRS Vulkan::Headers INTERFACE_INCLUDE_DIRECTORIES)
     get_target_property(VulkanRegistry_DIR Vulkan::Registry INTERFACE_INCLUDE_DIRECTORIES)
 else()
     find_package(VulkanHeaders)


### PR DESCRIPTION
Solves ISSUE #210.

The problem lies in the desynchronization of property definitions between the IF-statement and the ELSE-statement branches:
when the IF-statement branch is taken infact `VulkanHeaders_INCLUDE_DIRS` might not be defined at all, while in the ELSE-statement branch it's  the `find_package(VulkanHeaders)` that takes care of defining it.
Check the diff to clearly understand the context.

This Pull Request aims to ensure that the `VulkanHeaders_INCLUDE_DIRS` property is defined regardless of which branch is taken. 