### PR TITLE
CMake: Fix libdir in pkg-config file, dehardcode includedir

### DIFF
--- a/loader/vulkan.pc.in
+++ b/loader/vulkan.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @CMAKE_PROJECT_NAME@
 Description: Vulkan Loader


### PR DESCRIPTION
Fixes #489.
Supersedes #214.

Those `CMAKE_INSTALL_FULL_*` defines depend on `GNUInstallDirs`, which is included in `CMakeLists.txt`.