### PR TITLE
FindVulkanHeaders: Match header lines more precisely

### DIFF
--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -138,7 +138,7 @@ foreach(VulkanHeaders_line ${VulkanHeaders_lines})
     #   Format is:
     #      #define VK_HEADER_VERSION Z
     #   Where Z is the patch version which we just grab off the end
-    string(REGEX MATCH "define.*VK_HEADER_VERSION.*[0-9]+" VulkanHeaders_out ${VulkanHeaders_line})
+    string(REGEX MATCH "define.*VK_HEADER_VERSION[^_].*[0-9]+" VulkanHeaders_out ${VulkanHeaders_line})
     list(LENGTH VulkanHeaders_out VulkanHeaders_len)
     if (VulkanHeaders_len)
         string(REGEX MATCH "[0-9]+" VulkanHeaders_VERSION_PATCH "${VulkanHeaders_out}")


### PR DESCRIPTION
In recent versions of Vulkan-Headers, we need to avoid matching the line
that defines VK_HEADER_VERSION_COMPLETE, because that would result in
thinking the micro version was 1 instead of the correct 134.

Fixes: https://github.com/KhronosGroup/Vulkan-Loader/issues/352  
Signed-off-by: Simon McVittie <smcv@collabora.com>