### PR TITLE
loader: Preload ICD's to speed up vkEnumerateInstanceExtensionProperties

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -452,6 +452,8 @@ VkResult loader_validate_instance_extensions(struct loader_instance *inst, const
                                              const VkInstanceCreateInfo *pCreateInfo);
 
 void loader_initialize(void);
+void loader_preload_icds(void);
+void loader_unload_preloaded_icds(void);
 bool has_vk_extension_property_array(const VkExtensionProperties *vk_ext_prop, const uint32_t count,
                                      const VkExtensionProperties *ext_array);
 bool has_vk_extension_property(const VkExtensionProperties *vk_ext_prop, const struct loader_extension_list *ext_list);

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -656,6 +656,11 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
                                          ptr_instance->tmp_report_callbacks);
         util_FreeDebugReportCreateInfos(pAllocator, ptr_instance->tmp_report_create_infos, ptr_instance->tmp_report_callbacks);
     }
+
+    // Unload preloaded layers, so if vkEnumerateInstanceExtensionProperties or vkCreateInstance is called again, the ICD's are up
+    // to date
+    loader_unload_preloaded_icds();
+
     loader_instance_heap_free(ptr_instance, ptr_instance->disp);
     loader_instance_heap_free(ptr_instance, ptr_instance);
     loader_platform_thread_unlock_mutex(&loader_lock);


### PR DESCRIPTION
The ideal of having the loader be stateless causes serious slowdowns
in application startup due to the need to load then unload ICD's
repeatedly while calling vkEnumerateInstanceExtensionProperties. By pre-
loading the ICD's which are found using loader_icd_scan, the
unecessary reloading of ICD's is avoided.

The preloaded ICD's will be unloaded with vkDestroyInstance. This
allows subsequent vkEnumerateInstanceExtensionProperties calls to use the 
most recent ICD on the system, preventing issue where a new driver was
installed but an application couldn't use it unless they unloaded the loader
library completely.

Changes to be committed:
	modified:   loader/loader.c
	modified:   loader/loader.h
	modified:   loader/trampoline.c

Change-Id: Id169f94bea15e569b75c3a663b25444cc6c52c40