### PR TITLE
Add support for VK_EXT_metal_surface

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -38,6 +38,7 @@ elseif(ANDROID)
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
 elseif(APPLE)
     add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
+    add_definitions(-DVK_USE_PLATFORM_METAL_EXT)
 elseif(UNIX AND NOT APPLE) # i.e.: Linux
     if(BUILD_WSI_XCB_SUPPORT)
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR)

--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -3051,28 +3051,6 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateImagePipeSurfaceFUCHSIA(
 
 #endif // VK_USE_PLATFORM_FUCHSIA
 
-// ---- VK_EXT_metal_surface extension trampoline/terminators
-
-#ifdef VK_USE_PLATFORM_METAL_EXT
-VKAPI_ATTR VkResult VKAPI_CALL CreateMetalSurfaceEXT(
-    VkInstance                                  instance,
-    const VkMetalSurfaceCreateInfoEXT*          pCreateInfo,
-    const VkAllocationCallbacks*                pAllocator,
-    VkSurfaceKHR*                               pSurface) {
-#error("Not implemented. Likely needs to be manually generated!");
-    return disp->CreateMetalSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface);
-}
-
-VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateMetalSurfaceEXT(
-    VkInstance                                  instance,
-    const VkMetalSurfaceCreateInfoEXT*          pCreateInfo,
-    const VkAllocationCallbacks*                pAllocator,
-    VkSurfaceKHR*                               pSurface) {
-#error("Not implemented. Likely needs to be manually generated!");
-}
-
-#endif // VK_USE_PLATFORM_METAL_EXT
-
 // ---- VK_EXT_buffer_device_address extension trampoline/terminators
 
 VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
@@ -3979,16 +3957,6 @@ bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *na
     }
 #endif // VK_USE_PLATFORM_FUCHSIA
 
-    // ---- VK_EXT_metal_surface extension commands
-#ifdef VK_USE_PLATFORM_METAL_EXT
-    if (!strcmp("vkCreateMetalSurfaceEXT", name)) {
-        *addr = (ptr_instance->enabled_known_extensions.ext_metal_surface == 1)
-                     ? (void *)CreateMetalSurfaceEXT
-                     : NULL;
-        return true;
-    }
-#endif // VK_USE_PLATFORM_METAL_EXT
-
     // ---- VK_EXT_buffer_device_address extension commands
     if (!strcmp("vkGetBufferDeviceAddressEXT", name)) {
         *addr = (void *)GetBufferDeviceAddressEXT;
@@ -4114,12 +4082,6 @@ void extensions_create_instance(struct loader_instance *ptr_instance, const VkIn
         } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_FUCHSIA_IMAGEPIPE_SURFACE_EXTENSION_NAME)) {
             ptr_instance->enabled_known_extensions.fuchsia_imagepipe_surface = 1;
 #endif // VK_USE_PLATFORM_FUCHSIA
-
-    // ---- VK_EXT_metal_surface extension commands
-#ifdef VK_USE_PLATFORM_METAL_EXT
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_METAL_SURFACE_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.ext_metal_surface = 1;
-#endif // VK_USE_PLATFORM_METAL_EXT
         }
     }
 }

--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -437,7 +437,6 @@ union loader_instance_extension_enables {
         uint8_t ext_display_surface_counter : 1;
         uint8_t ext_debug_utils : 1;
         uint8_t fuchsia_imagepipe_surface : 1;
-        uint8_t ext_metal_surface : 1;
     };
     uint64_t padding[4];
 };

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -333,6 +333,9 @@ struct loader_instance {
     bool wsi_ios_surface_enabled;
 #endif
     bool wsi_headless_surface_enabled;
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+    bool wsi_metal_surface_enabled;
+#endif
     bool wsi_display_enabled;
     bool wsi_display_props2_enabled;
 };

--- a/loader/wsi.h
+++ b/loader/wsi.h
@@ -42,6 +42,9 @@ typedef struct {
 #ifdef VK_USE_PLATFORM_MACOS_MVK
         VkIcdSurfaceMacOS macos_surf;
 #endif  // VK_USE_PLATFORM_MACOS_MVK
+#ifdef VK_USE_PLATFORM_METAL_EXT
+        VkIcdSurfaceMetal metal_surf;
+#endif // VK_USE_PLATFORM_METAL_EXT
         VkIcdSurfaceDisplay display_surf;
         VkIcdSurfaceHeadless headless_surf;
     };
@@ -125,6 +128,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateMacOSSurfaceMVK(VkInstance insta
 #ifdef VK_USE_PLATFORM_IOS_MVK
 VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateIOSSurfaceMVK(VkInstance instance, const VkIOSSurfaceCreateInfoMVK *pCreateInfo,
                                                               const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface);
+#endif
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateMetalSurfaceEXT(VkInstance instance, const VkMetalSurfaceCreateInfoEXT *pCreateInfo,
+                                                                const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface);
 #endif
 VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDevice physicalDevice,
                                                                                 uint32_t *pPropertyCount,

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "Vulkan-Headers",
       "build_dir" : "Vulkan-Headers/build",
       "install_dir" : "Vulkan-Headers/build/install",
-      "commit" : "v1.1.123"
+      "commit" : "ba091ba6a947f79623b28fe8bfccdce1ab9fa467"
     }
   ],
   "install_names" : {

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -37,6 +37,7 @@ WSI_EXT_NAMES = ['VK_KHR_surface',
                  'VK_MVK_macos_surface',
                  'VK_MVK_ios_surface',
                  'VK_EXT_headless_surface',
+                 'VK_EXT_metal_surface',
                  'VK_KHR_swapchain',
                  'VK_KHR_display_swapchain',
                  'VK_KHR_get_display_properties2']


### PR DESCRIPTION
This PR adds support for the `VK_EXT_metal_surface` extension. This extension is treated like the other WSI extensions in that surface create is handled by the loader unless a driver implements Loader/ICD interface version 3 or later, and the driver also implements the `vkCreateMetalSurfaceKHR` extension. In that situation, the driver will handle surface creation.

Note that this PR depends on a change in Vulkan-Headers (KhronosGroup/Vulkan-Headers#80). I put the WIP label in this PR's title to reference the fact that this should not be merged until the corresponding headers PR is merged.

This fixes #207.