### PR TITLE
loader: print early layer library errors to stderr

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -414,8 +414,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
     }
 
     // Save the application version
-    if (NULL == pCreateInfo || NULL == pCreateInfo->pApplicationInfo || 0 == pCreateInfo->pApplicationInfo->apiVersion)
-{
+    if (NULL == pCreateInfo || NULL == pCreateInfo->pApplicationInfo || 0 == pCreateInfo->pApplicationInfo->apiVersion) {
         ptr_instance->app_api_major_version = 1;
         ptr_instance->app_api_minor_version = 0;
     } else {


### PR DESCRIPTION
When creating the chain for instances and devices, the loader attempts
to load layer library files using the helper function
loaderOpenLayerFile. If the layer library fails to load, this function
is reporting errors by using a debug report message with type
VK_DEBUG_REPORT_ERROR_BIT_EXT.

That is fine for the device chain, but it's not useful for the instance
chain, because those errors would need to be processed by a debug report
messenger that can only be created once the instance itself has been
created, which is what the loader is doing when it reports the problem.

This commit makes the loader report the error using stderr for the
instance case so applications and users can detect possible problems
related to layer setups more easily.