### PR TITLE
loader: add per-directory override layer settings

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -156,6 +156,7 @@ struct loader_layer_properties {
     bool keep;
     uint32_t num_blacklist_layers;
     char (*blacklist_layer_names)[MAX_STRING_SIZE];
+    char app_key_path[MAX_STRING_SIZE];
 };
 
 struct loader_layer_list {

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -38,7 +38,6 @@
 //#ifndef _GNU_SOURCE
 //#define _GNU_SOURCE 1
 //#endif
-// TBD: Are the contents of the following file used?
 #include <unistd.h>
 // Note: The following file is for dynamic loading:
 #include <dlfcn.h>
@@ -99,6 +98,8 @@ static inline bool loader_platform_is_path_absolute(const char *path) {
 }
 
 static inline char *loader_platform_dirname(char *path) { return dirname(path); }
+
+static inline char *loader_current_directory(char buffer[1024]) { return getcwd(buffer, 1024); }
 
 // Dynamic Loading of libraries:
 typedef void *loader_platform_dl_handle;
@@ -162,6 +163,7 @@ static inline void loader_platform_thread_cond_broadcast(loader_platform_thread_
 #include <io.h>
 #include <stdbool.h>
 #include <shlwapi.h>
+#include <direct.h>
 #ifdef __cplusplus
 #include <iostream>
 #include <string>
@@ -277,6 +279,12 @@ static inline char *loader_platform_dirname(char *path) {
         }
     }
     return path;
+}
+
+static inline char *loader_current_directory(char buffer[1024]) {
+    DWORD ret = GetCurrentDirectory(1024, buffer);
+    if (ret == 0) return NULL;
+    return buffer;
 }
 
 // Dynamic Loading:


### PR DESCRIPTION
Enables the VkLayer_override.json to contain multiple entries distinguised
by a new string item called "app_key" which containts the absolute path
to the directory that the override layer is applied to.

Changes to be committed:
	modified:   loader/loader.c
	modified:   loader/loader.h
	modified:   loader/vk_loader_platform.h

Change-Id: I9ddbc98a098d48064110db6c29998eddb336fcda