### PR TITLE
loader: add null check to loaderValidateLayers

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7203,6 +7203,10 @@ VkStringErrorFlags vk_string_validate(const int max_length, const char *utf8) {
     int num_char_bytes = 0;
     int i, j;
 
+    if (utf8 == NULL) {
+        return VK_STRING_ERROR_NULL_PTR;
+    }
+
     for (i = 0; i <= max_length; i++) {
         if (utf8[i] == 0) {
             break;

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -67,6 +67,7 @@ typedef enum VkStringErrorFlagBits {
     VK_STRING_ERROR_NONE = 0x00000000,
     VK_STRING_ERROR_LENGTH = 0x00000001,
     VK_STRING_ERROR_BAD_DATA = 0x00000002,
+    VK_STRING_ERROR_NULL_PTR = 0x00000004,
 } VkStringErrorFlagBits;
 typedef VkFlags VkStringErrorFlags;
 


### PR DESCRIPTION
The loader will now make sure to check if utf8 is null before
validating the string, preventing needless segfaults.

Change-Id: I48139e56719e3c518b85f2ded1ca0b682447413f