### PR TITLE
build: Fix Vulkan registry detection

### DIFF
--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -76,7 +76,7 @@ else()
   # do a normal search without hints.
   find_path(VulkanHeaders_INCLUDE_DIR NAMES vulkan/vulkan.h)
   get_filename_component(VULKAN_REGISTRY_PATH_HINT ${VulkanHeaders_INCLUDE_DIR} DIRECTORY)
-  find_path(VulkanRegistry_DIR NAMES vk.xml HINTS ${VULKAN_REGISTRY_PATH_HINT})
+  find_path(VulkanRegistry_DIR NAMES vk.xml HINTS ${VULKAN_REGISTRY_PATH_HINT}/share/vulkan/registry)
 endif()
 
 set(VulkanHeaders_INCLUDE_DIRS ${VulkanHeaders_INCLUDE_DIR})


### PR DESCRIPTION
Fix incomplete VULKAN_REGISTRY_PATH_HINT for the case where
VULKAN_HEADERS_INSTALL_DIR is not specified.  The hint extracted the
DIRECTORY of the include dir (e.g. "/usr"), but missed the rest of the
expected path for finding vk.xml (e.g. "/usr/share/vulkan/registry").

Tested with CMake 3.16.0.

Fixes: 18664450a ("build: Fix Vulkan headers detection with CMake.")