### PR TITLE
build: Fix Vulkan headers detection with CMake.

### DIFF
--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -45,21 +45,38 @@
 #   VulkanRegistry_DIR           - the VulkanRegistry directory
 #
 
-# Use HINTS instead of PATH to search these locations before
-# searching system environment variables like $PATH that may
-# contain SDK directories.
-find_path(VulkanHeaders_INCLUDE_DIR
-    NAMES vulkan/vulkan.h
-    HINTS
-        ${VULKAN_HEADERS_INSTALL_DIR}/include
-        "$ENV{VULKAN_HEADERS_INSTALL_DIR}/include"
-        "$ENV{VULKAN_SDK}/include")
+# Probe command-line arguments and the environment to see if they specify the
+# Vulkan headers installation path.
+if(NOT DEFINED VULKAN_HEADERS_INSTALL_DIR)
+  if (DEFINED ENV{VULKAN_HEADERS_INSTALL_DIR})
+    set(VULKAN_HEADERS_INSTALL_DIR "$ENV{VULKAN_HEADERS_INSTALL_DIR}")
+  elseif(DEFINED ENV{VULKAN_SDK})
+    set(VULKAN_HEADERS_INSTALL_DIR "$ENV{VULKAN_SDK}/include")
+  endif()
+endif()
 
-if(VulkanHeaders_INCLUDE_DIR)
-   get_filename_component(VULKAN_REGISTRY_PATH_HINT ${VulkanHeaders_INCLUDE_DIR} DIRECTORY)
-   find_path(VulkanRegistry_DIR
-       NAMES vk.xml
-       HINTS "${VULKAN_REGISTRY_PATH_HINT}/share/vulkan/registry")
+if(DEFINED VULKAN_HEADERS_INSTALL_DIR)
+  # When CMAKE_FIND_ROOT_PATH_INCLUDE is set to ONLY, the HINTS in find_path()
+  # are re-rooted, which prevents VULKAN_HEADERS_INSTALL_DIR to work as
+  # expected. So use NO_CMAKE_FIND_ROOT_PATH to avoid it.
+
+  # Use HINTS instead of PATH to search these locations before
+  # searching system environment variables like $PATH that may
+  # contain SDK directories.
+  find_path(VulkanHeaders_INCLUDE_DIR
+      NAMES vulkan/vulkan.h
+      HINTS ${VULKAN_HEADERS_INSTALL_DIR}/include
+      NO_CMAKE_FIND_ROOT_PATH)
+  find_path(VulkanRegistry_DIR
+      NAMES vk.xml
+      HINTS ${VULKAN_HEADERS_INSTALL_DIR}/share/vulkan/registry
+      NO_CMAKE_FIND_ROOT_PATH)
+else()
+  # If VULKAN_HEADERS_INSTALL_DIR, or one of its variants was not specified,
+  # do a normal search without hints.
+  find_path(VulkanHeaders_INCLUDE_DIR NAMES vulkan/vulkan.h)
+  get_filename_component(VULKAN_REGISTRY_PATH_HINT ${VulkanHeaders_INCLUDE_DIR} DIRECTORY)
+  find_path(VulkanRegistry_DIR NAMES vk.xml HINTS ${VULKAN_REGISTRY_PATH_HINT})
 endif()
 
 set(VulkanHeaders_INCLUDE_DIRS ${VulkanHeaders_INCLUDE_DIR})


### PR DESCRIPTION
The logic used to find the location of the Vulkan headers and
registry used simple find_path() calls with HINTS. Unfortunately,
this doesn't work when using a custom toolchain file that sets
CMAKE_FIND_ROOT_PATH_INCLUDE to ONLY, which can happen when
cross-compiling with a custom sysroot.

This patch changes the logic so that:

  - If VULKAN_HEADERS_INSTALL_DIR is specified on the command-line,
    or if it is set in the environment, or if VULKAN_SDK is set in
    the environment, the corresponding paths will be searched for
    the Vulkan headers and register, ignoring the
    CMAKE_FIND_ROOT_PATH. This does not affect other parts of the
    build.

  - Otherwise, use a regular find_path() call which may be restricted
    to the CMAKE_FIND_ROOT_PATH depending on previous configuration
    settings.

This should be equivalent to the previous behaviour, except when
CMAKE_FIND_ROOT_PATH_INCLUDE is set to ONLY.