### PR TITLE
build:Add def file for Windows GN build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -97,11 +97,13 @@ if (!is_android) {
       "loader/wsi.h",
     ]
     if (is_win) {
+      output_name = "vulkan-1"
       sources += [
         "loader/dirent_on_windows.c",
         "loader/dirent_on_windows.h",
         "loader/dxgi_loader.c",
         "loader/dxgi_loader.h",
+        "loader/vulkan-1.def",
       ]
       if (!is_clang) {
         cflags = [


### PR DESCRIPTION
Copied the vulkan-1.def file to libvulkan.def and updated
GN build to use that file so that functions are correclty
exported for GetProcAddress() lookup.

Fixes #292