### PR TITLE
Fix crash in tooling info terminator

### DIFF
--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -3235,7 +3235,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolPropertiesEXT(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     disp = loader_get_instance_layer_dispatch(physicalDevice);
-    return disp->GetPhysicalDeviceToolPropertiesEXT(unwrapped_phys_dev, pToolCount, pToolProperties);
+    if (disp->GetPhysicalDeviceToolPropertiesEXT != NULL) {
+        return disp->GetPhysicalDeviceToolPropertiesEXT(unwrapped_phys_dev, pToolCount, pToolProperties);
+    } else {
+        return VK_SUCCESS;
+    }
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceToolPropertiesEXT(

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -49,7 +49,8 @@ ADD_INST_CMDS = ['vkCreateInstance',
 
 AVOID_EXT_NAMES = ['VK_EXT_debug_report']
 
-NULL_CHECK_EXT_NAMES= ['VK_EXT_debug_utils']
+NULL_CHECK_EXT_NAMES= ['VK_EXT_debug_utils',
+                       'VK_EXT_tooling_info']
 
 AVOID_CMD_NAMES = ['vkCreateDebugUtilsMessengerEXT',
                    'vkDestroyDebugUtilsMessengerEXT',


### PR DESCRIPTION
Since the tooling info extension is implemented in the layers, the loader can't blindly call down into the driver. Doing so will result in a crash.

@mark-lunarg, if you test this and it works right for you, I'll go ahead and merge it.