### PR TITLE
Update Linux distro used in Travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,17 @@ matrix:
   include:
     # Linux GCC debug build.
     - os: linux
+      dist: bionic
       compiler: gcc
       env: VULKAN_BUILD_TARGET=LINUX
     # Linux clang debug build.
     - os: linux
+      dist: bionic
       compiler: clang
       env: VULKAN_BUILD_TARGET=LINUX
     # Linux GN debug build
     - os: linux
+      dist: bionic
       env: VULKAN_BUILD_TARGET=GN
     # MacOS clang debug build.
     - os: osx
@@ -41,15 +44,8 @@ cache: ccache
 
 before_install:
   - set -e
-  - CMAKE_VERSION=3.10.2
   - |
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      # Upgrade to the desired version of CMake
-      CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
-      echo CMAKE_URL=${CMAKE_URL}
-      mkdir cmake-${CMAKE_VERSION} && travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake-${CMAKE_VERSION}
-      export PATH=${PWD}/cmake-${CMAKE_VERSION}/bin:${PATH}
-    else
+    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       brew install cmake || brew upgrade cmake
     fi
     cmake --version


### PR DESCRIPTION
Ubuntu bionic comes with cmake 3.10.2. We could get rid of the custom cmake installation step.