### PR TITLE
loader: Remove SEEK_END usage

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2653,7 +2653,12 @@ static VkResult loader_get_json(const struct loader_instance *inst, const char *
         res = VK_ERROR_INITIALIZATION_FAILED;
         goto out;
     }
-    fseek(file, 0, SEEK_END);
+    // NOTE: We can't just use fseek(file, 0, SEEK_END) because that isn't guaranteed to be supported on all systems
+    do {
+        // We're just seeking the end of the file, so this buffer is never used
+        char buffer[256];
+        fread(buffer, 1, sizeof(buffer), file);
+    } while (!feof(file));
     len = ftell(file);
     fseek(file, 0, SEEK_SET);
     json_buf = (char *)loader_stack_alloc(len + 1);


### PR DESCRIPTION
This fixes #488.

By using fread instead of fseek(file, 0, SEEK_END), this method should be more portable if we use an implementation in the future that doesn't support SEEK_END.