### PR TITLE
Revert "Generate libvulkan.so.1 on Linux instead of libvulkan.so"

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -173,10 +173,14 @@ if (!is_android) {
 
       runtime_deps = [ "//sdk/lib/fdio:fdio_sdk" ]
     }
+  }
 
-    # Create libvulkan.so.1 on Linux instead of libvulkan.so
-    if (is_linux && vulkan_loader_shared) {
-      output_extension = "so.1"
+  if (is_linux && vulkan_loader_shared) {
+    copy("libvulkan-abi1") {
+      sources = [ "${root_out_dir}/libvulkan.so" ]
+      outputs = [ "${root_out_dir}/libvulkan.so.1" ]
+
+      deps = [ ":libvulkan" ]
     }
   }
 }


### PR DESCRIPTION
Causes Chromium to pick up ANGLE's build of Vulkan-Loader instead of the
system one, with the caveat that the gn build of Vulkan-Loader doesn't
support VK_KHR_xlib_surface which Chromium depends on.

This change can be re-introduced once Chromium switches to
VK_KHR_xcb_surface.

This reverts commit 8308d6744d50e4dc357e60282436f6ec0942b8c8.