### PR TITLE
Make invalid standard validation layer an error

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -476,9 +476,9 @@ VkResult loader_init_generic_list(const struct loader_instance *inst, struct loa
 void loader_destroy_generic_list(const struct loader_instance *inst, struct loader_generic_list *list);
 void loaderDestroyLayerList(const struct loader_instance *inst, struct loader_device *device, struct loader_layer_list *layer_list);
 void loaderDeleteLayerListAndProperties(const struct loader_instance *inst, struct loader_layer_list *layer_list);
-void loaderAddLayerNameToList(const struct loader_instance *inst, const char *name, const enum layer_type_flags type_flags,
-                              const struct loader_layer_list *source_list, struct loader_layer_list *target_list,
-                              struct loader_layer_list *expanded_target_list);
+VkResult loaderAddLayerNameToList(const struct loader_instance *inst, const char *name, const enum layer_type_flags type_flags,
+                                  const struct loader_layer_list *source_list, struct loader_layer_list *target_list,
+                                  struct loader_layer_list *expanded_target_list);
 void loader_scanned_icd_clear(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
 VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
 void loaderScanForLayers(struct loader_instance *inst, struct loader_layer_list *instance_layers);


### PR DESCRIPTION
This fixes #440. See that issue for motivation.

A couple of notes on this:
- The loader already logged a message when someone used standard validation incorrectly, but it was logged as a warning and it didn't stop the application from continuing.
- This change makes that warning into an error message and it uses a special error message that tells you to use khronos validation
- This change also will cause `vkCreateInstance` to fail with the error code `VK_ERROR_LAYER_NOT_PRESENT` when the old standard validation is used illegally.
- If the standard validation is actually present on a system (which would occur if an old copy of the layers is present) then no error will happen. This only happens when the standard validation layer is enabled and not found.

If people would verify that all sounds correct, I'd appreciate it.