### PR TITLE
loader/CMakeList.txt: fix execution of asm_offset (again)

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -164,7 +164,7 @@ else(UNIX AND NOT APPLE) # i.e.: Linux
         set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas.S)
         add_executable(asm_offset asm_offset.c)
         target_link_libraries(asm_offset Vulkan::Headers)
-        add_custom_command(OUTPUT gen_defines.asm DEPENDS asm_offset COMMAND asm_offset GAS)
+        add_custom_command(OUTPUT gen_defines.asm DEPENDS asm_offset COMMAND ./asm_offset GAS)
         add_custom_target(loader_asm_gen_files DEPENDS gen_defines.asm)
     else()
         message(WARNING "Could not find working x86 GAS assembler\n${ASM_FAILURE_MSG}")


### PR DESCRIPTION
As https://github.com/KhronosGroup/Vulkan-Loader/pull/239 break cross-compile again this could also be a solution. As long as `asm_offset` is not placed in your SYSROOT of a toolchain or buildsystem it will fail to compile.

```
[3/15] Generating gen_defines.asm
FAILED: loader/gen_defines.asm 
cd /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/vulkan-loader-1.1.123/.x86_64-libreelec-linux-gnu/loader && asm_offset GAS
/bin/sh: 1: asm_offset: not found
ninja: build stopped: subcommand failed.
```

Also I don't get what the actual problem with `${CMAKE_CURRENT_BINARY_DIR}` is because it's used here several times too https://github.com/KhronosGroup/Vulkan-Loader/blob/master/loader/CMakeLists.txt#L158-L162
```
file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/asm_test.S
               ".intel_syntax noprefix\n.text\n.global sample\nsample:\nmov ecx, [eax + 16]\n")
    set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
    try_compile(ASSEMBLER_WORKS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/asm_test.S)
    file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/asm_test.S)
```
---
And according to https://cmake.org/cmake/help/v3.0/variable/CMAKE_CURRENT_BINARY_DIR.html
it just adds the full path to the currently executed binary.
```
The path to the binary directory currently being processed.

This the full path to the build directory that is currently being processed by cmake. Each directory added by add_subdirectory will create a binary directory in the build tree, and as it is being processed this variable will be set. For in-source builds this is the current source directory being processed.
```
---
Either use `${CMAKE_CURRENT_BINARY_DIR}/asm_offset` or `./asm_offset` install it to a proper `SYSROOT` or use an absolute path etc.

---
Buildlog:
```
BUILD      vulkan-loader (target)
    TOOLCHAIN      cmake (auto-detect)
Executing (target): cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE=/home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/etc/cmake-x86_64-libreelec-linux-gnu.conf -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=Off -DBUILD_WSI_WAYLAND_SUPPORT=Off /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/vulkan-loader-1.1.123
-- The C compiler identification is GNU 9.2.0
-- The CXX compiler identification is GNU 9.2.0
-- Check for working C compiler: /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc
-- Check for working C compiler: /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++
-- Check for working CXX compiler: /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found VulkanHeaders: /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include  
-- Found VulkanRegistry: /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/share/vulkan/registry  
-- Detected Vulkan Version 1.1.123
-- Found PkgConfig: /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/bin/pkg-config (found version "0.29.2") 
-- Found xcb: /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include  
-- Found X11: /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include   
-- Looking for XOpenDisplay in /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libX11.so;/home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libXext.so
-- Looking for XOpenDisplay in /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libX11.so;/home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Looking for secure_getenv
-- Looking for secure_getenv - found
-- Looking for __secure_getenv
-- Looking for __secure_getenv - not found
-- The ASM compiler identification is GNU
-- Found assembler: /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc
-- Looking for cet.h
-- Looking for cet.h - found
-- Configuring done
-- Generating done
-- Build files have been written to: /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/vulkan-loader-1.1.123/.x86_64-libreelec-linux-gnu
Executing (target): ninja 
[3/15] Generating gen_defines.asm
FAILED: loader/gen_defines.asm 
cd /home/supervisedthinking/git/libreelec-rr/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.80-devel/vulkan-loader-1.1.123/.x86_64-libreelec-linux-gnu/loader && asm_offset GAS
/bin/sh: 1: asm_offset: not found
ninja: build stopped: subcommand failed.
```