### PR TITLE
docs: Remove mentions of COPYRIGHT.txt from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ This scheme was adopted following the 1.1.96 Vulkan specification release.
 This work is released as open source under a Apache-style license from Khronos
 including a Khronos copyright.
 
-See COPYRIGHT.txt for a full list of licenses used in this repository.
-
 ## Acknowledgements
 
 While this project has been developed primarily by LunarG, Inc., there are many other


### PR DESCRIPTION
The COPYRIGHT.txt file itself was removed in https://github.com/KhronosGroup/Vulkan-Loader/commit/d7452989ff0cfbaeaecfb63d8516cab63cf41bee.