### PR TITLE
Convert GN libs lists to frameworks

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -127,7 +127,7 @@ if (!is_android) {
       libs = [ "Cfgmgr32.lib" ]
     }
     if (is_mac) {
-      libs = [ "CoreFoundation.framework" ]
+      frameworks = [ "CoreFoundation.framework" ]
     }
     public_deps = [ "$vulkan_headers_dir:vulkan_headers" ]
     configs -= [ "//build/config/compiler:chromium_code" ]


### PR DESCRIPTION
GN recently added support for Apple frameworks to link, rather than
overloading the libs lists. This pulls .frameworks out of the libs
lists, so that GN can stop supporting .frameworks in libs in the
future.

Bug: chromium:1052560