### PR TITLE
Fix invalid cleanup on allocation error

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -538,9 +538,7 @@ out:
 
     if (NULL != ptr_instance) {
         if (res != VK_SUCCESS) {
-            if (NULL != ptr_instance->next) {
-                loader.instances = ptr_instance->next;
-            }
+            loader.instances = ptr_instance->next;
             if (NULL != ptr_instance->disp) {
                 loader_instance_heap_free(ptr_instance, ptr_instance->disp);
             }


### PR DESCRIPTION
This fixes a bug where an unsuccessful allocation could cause the loader to store an invalid ICD. This invalid ICD caused a few problems, but the one we were seeing was a circular list of ICDs which caused an application to hang.