### PR TITLE
Allow Vulkan-Headers to be in external.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS API_NAME="Vulkan")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(PythonInterp 3 QUIET)
 
+# Add the externals directory early so we pickup the headers if they're present
+add_subdirectory(external)
+
 if (TARGET Vulkan::Headers)
     message(STATUS "Using Vulkan headers from Vulkan::Headers target")
     get_target_property(VulkanHeaders_INCLUDE_DIRS Vulkan::Headers INTERFACE_INCLUDE_DIRECTORIES)
@@ -214,7 +217,6 @@ if(BUILD_LOADER)
     add_subdirectory(loader)
 endif()
 
-add_subdirectory(external)
 if(BUILD_TESTS)
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS API_NAME="Vulkan")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(PythonInterp 3 QUIET)
 
+if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest)
+    option(BUILD_TESTS "Build Tests" ON)
+else()
+    option(BUILD_TESTS "Build Tests" OFF)
+endif()
+
 # Add the externals directory early so we pickup the headers if they're present
 add_subdirectory(external)
 
@@ -126,12 +132,6 @@ if(WIN32)
 endif()
 
 option(BUILD_LOADER "Build loader" ON)
-
-if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest)
-    option(BUILD_TESTS "Build Tests" ON)
-else()
-    option(BUILD_TESTS "Build Tests" OFF)
-endif()
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(COMMON_COMPILE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -37,3 +37,7 @@ if(BUILD_TESTS)
                            "Provide Google Test in external/googletest or set BUILD_TESTS=OFF")
     endif()
 endif()
+
+if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers")
+  add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers")
+endif()

--- a/external/README.md
+++ b/external/README.md
@@ -1,9 +1,17 @@
 # External dependencies
 
 This directory provides a location where external projects can be cloned that are used by the loader.
-Currently, the only project that can be used by the loader is Google Test.
-It can be enabled by cloning it here like:
+
+In order to build tests the Google Test library must be present. It can be
+checked out with:
 
 ```
 git clone https://github.com/google/googletest.git
+```
+
+If you don't have a local install of the Vulkan Headers they can be placed in
+the externals folder with:
+
+```
+git clone https://github.com/KhronosGroup/Vulkan-Headers.git
 ```


### PR DESCRIPTION
This CL updates the CMake files to allow Vulkan-Headers to be in the
external folder. If the external/Vulkan-Headers folder is present the
scripts will use that version of the headers.