### PR TITLE
WIP: Use RTLD deepbind for library loading

### DIFF
--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -135,8 +135,16 @@ static inline loader_platform_dl_handle loader_platform_open_library(const char 
 // When loading the library, we use RTLD_LAZY so that not all symbols have to be
 // resolved at this time (which improves performance). Note that if not all symbols
 // can be resolved, this could cause crashes later. Use the LD_BIND_NOW environment
-// variable to force all symbols to be resolved here.
+// variable to force all symbols to be resolved here. On Linux use RTLD_DEEPBIND
+// to ensure that implementation's own dependencies are first in lookup order.
+// This may be useful when both application and driver use different versions
+// of the same library.
+#if defined(__linux__) && !defined(LOADER_ADDRESS_SANITIZER)
+    // Address Sanitizer breaks with RTLD_DEEPBIND, remove it if ASAN is found
+    return dlopen(libPath, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+#else
     return dlopen(libPath, RTLD_LAZY | RTLD_LOCAL);
+#endif
 }
 static inline const char *loader_platform_open_library_error(const char *libPath) { return dlerror(); }
 static inline void loader_platform_close_library(loader_platform_dl_handle library) { dlclose(library); }


### PR DESCRIPTION
This change was previously put into master as a result of #427 and #430. We then found that the change can't coexist with the Steam Fossilize layer, which cases Steam games to crash when launched with shader pre-caching (which is the default behavior). The goal of this PR is to add deepbind back in, after we've worked out how to make the change coexist with fossilize. See #433 For the issue at hand.