### PR TITLE
Remove duplicate key / value in scripts/common_codegen.py

### DIFF
--- a/scripts/common_codegen.py
+++ b/scripts/common_codegen.py
@@ -59,7 +59,6 @@ platform_dict = {
     'directfb' : 'VK_USE_PLATFORM_DIRECTFB_EXT',
     'xlib_xrandr' : 'VK_USE_PLATFORM_XLIB_XRANDR_EXT',
     'provisional' : 'VK_ENABLE_BETA_EXTENSIONS',
-    'directfb' : 'VK_USE_PLATFORM_DIRECTFB_EXT',
 }
 
 #


### PR DESCRIPTION
'directfb' : 'VK_USE_PLATFORM_DIRECTFB_EXT' was duplicated in scripts/common_codegen.py during merge.

Nicolas Caramelli