### PR TITLE
loader: Fix crash in vkGetDeviceQueue2

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -2452,7 +2452,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkTrimCommandPool(
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2 *pQueueInfo, VkQueue *pQueue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     disp->GetDeviceQueue2(device, pQueueInfo, pQueue);
-    if (pQueue != NULL) {
+    if (pQueue != NULL && *pQueue != NULL) {
         loader_set_dispatch(*pQueue, disp);
     }
 }


### PR DESCRIPTION
This fixes #416. See that issue for the details.