### PR TITLE
loader: Remove loader_platform_basename dead code

### DIFF
--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -279,31 +279,6 @@ static inline char *loader_platform_dirname(char *path) {
     return path;
 }
 
-// WIN32 runtime doesn't have basename().
-// Microsoft also doesn't have basename().  Paths are different on Windows, and
-// so this is just a temporary solution in order to get us compiling, so that we
-// can test some scenarios, and develop the correct solution for Windows.
-// TODO: Develop a better, permanent solution for Windows, to replace this
-// temporary code:
-static char *loader_platform_basename(char *pathname) {
-    char *current, *next;
-
-    // TODO/TBD: Do we need to deal with the Windows's ":" character?
-
-    for (current = pathname; *current != '\0'; current = next) {
-        next = strchr(current, DIRECTORY_SYMBOL);
-        if (next == NULL) {
-            // No more DIRECTORY_SYMBOL's so return p:
-            return current;
-        } else {
-            // Point one character past the DIRECTORY_SYMBOL:
-            next++;
-        }
-    }
-    // We shouldn't get to here, but this makes the compiler happy:
-    return current;
-}
-
 // Dynamic Loading:
 typedef HMODULE loader_platform_dl_handle;
 static loader_platform_dl_handle loader_platform_open_library(const char *lib_path) {


### PR DESCRIPTION
The loader_platform_basename function is not being used anywhere
else and was last modified 4 years ago. Considering the amount of
TODO comments and mentions to replace this, there doesn't seem
like a pressing need to keep it.

Changes to be committed:
	modified:   loader/vk_loader_platform.h

Change-Id: Icd7a4d1104889e0519081831fbfaaaa46690438c