### PR TITLE
Remove extra defines from GN build.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -51,7 +51,7 @@ config("vulkan_loader_config") {
     "loader/generated",
     "loader",
   ]
-  defines = [ "API_NAME=\"Vulkan\"" ] + vulkan_loader_extra_defines
+  defines = [ "API_NAME=\"Vulkan\"" ]
 
   if (is_win) {
     cflags = [ "/wd4201" ]

--- a/build-gn/secondary/build_overrides/vulkan_loader.gni
+++ b/build-gn/secondary/build_overrides/vulkan_loader.gni
@@ -19,6 +19,5 @@ vulkan_headers_dir = "//external/Vulkan-Headers"
 vulkan_gen_subdir = "" 
 
 # Vulkan loader build options
-vulkan_loader_extra_defines = []
 vulkan_loader_shared = true
 


### PR DESCRIPTION
No longer needed with updated ANGLE/Chromium integration.

See http://anglebug.com/3320 for more context.

@tobine can you forward this to the right folks?