### PR TITLE
Allow vkGetInstanceProcAddr to resolve itself with no instance

### DIFF
--- a/loader/gpa_helper.h
+++ b/loader/gpa_helper.h
@@ -229,6 +229,7 @@ static inline void *globalGetProcAddr(const char *name) {
     if (!strcmp(name, "EnumerateInstanceExtensionProperties")) return vkEnumerateInstanceExtensionProperties;
     if (!strcmp(name, "EnumerateInstanceLayerProperties")) return vkEnumerateInstanceLayerProperties;
     if (!strcmp(name, "EnumerateInstanceVersion")) return vkEnumerateInstanceVersion;
+    if (!strcmp(name, "GetInstanceProcAddr")) return vkGetInstanceProcAddr;
 
     return NULL;
 }


### PR DESCRIPTION
Fixes #365