### PR TITLE
Fix some issues when EnumerateAdapterPhysicalDevices is available

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7153,7 +7153,8 @@ VkResult ReadSortedPhysicalDevices(struct loader_instance *inst, struct LoaderSo
                         res = VK_ERROR_OUT_OF_HOST_MEMORY;
                         goto out;
                     } else {
-                        loader_log(inst, VK_DEBUG_REPORT_WARNING_BIT_EXT, 0, "Failed to convert DXGI adapter into Vulkan physical device");
+                        loader_log(inst, VK_DEBUG_REPORT_WARNING_BIT_EXT, 0,
+                                   "Failed to convert DXGI adapter into Vulkan physical device");
                         continue;
                     }
                 }

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7147,11 +7147,15 @@ VkResult ReadSortedPhysicalDevices(struct loader_instance *inst, struct LoaderSo
                 }
 
                 if (vkres != VK_SUCCESS) {
-                    loader_log(inst, VK_DEBUG_REPORT_WARNING_BIT_EXT, 0, "Failed to convert DXGI adapter into Vulkan physical device");
-                    continue;
-                } else if (vkres == VK_ERROR_OUT_OF_HOST_MEMORY) {
-                    res = VK_ERROR_OUT_OF_HOST_MEMORY;
-                    goto out;
+                    loader_instance_heap_free(inst, sorted_array[*sorted_count].physical_devices);
+                    sorted_array[*sorted_count].physical_devices = NULL;
+                    if (vkres == VK_ERROR_OUT_OF_HOST_MEMORY) {
+                        res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                        goto out;
+                    } else {
+                        loader_log(inst, VK_DEBUG_REPORT_WARNING_BIT_EXT, 0, "Failed to convert DXGI adapter into Vulkan physical device");
+                        continue;
+                    }
                 }
                 inst->total_gpu_count += (sorted_array[*sorted_count].device_count = count);
                 sorted_array[*sorted_count].icd_index = icd_idx;
@@ -7974,7 +7978,7 @@ VkResult setupLoaderTermPhysDevGroups(struct loader_instance *inst) {
 
         // Check if this group can be sorted
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-        bool icd_sorted = icd_term->scanned_icd->EnumerateAdapterPhysicalDevices != NULL;
+        bool icd_sorted = sorted_count && (icd_term->scanned_icd->EnumerateAdapterPhysicalDevices != NULL);
 #else
         bool icd_sorted = false;
 #endif


### PR DESCRIPTION
1) Fix a memory leak with sorted_array[].physical_devices when EnumerateAdapterPhysicalDevices  returns an error. This fixes a failure with the "dEQP-VK.api.device_init.create_instance_device_intentional_alloc_fail" Vulkan CTS test.

2) Fix an issue with vkEnumeratePhysicalDeviceGroups() when fpCreateDXGIFactory1() fails, which will happen with Windows versions before version 10.