### PR TITLE
cmake: prefer VulkanHeadersConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ if(BUILD_STATIC_LOADER)
         "or tested as part of the loader. Use it at your own risk.")
 endif()
 
+# first try to find a `VulkanHeadersConfig.cmake` file, then fall back to `FindVulkanHeaders.cmake`
+find_package(VulkanHeaders CONFIG)
 if (TARGET Vulkan::Headers)
     message(STATUS "Using Vulkan headers from Vulkan::Headers target")
     get_target_property(VulkanHeaders_INCLUDE_DIRS Vulkan::Headers INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
First try to find a `VulkanHeadersConfig.cmake` file, and if no such file
is found fall back to the `FindVulkanHeaders.cmake` file.

The following PR would generate and add such a target: https://github.com/KhronosGroup/Vulkan-Headers/pull/110

With the previous change the target `Vulkan::Headers` can never be found in the first cmake-configure run, because the subdirectory, which provided the target was moved down after the check.
https://github.com/KhronosGroup/Vulkan-Loader/commit/ba1f7760c20e2925d71b4a5783fd4c34c7c2e980
