### PR TITLE
Allow building a static loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ endif()
 
 if(WIN32)
     option(ENABLE_WIN10_ONECORE "Link the loader with OneCore umbrella libraries" OFF)
+    option(ENABLE_STATIC_LOADER "Build the loader as a static library" OFF)
 endif()
 
 option(BUILD_LOADER "Build loader" ON)

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -189,19 +189,31 @@ if(WIN32)
     target_compile_options(loader-opt PUBLIC ${MSVC_LOADER_COMPILE_OPTIONS})
     target_include_directories(loader-opt PRIVATE "$<TARGET_PROPERTY:Vulkan::Headers,INTERFACE_INCLUDE_DIRECTORIES>")
 
-    add_library(vulkan
-                SHARED
-                $<TARGET_OBJECTS:loader-opt>
-                $<TARGET_OBJECTS:loader-norm>
-                $<TARGET_OBJECTS:loader-unknown-chain>
-                ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-1.def
-                ${CMAKE_CURRENT_SOURCE_DIR}/loader.rc)
-    set_target_properties(vulkan
-                          PROPERTIES LINK_FLAGS_DEBUG
-                                     "/ignore:4098"
-                                     OUTPUT_NAME
-                                     vulkan-1)
-    target_link_libraries(vulkan Vulkan::Headers)
+    if(NOT ENABLE_STATIC_LOADER)
+        target_compile_definitions(loader-norm PUBLIC LOADER_DYNAMIC_LIB)
+        target_compile_definitions(loader-opt PUBLIC LOADER_DYNAMIC_LIB)
+
+        add_library(vulkan
+                    SHARED
+                    $<TARGET_OBJECTS:loader-opt>
+                    $<TARGET_OBJECTS:loader-norm>
+                    $<TARGET_OBJECTS:loader-unknown-chain>
+                    ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-1.def
+                    ${CMAKE_CURRENT_SOURCE_DIR}/loader.rc)
+        set_target_properties(vulkan
+                              PROPERTIES LINK_FLAGS_DEBUG
+                                         "/ignore:4098"
+                                         OUTPUT_NAME
+                                         vulkan-1)
+        target_link_libraries(vulkan Vulkan::Headers)
+    else()
+        add_library(vulkan
+                    STATIC
+                    $<TARGET_OBJECTS:loader-opt>
+                    $<TARGET_OBJECTS:loader-norm>
+                    $<TARGET_OBJECTS:loader-unknown-chain>)
+        set_target_properties(vulkan PROPERTIES OUTPUT_NAME VKstatic.1)
+    endif()
 
     if(ENABLE_WIN10_ONECORE)
         target_link_libraries(vulkan OneCoreUAP.lib LIBCMT.LIB LIBCMTD.LIB LIBVCRUNTIME.LIB LIBUCRT.LIB)
@@ -224,6 +236,7 @@ else()
 
     add_library(vulkan SHARED ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS})
     add_dependencies(vulkan loader_asm_gen_files)
+    target_compile_definitions(vulkan PUBLIC LOADER_DYNAMIC_LIB)
     set_target_properties(vulkan
                           PROPERTIES SOVERSION
                                      "1"
@@ -256,6 +269,7 @@ else()
             ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan.hpp)
         add_library(vulkan-framework SHARED ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS} ${FRAMEWORK_HEADERS})
         add_dependencies(vulkan-framework loader_asm_gen_files)
+        target_compile_definitions(vulkan-framework PUBLIC LOADER_DYNAMIC_LIB)
         target_link_libraries(vulkan-framework -ldl -lpthread -lm "-framework CoreFoundation")
         target_link_libraries(vulkan-framework Vulkan::Headers)
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7340,7 +7340,7 @@ out:
     return result;
 }
 
-#if defined(_WIN32)
+#if defined(_WIN32) && defined(LOADER_DYNAMIC_LIB)
 BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved) {
     switch (reason) {
         case DLL_PROCESS_ATTACH:

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -420,6 +420,9 @@ static inline void loader_init_dispatch(void *obj, const void *data) {
 // Global variables used across files
 extern struct loader_struct loader;
 extern THREAD_LOCAL_DECL struct loader_instance *tls_instance;
+#if defined(_WIN32) && !defined(LOADER_DYNAMIC_LIB)
+extern LOADER_PLATFORM_THREAD_ONCE_DEFINITION(once_init);
+#endif
 extern loader_platform_thread_mutex loader_lock;
 extern loader_platform_thread_mutex loader_json_lock;
 

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -330,9 +330,25 @@ typedef HANDLE loader_platform_thread;
 // The once init functionality is not used when building a DLL on Windows. This is because there is no way to clean up the
 // resources allocated by anything allocated by once init. This isn't a problem for static libraries, but it is for dynamic
 // ones. When building a DLL, we use DllMain() instead to allow properly cleaning up resources.
+#if defined(LOADER_DYNAMIC_LIB)
 #define LOADER_PLATFORM_THREAD_ONCE_DECLARATION(var)
 #define LOADER_PLATFORM_THREAD_ONCE_DEFINITION(var)
 #define LOADER_PLATFORM_THREAD_ONCE(ctl, func)
+#else
+#define LOADER_PLATFORM_THREAD_ONCE_DECLARATION(var) INIT_ONCE var = INIT_ONCE_STATIC_INIT;
+#define LOADER_PLATFORM_THREAD_ONCE_DEFINITION(var) INIT_ONCE var;
+#define LOADER_PLATFORM_THREAD_ONCE(ctl, func) loader_platform_thread_once_fn(ctl, func)
+static BOOL CALLBACK InitFuncWrapper(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *Context) {
+    void (*func)(void) = (void (*)(void))Parameter;
+    func();
+    return TRUE;
+}
+static void loader_platform_thread_once_fn(void *ctl, void (*func)(void)) {
+    assert(func != NULL);
+    assert(ctl != NULL);
+    InitOnceExecuteOnce((PINIT_ONCE)ctl, InitFuncWrapper, (void *)func, NULL);
+}
+#endif
 
 // Thread IDs:
 typedef DWORD loader_platform_thread_id;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,6 +105,9 @@ else()
 endif()
 
 target_link_libraries(vk_loader_validation_tests "${LOADER_LIB}" gtest gtest_main)
+if(BUILD_LOADER AND ENABLE_STATIC_LOADER)
+    set_target_properties(vk_loader_validation_tests PROPERTIES LINK_FLAGS "/ignore:4098")
+endif()
 
 # Copy loader and googletest (gtest) libs to test dir so the test executable can find them.
 if(WIN32)
@@ -124,7 +127,7 @@ if(WIN32)
                        COMMAND xcopy /Y /I ${GTEST_COPY_SRC1} ${GTEST_COPY_DEST}
                        COMMAND xcopy /Y /I ${GTEST_COPY_SRC2} ${GTEST_COPY_DEST})
     # Copy the loader shared lib (if built) to the test application directory so the test app finds it.
-    if(TARGET vulkan)
+    if((NOT ENABLE_STATIC_LOADER) AND TARGET vulkan)
         add_custom_command(TARGET vk_loader_validation_tests POST_BUILD
                            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:vulkan> $<TARGET_FILE_DIR:vk_loader_validation_tests>)
     endif()


### PR DESCRIPTION
ANGLE builds the vulkan loader on Mac to load swiftshader as a
backend. In Chrome we don't want to ship extra dylibs so ANGLE
is going to statically link the vulkan loader. The following two
commits need to be reverted for this to work:

Revert "loader: Remove code for building a static loader"

This reverts commit 08d344208e60e0bb8c8fbe25b9b1f2bf63801e2f.

Revert "repo: Remove the option to build a static loader"

This reverts commit 161b28c1e9a9894ca11f67fc9593dbcf64866bfe.