### PR TITLE
docs: Fix wrong description for vkNegotiateLoaderLayerInterfaceVersion

### DIFF
--- a/loader/LoaderAndLayerInterface.md
+++ b/loader/LoaderAndLayerInterface.md
@@ -1040,10 +1040,8 @@ The loader will then individually call each layer’s
 “VkNegotiateLayerInterface”. The layer will either accept the loader's version
 set in "loaderLayerInterfaceVersion", or modify it to the closest value version
 of the interface that the layer can support.  The value should not be higher
-than the version requested by the loader.  If the layer can't support at a
-minimum the version requested, then the layer should return an error like
-"VK_ERROR_INITIALIZATION_FAILED".  If a layer can support some version, then
-the layer should do the following:
+than the version requested by the loader. If a layer can support some versions,
+then the layer should do the following:
  1. Adjust the version to the layer's desired version.
  2. The layer should fill in the function pointer values to its internal
 functions:


### PR DESCRIPTION
Below statement isn't accurate:
"
If the layer can't support at a minimum the version requested, then the
layer should return an error like "VK_ERROR_INITIALIZATION_FAILED".
"

There is no exact definition about the "a minimum the version requested"
in the surrounding context, and vkNegotiateLoaderLayerInterfaceVersion
has below semanteme now:
1:It will accept the loaderLayerInterfaceVersion and return VK_SUCCESS.
2:It will set loaderLayerInterfaceVersion to closest value version of the
  interface that the layer can support and return VK_SUCCESS.

So I think vkNegotiateLoaderLayerInterfaceVersion should never return the
error code, VK_ERROR_INITIALIZATION_FAILED.

Note: this patch also converts "some version" to "some versions".