### PR TITLE
Only use secure getenv for finding layers

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1785,7 +1785,7 @@ bool loaderImplicitLayerIsEnabled(const struct loader_instance *inst, const stru
         enable = true;
     } else {
         // Otherwise, only enable this layer if the enable environment variable is defined
-        env_value = loader_secure_getenv(prop->enable_env_var.name, inst);
+        env_value = loader_getenv(prop->enable_env_var.name, inst);
         if (env_value && !strcmp(prop->enable_env_var.value, env_value)) {
             enable = true;
         }
@@ -1794,7 +1794,7 @@ bool loaderImplicitLayerIsEnabled(const struct loader_instance *inst, const stru
 
     // The disable_environment has priority over everything else.  If it is defined, the layer is always
     // disabled.
-    env_value = loader_secure_getenv(prop->disable_env_var.name, inst);
+    env_value = loader_getenv(prop->disable_env_var.name, inst);
     if (env_value) {
         enable = false;
     }
@@ -5399,7 +5399,7 @@ static void loaderAddEnvironmentLayers(struct loader_instance *inst, const enum 
                                        struct loader_layer_list *target_list, struct loader_layer_list *expanded_target_list,
                                        const struct loader_layer_list *source_list) {
     char *next, *name;
-    char *layer_env = loader_secure_getenv(env_name, inst);
+    char *layer_env = loader_getenv(env_name, inst);
     if (layer_env == NULL) {
         goto out;
     }


### PR DESCRIPTION
This fixes #266.

Currently, the loader will not read most envars when an application is run with administrator or root privileges. This is done for security purposes, so that an application run with elevated permissions will not run a library that did not require elevated permissions to be installed. This PR changes that behavior so that only environment variables that are used to locate layers or drivers are disabled in that case. It allows using environment variables to enabled/disable layers that are already installed.