### PR TITLE
Unbreak build when Vulkan-ValidationLayers is installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ else()
 
     # set up the Vulkan::Headers target for consistency
     add_library(vulkan-headers INTERFACE)
-    target_include_directories(vulkan-headers INTERFACE "${VulkanHeaders_INCLUDE_DIRS}")
+    target_include_directories(vulkan-headers SYSTEM INTERFACE "${VulkanHeaders_INCLUDE_DIRS}")
     add_library(Vulkan::Headers ALIAS vulkan-headers)
 endif()
 
@@ -132,7 +132,7 @@ if(UNIX AND NOT APPLE) # i.e.: Linux
 
     if(BUILD_WSI_WAYLAND_SUPPORT)
         find_package(Wayland REQUIRED)
-        include_directories(${WAYLAND_CLIENT_INCLUDE_DIR})
+        include_directories(SYSTEM ${WAYLAND_CLIENT_INCLUDE_DIR})
     endif()
 endif()
 


### PR DESCRIPTION
When `-I loader` is put after system headers not marked by `-isystem` the build may fail e.g.,
```c
$ pkg install vulkan-validation-layers
$ cmake -B _build -G Ninja
$ cmake --build _build
FAILED: loader/CMakeFiles/vulkan.dir/loader.c.o
/usr/bin/cc -DAPI_NAME=\"Vulkan\" -DEXTRASYSCONFDIR=\"/etc\" -DFALLBACK_CONFIG_DIRS=\"/etc/xdg\" -DFALLBACK_DATA_DIRS=\"/usr/local/share:/usr/share\" -DSYSCONFDIR=\"/usr/local/etc\" -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_WAYLAND_KHR -DVK_USE_PLATFORM_XCB_KHR -DVK_USE_PLATFORM_XLIB_KHR -DVK_USE_PLATFORM_XLIB_XRANDR_EXT -Dvulkan_EXPORTS -I/usr/local/include -I../loader -I../loader/generated -Iloader -std=c99 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -fno-strict-aliasing -fno-builtin-memcmp -fvisibility=hidden -Wpointer-arith -Wno-typedef-redefinition -fPIC -MD -MT loader/CMakeFiles/vulkan.dir/loader.c.o -MF loader/CMakeFiles/vulkan.dir/loader.c.o.d -o loader/CMakeFiles/vulkan.dir/loader.c.o   -c ../loader/loader.c
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:56:9: warning: 'VULKAN_DIR' macro redefined [-Wmacro-redefined]
#define VULKAN_DIR "/vulkan/"
        ^
../loader/vk_loader_platform.h:56:9: note: previous definition is here
#define VULKAN_DIR "vulkan/"
        ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:86:20: error: redefinition of 'loader_platform_file_exists'
static inline bool loader_platform_file_exists(const char *path) {
                   ^
../loader/vk_loader_platform.h:87:20: note: previous definition is here
static inline bool loader_platform_file_exists(const char *path) {
                   ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:93:20: error: redefinition of 'loader_platform_is_path_absolute'
static inline bool loader_platform_is_path_absolute(const char *path) {
                   ^
../loader/vk_loader_platform.h:94:20: note: previous definition is here
static inline bool loader_platform_is_path_absolute(const char *path) {
                   ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:100:21: error: redefinition of 'loader_platform_dirname'
static inline char *loader_platform_dirname(char *path) { return dirname(path); }
                    ^
../loader/vk_loader_platform.h:101:21: note: previous definition is here
static inline char *loader_platform_dirname(char *path) { return dirname(path); }
                    ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:104:41: error: redefinition of 'loader_platform_open_library'
static inline loader_platform_dl_handle loader_platform_open_library(const char *libPath) {
                                        ^
../loader/vk_loader_platform.h:105:41: note: previous definition is here
static inline loader_platform_dl_handle loader_platform_open_library(const char *libPath) {
                                        ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:111:27: error: redefinition of 'loader_platform_open_library_error'
static inline const char *loader_platform_open_library_error(const char *libPath) { return dlerror(); }
                          ^
../loader/vk_loader_platform.h:112:27: note: previous definition is here
static inline const char *loader_platform_open_library_error(const char *libPath) { return dlerror(); }
                          ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:112:20: error: redefinition of 'loader_platform_close_library'
static inline void loader_platform_close_library(loader_platform_dl_handle library) { dlclose(library); }
                   ^
../loader/vk_loader_platform.h:113:20: note: previous definition is here
static inline void loader_platform_close_library(loader_platform_dl_handle library) { dlclose(library); }
                   ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:113:21: error: redefinition of 'loader_platform_get_proc_address'
static inline void *loader_platform_get_proc_address(loader_platform_dl_handle library, const char *name) {
                    ^
../loader/vk_loader_platform.h:114:21: note: previous definition is here
static inline void *loader_platform_get_proc_address(loader_platform_dl_handle library, const char *name) {
                    ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:118:27: error: redefinition of 'loader_platform_get_proc_address_error'
static inline const char *loader_platform_get_proc_address_error(const char *name) { return dlerror(); }
                          ^
../loader/vk_loader_platform.h:119:27: note: previous definition is here
static inline const char *loader_platform_get_proc_address_error(const char *name) { return dlerror(); }
                          ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:131:41: error: redefinition of 'loader_platform_get_thread_id'
static inline loader_platform_thread_id loader_platform_get_thread_id() { return pthread_self(); }
                                        ^
../loader/vk_loader_platform.h:132:41: note: previous definition is here
static inline loader_platform_thread_id loader_platform_get_thread_id() { return pthread_self(); }
                                        ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:135:20: error: redefinition of 'loader_platform_thread_create_mutex'
static inline void loader_platform_thread_create_mutex(loader_platform_thread_mutex *pMutex) { pthread_mutex_init(pMutex, NULL); }
                   ^
../loader/vk_loader_platform.h:136:20: note: previous definition is here
static inline void loader_platform_thread_create_mutex(loader_platform_thread_mutex *pMutex) { pthread_mutex_init(pMutex, NULL); }
                   ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:136:20: error: redefinition of 'loader_platform_thread_lock_mutex'
static inline void loader_platform_thread_lock_mutex(loader_platform_thread_mutex *pMutex) { pthread_mutex_lock(pMutex); }
                   ^
../loader/vk_loader_platform.h:137:20: note: previous definition is here
static inline void loader_platform_thread_lock_mutex(loader_platform_thread_mutex *pMutex) { pthread_mutex_lock(pMutex); }
                   ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:137:20: error: redefinition of 'loader_platform_thread_unlock_mutex'
static inline void loader_platform_thread_unlock_mutex(loader_platform_thread_mutex *pMutex) { pthread_mutex_unlock(pMutex); }
                   ^
../loader/vk_loader_platform.h:138:20: note: previous definition is here
static inline void loader_platform_thread_unlock_mutex(loader_platform_thread_mutex *pMutex) { pthread_mutex_unlock(pMutex); }
                   ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:138:20: error: redefinition of 'loader_platform_thread_delete_mutex'
static inline void loader_platform_thread_delete_mutex(loader_platform_thread_mutex *pMutex) { pthread_mutex_destroy(pMutex); }
                   ^
../loader/vk_loader_platform.h:139:20: note: previous definition is here
static inline void loader_platform_thread_delete_mutex(loader_platform_thread_mutex *pMutex) { pthread_mutex_destroy(pMutex); }
                   ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:140:20: error: redefinition of 'loader_platform_thread_init_cond'
static inline void loader_platform_thread_init_cond(loader_platform_thread_cond *pCond) { pthread_cond_init(pCond, NULL); }
                   ^
../loader/vk_loader_platform.h:141:20: note: previous definition is here
static inline void loader_platform_thread_init_cond(loader_platform_thread_cond *pCond) { pthread_cond_init(pCond, NULL); }
                   ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:141:20: error: redefinition of 'loader_platform_thread_cond_wait'
static inline void loader_platform_thread_cond_wait(loader_platform_thread_cond *pCond, loader_platform_thread_mutex *pMutex) {
                   ^
../loader/vk_loader_platform.h:142:20: note: previous definition is here
static inline void loader_platform_thread_cond_wait(loader_platform_thread_cond *pCond, loader_platform_thread_mutex *pMutex) {
                   ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:144:20: error: redefinition of 'loader_platform_thread_cond_broadcast'
static inline void loader_platform_thread_cond_broadcast(loader_platform_thread_cond *pCond) { pthread_cond_broadcast(pCond); }
                   ^
../loader/vk_loader_platform.h:145:20: note: previous definition is here
static inline void loader_platform_thread_cond_broadcast(loader_platform_thread_cond *pCond) { pthread_cond_broadcast(pCond); }
                   ^
In file included from ../loader/loader.c:85:
In file included from ../loader/generated/vk_loader_extensions.c:31:
/usr/local/include/vk_loader_platform.h:369:20: error: redefinition of 'loader_platform_is_path'
static inline bool loader_platform_is_path(const char *path) { return strchr(path, DIRECTORY_SYMBOL) != NULL; }
                   ^
../loader/vk_loader_platform.h:370:20: note: previous definition is here
static inline bool loader_platform_is_path(const char *path) { return strchr(path, DIRECTORY_SYMBOL) != NULL; }
                   ^
1 warning and 17 errors generated.
ninja: build stopped: subcommand failed.
```
