### PR TITLE
Add Cfgmgr32.lib to GN build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -120,6 +120,7 @@ if (!is_android) {
       if (is_clang) {
           cflags = [ "-Wno-incompatible-pointer-types" ]
       }
+      libs = [ "Cfgmgr32.lib" ]
     }
     if (is_mac) {
       libs = [ "CoreFoundation.framework" ]


### PR DESCRIPTION
Fixes #288 

Reproduced the issue with the GN standalone build on windows. Fixed by linking with Cfgmgr32.lib [like the CMake build already does](https://github.com/KhronosGroup/Vulkan-Loader/blob/08d344208e60e0bb8c8fbe25b9b1f2bf63801e2f/loader/CMakeLists.txt#L210)