### PR TITLE
cmake: remove mingw lib prefix

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -224,7 +224,9 @@ if(WIN32)
                           PROPERTIES LINK_FLAGS_DEBUG
                                      "/ignore:4098"
                                      OUTPUT_NAME
-                                     vulkan-1)
+                                     vulkan-1
+                                     PREFIX
+                                     "")
     target_link_libraries(vulkan Vulkan::Headers)
 
     if(ENABLE_WIN10_ONECORE)


### PR DESCRIPTION
we want the dll to be named vulkan-1.dll and not libvulkan-1.dll
as it is the default on mingw (for drop-in replacement)