### PR TITLE
travis: Remove GN build failures from 'allowed' list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: CHECK_COMMIT_FORMAT=ON
-    - env: VULKAN_BUILD_TARGET=GN
   include:
     # Linux GCC debug build.
     - os: linux


### PR DESCRIPTION
GN build failures will now cause the travis builds to fail.

