### PR TITLE
Move variables into scope they are referenced within

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7061,10 +7061,10 @@ struct LoaderSortedPhysicalDevice {
 VkResult ReadSortedPhysicalDevices(struct loader_instance *inst, struct LoaderSortedPhysicalDevice **sorted_devices, uint32_t* sorted_count)
 {
     VkResult res = VK_SUCCESS;
-    uint32_t sorted_alloc = 0;
-    struct loader_icd_term* icd_term = NULL;
 
 #if defined(_WIN32)
+    uint32_t sorted_alloc = 0;
+    struct loader_icd_term* icd_term = NULL;
     IDXGIFactory6* dxgi_factory = NULL;
     HRESULT hres = fpCreateDXGIFactory1(&IID_IDXGIFactory6, &dxgi_factory);
     if (hres != S_OK) {

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7064,7 +7064,7 @@ VkResult ReadSortedPhysicalDevices(struct loader_instance *inst, struct LoaderSo
 
 #if defined(_WIN32)
     uint32_t sorted_alloc = 0;
-    struct loader_icd_term* icd_term = NULL;
+    struct loader_icd_term *icd_term = NULL;
     IDXGIFactory6* dxgi_factory = NULL;
     HRESULT hres = fpCreateDXGIFactory1(&IID_IDXGIFactory6, &dxgi_factory);
     if (hres != S_OK) {


### PR DESCRIPTION
This prevents unused variable warnings/errors on non-Windows
platforms.

Fixes #459