### PR TITLE
Allow Vulkan Headers to be in external/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ external/*
 .vscode/
 .DS_Store
 _out64
+out/
 out32/*
 out64/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@ add_definitions(-DAPI_NAME="Vulkan")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(PythonInterp 3 QUIET)
 
+if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/external/Vulkan-Headers")
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/Vulkan-Headers)
+endif()
+
 if (TARGET Vulkan::Headers)
     message(STATUS "Using Vulkan headers from Vulkan::Headers target")
     get_target_property(VulkanHeaders_INCLUDE_DIRS Vulkan::Headers INTERFACE_INCLUDE_DIRECTORIES)
@@ -133,7 +137,7 @@ else()
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-    set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-stringop-truncation -Wno-stringop-overflow")
+    set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-stringop-truncation -Wno-stringop-overflow -Wno-unknown-warning-option")
     set(COMMON_COMPILE_FLAGS "${COMMON_COMPILE_FLAGS} -fno-strict-aliasing -fno-builtin-memcmp")
 
     # For GCC version 7.1 or greater, we need to disable the implicit fallthrough warning since there's no consistent way to satisfy

--- a/external/README.md
+++ b/external/README.md
@@ -1,9 +1,10 @@
 # External dependencies
 
 This directory provides a location where external projects can be cloned that are used by the loader.
-Currently, the only project that can be used by the loader is Google Test.
-It can be enabled by cloning it here like:
+
+They can be enabled by cloning it here like:
 
 ```
-git clone https://github.com/google/googletest.git
+git clone https://github.com/google/googletest
+git clone https://github.com/KhronosGroup/Vulkan-Headers
 ```


### PR DESCRIPTION
This CL adds a check for Vulkan-Headers in the external/ folder and
uses it to build instead of looking for the SDK.