### PR TITLE
Use unsafe file search for GN builds.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -51,7 +51,10 @@ config("vulkan_loader_config") {
     "loader/generated",
     "loader",
   ]
-  defines = [ "API_NAME=\"Vulkan\"" ]
+  defines = [
+    "API_NAME=\"Vulkan\"",
+    "USE_UNSAFE_FILE_SEARCH=1"
+  ]
 
   if (is_win) {
     cflags = [ "/wd4201" ]

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -23,6 +23,9 @@ include(CheckIncludeFile)
 
 check_function_exists(secure_getenv HAVE_SECURE_GETENV)
 check_function_exists(__secure_getenv HAVE___SECURE_GETENV)
+if(NOT (HAVE_SECURE_GETENV OR HAVE__SECURE_GETENV))
+    message(WARNING "Using non-secure environmental lookups. This loader will not properly disable environent variables when run with elevated permissions.")
+endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/loader_cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/loader_cmake_config.h)
 
 if(WIN32)

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -266,16 +266,13 @@ static inline char *loader_secure_getenv(const char *name, const struct loader_i
     return IsHighIntegrity() ? NULL : loader_getenv(name, inst);
 #else
 // Linux
-#ifdef HAVE_SECURE_GETENV
+#if defined(HAVE_SECURE_GETENV) && !defined(USE_UNSAFE_FILE_SEARCH)
     (void)inst;
     return secure_getenv(name);
-#elif defined(HAVE___SECURE_GETENV)
+#elif defined(HAVE___SECURE_GETENV) && !defined(USE_UNSAFE_FILE_SEARCH)
     (void)inst;
     return __secure_getenv(name);
 #else
-#pragma message(                                                                       \
-    "Warning:  Falling back to non-secure getenv for environmental lookups!  Consider" \
-    " updating to a different libc.")
     return loader_getenv(name, inst);
 #endif
 #endif
@@ -338,9 +335,11 @@ static inline char *loader_getenv(const char *name, const struct loader_instance
 }
 
 static inline char *loader_secure_getenv(const char *name, const struct loader_instance *inst) {
+#if !defined(USE_UNSAFE_FILE_SEARCH)
     if (IsHighIntegrity()) {
         return NULL;
     }
+#endif
 
     return loader_getenv(name, inst);
 }


### PR DESCRIPTION
ANGLE is failing to locate validation layers on some platforms because
it cannot access VK_ICD_FILENAMES and VK_LAYER_PATH. This ensures that
these variables will always be picked up.