### PR TITLE
build: Update known-good for 126 header patch

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
       "sub_dir" : "Vulkan-Headers",
       "build_dir" : "Vulkan-Headers/build",
       "install_dir" : "Vulkan-Headers/build/install",
-      "commit" : "v1.1.126"
+      "commit" : "5bc459e2921304c32568b73edaac8d6df5f98b84"
     }
   ],
   "install_names" : {


### PR DESCRIPTION
An updated version of `vulkan.hpp` was added to the Vulkan-Headers
repository to address an issue discovered when building `cubepp` in the
Vulkan-Tools repository

Change-Id: I347ee871b596a1ba29e4190862c6b8e9aeb629f9