### PR TITLE
Match ICDs against DXGI adapters

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -213,10 +213,10 @@ if(WIN32)
     endif()
 
     if(ENABLE_WIN10_ONECORE)
-        target_link_libraries(vulkan OneCoreUAP.lib LIBCMT.LIB LIBCMTD.LIB LIBVCRUNTIME.LIB LIBUCRT.LIB)
+        target_link_libraries(vulkan OneCoreUAP.lib LIBCMT.LIB LIBCMTD.LIB LIBVCRUNTIME.LIB LIBUCRT.LIB Dxgi)
         set_target_properties(vulkan PROPERTIES LINK_FLAGS "/NODEFAULTLIB")
     else()
-        target_link_libraries(vulkan Cfgmgr32)
+        target_link_libraries(vulkan Cfgmgr32 Dxgi)
     endif()
 
     add_dependencies(vulkan loader_asm_gen_files)


### PR DESCRIPTION
Previously, ICDs located through the HKLM registry would be loaded all the time. This changes the loader to iterate DXGI adapters and only loader the driver is there is an adapter that it corresponds to. This is aimed at solving one of the crashes discussed in #182.