### PR TITLE
Check for null when creating a queue

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -864,7 +864,9 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceQueue(VkDevice device, uint3
     disp = loader_get_dispatch(device);
 
     disp->GetDeviceQueue(device, queueNodeIndex, queueIndex, pQueue);
-    loader_set_dispatch(*pQueue, disp);
+    if (pQueue != NULL) {
+        loader_set_dispatch(*pQueue, disp);
+    }
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
@@ -2450,8 +2452,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkTrimCommandPool(
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2 *pQueueInfo, VkQueue *pQueue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     disp->GetDeviceQueue2(device, pQueueInfo, pQueue);
-    if (*pQueue != VK_NULL_HANDLE)
-    {
+    if (pQueue != NULL) {
         loader_set_dispatch(*pQueue, disp);
     }
 }


### PR DESCRIPTION
This fixes #384. Without a null check when creating a queue, it becomes impossible to test for the case where the provided queue is null. Normally I would prefer to check the return code, but these functions are void return.
