### PR TITLE
loader: fix wrongly returned error code

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4472,6 +4472,7 @@ VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_t
                 res = temp_res;
             }
             if (temp_res == VK_ERROR_OUT_OF_HOST_MEMORY) {
+                res = VK_ERROR_OUT_OF_HOST_MEMORY;
                 break;
             } else {
                 continue;
@@ -7512,7 +7513,8 @@ terminator_EnumerateInstanceExtensionProperties(const VkEnumerateInstanceExtensi
         // Scan/discover all ICD libraries
         memset(&icd_tramp_list, 0, sizeof(icd_tramp_list));
         res = loader_icd_scan(NULL, &icd_tramp_list);
-        if (VK_SUCCESS != res) {
+        // EnumerateInstanceExtensionProperties can't return anything other than OOM or VK_ERROR_LAYER_NOT_PRESENT
+        if ((VK_SUCCESS != res && icd_tramp_list.count > 0) || res == VK_ERROR_OUT_OF_HOST_MEMORY) {
             goto out;
         }
         // Get extensions from all ICD's, merge so no duplicates


### PR DESCRIPTION
vkEnumerateInstanceExtensionProperties was returning VK_ERROR_INITIALIZATION_FAILED
when a single malformed manifest file was found. This was due to the way
`loader_scan_icd` returns an error if it found an invalid ICD's but no valid ones.

Fixes #421 

Change-Id: I84b39774b766d20d607c990bddc921b1c2a4297a