### PR TITLE
loader: Fix deadlock introduced by preloading ICDs

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -657,13 +657,13 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
         util_FreeDebugReportCreateInfos(pAllocator, ptr_instance->tmp_report_create_infos, ptr_instance->tmp_report_callbacks);
     }
 
-    // Unload preloaded layers, so if vkEnumerateInstanceExtensionProperties or vkCreateInstance is called again, the ICD's are up
-    // to date
-    loader_unload_preloaded_icds();
-
     loader_instance_heap_free(ptr_instance, ptr_instance->disp);
     loader_instance_heap_free(ptr_instance, ptr_instance);
     loader_platform_thread_unlock_mutex(&loader_lock);
+
+    // Unload preloaded layers, so if vkEnumerateInstanceExtensionProperties or vkCreateInstance is called again, the ICD's are up
+    // to date
+    loader_unload_preloaded_icds();
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount,


### PR DESCRIPTION
The call to `loader_unload_preloaded_icds()` in vkDestroyInstance happens before the
loader_lock mutex was released, causing a deadlock due to the mutex not allowing
self re-entrant locking.
The fix is simply unload the ICDs after this lock was released.

Resolves #372 

Change-Id: I3f5774463b9872127893ed00183693dcf17a35d1