### PR TITLE
Change CMake paths for asm_offset.

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -164,7 +164,7 @@ else(UNIX AND NOT APPLE) # i.e.: Linux
         set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas.S)
         add_executable(asm_offset asm_offset.c)
         target_link_libraries(asm_offset Vulkan::Headers)
-        add_custom_command(OUTPUT gen_defines.asm DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/asm_offset COMMAND ${CMAKE_CURRENT_BINARY_DIR}/asm_offset GAS)
+        add_custom_command(OUTPUT gen_defines.asm DEPENDS asm_offset COMMAND asm_offset GAS)
         add_custom_target(loader_asm_gen_files DEPENDS gen_defines.asm)
     else()
         message(WARNING "Could not find working x86 GAS assembler\n${ASM_FAILURE_MSG}")


### PR DESCRIPTION
The current Unix configuration for the asm_offset program uses the
CMAKE_CURRENT_BINARY_DIR as the path prefix. This breaks if the loaders
are used in a third_party repository. This CL removes the path prefixes
from the asm_offset command, which makes it the same as how Windows is
configured.