### PR TITLE
loader: Fix symbol lookup order

### DIFF
--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -123,11 +123,18 @@ static inline char *loader_platform_executable_path(char *buffer, size_t size) {
 // Dynamic Loading of libraries:
 typedef void *loader_platform_dl_handle;
 static inline loader_platform_dl_handle loader_platform_open_library(const char *libPath) {
-    // When loading the library, we use RTLD_LAZY so that not all symbols have to be
-    // resolved at this time (which improves performance). Note that if not all symbols
-    // can be resolved, this could cause crashes later. Use the LD_BIND_NOW environment
-    // variable to force all symbols to be resolved here.
+// When loading the library, we use RTLD_LAZY so that not all symbols have to be
+// resolved at this time (which improves performance). Note that if not all symbols
+// can be resolved, this could cause crashes later. Use the LD_BIND_NOW environment
+// variable to force all symbols to be resolved here. On Linux use RTLD_DEEPBIND
+// to ensure that implementation's own dependencies are first in lookup order.
+// This may be useful when both application and driver use different versions
+// of the same library.
+#ifdef __linux__
+    return dlopen(libPath, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+#else
     return dlopen(libPath, RTLD_LAZY | RTLD_LOCAL);
+#endif
 }
 static inline const char *loader_platform_open_library_error(const char *libPath) { return dlerror(); }
 static inline void loader_platform_close_library(loader_platform_dl_handle library) { dlclose(library); }


### PR DESCRIPTION
Some Vulkan implementations may rely on external libraries.
One example is mesa driver, that uses libLLVM.so. If user
application also links with LLVM, some clashes may take place.
This patch ensures that library's own symbols are looked up
before any other symbols in current process.