### PR TITLE
loader: Properly check for elevated permissions

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -287,13 +287,12 @@ static inline char *loader_secure_getenv(const char *name, const struct loader_i
     out = __secure_getenv(name);
 #else
     out = loader_getenv(name, inst);
+#if !defined(USE_UNSAFE_FILE_SEARCH)
+    loader_log(inst, LOADER_INFO_BIT, 0, "Loader is using non-secure environment variable lookup for %s", name);
 #endif
 #endif
-    if (out == NULL) {
-        loader_log(inst, LOADER_INFO_BIT, 0,
-                   "Loader is running with elevated permissions. Environment variable %s will be ignored.", name);
-    }
     return out;
+#endif
 }
 
 static inline void loader_free_getenv(char *val, const struct loader_instance *inst) {
@@ -355,8 +354,8 @@ static inline char *loader_getenv(const char *name, const struct loader_instance
 static inline char *loader_secure_getenv(const char *name, const struct loader_instance *inst) {
 #if !defined(USE_UNSAFE_FILE_SEARCH)
     if (IsHighIntegrity()) {
-        loader_log(inst, LOADER_INFO_BIT, 0,
-                   "Loader is running with elevated permissions. Environment variable %s will be ignored.", name);
+        loader_log(inst, LOADER_INFO_BIT, 0, "Loader is running with elevated permissions. Environment variable %s will be ignored",
+                   name);
         return NULL;
     }
 #endif


### PR DESCRIPTION
The status message for the loader not searching environment
variables when running with elevated permissions didn't properly
check on Linux. This commit adds in proper guards to make sure the status
message only prints when running with elevated permissions.

Change-Id: I993bb08de21bb0e338852368c24fe615d0d1f9b9