### PR TITLE
cmake: fix finding the registry

### DIFF
--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -76,7 +76,7 @@ else()
   # do a normal search without hints.
   find_path(VulkanHeaders_INCLUDE_DIR NAMES vulkan/vulkan.h)
   get_filename_component(VULKAN_REGISTRY_PATH_HINT ${VulkanHeaders_INCLUDE_DIR} DIRECTORY)
-  find_path(VulkanRegistry_DIR NAMES vk.xml HINTS ${VULKAN_REGISTRY_PATH_HINT})
+  find_path(VulkanRegistry_DIR NAMES vk.xml HINTS ${VULKAN_REGISTRY_PATH_HINT}/share/vulkan/registry)
 endif()
 
 set(VulkanHeaders_INCLUDE_DIRS ${VulkanHeaders_INCLUDE_DIR})


### PR DESCRIPTION
The Vulkan-Loader repository will fail to find the Vulkan registry in the /usr/loca/share/vulkan/registry when the VULKAN_HEADERS_INSTALL_DIR cmake flag is not given.