### PR TITLE
Revert "loader: Return error if layer loading failed"

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5942,7 +5942,7 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
 
             lib_handle = loaderOpenLayerFile(inst, "instance", layer_prop);
             if (!lib_handle) {
-                return VK_ERROR_LAYER_NOT_PRESENT;
+                continue;
             }
 
             if (NULL == layer_prop->functions.negotiate_layer_interface) {


### PR DESCRIPTION
This reverts commit 49648d8fb398ac7d3d8e159939de060b8e759ecf.
Many layers were relying on silently failing to allow 32/64 bit versions
to work on linux. A later commit will properly check for failing layers.