### PR TITLE
loader: allow concurrent layer device creation

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2056,7 +2056,8 @@ struct loader_icd_term *loader_get_icd_and_device(const VkDevice device, struct 
             for (struct loader_device *dev = icd_term->logical_device_list; dev; dev = dev->next)
                 // Value comparison of device prevents object wrapping by layers
                 if (loader_get_dispatch(dev->icd_device) == loader_get_dispatch(device) ||
-                    loader_get_dispatch(dev->chain_device) == loader_get_dispatch(device)) {
+                    (dev->chain_device != VK_NULL_HANDLE &&
+                     loader_get_dispatch(dev->chain_device) == loader_get_dispatch(device))) {
                     *found_dev = dev;
                     if (NULL != icd_index) {
                         *icd_index = index;


### PR DESCRIPTION
This PR fixes a small problem that can be caused when layers create their own `VkDevices`.

The problem occurs when using a layer that works as follows:
```
VkResult LAYER_CreateDevice(....){
  // ...
  VkResult ret = nextCreateDevice(...);
  // ...
  VkResult retNew = layerCreateDevice(...);
  // ...
}
```
Where `LAYER_CreateDevice` is the layer's `CreateDevice` function, `nextCreateDevice` is the next layer's `CreateDevice` and `layerCreateDevice` is the `PFN_vkLayerCreateDevice` callback. The problem is, that the call to `layerCreateDevice` will cause a segfault.

A possible workaround is to swap the `layerCreateDevice` and `nextCreateDevice` calls.

The individual steps that lead to the segfault are:
 * The application calls `vkCreateDevice` https://github.com/KhronosGroup/Vulkan-Loader/blob/a037f81384d3c7d1f621fb5453aa0dda6eb6ac6a/loader/trampoline.c#L753
 * A `loader_device` is allocated: https://github.com/KhronosGroup/Vulkan-Loader/blob/a037f81384d3c7d1f621fb5453aa0dda6eb6ac6a/loader/loader.c#L5416
 * This device is passed as `VkDevice` down the chain through the layers.
   General Note: that's an interesting fact which is not obvious for layer-writers, so that should probably be warned about somewhere. A layer that implements `CreateDevice` like this, will fail:
```
VkResult LAYER_CreateDevice(..., VkDevice *pDevice ) {
   VkDevice next = VK_NULL_HANDLE;
   // ...
   VkResult ret = nextCreateDevice(..., &next);
   *pDevice = next;
   return ret;
}
```
 * The layer invokes `nextCreateDevice` which forwards the call to the terminator. https://github.com/KhronosGroup/Vulkan-Loader/blob/a037f81384d3c7d1f621fb5453aa0dda6eb6ac6a/loader/loader.c#L6276
 * The terminator fills `dev->icd_device` and adds the device to the devices list. https://github.com/KhronosGroup/Vulkan-Loader/blob/a037f81384d3c7d1f621fb5453aa0dda6eb6ac6a/loader/loader.c#L6501
  Note that `dev->chain_device` is `nullptr` at this point.
 * The terminator finishes and the layer continues.
 * The layer invokes `layerCreateDevice`, which triggers a call to `loader_get_icd_and_device`
 * `loader_get_icd_and_device` segfaults, as there is now a device in the list where `dev->chain_device` is `nullptr`.

The problem is that the layer did not yet finish `LAYER_CreateDevice` so the trampoline-part was not invoked yet: https://github.com/KhronosGroup/Vulkan-Loader/blob/a037f81384d3c7d1f621fb5453aa0dda6eb6ac6a/loader/loader.c#L5859
This PR changes the situation by acknowleding that a device might not have `dev->chain_device` set.
