### PR TITLE
Generate libvulkan.so.1 on Linux instead of libvulkan.so

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -173,14 +173,10 @@ if (!is_android) {
 
       runtime_deps = [ "//sdk/lib/fdio:fdio_sdk" ]
     }
-  }
 
-  if (is_linux && vulkan_loader_shared) {
-    copy("libvulkan-abi1") {
-      sources = [ "${root_out_dir}/libvulkan.so" ]
-      outputs = [ "${root_out_dir}/libvulkan.so.1" ]
-
-      deps = [ ":libvulkan" ]
+    # Create libvulkan.so.1 on Linux instead of libvulkan.so
+    if (is_linux && vulkan_loader_shared) {
+      output_extension = "so.1"
     }
   }
 }


### PR DESCRIPTION
This is the Linux way.  Previously, a copy step was added to copy
libvulkan.so to libvulkan.so.1.  However, that only runs if everything
is built and not when a specific target is built.

There is no need for libvulkan.so on Linux, so this change makes the
libvulkan target directly generate libvulkan.so.1 and removes the copy
step.