### PR TITLE
loader: NULL out freed memory properly

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4928,6 +4928,7 @@ void loaderScanForImplicitLayers(struct loader_instance *inst, struct loader_lay
             res = loaderAddLayerProperties(inst, instance_layers, json, true, file_str);
 
             loader_instance_heap_free(inst, file_str);
+            manifest_files.filename_list[i] = NULL;
             cJSON_Delete(json);
 
             if (VK_ERROR_OUT_OF_HOST_MEMORY == res) {


### PR DESCRIPTION
Previously was double-freeing the memory, which could cause a crash.

Change-Id: Ia4838c9900a19ef345a8becc81ebbacb0a60d9e5