### PR TITLE
loader: move asm_test.S into file; Make more complicated

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -155,11 +155,8 @@ else(UNIX AND NOT APPLE) # i.e.: Linux
     if(HAVE_CET_H)
         set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS HAVE_CET_H)
     endif()
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/asm_test.S
-               ".intel_syntax noprefix\n.text\n.global sample\nsample:\nmov ecx, [eax + 16]\n")
     set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-    try_compile(ASSEMBLER_WORKS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/asm_test.S)
-    file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/asm_test.S)
+    try_compile(ASSEMBLER_WORKS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/asm_test.S)
     if(ASSEMBLER_WORKS)
         set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas.S)
         add_executable(asm_offset asm_offset.c)

--- a/loader/asm_test.S
+++ b/loader/asm_test.S
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2019 The Khronos Group Inc.
+# Copyright (c) 2019 Valve Corporation
+# Copyright (c) 2019 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.intel_syntax noprefix
+.text
+.global sample
+.set PHYS_DEV_OFFSET_INST_DISPATCH, 10
+.set PTR_SIZE, 4
+sample:
+  mov ecx, [eax + (PHYS_DEV_OFFSET_INST_DISPATCH + (PTR_SIZE * 4))]


### PR DESCRIPTION
The syntax used in the offset asm file is more complicated then what is
in the asm_test file. This CL extends the asm_test file slightly to
catch more compilers which are unable to process the offset assembly.

The version of clang I have available gets tripped up on the
`(PHYS_DEV_OFFSET_INST_DISPATCH + (PTR_SIZE * 4))`. This adds that
construct into the test assembly file.