### PR TITLE
build: Find headers package from external dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,6 @@ if(BUILD_STATIC_LOADER)
         "or tested as part of the loader. Use it at your own risk.")
 endif()
 
-# Add the externals directory early so we pickup the headers if they're present
-add_subdirectory(external)
-
 if (TARGET Vulkan::Headers)
     message(STATUS "Using Vulkan headers from Vulkan::Headers target")
     get_target_property(VulkanHeaders_INCLUDE_DIRS Vulkan::Headers INTERFACE_INCLUDE_DIRECTORIES)
@@ -229,6 +226,7 @@ if(BUILD_LOADER)
     add_subdirectory(loader)
 endif()
 
+add_subdirectory(external)
 if(BUILD_TESTS)
     add_subdirectory(tests)
 endif()

--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -74,7 +74,7 @@ if(DEFINED VULKAN_HEADERS_INSTALL_DIR)
 else()
   # If VULKAN_HEADERS_INSTALL_DIR, or one of its variants was not specified,
   # do a normal search without hints.
-  find_path(VulkanHeaders_INCLUDE_DIR NAMES vulkan/vulkan.h)
+  find_path(VulkanHeaders_INCLUDE_DIR NAMES vulkan/vulkan.h HINTS "${CMAKE_CURRENT_SOURCE_DIR}/external/Vulkan-Headers/include")
   get_filename_component(VULKAN_REGISTRY_PATH_HINT ${VulkanHeaders_INCLUDE_DIR} DIRECTORY)
   find_path(VulkanRegistry_DIR NAMES vk.xml HINTS ${VULKAN_REGISTRY_PATH_HINT}/share/vulkan/registry
     "${VULKAN_REGISTRY_PATH_HINT}/registry")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -37,7 +37,3 @@ if(BUILD_TESTS)
                            "Provide Google Test in external/googletest or set BUILD_TESTS=OFF")
     endif()
 endif()
-
-if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers")
-  add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers")
-endif()


### PR DESCRIPTION
This fixes #361. 

A previous change allowed finding vulkan headers in the external directory. This change modifies that to use the find_package() interface through CMake. This allows versioning to work properly and also allows `VULKAN_HEADERS_INSTALL_DIR` to override what's in the external directory.
