### PR TITLE
Make includes from Windows SDK lowercase for MinGW compat

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -66,9 +66,9 @@
 #include "murmurhash.h"
 
 #if defined(_WIN32)
-#include <Cfgmgr32.h>
+#include <cfgmgr32.h>
 #include <initguid.h>
-#include <Devpkey.h>
+#include <devpkey.h>
 #include <winternl.h>
 #include <d3dkmthk.h>
 

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -25,7 +25,7 @@
 
 #if defined(_WIN32)
 // WinSock2.h must be included *BEFORE* windows.h
-#include <WinSock2.h>
+#include <winsock2.h>
 #endif  // _WIN32
 
 #include "vulkan/vk_platform.h"


### PR DESCRIPTION
MinGW-w64 ships all Windows SDK headers as lowercase, which prevents
cross-compiling this code from Linux.

Windows filesystems are case insensitive so it should work fine with
lowercase includes.

For the reference, I used this simple regex to find occurrences: `"#include [\"<].*[A-Z].*[\">]"`.

On my distro (Mageia 7), the headers are located and named as follows:
```
mingw32-headers:/usr/i686-w64-mingw32/sys-root/mingw/include/cfgmgr32.h
mingw32-headers:/usr/i686-w64-mingw32/sys-root/mingw/include/devpkey.h
mingw32-headers:/usr/i686-w64-mingw32/sys-root/mingw/include/winsock2.h
mingw64-headers:/usr/x86_64-w64-mingw32/sys-root/mingw/include/cfgmgr32.h
mingw64-headers:/usr/x86_64-w64-mingw32/sys-root/mingw/include/devpkey.h
mingw64-headers:/usr/x86_64-w64-mingw32/sys-root/mingw/include/winsock2.h
```

Needed to fix this @godotengine issue: godotengine/godot#31096.