### PR TITLE
Reset value_size after each call to RegEnumValue

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -999,7 +999,8 @@ VkResult loaderGetRegistryFiles(const struct loader_instance *inst, char *locati
                         }
                     }
                 }
-                name_size = 2048;
+                name_size = sizeof(name);
+                value_size = sizeof(value);
             }
             RegCloseKey(key);
         }


### PR DESCRIPTION
I encountered this situation from a user report where somehow the `(Default)` registry value had been set to the empty string, instead of being completely unset, but this could happen if a string value was added as well as long as it's less than 4 characters (which means value_size gets truncated).

To repro you can import this .reg (after backing up your own key):

```reg
Windows Registry Editor Version 5.00

[HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\Vulkan\ImplicitLayers]
"C:\\Program Files\\GPUOpen\\Radeon GPU Analyzer\\layer\\VK_LAYER_RGA_pipeline_extraction_win32.json"=dword:00000000
"C:\\Program Files (x86)\\Steam\\SteamOverlayVulkanLayer64.json"=dword:00000000
"C:\\Program Files (x86)\\Steam\\SteamFossilizeVulkanLayer64.json"=dword:00000000
@=""
"C:\\Program Files\\RenderDoc\\renderdoc.json"=dword:00000000
```

This is the order the values come out in `RegEnumValue`, and when iterating the `renderdoc.json` isn't found because after the `@=""` entry `value_size` gets set to 1, and the enumerate that would find `renderdoc.json` instead ends up returning `ERROR_MORE_DATA`.

I also removed the hardcoded constant of `name_size`, though that's not relevant to the fix.