### PR TITLE
loader: Do not return OOM when layer count is 0

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3129,7 +3129,7 @@ static VkResult loaderReadLayerJson(const struct loader_instance *inst, struct l
         // Allocate buffer for layer names
         props->component_layer_names =
             loader_instance_heap_alloc(inst, sizeof(char[MAX_STRING_SIZE]) * count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-        if (NULL == props->component_layer_names) {
+        if (NULL == props->component_layer_names && count > 0) {
             result = VK_ERROR_OUT_OF_HOST_MEMORY;
             goto out;
         }
@@ -3178,7 +3178,7 @@ static VkResult loaderReadLayerJson(const struct loader_instance *inst, struct l
                 // Allocate the blacklist array
                 props->blacklist_layer_names = loader_instance_heap_alloc(
                     inst, sizeof(char[MAX_STRING_SIZE]) * props->num_blacklist_layers, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-                if (props->blacklist_layer_names == NULL) {
+                if (props->blacklist_layer_names == NULL && props->num_blacklist_layers > 0) {
                     result = VK_ERROR_OUT_OF_HOST_MEMORY;
                     goto out;
                 }
@@ -3216,7 +3216,7 @@ static VkResult loaderReadLayerJson(const struct loader_instance *inst, struct l
             // Allocate buffer for override paths
             props->override_paths =
                 loader_instance_heap_alloc(inst, sizeof(char[MAX_STRING_SIZE]) * count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-            if (NULL == props->override_paths) {
+            if (NULL == props->override_paths && count > 0) {
                 result = VK_ERROR_OUT_OF_HOST_MEMORY;
                 goto out;
             }

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -122,7 +122,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
 
     // We'll need to save the dl handles so we can close them later
     loader_platform_dl_handle *libs = malloc(sizeof(loader_platform_dl_handle) * layers.count);
-    if (libs == NULL) {
+    if (libs == NULL && layers.count > 0) {
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
     size_t lib_count = 0;
@@ -216,7 +216,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
 
     // We'll need to save the dl handles so we can close them later
     loader_platform_dl_handle *libs = malloc(sizeof(loader_platform_dl_handle) * layers.count);
-    if (libs == NULL) {
+    if (libs == NULL && layers.count > 0) {
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
     size_t lib_count = 0;
@@ -310,7 +310,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
 
     // We'll need to save the dl handles so we can close them later
     loader_platform_dl_handle *libs = malloc(sizeof(loader_platform_dl_handle) * layers.count);
-    if (libs == NULL) {
+    if (libs == NULL && layers.count > 0) {
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
     size_t lib_count = 0;


### PR DESCRIPTION
An application program that overrides malloc with an implementation that
returns NULL for a zero-sized allocation will cause some loader and
trampoline functions to incorrectly return VK_ERROR_OUT_OF_HOST_MEMORY
if there are no layers on the system. This patch prevents these errors
by also checking the layer count.

Fixes: https://github.com/KhronosGroup/Vulkan-Loader/issues/543