### PR TITLE
Fix vulkan link to cfgmgr32 on case-sensitive fs

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -228,7 +228,7 @@ if(WIN32)
         target_link_libraries(vulkan OneCoreUAP.lib LIBCMT.LIB LIBCMTD.LIB LIBVCRUNTIME.LIB LIBUCRT.LIB)
         set_target_properties(vulkan PROPERTIES LINK_FLAGS "/NODEFAULTLIB")
     else()
-        target_link_libraries(vulkan Cfgmgr32)
+        target_link_libraries(vulkan cfgmgr32)
     endif()
 
     add_dependencies(vulkan loader_asm_gen_files)


### PR DESCRIPTION
On MinGW from Linux this fails because cfgmgr32 is lowercase. This will still work on win32.