### PR TITLE
Debug utils terms

### DIFF
--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -238,6 +238,12 @@ VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_icd_term *icd_t
     // ---- VK_EXT_debug_utils extension commands
     LOOKUP_GIPA(SetDebugUtilsObjectNameEXT, false);
     LOOKUP_GIPA(SetDebugUtilsObjectTagEXT, false);
+    LOOKUP_GIPA(QueueBeginDebugUtilsLabelEXT, false);
+    LOOKUP_GIPA(QueueEndDebugUtilsLabelEXT, false);
+    LOOKUP_GIPA(QueueInsertDebugUtilsLabelEXT, false);
+    LOOKUP_GIPA(CmdBeginDebugUtilsLabelEXT, false);
+    LOOKUP_GIPA(CmdEndDebugUtilsLabelEXT, false);
+    LOOKUP_GIPA(CmdInsertDebugUtilsLabelEXT, false);
     LOOKUP_GIPA(CreateDebugUtilsMessengerEXT, false);
     LOOKUP_GIPA(DestroyDebugUtilsMessengerEXT, false);
     LOOKUP_GIPA(SubmitDebugUtilsMessageEXT, false);
@@ -2711,7 +2717,18 @@ VKAPI_ATTR void VKAPI_CALL QueueBeginDebugUtilsLabelEXT(
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (disp->QueueBeginDebugUtilsLabelEXT != NULL) {
-    disp->QueueBeginDebugUtilsLabelEXT(queue, pLabelInfo);
+        disp->QueueBeginDebugUtilsLabelEXT(queue, pLabelInfo);
+    }
+}
+
+VKAPI_ATTR void VKAPI_CALL terminator_QueueBeginDebugUtilsLabelEXT(
+    VkQueue                                     queue,
+    const VkDebugUtilsLabelEXT*                 pLabelInfo) {
+    uint32_t icd_index = 0;
+    struct loader_device *dev;
+    struct loader_icd_term *icd_term = loader_get_icd_and_device(queue, &dev, &icd_index);
+    if (NULL != icd_term && NULL != icd_term->dispatch.QueueBeginDebugUtilsLabelEXT) {
+        icd_term->dispatch.QueueBeginDebugUtilsLabelEXT(queue, pLabelInfo);
     }
 }
 
@@ -2719,7 +2736,17 @@ VKAPI_ATTR void VKAPI_CALL QueueEndDebugUtilsLabelEXT(
     VkQueue                                     queue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (disp->QueueEndDebugUtilsLabelEXT != NULL) {
-    disp->QueueEndDebugUtilsLabelEXT(queue);
+        disp->QueueEndDebugUtilsLabelEXT(queue);
+    }
+}
+
+VKAPI_ATTR void VKAPI_CALL terminator_QueueEndDebugUtilsLabelEXT(
+    VkQueue                                     queue) {
+    uint32_t icd_index = 0;
+    struct loader_device *dev;
+    struct loader_icd_term *icd_term = loader_get_icd_and_device(queue, &dev, &icd_index);
+    if (NULL != icd_term && NULL != icd_term->dispatch.QueueEndDebugUtilsLabelEXT) {
+        icd_term->dispatch.QueueEndDebugUtilsLabelEXT(queue);
     }
 }
 
@@ -2728,7 +2755,18 @@ VKAPI_ATTR void VKAPI_CALL QueueInsertDebugUtilsLabelEXT(
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (disp->QueueInsertDebugUtilsLabelEXT != NULL) {
-    disp->QueueInsertDebugUtilsLabelEXT(queue, pLabelInfo);
+        disp->QueueInsertDebugUtilsLabelEXT(queue, pLabelInfo);
+    }
+}
+
+VKAPI_ATTR void VKAPI_CALL terminator_QueueInsertDebugUtilsLabelEXT(
+    VkQueue                                     queue,
+    const VkDebugUtilsLabelEXT*                 pLabelInfo) {
+    uint32_t icd_index = 0;
+    struct loader_device *dev;
+    struct loader_icd_term *icd_term = loader_get_icd_and_device(queue, &dev, &icd_index);
+    if (NULL != icd_term && NULL != icd_term->dispatch.QueueInsertDebugUtilsLabelEXT) {
+        icd_term->dispatch.QueueInsertDebugUtilsLabelEXT(queue, pLabelInfo);
     }
 }
 
@@ -2737,7 +2775,18 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginDebugUtilsLabelEXT(
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (disp->CmdBeginDebugUtilsLabelEXT != NULL) {
-    disp->CmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
+        disp->CmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
+    }
+}
+
+VKAPI_ATTR void VKAPI_CALL terminator_CmdBeginDebugUtilsLabelEXT(
+    VkCommandBuffer                             commandBuffer,
+    const VkDebugUtilsLabelEXT*                 pLabelInfo) {
+    uint32_t icd_index = 0;
+    struct loader_device *dev;
+    struct loader_icd_term *icd_term = loader_get_icd_and_device(commandBuffer, &dev, &icd_index);
+    if (NULL != icd_term && NULL != icd_term->dispatch.CmdBeginDebugUtilsLabelEXT) {
+        icd_term->dispatch.CmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
     }
 }
 
@@ -2745,7 +2794,17 @@ VKAPI_ATTR void VKAPI_CALL CmdEndDebugUtilsLabelEXT(
     VkCommandBuffer                             commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (disp->CmdEndDebugUtilsLabelEXT != NULL) {
-    disp->CmdEndDebugUtilsLabelEXT(commandBuffer);
+        disp->CmdEndDebugUtilsLabelEXT(commandBuffer);
+    }
+}
+
+VKAPI_ATTR void VKAPI_CALL terminator_CmdEndDebugUtilsLabelEXT(
+    VkCommandBuffer                             commandBuffer) {
+    uint32_t icd_index = 0;
+    struct loader_device *dev;
+    struct loader_icd_term *icd_term = loader_get_icd_and_device(commandBuffer, &dev, &icd_index);
+    if (NULL != icd_term && NULL != icd_term->dispatch.CmdEndDebugUtilsLabelEXT) {
+        icd_term->dispatch.CmdEndDebugUtilsLabelEXT(commandBuffer);
     }
 }
 
@@ -2754,7 +2813,18 @@ VKAPI_ATTR void VKAPI_CALL CmdInsertDebugUtilsLabelEXT(
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (disp->CmdInsertDebugUtilsLabelEXT != NULL) {
-    disp->CmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
+        disp->CmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
+    }
+}
+
+VKAPI_ATTR void VKAPI_CALL terminator_CmdInsertDebugUtilsLabelEXT(
+    VkCommandBuffer                             commandBuffer,
+    const VkDebugUtilsLabelEXT*                 pLabelInfo) {
+    uint32_t icd_index = 0;
+    struct loader_device *dev;
+    struct loader_icd_term *icd_term = loader_get_icd_and_device(commandBuffer, &dev, &icd_index);
+    if (NULL != icd_term && NULL != icd_term->dispatch.CmdInsertDebugUtilsLabelEXT) {
+        icd_term->dispatch.CmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
     }
 }
 
@@ -4370,6 +4440,18 @@ PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *de
             addr = (PFN_vkVoidFunction)terminator_SetDebugUtilsObjectNameEXT;
         } else if(!strcmp(pName, "vkSetDebugUtilsObjectTagEXT")) {
             addr = (PFN_vkVoidFunction)terminator_SetDebugUtilsObjectTagEXT;
+        } else if(!strcmp(pName, "vkQueueBeginDebugUtilsLabelEXT")) {
+            addr = (PFN_vkVoidFunction)terminator_QueueBeginDebugUtilsLabelEXT;
+        } else if(!strcmp(pName, "vkQueueEndDebugUtilsLabelEXT")) {
+            addr = (PFN_vkVoidFunction)terminator_QueueEndDebugUtilsLabelEXT;
+        } else if(!strcmp(pName, "vkQueueInsertDebugUtilsLabelEXT")) {
+            addr = (PFN_vkVoidFunction)terminator_QueueInsertDebugUtilsLabelEXT;
+        } else if(!strcmp(pName, "vkCmdBeginDebugUtilsLabelEXT")) {
+            addr = (PFN_vkVoidFunction)terminator_CmdBeginDebugUtilsLabelEXT;
+        } else if(!strcmp(pName, "vkCmdEndDebugUtilsLabelEXT")) {
+            addr = (PFN_vkVoidFunction)terminator_CmdEndDebugUtilsLabelEXT;
+        } else if(!strcmp(pName, "vkCmdInsertDebugUtilsLabelEXT")) {
+            addr = (PFN_vkVoidFunction)terminator_CmdInsertDebugUtilsLabelEXT;
         }
     }
 #ifdef VK_USE_PLATFORM_WIN32_KHR

--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -386,6 +386,12 @@ struct loader_icd_term_dispatch {
     // ---- VK_EXT_debug_utils extension commands
     PFN_vkSetDebugUtilsObjectNameEXT SetDebugUtilsObjectNameEXT;
     PFN_vkSetDebugUtilsObjectTagEXT SetDebugUtilsObjectTagEXT;
+    PFN_vkQueueBeginDebugUtilsLabelEXT QueueBeginDebugUtilsLabelEXT;
+    PFN_vkQueueEndDebugUtilsLabelEXT QueueEndDebugUtilsLabelEXT;
+    PFN_vkQueueInsertDebugUtilsLabelEXT QueueInsertDebugUtilsLabelEXT;
+    PFN_vkCmdBeginDebugUtilsLabelEXT CmdBeginDebugUtilsLabelEXT;
+    PFN_vkCmdEndDebugUtilsLabelEXT CmdEndDebugUtilsLabelEXT;
+    PFN_vkCmdInsertDebugUtilsLabelEXT CmdInsertDebugUtilsLabelEXT;
     PFN_vkCreateDebugUtilsMessengerEXT CreateDebugUtilsMessengerEXT;
     PFN_vkDestroyDebugUtilsMessengerEXT DestroyDebugUtilsMessengerEXT;
     PFN_vkSubmitDebugUtilsMessageEXT SubmitDebugUtilsMessageEXT;

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2014-2019 The Khronos Group Inc.
- * Copyright (c) 2014-2019 Valve Corporation
- * Copyright (c) 2014-2019 LunarG, Inc.
+ * Copyright (c) 2014-2020 The Khronos Group Inc.
+ * Copyright (c) 2014-2020 Valve Corporation
+ * Copyright (c) 2014-2020 LunarG, Inc.
  * Copyright (C) 2015 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2044,7 +2044,7 @@ out:
     return res;
 }
 
-struct loader_icd_term *loader_get_icd_and_device(const VkDevice device, struct loader_device **found_dev, uint32_t *icd_index) {
+struct loader_icd_term *loader_get_icd_and_device(const void *device, struct loader_device **found_dev, uint32_t *icd_index) {
     *found_dev = NULL;
     for (struct loader_instance *inst = loader.instances; inst; inst = inst->next) {
         uint32_t index = 0;
@@ -4850,6 +4850,32 @@ static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL loader_gpa_instance_internal(VkI
     }
     if (!strcmp(pName, "vkCreateDevice")) {
         return (PFN_vkVoidFunction)terminator_CreateDevice;
+    }
+
+    // The VK_EXT_debug_utils functions need a special case here so the terminators can still be found from vkGetInstanceProcAddr
+    if (!strcmp(pName, "vkSetDebugUtilsObjectNameEXT")) {
+        return (PFN_vkVoidFunction)terminator_SetDebugUtilsObjectNameEXT;
+    }
+    if (!strcmp(pName, "vkSetDebugUtilsObjectTagEXT")) {
+        return (PFN_vkVoidFunction)terminator_SetDebugUtilsObjectTagEXT;
+    }
+    if (!strcmp(pName, "vkQueueBeginDebugUtilsLabelEXT")) {
+        return (PFN_vkVoidFunction)terminator_QueueBeginDebugUtilsLabelEXT;
+    }
+    if (!strcmp(pName, "vkQueueEndDebugUtilsLabelEXT")) {
+        return (PFN_vkVoidFunction)terminator_QueueEndDebugUtilsLabelEXT;
+    }
+    if (!strcmp(pName, "vkQueueInsertDebugUtilsLabelEXT")) {
+        return (PFN_vkVoidFunction)terminator_QueueInsertDebugUtilsLabelEXT;
+    }
+    if (!strcmp(pName, "vkCmdBeginDebugUtilsLabelEXT")) {
+        return (PFN_vkVoidFunction)terminator_CmdBeginDebugUtilsLabelEXT;
+    }
+    if (!strcmp(pName, "vkCmdEndDebugUtilsLabelEXT")) {
+        return (PFN_vkVoidFunction)terminator_CmdEndDebugUtilsLabelEXT;
+    }
+    if (!strcmp(pName, "vkCmdInsertDebugUtilsLabelEXT")) {
+        return (PFN_vkVoidFunction)terminator_CmdInsertDebugUtilsLabelEXT;
     }
 
     // inst is not wrapped

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -477,7 +477,7 @@ void loaderScanForImplicitLayers(struct loader_instance *inst, struct loader_lay
 bool loaderImplicitLayerIsEnabled(const struct loader_instance *inst, const struct loader_layer_properties *prop);
 VkResult loader_get_icd_loader_instance_extensions(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list,
                                                    struct loader_extension_list *inst_exts);
-struct loader_icd_term *loader_get_icd_and_device(const VkDevice device, struct loader_device **found_dev, uint32_t *icd_index);
+struct loader_icd_term *loader_get_icd_and_device(const void *device, struct loader_device **found_dev, uint32_t *icd_index);
 void loader_init_dispatch_dev_ext(struct loader_instance *inst, struct loader_device *dev);
 void *loader_dev_ext_gpa(struct loader_instance *inst, const char *funcName);
 void *loader_get_dev_ext_trampoline(uint32_t index);

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2017 The Khronos Group Inc.
-# Copyright (c) 2015-2017 Valve Corporation
-# Copyright (c) 2015-2017 LunarG, Inc.
+# Copyright (c) 2015-2020 The Khronos Group Inc.
+# Copyright (c) 2015-2020 Valve Corporation
+# Copyright (c) 2015-2020 LunarG, Inc.
 # Copyright (c) 2015-2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,6 +63,12 @@ DEVICE_CMDS_NEED_TERM = ['vkGetDeviceProcAddr',
                          'vkDebugMarkerSetObjectNameEXT',
                          'vkSetDebugUtilsObjectNameEXT',
                          'vkSetDebugUtilsObjectTagEXT',
+                         'vkQueueBeginDebugUtilsLabelEXT',
+                         'vkQueueEndDebugUtilsLabelEXT',
+                         'vkQueueInsertDebugUtilsLabelEXT',
+                         'vkCmdBeginDebugUtilsLabelEXT',
+                         'vkCmdEndDebugUtilsLabelEXT',
+                         'vkCmdInsertDebugUtilsLabelEXT',
                          'vkGetDeviceGroupSurfacePresentModes2EXT']
 
 # These are the aliased functions that use the same terminator for both extension and core versions
@@ -1180,29 +1186,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
 
                 elif ext_cmd.handle_type == 'VkInstance':
                     funcs += '#error("Not implemented. Likely needs to be manually generated!");\n'
-                elif 'DebugUtilsLabel' in ext_cmd.name:
-                    funcs += '    const VkLayerDispatchTable *disp = loader_get_dispatch('
-                    funcs += ext_cmd.params[0].name
-                    funcs += ');\n'
-                    if ext_cmd.ext_name in NULL_CHECK_EXT_NAMES:
-                        funcs += '    if (disp->' + base_name + ' != NULL) {\n'
-                        funcs += '    '
-                    funcs += '    '
-                    if has_return_type:
-                        funcs += 'return '
-                    funcs += 'disp->'
-                    funcs += base_name
-                    funcs += '('
-                    count = 0
-                    for param in ext_cmd.params:
-                        if count != 0:
-                            funcs += ', '
-                        funcs += param.name
-                        count += 1
-                    funcs += ');\n'
-                    if ext_cmd.ext_name in NULL_CHECK_EXT_NAMES:
-                        funcs += '    }\n'
-                elif 'DebugMarkerSetObject' in ext_cmd.name or 'SetDebugUtilsObject' in ext_cmd.name:
+                elif 'DebugMarkerSetObject' in ext_cmd.name or 'SetDebugUtilsObject' in ext_cmd.name or 'DebugUtilsLabel' in ext_cmd.name:
                     funcs += '    uint32_t icd_index = 0;\n'
                     funcs += '    struct loader_device *dev;\n'
                     funcs += '    struct loader_icd_term *icd_term = loader_get_icd_and_device(%s, &dev, &icd_index);\n' % (ext_cmd.params[0].name)


### PR DESCRIPTION
This fixes #116.

This PR addresses the bug where the loader returns an invalid function pointers when an application calls `vkGetInstanceProcAddr` on the methods from the `VK_EXT_debug_utils` extension. Previously, the function pointers would run fine, but they would never call into the driver. This makes them call into the driver.

I'd be lying if I said I was 100% happy with this change. I wound up adding terminators for each function in this extension because doing so allowed me to use the existing instance functionality for choosing which driver to call into. But I do think this should do the job. This is a very special case because debug utils is an instance extension that contains device level functions.