### PR TITLE
fix some non-msvc compiler warnings

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -888,7 +888,7 @@ VkResult loaderGetRegistryFiles(const struct loader_instance *inst, char *locati
     }
 
     if (is_driver) {
-        HRESULT hres = fpCreateDXGIFactory1(&IID_IDXGIFactory1, &dxgi_factory);
+        HRESULT hres = fpCreateDXGIFactory1(&IID_IDXGIFactory1, (void **)&dxgi_factory);
         if (hres != S_OK) {
             loader_log(
                 inst, VK_DEBUG_REPORT_WARNING_BIT_EXT, 0,

--- a/tests/loader_validation_tests.cpp
+++ b/tests/loader_validation_tests.cpp
@@ -27,7 +27,9 @@
  */
 
 // Following items are needed for C++ to work with PRIxLEAST64
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
 
 #include <stdint.h>  // For UINT32_MAX

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -34,7 +34,9 @@
 #include <string.h>
 
 #ifdef _WIN32
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 // WinSock2.h must be included *BEFORE* windows.h
 #include <winsock2.h>
 #endif
@@ -42,10 +44,10 @@
 #include <vulkan/vk_sdk_platform.h>
 #include <vulkan/vulkan.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #pragma warning(push)
 /*
-    warnings 4251 and 4275 have to do with potential dll-interface mismatch
+    MSVC warnings 4251 and 4275 have to do with potential dll-interface mismatch
     between library (gtest) and users. Since we build the gtest library
     as part of the test build we know that the dll-interface will match and
     can disable these warnings.
@@ -71,7 +73,7 @@
 #pragma pop_macro("None")
 #endif
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 


### PR DESCRIPTION
changes:
* loader/loader.c: cast dxgi_factory to void** type
* tests/loader_validation_tests.cpp: check if __STDC_FORMAT_MACROS is already defined
* tests/test_common.h: check if NOMINMAX is already defined
* tests/test_common.h: check _MSC_VER instead of WIN32 before pragma warning directive