### PR TITLE
loader: Fix AArch64 Android build

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -259,7 +259,10 @@ else()
                                      "1"
                                      VERSION
                                      "${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}")
-    target_link_libraries(vulkan ${CMAKE_DL_LIBS} pthread m)
+    target_link_libraries(vulkan ${CMAKE_DL_LIBS} m)
+    if (NOT ANDROID)
+        target_link_libraries(vulkan pthread)
+    endif()
     target_link_libraries(vulkan Vulkan::Headers)
     if(APPLE)
         find_library(COREFOUNDATION_LIBRARY NAMES CoreFoundation)


### PR DESCRIPTION
The Android NDK doesn't provide a separate libpthread. Don't
explicitly link it in when builing for Android.

Signed-off-by: Kévin Petit <kevin.petit@arm.com>