### PR TITLE
loader: Return error if layer loading failed

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5882,7 +5882,7 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
 
             lib_handle = loaderOpenLayerFile(inst, "instance", layer_prop);
             if (!lib_handle) {
-                continue;
+                return VK_ERROR_LAYER_NOT_PRESENT;
             }
 
             if (NULL == layer_prop->functions.negotiate_layer_interface) {


### PR DESCRIPTION
Loader will now fail vkCreateInstance with VK_ERROR_LAYER_NOT_PRESENT
if the layer's library failed to load. Previously, it would log the
error but continue, leading to false positives since it would return
VK_SUCCESS. No additional error reporting should be necessary since `loaderOpenLayerFile`
reports errors already.

Fixes #18

Change-Id: I00804b6f02cc6e927ac0219b4cb0c2361d6561fe