### PR TITLE
loader: Preload ICD use its own mutex

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -422,6 +422,7 @@ extern struct loader_struct loader;
 extern THREAD_LOCAL_DECL struct loader_instance *tls_instance;
 extern loader_platform_thread_mutex loader_lock;
 extern loader_platform_thread_mutex loader_json_lock;
+extern loader_platform_thread_mutex loader_preload_icd_lock;
 
 struct loader_msg_callback_map_entry {
     VkDebugReportCallbackEXT icd_obj;


### PR DESCRIPTION
Previously, if a layer called a pre-instance function
while being initialized (inside vkCreateInstance) a deadlock
would occur because the preload icd call used the same mutex.

Fixes #400 

Change-Id: I085ecfbcab26d746d77ca8466b4f63a13f6bea10