### PR TITLE
Make instance version report patch version

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7101,7 +7101,7 @@ VKAPI_ATTR VkResult VKAPI_CALL
 terminator_EnumerateInstanceVersion(const VkEnumerateInstanceVersionChain *chain, uint32_t* pApiVersion) {
     // NOTE: The Vulkan WG doesn't want us checking pApiVersion for NULL, but instead
     // prefers us crashing.
-    *pApiVersion = VK_MAKE_VERSION(loader_major_version, loader_minor_version, 0);
+    *pApiVersion = VK_MAKE_VERSION(loader_major_version, loader_minor_version, VK_HEADER_VERSION);
     return VK_SUCCESS;
 }
 


### PR DESCRIPTION
The loader previously reported only major/minor version in `vkEnumerateInstanceVersion`. This makes it report the patch version as well.
