### PR TITLE
Fix not finding registry path in some cases.

### DIFF
--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -76,7 +76,8 @@ else()
   # do a normal search without hints.
   find_path(VulkanHeaders_INCLUDE_DIR NAMES vulkan/vulkan.h)
   get_filename_component(VULKAN_REGISTRY_PATH_HINT ${VulkanHeaders_INCLUDE_DIR} DIRECTORY)
-  find_path(VulkanRegistry_DIR NAMES vk.xml HINTS ${VULKAN_REGISTRY_PATH_HINT}/share/vulkan/registry)
+  find_path(VulkanRegistry_DIR NAMES vk.xml HINTS ${VULKAN_REGISTRY_PATH_HINT}/share/vulkan/registry
+    "${VULKAN_REGISTRY_PATH_HINT}/registry")
 endif()
 
 set(VulkanHeaders_INCLUDE_DIRS ${VulkanHeaders_INCLUDE_DIR})


### PR DESCRIPTION
The Vulkan Headers detection script was coded to look for the Vulkan
registry in ${VULKAN_REGISTRY_PATH_HINT}/share/vulkan/registry. When
using the Vulkan-Headers repo the registry is located in just
${VULKAN_REGISTRY_PATH_HINT}/registry. This fix should allow both uses.

PTAL

@tobine fyi.