### PR TITLE
Loader Test Framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,9 @@ jobs:
             - name: Build the loader
               run: make -C build
 
+            - name: Run regression tests
+              run: ./build/tests/test_regression
+
             - name: Verify generated source files
               run: python scripts/generate_source.py --verify external/Vulkan-Headers/registry
 
@@ -89,10 +92,13 @@ jobs:
             - name: Get Google Test
               run: git clone --branch release-1.8.1 https://github.com/google/googletest.git external/googletest
 
+            - name: Get Detours
+              run: git clone --branch v4.0.1 https://github.com/microsoft/Detours.git external/detours
+
             - name: Generate build files
               run: cmake -S. -Bbuild -A${{matrix.arch}} "-Cexternal/helper.cmake"
               if: matrix.os != 'windows-2016'
-            
+
             - name: Generate build files
               run: cmake -S. -Bbuild -A${{matrix.arch}} "-DCMAKE_SYSTEM_VERSION=10.0.17763.0" "-Cexternal/helper.cmake"
               if: matrix.os == 'windows-2016'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,6 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment ve
 
 project(Vulkan-Loader)
 
-enable_testing()
-
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS API_NAME="Vulkan")
 
 # Enable beta Vulkan extensions
@@ -36,6 +34,10 @@ if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest)
     option(BUILD_TESTS "Build Tests" ON)
 else()
     option(BUILD_TESTS "Build Tests" OFF)
+endif()
+
+if(BUILD_TESTS)
+    enable_testing()
 endif()
 
 if(APPLE)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -19,21 +19,96 @@
 
 # googletest is an optional external dependency for this repo.
 if(BUILD_TESTS)
+    # Set gtest build configuration
+    set(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
+    set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
+    set(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically")
+    set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
     # Attempt to enable if it is available.
-    if(TARGET gtest_main)
+    if(TARGET gtest)
         # Already enabled as a target (perhaps by a project enclosing this one)
         message(STATUS "Vulkan-Loader/external: " "googletest already configured - using it")
     elseif(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/googletest")
         # The googletest directory exists, so enable it as a target.
         message(STATUS "Vulkan-Loader/external: " "googletest found - configuring it for tests")
-        set(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
-        set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
-        set(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically")
-        set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
         # EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
         add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/googletest" EXCLUDE_FROM_ALL)
     else()
-        message(SEND_ERROR "Vulkan-Loader/external: " "Google Test was not found.  "
-                           "Provide Google Test in external/googletest or set BUILD_TESTS=OFF")
+        message(FATAL_ERROR "Vulkan-Loader/external: Google Test was not found. Please download it and place it in this folder")
+    endif()
+    if (WIN32)
+        if(TARGET detours)
+            # Already enabled as a target (perhaps by a project enclosing this one)
+            message(STATUS "Vulkan-Loader/external: " "detours already configured - using it")
+        else()
+            if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/detours")
+                # The detours directory exists, so enable it as a target.
+                message(STATUS "Vulkan-Loader/external: " "detours found - configuring it for tests")
+            else()
+                message(FATAL_ERROR "Vulkan-Loader/external: Microsoft Detours was not found. Please download it and place it in this folder")
+            endif()
+            add_library(detours STATIC
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/creatwth.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/detours.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/detours.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/detver.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/disasm.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/disolarm.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/disolarm64.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/disolia64.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/disolx64.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/disolx86.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/image.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/detours/src/modules.cpp
+                )
+            target_include_directories(detours PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/detours/src)
+
+            macro(GET_WIN32_WINNT version)
+                if(WIN32 AND CMAKE_SYSTEM_VERSION)
+            		set(ver ${CMAKE_SYSTEM_VERSION})
+            		string(REGEX MATCH "^([0-9]+).([0-9])" ver ${ver})
+            		string(REGEX MATCH "^([0-9]+)" verMajor ${ver})
+            		# Check for Windows 10, b/c we'll need to convert to hex 'A'.
+            		if("${verMajor}" MATCHES "10")
+            			set(verMajor "A")
+            			string(REGEX REPLACE "^([0-9]+)" ${verMajor} ver ${ver})
+            		endif("${verMajor}" MATCHES "10")
+            		# Remove all remaining '.' characters.
+            		string(REPLACE "." "" ver ${ver})
+            		# Prepend each digit with a zero.
+            		string(REGEX REPLACE "([0-9A-Z])" "0\\1" ver ${ver})
+            		set(${version} "0x${ver}")
+                endif()
+            endmacro()
+
+            set(DETOURS_MAJOR_VERSION "4")
+            set(DETOURS_MINOR_VERSION "0")
+            set(DETOURS_PATCH_VERSION "1")
+            set(DETOURS_VERSION "${DETOURS_MAJOR_VERSION}.${DETOURS_MINOR_VERSION}.${DETOURS_PATCH_VERSION}")
+
+            include_directories("${CMAKE_CURRENT_SOURCE_DIR}/detours/src")
+
+            if(MSVC_VERSION GREATER_EQUAL 1700)
+                target_compile_definitions(detours PUBLIC DETOURS_CL_17_OR_NEWER)
+            endif(MSVC_VERSION GREATER_EQUAL 1700)
+            GET_WIN32_WINNT(ver)
+            if(ver EQUAL 0x0700)
+                target_compile_definitions(detours PUBLIC _USING_V110_SDK71_ DETOURS_WIN_7)
+            endif(ver EQUAL 0x0700)
+            target_compile_definitions(detours PUBLIC "_WIN32_WINNT=${ver}")
+
+            if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+                target_compile_definitions(detours PUBLIC "DETOURS_TARGET_PROCESSOR=X64" DETOURS_X64 DETOURS_64BIT _AMD64_)
+            else("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+                target_compile_definitions(detours PUBLIC "DETOURS_TARGET_PROCESSOR=X86" DETOURS_X86 _X86_)
+            endif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+
+            target_compile_definitions(detours PUBLIC  "DETOURS_VERSION=0x4c0c1" WIN32_LEAN_AND_MEAN)
+
+            if(MSVC)
+                target_compile_definitions(detours PUBLIC  "_CRT_SECURE_NO_WARNINGS=1")
+                set_target_properties(detours PROPERTIES COMPILE_FLAGS /EHsc)
+            endif()
+        endif()
     endif()
 endif()

--- a/external/README.md
+++ b/external/README.md
@@ -2,11 +2,21 @@
 
 This directory provides a location where external projects can be cloned that are used by the loader.
 
-In order to build tests the Google Test library must be present. It can be
-checked out with:
+Tests require GoogleTest on all platforms and Detours on Windows only.
+
+The dependencies for testing need to be manually downloaded into this folder. CMake configuring will fail if they are not present
+If the repositories are already in the `external` folder, then CMake won't download them.
+
+To download googletest
 
 ```
 git clone https://github.com/google/googletest.git
+```
+
+To download Detours (only necessary for Windows)
+
+```
+git clone https://github.com/microsoft/Detours.git
 ```
 
 If you don't have a local install of the Vulkan Headers they can be placed in

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -99,13 +99,16 @@ if(WIN32)
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_CRT_SECURE_NO_WARNINGS")
     # ~~~
-    # Build dev_ext_trampoline.c with -O2 to allow tail-call optimization.
-    # Build other C files with normal options.
+    # Build dev_ext_trampoline.c and unknown_ext_chain.c with /O2 to allow tail-call optimization.
     # Setup two CMake targets (loader-norm and loader-opt) for the different compilation flags.
     # ~~~
-    separate_arguments(LOCAL_C_FLAGS_DBG WINDOWS_COMMAND ${CMAKE_C_FLAGS_DEBUG})
-    set(CMAKE_C_FLAGS_DEBUG " ")
-    separate_arguments(LOCAL_C_FLAGS_REL WINDOWS_COMMAND ${CMAKE_C_FLAGS_RELEASE})
+    set(MODIFIED_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
+
+    string(REPLACE "/Od" "/O2" MODIFIED_C_FLAGS_DEBUG ${MODIFIED_C_FLAGS_DEBUG})
+    string(REPLACE "/Ob0" "/Ob2" MODIFIED_C_FLAGS_DEBUG ${MODIFIED_C_FLAGS_DEBUG})
+    string(REGEX REPLACE "/RTC." "" MODIFIED_C_FLAGS_DEBUG ${MODIFIED_C_FLAGS_DEBUG})  #remove run-time error checks
+
+    separate_arguments(MODIFIED_C_FLAGS_DEBUG WINDOWS_COMMAND ${MODIFIED_C_FLAGS_DEBUG})
 endif()
 
 set(NORMAL_LOADER_SRCS
@@ -173,7 +176,7 @@ if(WIN32)
         message(WARNING "Could not find working MASM assebler\n${ASM_FAILURE_MSG}")
         add_custom_target(loader_asm_gen_files)
         add_library(loader-unknown-chain OBJECT unknown_ext_chain.c)
-        target_compile_options(loader-unknown-chain PUBLIC "$<$<CONFIG:DEBUG>:${LOCAL_C_FLAGS_REL}>")
+        set_target_properties(loader-unknown-chain PROPERTIES CMAKE_C_FLAGS_DEBUG "${MODIFIED_C_FLAGS_DEBUG}")
         target_compile_options(loader-unknown-chain PUBLIC ${MSVC_LOADER_COMPILE_OPTIONS})
     endif()
 elseif(APPLE)
@@ -207,13 +210,13 @@ endif()
 
 if(WIN32)
     add_library(loader-norm OBJECT ${NORMAL_LOADER_SRCS} dirent_on_windows.c)
-    target_compile_options(loader-norm PUBLIC "$<$<CONFIG:DEBUG>:${LOCAL_C_FLAGS_DBG}>")
+    # target_compile_options(loader-norm PUBLIC "$<$<CONFIG:DEBUG>:${LOCAL_C_FLAGS_DBG}>")
     target_compile_options(loader-norm PUBLIC ${MSVC_LOADER_COMPILE_OPTIONS})
     target_include_directories(loader-norm PRIVATE "$<TARGET_PROPERTY:Vulkan::Headers,INTERFACE_INCLUDE_DIRECTORIES>")
 
     add_library(loader-opt OBJECT ${OPT_LOADER_SRCS})
     add_dependencies(loader-opt loader_asm_gen_files)
-    target_compile_options(loader-opt PUBLIC "$<$<CONFIG:DEBUG>:${LOCAL_C_FLAGS_REL}>")
+    set_target_properties(loader-opt PROPERTIES CMAKE_C_FLAGS_DEBUG "${MODIFIED_C_FLAGS_DEBUG}")
     target_compile_options(loader-opt PUBLIC ${MSVC_LOADER_COMPILE_OPTIONS})
     target_include_directories(loader-opt PRIVATE "$<TARGET_PROPERTY:Vulkan::Headers,INTERFACE_INCLUDE_DIRECTORIES>")
 
@@ -225,8 +228,8 @@ if(WIN32)
                 ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-1.def
                 ${CMAKE_CURRENT_SOURCE_DIR}/loader.rc)
     set_target_properties(vulkan
-                          PROPERTIES LINK_FLAGS_DEBUG
-                                     "/ignore:4098"
+                          PROPERTIES
+                          #LINK_FLAGS_DEBUG "/ignore:4098"
                                      OUTPUT_NAME
                                      vulkan-1
                                      PREFIX

--- a/loader/adapters.h
+++ b/loader/adapters.h
@@ -18,6 +18,8 @@
 * Author: Lenny Komow <lenny@lunarg.com>
 */
 
+#pragma once
+
 typedef struct LoaderEnumAdapters2 {
     ULONG adapter_count;
     struct {

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -77,6 +77,10 @@
 #include <dxgi1_6.h>
 #include "adapters.h"
 
+#if !defined(NDEBUG)
+#include <crtdbg.h>
+#endif
+
 typedef HRESULT (APIENTRY *PFN_CreateDXGIFactory1)(REFIID riid, void **ppFactory);
 static PFN_CreateDXGIFactory1 fpCreateDXGIFactory1;
 #endif
@@ -2511,6 +2515,13 @@ void loader_initialize(void) {
     HMODULE dxgi_module = LoadLibrary(systemPath);
     fpCreateDXGIFactory1 = dxgi_module == NULL ? NULL :
         (PFN_CreateDXGIFactory1)GetProcAddress(dxgi_module, "CreateDXGIFactory1");
+
+#if !defined(NDEBUG)
+    _set_error_mode(_OUT_TO_STDERR);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+#endif
+
 #endif
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ elseif(ANDROID)
 elseif(APPLE)
     add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
 elseif(UNIX AND NOT APPLE) # i.e.: Linux
+    target_compile_options(vk_loader_validation_tests PUBLIC -fPIC)
     if(BUILD_WSI_XCB_SUPPORT)
         add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
     endif()
@@ -135,3 +136,41 @@ if(WIN32)
 endif()
 
 add_subdirectory(layers)
+
+option(TEST_USE_ADDRESS_SANITIZER "Linux only: Advanced memory checking" OFF)
+
+add_subdirectory(framework)
+
+add_executable(test_regression loader_testing_main.cpp loader_regression_tests.cpp loader_version_tests.cpp)
+target_link_libraries(test_regression PRIVATE testing_dependencies)
+
+add_executable(test_wsi loader_testing_main.cpp loader_wsi_tests.cpp)
+target_link_libraries(test_wsi PRIVATE testing_dependencies)
+
+if(UNIX AND NOT APPLE) # i.e. Linux
+    if(BUILD_WSI_XCB_SUPPORT)
+        target_include_directories(test_wsi PRIVATE ${XCB_INCLUDE_DIRS})
+        target_link_libraries(test_wsi PRIVATE ${XCB_LIBRARIES})
+    endif()
+
+    if(BUILD_WSI_XLIB_SUPPORT)
+        target_include_directories(test_wsi PRIVATE ${X11_INCLUDE_DIR})
+        target_link_libraries(test_wsi PRIVATE ${X11_LIBRARIES})
+    endif()
+
+    if(BUILD_WSI_WAYLAND_SUPPORT)
+        target_include_directories(test_wsi PRIVATE ${WAYLAND_CLIENT_INCLUDE_DIR})
+        target_link_libraries(test_wsi PRIVATE ${WAYLAND_CLIENT_LIBRARIES})
+    endif()
+endif()
+
+if(WIN32)
+    # Copy loader and googletest (gtest) libs to test dir so the test executable can find them.
+    add_custom_command(TARGET test_regression POST_BUILD
+                       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:gtest> $<TARGET_FILE_DIR:test_regression>)
+    # Copy the loader shared lib (if built) to the test application directory so the test app finds it.
+    if(TARGET vulkan)
+        add_custom_command(TARGET test_regression POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:vulkan> $<TARGET_FILE_DIR:test_regression>)
+    endif()
+endif()

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -1,0 +1,83 @@
+# ~~~
+# Copyright (c) 2021 Valve Corporation
+# Copyright (c) 2021 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+add_library(testing_framework_util STATIC test_util.cpp test_util.h)
+target_link_libraries(testing_framework_util PUBLIC Vulkan::Headers)
+if(UNIX)
+    target_link_libraries(testing_framework_util PUBLIC ${CMAKE_DL_LIBS})
+endif()
+
+target_compile_options(testing_framework_util INTERFACE
+    $<$<PLATFORM_ID:WIN32>:-DVK_USE_PLATFORM_WIN32_KHR>
+    $<$<PLATFORM_ID:ANDROID>:-DVK_USE_PLATFORM_ANDROID_KHR>
+    $<$<PLATFORM_ID:APPLE>:-DVK_USE_PLATFORM_MACOS_MVK>
+    $<$<AND:$<PLATFORM_ID:UNIX>,$<NOT:$<PLATFORM_ID:APPLE>>>:
+        $<$<BUILD_WSI_XCB_SUPPORT>:-DVK_USE_PLATFORM_XCB_KHR>
+        $<$<BUILD_WSI_XLIB_SUPPORT>:-DVK_USE_PLATFORM_XLIB_KHR>
+        $<$<BUILD_WSI_WAYLAND_SUPPORT>:-DVK_USE_PLATFORM_WAYLAND_KHR>>
+    )
+if(UNIX AND NOT APPLE)
+    target_compile_options(testing_framework_util PUBLIC -fPIC)
+endif()
+target_include_directories(testing_framework_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+
+if (TEST_USE_ADDRESS_SANITIZER AND UNIX)
+    target_compile_options(testing_framework_util PUBLIC -fsanitize=address)
+    target_link_options(testing_framework_util PUBLIC -fsanitize=address)
+    target_compile_options(vulkan PUBLIC -fsanitize=address)
+    target_link_options(vulkan PUBLIC -fsanitize=address)
+endif()
+
+add_subdirectory(shim)
+add_subdirectory(icd)
+add_subdirectory(layer)
+
+#configure the framework_config.h.in file - used to locate all the binaries generated so that it can be used in the tests
+#setup framework_config_temp.h.in in the current binary directory
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/framework_config.h.in" "${CMAKE_CURRENT_BINARY_DIR}/framework_config_temp.h.in")
+
+# setup framework_config.h.in using framework_config_temp.h.in as a source
+file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/framework_config_$<CONFIG>.h" INPUT "${CMAKE_CURRENT_BINARY_DIR}/framework_config_temp.h.in")
+
+# copy framework_config_$<CONFIG> to the loader build directory
+add_custom_command(
+    PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_BINARY_DIR}/framework_config_$<CONFIG>.h" "${CMAKE_CURRENT_BINARY_DIR}/framework_config.h"
+    VERBATIM
+    PRE_BUILD
+    DEPENDS  "${CMAKE_CURRENT_BINARY_DIR}/framework_config_$<CONFIG>.h"
+    OUTPUT   "${CMAKE_CURRENT_BINARY_DIR}/framework_config.h"
+    COMMENT  "creating framework_config.h file ({event: PRE_BUILD}, {filename: framework_config.h })"
+    )
+add_custom_target (generate_framework_config DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/framework_config.h")
+add_dependencies (testing_framework_util generate_framework_config)
+
+add_library(test-environment STATIC test_environment.cpp test_environment.h)
+target_link_libraries(test-environment
+    PUBLIC gtest
+    testing_framework_util shim-library)
+target_include_directories(test-environment PUBLIC ${CMAKE_BINARY_DIR}/tests/framework)
+target_compile_definitions(test-environment PUBLIC "GTEST_LINKED_AS_SHARED_LIBRARY=1")
+
+add_library(testing_dependencies INTERFACE)
+
+target_compile_options(testing_dependencies INTERFACE $<$<PLATFORM_ID:WIN32>:${MSVC_LOADER_COMPILE_OPTIONS},/permissive->)
+target_compile_definitions(testing_dependencies INTERFACE
+# Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
+    $<$<PLATFORM_ID:WIN32>:-DWIN32_LEAN_AND_MEAN,-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING>)
+
+target_link_libraries(testing_dependencies INTERFACE Vulkan::Headers testing_framework_util test-environment)

--- a/tests/framework/README.md
+++ b/tests/framework/README.md
@@ -1,0 +1,31 @@
+## Loader Testing Framework
+
+The loader testing framework is a mocking environment which fakes many of the global systems that vulkan requires to run. This allows the writing of tests against a known driver, layer, and system configuration.
+
+The framework consists of:
+* Test ICD and Test Layer - Programmable components which can have specific behavior, capabilities, features, extensions, and allow querying of various actions the loader takes
+* Shim - Platform specific functionality that isolates the loader from the rest of the system
+  * Linux - Redirects of filesystem access
+  * Windows - Overrides registry with framework component and has dll injection for
+* Manifest Writer - Programmatically create layer & ICD manifests and put them in a folder the framework will use
+* Tests - Written with GoogleTest, these are the specific test cases written using the various components
+* Utility - Glue code like environment variable, paths, boilerplate helpers
+
+### Test ICD and Layer
+The layer and ICD interface have several combinations of functionality that is determined by the presence or lack of exported functions in a shared library. To accomplish the testing of these combinations, multiple binaries are created using the same C++ file. These exports are controlled by macro defines which are set through CMake.
+
+To make it easy to run tests from the command line, extensive use CMake is made to put the paths of all the binaries into header files that tests can directly reference. These are the various `config.h.in` files scattered throughout the framework.
+Note: Due to hard coding of paths, moving the project to another folder without rebuilding will cause the tests to break.
+
+Because the test ICDs and layers are loaded by the loader, the framework loads them directly and pulls the exported backdoor function which acts as the communication channel between the framework and the test ICDs & layers.
+
+### Shim
+
+Because the loader makes many calls to various OS functionality, the framework intercepts certain calls and makes a few of its own calls to OS functionality to allow proper isolation of the loader from the system it is running on.
+This allows multiple tests to be run in isolation.
+
+### Running
+
+CMake Build options: set `BUILD_TESTS` to enable tests, and `TEST_USE_ADDRESS_SANITIZER` to enable Address Sanitizer inside the testing framework
+
+Run the executables as normal

--- a/tests/framework/framework_config.h.in
+++ b/tests/framework/framework_config.h.in
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#pragma once
+#define FRAMEWORK_BUILD_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+
+#define FRAMEWORK_VULKAN_LIBRARY_PATH "$<TARGET_FILE:vulkan>"
+
+#define SHIM_LIBRARY_NAME "$<TARGET_FILE:shim-library>"
+
+#define TEST_ICD_BUILD_LOCATION "$<TARGET_FILE_DIR:test_icd_export_none>"
+
+#define TEST_ICD_PATH_EXPORT_NONE "$<TARGET_FILE:test_icd_export_none>"
+#define TEST_ICD_PATH_EXPORT_ICD_GIPA "$<TARGET_FILE:test_icd_export_icd_gipa>"
+#define TEST_ICD_PATH_EXPORT_NEGOTIATE_INTERFACE_VERSION "$<TARGET_FILE:test_icd_export_negotiate_interface_version>"
+
+#define TEST_ICD_PATH_VERSION_2 "$<TARGET_FILE:test_icd_version_2>"
+
+// assumes version 2 exports
+#define TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA "$<TARGET_FILE:test_icd_version_2_export_icd_gpdpa>"
+
+// Assumes version 2 exports
+#define TEST_ICD_PATH_VERSION_2_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES "$<TARGET_FILE:test_icd_version_2_export_icd_enumerate_adapter_physical_devices>"

--- a/tests/framework/icd/CMakeLists.txt
+++ b/tests/framework/icd/CMakeLists.txt
@@ -1,0 +1,58 @@
+# ~~~
+# Copyright (c) 2021 Valve Corporation
+# Copyright (c) 2021 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_library(test_icd_deps INTERFACE)
+
+target_compile_options(test_icd_deps INTERFACE
+    $<$<PLATFORM_ID:WIN32>:${MSVC_LOADER_COMPILE_OPTIONS},/permissive->)
+
+target_compile_definitions(test_icd_deps INTERFACE
+# Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
+    $<$<PLATFORM_ID:WIN32>:-DWIN32_LEAN_AND_MEAN,-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING>
+    VK_NO_PROTOTYPES)
+
+target_link_libraries(test_icd_deps INTERFACE testing_framework_util)
+
+set(TEST_ICD_SOURCES test_icd.cpp test_icd.h)
+
+# test icd without any config macros defined
+add_library(test_icd_export_none SHARED ${TEST_ICD_SOURCES})
+target_link_libraries(test_icd_export_none PRIVATE test_icd_deps)
+
+add_library(test_icd_export_icd_gipa SHARED ${TEST_ICD_SOURCES})
+target_link_libraries(test_icd_export_icd_gipa PRIVATE test_icd_deps)
+target_compile_definitions(test_icd_export_icd_gipa PRIVATE TEST_ICD_EXPORT_ICD_GIPA=1)
+
+add_library(test_icd_export_negotiate_interface_version SHARED ${TEST_ICD_SOURCES})
+target_link_libraries(test_icd_export_negotiate_interface_version PRIVATE test_icd_deps)
+target_compile_definitions(test_icd_export_negotiate_interface_version PRIVATE TEST_ICD_EXPORT_NEGOTIATE_INTERFACE_VERSION=1)
+
+set(TEST_ICD_VERSION_2_DEFINES TEST_ICD_EXPORT_NEGOTIATE_INTERFACE_VERSION=1 TEST_ICD_EXPORT_ICD_GIPA=1)
+
+add_library(test_icd_version_2 SHARED ${TEST_ICD_SOURCES})
+target_link_libraries(test_icd_version_2 PRIVATE test_icd_deps)
+target_compile_definitions(test_icd_version_2 PRIVATE ${TEST_ICD_VERSION_2_DEFINES})
+
+add_library(test_icd_version_2_export_icd_enumerate_adapter_physical_devices SHARED ${TEST_ICD_SOURCES})
+target_link_libraries(test_icd_version_2_export_icd_enumerate_adapter_physical_devices PRIVATE test_icd_deps)
+target_compile_definitions(test_icd_version_2_export_icd_enumerate_adapter_physical_devices PRIVATE TEST_ICD_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES=1 ${TEST_ICD_VERSION_2_DEFINES})
+
+add_library(test_icd_version_2_export_icd_gpdpa SHARED ${TEST_ICD_SOURCES})
+target_link_libraries(test_icd_version_2_export_icd_gpdpa PRIVATE test_icd_deps)
+target_compile_definitions(test_icd_version_2_export_icd_gpdpa PRIVATE TEST_ICD_EXPORT_ICD_GPDPA=1 ${TEST_ICD_VERSION_2_DEFINES})

--- a/tests/framework/icd/physical_device.h
+++ b/tests/framework/icd/physical_device.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#pragma once
+
+#include "test_util.h"
+
+struct PhysicalDevice {
+    PhysicalDevice() {}
+    PhysicalDevice(std::string name) : deviceName(name) {}
+    PhysicalDevice& set_properties(VkPhysicalDeviceProperties properties) {
+        this->properties = properties;
+        return *this;
+    }
+    PhysicalDevice& set_features(VkPhysicalDeviceFeatures features) {
+        this->features = features;
+        return *this;
+    }
+    PhysicalDevice& set_memory_properties(VkPhysicalDeviceMemoryProperties memory_properties) {
+        this->memory_properties = memory_properties;
+        return *this;
+    }
+    PhysicalDevice& add_queue_family_properties(VkQueueFamilyProperties properties, bool support_present = true) {
+        queue_family_properties.push_back(MockQueueFamilyProperties(properties, support_present));
+        return *this;
+    }
+    PhysicalDevice& add_queue_family_properties(MockQueueFamilyProperties properties) {
+        queue_family_properties.push_back(properties);
+        return *this;
+    }
+    DispatchableHandle<VkPhysicalDevice> vk_physical_device;
+    std::string deviceName;
+    VkPhysicalDeviceProperties properties{};
+    VkPhysicalDeviceFeatures features{};
+    VkPhysicalDeviceMemoryProperties memory_properties{};
+    std::vector<MockQueueFamilyProperties> queue_family_properties;
+    std::vector<VkFormatProperties> format_properties;
+
+    std::vector<Extension> extensions;
+
+    VkSurfaceCapabilitiesKHR surface_capabilities;
+    std::vector<VkSurfaceFormatKHR> surface_formats;
+    std::vector<VkPresentModeKHR> surface_present_modes;
+};

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -1,0 +1,538 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#include "test_icd.h"
+
+/*
+Cmake driven macro defines
+
+conditionally export vk_icdGetInstanceProcAddr
+TEST_ICD_EXPORT_ICD_GIPA
+
+conditionally export vk_icdNegotiateLoaderICDInterfaceVersion
+TEST_ICD_EXPORT_NEGOTIATE_INTERFACE_VERSION
+
+conditionally export vk_icdGetPhysicalDeviceProcAddr
+TEST_ICD_EXPORT_ICD_GPDPA
+
+conditionally export vk_icdEnumerateAdapterPhysicalDevices
+TEST_ICD_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES
+*/
+
+TestICD icd;
+extern "C" {
+FRAMEWORK_EXPORT TestICD* get_test_icd_func() { return &icd; }
+FRAMEWORK_EXPORT TestICD* get_new_test_icd_func() {
+    icd.~TestICD();
+    return new (&icd) TestICD();
+}
+}
+
+Layer& FindLayer(std::vector<Layer>& layers, std::string layerName) {
+    for (auto& layer : layers) {
+        if (layer.layerName == layerName) return layer;
+    }
+    assert(false && "Layer name not found!");
+    return layers[0];
+}
+bool CheckLayer(std::vector<Layer>& layers, std::string layerName) {
+    for (auto& layer : layers) {
+        if (layer.layerName == layerName) return true;
+    }
+    return false;
+}
+
+// typename T must have '.get()' function that returns a type U
+template <typename T, typename U>
+VkResult FillCountPtr(std::vector<T> const& data_vec, uint32_t* pCount, U* pData) {
+    if (pCount == nullptr) {
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+    if (pData == nullptr) {
+        *pCount = data_vec.size();
+        return VK_SUCCESS;
+    }
+    uint32_t amount_written = 0;
+    uint32_t amount_to_write = data_vec.size();
+    if (*pCount < data_vec.size()) {
+        amount_to_write = *pCount;
+    }
+    for (size_t i = 0; i < amount_to_write; i++) {
+        pData[i] = data_vec[i].get();
+        amount_written++;
+    }
+    if (*pCount < data_vec.size()) {
+        *pCount = amount_written;
+        return VK_INCOMPLETE;
+    }
+    *pCount = amount_written;
+    return VK_SUCCESS;
+}
+
+template <typename T>
+VkResult FillCountPtr(std::vector<T> const& data_vec, uint32_t* pCount, T* pData) {
+    if (pCount == nullptr) {
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+    if (pData == nullptr) {
+        *pCount = data_vec.size();
+        return VK_SUCCESS;
+    }
+    uint32_t amount_written = 0;
+    uint32_t amount_to_write = data_vec.size();
+    if (*pCount < data_vec.size()) {
+        amount_to_write = *pCount;
+    }
+    for (size_t i = 0; i < amount_to_write; i++) {
+        pData[i] = data_vec[i];
+        amount_written++;
+    }
+    if (*pCount < data_vec.size()) {
+        *pCount = amount_written;
+        return VK_INCOMPLETE;
+    }
+    *pCount = amount_written;
+    return VK_SUCCESS;
+}
+
+//// Instance Functions ////
+
+// VK_SUCCESS,VK_INCOMPLETE
+VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount,
+                                                                           VkExtensionProperties* pProperties) {
+    if (pLayerName != nullptr) {
+        auto& layer = FindLayer(icd.instance_layers, std::string(pLayerName));
+        return FillCountPtr(layer.extensions, pPropertyCount, pProperties);
+    } else {  // instance extensions
+        FillCountPtr(icd.instance_extensions, pPropertyCount, pProperties);
+    }
+
+    return VK_SUCCESS;
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount, VkLayerProperties* pProperties) {
+    return FillCountPtr(icd.instance_layers, pPropertyCount, pProperties);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceVersion(uint32_t* pApiVersion) {
+    if (pApiVersion != nullptr) {
+        *pApiVersion = VK_MAKE_VERSION(1, 0, 0);
+    }
+    return VK_SUCCESS;
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator, VkInstance* pInstance) {
+    if (pCreateInfo == nullptr || pCreateInfo->pApplicationInfo == nullptr) {
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    if (icd.icd_api_version < VK_MAKE_VERSION(1, 1, 0)) {
+        if (pCreateInfo->pApplicationInfo->apiVersion > VK_MAKE_VERSION(1, 0, 0)) {
+            return VK_ERROR_INCOMPATIBLE_DRIVER;
+        }
+    }
+    // VK_SUCCESS
+    *pInstance = icd.instance_handle.handle;
+
+    return VK_SUCCESS;
+}
+
+VKAPI_ATTR void VKAPI_CALL test_vkDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator) {}
+
+// VK_SUCCESS,VK_INCOMPLETE
+VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
+                                                               VkPhysicalDevice* pPhysicalDevices) {
+    if (pPhysicalDevices == nullptr) {
+        *pPhysicalDeviceCount = icd.physical_devices.size();
+    } else {
+        uint32_t handles_written = 0;
+        for (size_t i = 0; i < icd.physical_devices.size(); i++) {
+            if (i < *pPhysicalDeviceCount) {
+                handles_written++;
+                pPhysicalDevices[i] = icd.physical_devices[i].vk_physical_device.handle;
+            } else {
+                *pPhysicalDeviceCount = handles_written;
+                return VK_INCOMPLETE;
+            }
+        }
+        *pPhysicalDeviceCount = handles_written;
+    }
+    return VK_SUCCESS;
+}
+
+//// Physical Device functions ////
+
+// VK_SUCCESS,VK_INCOMPLETE
+VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                                     VkLayerProperties* pProperties) {
+    assert(false && "ICD's don't contain layers???");
+    return VK_SUCCESS;
+}
+
+// VK_SUCCESS, VK_INCOMPLETE, VK_ERROR_LAYER_NOT_PRESENT
+VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char* pLayerName,
+                                                                         uint32_t* pPropertyCount,
+                                                                         VkExtensionProperties* pProperties) {
+    auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+    if (pLayerName != nullptr) {
+        assert(false && "Drivers don't contain layers???");
+        return VK_SUCCESS;
+    } else {  // instance extensions
+        return FillCountPtr(phys_dev.extensions, pPropertyCount, pProperties);
+    }
+}
+
+VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice,
+                                                                         uint32_t* pQueueFamilyPropertyCount,
+                                                                         VkQueueFamilyProperties* pQueueFamilyProperties) {
+    auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+    FillCountPtr(phys_dev.queue_family_properties, pQueueFamilyPropertyCount, pQueueFamilyProperties);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                                   const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
+    // VK_SUCCESS
+    auto device_handle = DispatchableHandle<VkDevice>();
+    *pDevice = device_handle.handle;
+    icd.device_handles.emplace_back(std::move(device_handle));
+    return VK_SUCCESS;
+}
+
+VKAPI_ATTR void VKAPI_CALL test_vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
+    auto found = std::find(icd.device_handles.begin(), icd.device_handles.end(), device);
+    if (found != icd.device_handles.end()) icd.device_handles.erase(found);
+}
+
+//// WSI
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
+                                                              const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    return VK_SUCCESS;
+}
+#endif
+#ifdef VK_USE_PLATFORM_METAL_EXT
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMetalSurfaceEXT(VkInstance instance, const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
+                                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    return VK_SUCCESS;
+}
+#endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWaylandSurfaceKHR(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
+                                                              const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    return VK_SUCCESS;
+}
+#endif
+#ifdef VK_USE_PLATFORM_XCB_KHR
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXcbSurfaceKHR(VkInstance instance, const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    return VK_SUCCESS;
+}
+#endif
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXlibSurfaceKHR(VkInstance instance, const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
+                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    return VK_SUCCESS;
+}
+#endif
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
+                                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    if (nullptr != pSurface) {
+#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+        *pSurface = reinterpret_cast<VkSurfaceKHR>(++icd.created_surface_count);
+#else
+        *pSurface = ++icd.created_surface_count;
+#endif
+    }
+    return VK_SUCCESS;
+}
+#endif
+
+VKAPI_ATTR void VKAPI_CALL test_vkDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface,
+                                                    const VkAllocationCallbacks* pAllocator) {
+    // Nothing to do
+}
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                                         const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain) {
+    if (nullptr != pSwapchain) {
+#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+        *pSwapchain = reinterpret_cast<VkSwapchainKHR>(++icd.created_swapchain_count);
+#else
+        *pSwapchain = ++icd.created_swapchain_count;
+#endif
+    }
+    return VK_SUCCESS;
+}
+VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
+                                                                         VkSurfaceKHR surface, VkBool32* pSupported) {
+    if (nullptr != pSupported) {
+        *pSupported = icd.GetPhysDevice(physicalDevice).queue_family_properties.at(queueFamilyIndex).support_present;
+    }
+    return VK_SUCCESS;
+}
+VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+                                                                              VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
+    if (nullptr != pSurfaceCapabilities) {
+        *pSurfaceCapabilities = icd.GetPhysDevice(physicalDevice).surface_capabilities;
+    }
+    return VK_SUCCESS;
+}
+VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+                                                                         uint32_t* pSurfaceFormatCount,
+                                                                         VkSurfaceFormatKHR* pSurfaceFormats) {
+    FillCountPtr(icd.GetPhysDevice(physicalDevice).surface_formats, pSurfaceFormatCount, pSurfaceFormats);
+    return VK_SUCCESS;
+}
+VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfacePresentModesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+                                                                              uint32_t* pPresentModeCount,
+                                                                              VkPresentModeKHR* pPresentModes) {
+    FillCountPtr(icd.GetPhysDevice(physicalDevice).surface_present_modes, pPresentModeCount, pPresentModes);
+    return VK_SUCCESS;
+}
+
+//// stubs
+
+VKAPI_ATTR VkResult VKAPI_CALL test_stub_func_with_return() { return VK_SUCCESS; }
+VKAPI_ATTR void VKAPI_CALL test_stub_func_no_return() {}
+
+//// trampolines
+
+#define TO_VOID_PFN(func) reinterpret_cast<PFN_vkVoidFunction>(func)
+
+PFN_vkVoidFunction get_instance_func_ver_1_1(VkInstance instance, const char* pName) {
+    if (icd.icd_api_version < VK_MAKE_VERSION(1, 1, 0)) {
+        if (strcmp(pName, "test_vkEnumerateInstanceVersion") == 0) {
+            return TO_VOID_PFN(test_vkEnumerateInstanceVersion);
+        }
+    }
+    return nullptr;
+}
+PFN_vkVoidFunction get_instance_func_ver_1_2(VkInstance instance, const char* pName) {
+    if (icd.icd_api_version < VK_MAKE_VERSION(1, 2, 0)) {
+        return nullptr;
+    }
+    return nullptr;
+}
+
+PFN_vkVoidFunction get_instance_func_wsi(VkInstance instance, const char* pName) {
+    if (icd.min_icd_interface_version >= 3 && icd.enable_icd_wsi == true) {
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+        if (strcmp(pName, "vkCreateAndroidSurfaceKHR") == 0) {
+            icd.is_using_icd_wsi = UsingICDProvidedWSI::is_using;
+            return TO_VOID_PFN(test_vkCreateAndroidSurfaceKHR);
+        }
+#endif
+#ifdef VK_USE_PLATFORM_METAL_EXT
+        if (strcmp(pName, "vkCreateMetalSurfaceEXT") == 0) {
+            return TO_VOID_PFN(test_vkCreateMetalSurfaceEXT);
+        }
+#endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+        if (strcmp(pName, "vkCreateWaylandSurfaceKHR") == 0) {
+            return TO_VOID_PFN(test_vkCreateWaylandSurfaceKHR);
+        }
+#endif
+#ifdef VK_USE_PLATFORM_XCB_KHR
+        if (strcmp(pName, "vkCreateXcbSurfaceKHR") == 0) {
+            return TO_VOID_PFN(test_vkCreateXcbSurfaceKHR);
+        }
+#endif
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+        if (strcmp(pName, "vkCreateXlibSurfaceKHR") == 0) {
+            return TO_VOID_PFN(test_vkCreateXlibSurfaceKHR);
+        }
+#endif
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+        if (strcmp(pName, "vkCreateWin32SurfaceKHR") == 0) {
+            return TO_VOID_PFN(test_vkCreateWin32SurfaceKHR);
+        }
+#endif
+        if (strcmp(pName, "vkDestroySurfaceKHR") == 0) {
+            icd.is_using_icd_wsi = UsingICDProvidedWSI::is_using;
+            return TO_VOID_PFN(test_vkDestroySurfaceKHR);
+        }
+    }
+
+    if (strcmp(pName, "vkGetPhysicalDeviceSurfaceSupportKHR") == 0) return TO_VOID_PFN(test_vkGetPhysicalDeviceSurfaceSupportKHR);
+    if (strcmp(pName, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR") == 0)
+        return TO_VOID_PFN(test_vkGetPhysicalDeviceSurfaceCapabilitiesKHR);
+    if (strcmp(pName, "vkGetPhysicalDeviceSurfaceFormatsKHR") == 0) return TO_VOID_PFN(test_vkGetPhysicalDeviceSurfaceFormatsKHR);
+    if (strcmp(pName, "vkGetPhysicalDeviceSurfacePresentModesKHR") == 0)
+        return TO_VOID_PFN(test_vkGetPhysicalDeviceSurfacePresentModesKHR);
+
+    return nullptr;
+}
+
+PFN_vkVoidFunction get_instance_func(VkInstance instance, const char* pName) {
+    if (strcmp(pName, "vkEnumerateInstanceExtensionProperties") == 0)
+        return TO_VOID_PFN(test_vkEnumerateInstanceExtensionProperties);
+    if (strcmp(pName, "vkEnumerateInstanceLayerProperties") == 0) return TO_VOID_PFN(test_vkEnumerateInstanceLayerProperties);
+    if (strcmp(pName, "vkCreateInstance") == 0) return TO_VOID_PFN(test_vkCreateInstance);
+    if (strcmp(pName, "vkDestroyInstance") == 0) return TO_VOID_PFN(test_vkDestroyInstance);
+    if (strcmp(pName, "vkEnumeratePhysicalDevices") == 0) return TO_VOID_PFN(test_vkEnumeratePhysicalDevices);
+    // if (strcmp(pName, "vk_icdEnumerateAdapterPhysicalDevices") == 0) return
+    // TO_VOID_PFN(test_vk_icdEnumerateAdapterPhysicalDevices);
+    if (strcmp(pName, "vkEnumerateDeviceLayerProperties") == 0) return TO_VOID_PFN(test_vkEnumerateDeviceLayerProperties);
+    if (strcmp(pName, "vkEnumerateDeviceExtensionProperties") == 0) return TO_VOID_PFN(test_vkEnumerateDeviceExtensionProperties);
+    if (strcmp(pName, "vkGetPhysicalDeviceQueueFamilyProperties") == 0)
+        return TO_VOID_PFN(test_vkGetPhysicalDeviceQueueFamilyProperties);
+    if (strcmp(pName, "vkCreateDevice") == 0) return TO_VOID_PFN(test_vkCreateDevice);
+
+    if (strcmp(pName, "vkGetPhysicalDeviceFeatures") == 0 || strcmp(pName, "vkGetPhysicalDeviceProperties") == 0 ||
+        strcmp(pName, "vkGetPhysicalDeviceMemoryProperties") == 0 ||
+        strcmp(pName, "vkGetPhysicalDeviceSparseImageFormatProperties") == 0 ||
+        strcmp(pName, "vkGetPhysicalDeviceFormatProperties") == 0)
+        return TO_VOID_PFN(test_stub_func_no_return);
+    if (strcmp(pName, "vkGetPhysicalDeviceImageFormatProperties") == 0) return TO_VOID_PFN(test_stub_func_with_return);
+
+    PFN_vkVoidFunction ret_1_1 = get_instance_func_ver_1_1(instance, pName);
+    if (ret_1_1 != nullptr) return ret_1_1;
+
+    PFN_vkVoidFunction ret_1_2 = get_instance_func_ver_1_2(instance, pName);
+    if (ret_1_2 != nullptr) return ret_1_2;
+
+    PFN_vkVoidFunction ret_wsi = get_instance_func_wsi(instance, pName);
+    if (ret_wsi != nullptr) return ret_wsi;
+
+    return nullptr;
+}
+
+PFN_vkVoidFunction get_device_func(VkDevice device, const char* pName) {
+    if (strcmp(pName, "vkDestroyDevice") == 0) return TO_VOID_PFN(test_vkDestroyDevice);
+    if (strcmp(pName, "vkCreateSwapchainKHR") == 0) return TO_VOID_PFN(test_vkCreateSwapchainKHR);
+
+    return nullptr;
+}
+
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL test_vkGetInstanceProcAddr(VkInstance instance, const char* pName) {
+    return get_instance_func(instance, pName);
+}
+
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL test_vkGetDeviceProcAddr(VkDevice device, const char* pName) {
+    return get_device_func(device, pName);
+}
+
+PFN_vkVoidFunction base_get_instance_proc_addr(VkInstance instance, const char* pName) {
+    if (pName == nullptr) return nullptr;
+    if (instance == NULL) {
+        if (strcmp(pName, "vkGetInstanceProcAddr") == 0) return TO_VOID_PFN(test_vkGetInstanceProcAddr);
+        if (strcmp(pName, "vkEnumerateInstanceExtensionProperties") == 0)
+            return TO_VOID_PFN(test_vkEnumerateInstanceExtensionProperties);
+        if (strcmp(pName, "vkEnumerateInstanceLayerProperties") == 0) return TO_VOID_PFN(test_vkEnumerateInstanceLayerProperties);
+        if (strcmp(pName, "vkEnumerateInstanceVersion") == 0) return TO_VOID_PFN(test_vkEnumerateInstanceVersion);
+    }
+    if (strcmp(pName, "vkGetDeviceProcAddr") == 0) return TO_VOID_PFN(test_vkGetDeviceProcAddr);
+
+    auto instance_func_return = get_instance_func(instance, pName);
+    if (instance_func_return != nullptr) return instance_func_return;
+    return nullptr;
+}
+
+// Exported functions
+extern "C" {
+#if defined(TEST_ICD_EXPORT_NEGOTIATE_INTERFACE_VERSION)
+extern FRAMEWORK_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vk_icdNegotiateLoaderICDInterfaceVersion(uint32_t* pSupportedVersion) {
+    if (icd.called_vk_icd_gipa == CalledICDGIPA::not_called &&
+        icd.called_negotiate_interface == CalledNegotiateInterface::not_called)
+        icd.called_negotiate_interface = CalledNegotiateInterface::vk_icd_negotiate;
+    else if (icd.called_vk_icd_gipa != CalledICDGIPA::not_called)
+        icd.called_negotiate_interface = CalledNegotiateInterface::vk_icd_gipa_first;
+
+    // loader puts the minimum it supports in pSupportedVersion, if that is lower than our minimum
+    // If the ICD doesn't supports the interface version provided by the loader, report VK_ERROR_INCOMPATIBLE_DRIVER
+    if (icd.min_icd_interface_version > *pSupportedVersion) {
+        icd.interface_version_check = InterfaceVersionCheck::loader_version_too_old;
+        *pSupportedVersion = icd.min_icd_interface_version;
+        return VK_ERROR_INCOMPATIBLE_DRIVER;
+    }
+
+    // the loader-provided interface version is newer than that supported by the ICD
+    if (icd.max_icd_interface_version < *pSupportedVersion) {
+        icd.interface_version_check = InterfaceVersionCheck::loader_version_too_new;
+        *pSupportedVersion = icd.max_icd_interface_version;
+    }
+    // ICD interface version is greater than the loader's,  return the loader's version
+    else if (icd.max_icd_interface_version > *pSupportedVersion) {
+        icd.interface_version_check = InterfaceVersionCheck::icd_version_too_new;
+        // don't change *pSupportedVersion
+    } else {
+        icd.interface_version_check = InterfaceVersionCheck::version_is_supported;
+        *pSupportedVersion = icd.max_icd_interface_version;
+    }
+
+    return VK_SUCCESS;
+}
+#endif
+#if defined(TEST_ICD_EXPORT_ICD_GPDPA)
+FRAMEWORK_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_icdGetPhysicalDeviceProcAddr(VkInstance instance, const char* pName) {
+    // std::cout << "icdGetPhysicalDeviceProcAddr: " << pName << "\n";
+
+    return nullptr;
+}
+#endif
+#if defined(TEST_ICD_EXPORT_ICD_GIPA)
+FRAMEWORK_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_icdGetInstanceProcAddr(VkInstance instance, const char* pName) {
+    // std::cout << "icdGetInstanceProcAddr: " << pName << "\n";
+
+    if (icd.called_vk_icd_gipa == CalledICDGIPA::not_called) icd.called_vk_icd_gipa = CalledICDGIPA::vk_icd_gipa;
+
+    return base_get_instance_proc_addr(instance, pName);
+    return nullptr;
+}
+#else
+FRAMEWORK_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* pName) {
+    // std::cout << "icdGetInstanceProcAddr: " << pName << "\n";
+
+    if (icd.called_vk_icd_gipa == CalledICDGIPA::not_called) icd.called_vk_icd_gipa = CalledICDGIPA::vk_gipa;
+    return base_get_instance_proc_addr(instance, pName);
+}
+FRAMEWORK_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
+                                                                 const VkAllocationCallbacks* pAllocator, VkInstance* pInstance) {
+    return test_vkCreateInstance(pCreateInfo, pAllocator, pInstance);
+}
+FRAMEWORK_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char* pLayerName,
+                                                                                       uint32_t* pPropertyCount,
+                                                                                       VkExtensionProperties* pProperties) {
+    return test_vkEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties);
+}
+#endif  // TEST_ICD_EXPORT_ICD_GIPA
+
+#if defined(TEST_ICD_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES)
+#if defined(WIN32)
+FRAMEWORK_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vk_icdEnumerateAdapterPhysicalDevices(VkInstance instance, LUID adapterLUID,
+                                                                                      uint32_t* pPhysicalDeviceCount,
+                                                                                      VkPhysicalDevice* pPhysicalDevices) {
+    icd.called_enumerate_adapter_physical_devices = CalledEnumerateAdapterPhysicalDevices::called;
+    return test_vkEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
+
+    return VK_SUCCESS;
+}
+#endif  // defined(WIN32)
+#endif  // TEST_ICD_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES
+
+}  // extern "C"

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#pragma once
+
+#include "test_util.h"
+
+#include "layer/layer_util.h"
+
+#include "physical_device.h"
+
+
+enum class CalledICDGIPA { not_called, vk_icd_gipa, vk_gipa };
+
+enum class CalledNegotiateInterface { not_called, vk_icd_negotiate, vk_icd_gipa_first };
+
+enum class InterfaceVersionCheck { not_called, loader_version_too_old, loader_version_too_new, icd_version_too_new, version_is_supported};
+
+enum class CalledEnumerateAdapterPhysicalDevices { not_called, called, called_but_not_supported};
+
+enum class UsingICDProvidedWSI { not_using, is_using};
+
+struct TestICD {
+    fs::path manifest_file_path;
+
+    CalledICDGIPA called_vk_icd_gipa = CalledICDGIPA::not_called;
+    CalledNegotiateInterface called_negotiate_interface = CalledNegotiateInterface::not_called;
+
+    InterfaceVersionCheck interface_version_check = InterfaceVersionCheck::not_called;
+    uint32_t min_icd_interface_version = 0;
+    uint32_t max_icd_interface_version = 6;
+    uint32_t icd_interface_version_received = 0;
+
+    CalledEnumerateAdapterPhysicalDevices called_enumerate_adapter_physical_devices = CalledEnumerateAdapterPhysicalDevices::not_called;
+
+    bool enable_icd_wsi = false;
+    UsingICDProvidedWSI is_using_icd_wsi = UsingICDProvidedWSI::not_using;
+
+    uint32_t icd_api_version = VK_MAKE_VERSION(1, 0, 0);
+    std::vector<Layer> instance_layers;
+    std::vector<Extension> instance_extensions;
+    std::vector<PhysicalDevice> physical_devices;
+
+    DispatchableHandle<VkInstance> instance_handle;
+    std::vector<DispatchableHandle<VkDevice>> device_handles;
+
+    uint64_t created_surface_count = 0;
+    uint64_t created_swapchain_count = 0;
+
+
+    TestICD() {}
+    ~TestICD() {}
+
+    TestICD& SetMinICDInterfaceVersion(uint32_t icd_interface_version) {
+        this->min_icd_interface_version = icd_interface_version;
+        return *this;
+    }
+    TestICD& SetICDAPIVersion(uint32_t api_version) {
+        this->icd_api_version = api_version;
+        return *this;
+    }
+    TestICD& AddInstanceLayer(Layer layer) { return AddInstanceLayers({layer}); }
+
+    TestICD& AddInstanceLayers(std::vector<Layer> layers) {
+        this->instance_layers.reserve(layers.size() + this->instance_layers.size());
+        for (auto& layer : layers) {
+            this->instance_layers.push_back(layer);
+        }
+        return *this;
+    }
+    TestICD& AddInstanceExtension(Extension extension) { return AddInstanceExtensions({extension}); }
+
+    TestICD& AddInstanceExtensions(std::vector<Extension> extensions) {
+        this->instance_extensions.reserve(extensions.size() + this->instance_extensions.size());
+        for (auto& extension : extensions) {
+            this->instance_extensions.push_back(extension);
+        }
+        return *this;
+    }
+    PhysicalDevice& GetPhysDevice(VkPhysicalDevice physicalDevice) {
+        for (auto& phys_dev : physical_devices) {
+            if (phys_dev.vk_physical_device.handle == physicalDevice) return phys_dev;
+        }
+        assert(false && "vkPhysicalDevice not found!");
+        return physical_devices[0];
+    }
+
+    InstanceCreateInfo GetVkInstanceCreateInfo() {
+        InstanceCreateInfo info;
+        for (auto& layer : instance_layers) info.enabled_layers.push_back(layer.layerName.data());
+        for (auto& ext : instance_extensions) info.enabled_extensions.push_back(ext.extensionName.data());
+        return info;
+    }
+};
+
+using GetTestICDFunc = TestICD* (*)();
+#define GET_TEST_ICD_FUNC_STR "get_test_icd_func"
+
+using GetNewTestICDFunc = TestICD* (*)();
+#define GET_NEW_TEST_ICD_FUNC_STR "get_new_test_icd_func"

--- a/tests/framework/layer/CMakeLists.txt
+++ b/tests/framework/layer/CMakeLists.txt
@@ -1,0 +1,32 @@
+# ~~~
+# Copyright (c) 2021 Valve Corporation
+# Copyright (c) 2021 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+add_library(test_layer_util INTERFACE)
+target_include_directories(test_layer_util INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR})
+target_link_libraries(test_layer_util INTERFACE testing_framework_util)
+
+add_library(test_layer_deps INTERFACE)
+
+target_compile_options(test_layer_deps  INTERFACE
+    $<$<PLATFORM_ID:WIN32>:${MSVC_LOADER_COMPILE_OPTIONS},/permissive->)
+
+target_compile_definitions(test_layer_deps  INTERFACE
+# Workaround for TR1 deprecation in Visual Studio 15.5 until Google Test is updated
+    $<$<PLATFORM_ID:WIN32>:-DWIN32_LEAN_AND_MEAN,-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING>
+    VK_NO_PROTOTYPES)
+
+target_link_libraries(test_layer_deps INTERFACE Vulkan::Headers testing_framework_util test_layer_util)

--- a/tests/framework/layer/layer_util.h
+++ b/tests/framework/layer/layer_util.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#pragma once
+
+#include "test_util.h"
+
+struct Layer {
+    std::string layerName;
+    uint32_t specVersion = VK_MAKE_VERSION(1, 0, 0);
+    uint32_t implementationVersion = VK_MAKE_VERSION(1, 0, 0);
+    std::string description;
+    std::vector<Extension> extensions;
+
+    Layer(std::string layerName, uint32_t specVersion = VK_MAKE_VERSION(1, 0, 0),
+          uint32_t implementationVersion = VK_MAKE_VERSION(1, 0, 0), std::string description = "",
+          std::vector<Extension> extensions = {})
+        : layerName(layerName),
+          specVersion(specVersion),
+          implementationVersion(implementationVersion),
+          description(description),
+          extensions(extensions) {}
+
+    VkLayerProperties get() const noexcept {
+        VkLayerProperties props{};
+        std::strncpy(props.layerName, layerName.data(), VK_MAX_EXTENSION_NAME_SIZE);
+        props.specVersion = specVersion;
+        props.implementationVersion = implementationVersion;
+        std::strncpy(props.description, layerName.data(), VK_MAX_DESCRIPTION_SIZE);
+        return props;
+    }
+};

--- a/tests/framework/shim/CMakeLists.txt
+++ b/tests/framework/shim/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ~~~
+# Copyright (c) 2021 Valve Corporation
+# Copyright (c) 2021 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+if (WIN32)
+    add_library(shim-library SHARED shim.h windows_shim.cpp)
+    target_link_libraries(shim-library PRIVATE detours cfgmgr32 testing_framework_util)
+    target_include_directories(shim-library PUBLIC ${CMAKE_SOURCE_DIR}/loader ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+
+elseif(UNIX)
+    add_library(shim-library STATIC shim.h linux_shim.cpp)
+    target_link_libraries(shim-library PRIVATE testing_framework_util)
+    target_include_directories(shim-library PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+
+elseif(APPLE)
+
+endif()

--- a/tests/framework/shim/linux_shim.cpp
+++ b/tests/framework/shim/linux_shim.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#include "shim.h"
+
+static PlatformShim platform_shim;
+
+PlatformShim& get_platform_shim() {
+    platform_shim = PlatformShim();
+    return platform_shim;
+}
+
+extern "C" {
+
+using PFN_OPENDIR = DIR* (*)(const char* path_name);
+
+FRAMEWORK_EXPORT DIR* opendir(const char* path_name) {
+    static PFN_OPENDIR real_opendir = nullptr;
+    if (!real_opendir) real_opendir = (PFN_OPENDIR)dlsym(RTLD_NEXT, "opendir");
+
+    DIR* dir;
+    if (platform_shim.is_fake_path(path_name)) {
+        auto fake_path_name = platform_shim.get_fake_path(fs::path(path_name));
+        //printf("Open Dir %s as %s\n", path_name, fake_path_name.c_str());
+        dir = real_opendir(fake_path_name.c_str());
+    } else {
+        //  printf("Open Dir %s\n", path_name);
+        dir = real_opendir(path_name);
+    }
+
+    return dir;
+}
+
+using PFN_ACCESS = int (*)(const char* pathname, int mode);
+
+FRAMEWORK_EXPORT int access(const char* in_pathname, int mode) {
+    static PFN_ACCESS real_access = nullptr;
+    if (!real_access) real_access = (PFN_ACCESS)dlsym(RTLD_NEXT, "access");
+
+    fs::path path{in_pathname};
+    if (!path.has_parent_path()) {
+        return real_access(in_pathname, mode);
+    }
+
+    if (platform_shim.is_fake_path(path.parent_path())) {
+        fs::path fake_path = platform_shim.get_fake_path(path.parent_path());
+        fake_path /= path.filename();
+        // printf("ACCESS: in_pathname %s as %s\n", split.path.c_str(), fake_path.c_str());
+        return real_access(fake_path.c_str(), mode);
+    }
+    return real_access(in_pathname, mode);
+}
+
+using PFN_FOPEN = FILE* (*)(const char* filename, const char* mode);
+
+FRAMEWORK_EXPORT FILE* fopen(const char* in_filename, const char* mode) {
+    static PFN_FOPEN real_fopen = nullptr;
+    if (!real_fopen) real_fopen = (PFN_FOPEN)dlsym(RTLD_NEXT, "fopen");
+    //printf("fopen file %s\n", in_filename);
+
+    fs::path path{in_filename};
+    if (!path.has_parent_path()) {
+        return real_fopen(in_filename, mode);
+    }
+
+    // printf("path %s as %s\n", split.path.c_str(), split.name.c_str());
+
+    FILE* f_ptr;
+    if (platform_shim.is_fake_path(path.parent_path())) {
+        auto fake_path = platform_shim.get_fake_path(path.parent_path()) / path.filename();
+        // printf("fopen %s as %s\n", in_filename, fake_path.c_str());
+        f_ptr = real_fopen(fake_path.c_str(), mode);
+    } else {
+        // printf("fopen %s\n", filename);
+        f_ptr = real_fopen(in_filename, mode);
+    }
+
+    return f_ptr;
+}
+}  // extern "C"

--- a/tests/framework/shim/shim.h
+++ b/tests/framework/shim/shim.h
@@ -1,0 +1,519 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#pragma once
+
+#include "test_util.h"
+
+#if defined(WIN32)
+#include <strsafe.h>
+#include <cfgmgr32.h>
+#include <initguid.h>
+#include <devpkey.h>
+#include <winternl.h>
+
+#define CINTERFACE
+#include <dxgi1_6.h>
+#include <adapters.h>
+#endif
+
+enum class ManifestCategory { implicit_layer, explicit_layer, icd };
+enum class GpuType { unspecified, integrated, discrete, external };
+
+#if defined(WIN32)
+
+struct KeyWrapper;
+
+static const char* pnp_registry_path = "SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}";
+
+// Needed for DXGI mocking
+struct KnownDriverData {
+    const char* filename;
+    int vendor_id;
+};
+static std::array<KnownDriverData, 4> known_driver_list = {
+#if defined(_WIN64)
+    KnownDriverData{"igvk64.json", 0x8086}, KnownDriverData{"nv-vk64.json", 0x10de}, KnownDriverData{"amd-vulkan64.json", 0x1002},
+    KnownDriverData{"amdvlk64.json", 0x1002}
+#else
+    KnownDriverData{"igvk32.json", 0x8086}, KnownDriverData{"nv-vk32.json", 0x10de}, KnownDriverData{"amd-vulkan32.json", 0x1002},
+    KnownDriverData{"amdvlk32.json", 0x1002}
+#endif
+};
+
+struct DXGIAdapter {
+    DXGIAdapter(fs::path const& manifest_path, GpuType gpu_preference, uint32_t known_driver_index, DXGI_ADAPTER_DESC1 desc1,
+                uint32_t adapter_index)
+        : manifest_path(manifest_path),
+          gpu_preference(gpu_preference),
+          known_driver_index(known_driver_index),
+          desc1(desc1),
+          adapter_index(adapter_index) {}
+    fs::path manifest_path;
+    GpuType gpu_preference = GpuType::unspecified;
+    uint32_t known_driver_index = UINT_MAX;  // index into the known_driver_list, UINT_MAX if it shouldn't index at all.
+    DXGI_ADAPTER_DESC1 desc1{};
+    uint32_t adapter_index = 0;
+};
+
+struct SHIM_D3DKMT_ADAPTERINFO {
+    UINT hAdapter;
+    LUID AdapterLuid;
+    ULONG NumOfSources;
+    BOOL bPresentMoveRegionsPreferred;
+};
+
+struct D3DKMT_Adapter {
+    SHIM_D3DKMT_ADAPTERINFO info;
+    fs::path path;
+};
+
+#endif
+// Necessary to have inline definitions as shim is a dll and thus functions
+// defined in the .cpp wont be found by the rest of the application
+struct PlatformShim {
+    // Test Framework interface
+    void setup_override(DebugMode debug_mode = DebugMode::none);
+    void clear_override(DebugMode debug_mode = DebugMode::none);
+
+    void reset(DebugMode debug_mode = DebugMode::none);
+
+    void redirect_all_paths(fs::path const& path);
+
+    void set_path(ManifestCategory category, fs::path const& path);
+
+    void add_manifest(ManifestCategory category, fs::path const& path);
+
+// platform specific shim interface
+#if defined(WIN32)
+    void add_dxgi_adapter(fs::path const& manifest_path, GpuType gpu_preference, uint32_t known_driver_index,
+                          DXGI_ADAPTER_DESC1 desc1);
+    void add_d3dkmt_adapter(SHIM_D3DKMT_ADAPTERINFO adapter, fs::path const& path);
+    void add_CM_Device_ID(std::wstring const& id, fs::path const& icd_path, fs::path const& layer_path);
+
+    uint32_t next_adapter_handle = 1;  // increment everytime add_dxgi_adapter is called
+    std::vector<DXGIAdapter> dxgi_adapters;
+    std::unordered_map<IDXGIAdapter1*, uint32_t> dxgi_adapter_map;
+    // next two are a pair
+    std::vector<D3DKMT_Adapter> d3dkmt_adapters;
+
+    std::wstring CM_device_ID_list = {L'\0'};
+    std::vector<KeyWrapper> CM_device_ID_registry_keys;
+
+    uint32_t random_base_path = 0;
+
+    std::vector<fs::path> icd_paths;
+
+#elif defined(__linux__) || defined(__APPLE__)
+    bool is_fake_path(fs::path const& path);
+    fs::path const& get_fake_path(fs::path const& path);
+
+    std::unordered_map<std::string, fs::path> redirection_map;
+#endif
+   private:
+    void redirect_category(fs::path const& new_path, ManifestCategory category);
+#if defined(WIN32)
+#elif defined(__linux__) || defined(__APPLE__)
+    void add(fs::path const& path, fs::path const& new_path);
+    void remove(fs::path const& path);
+#endif
+};
+
+std::vector<std::string> parse_env_var_list(std::string const& var);
+
+// dynamically link on windows
+#if defined(WIN32)
+using PFN_get_platform_shim = PlatformShim& (*)();
+#define GET_PLATFORM_SHIM_STR "get_platform_shim"
+
+#elif defined(__linux__) || defined(__APPLE__)
+// statically link on linux
+PlatformShim& get_platform_shim();
+#endif
+
+// Functions which are called by the Test Framework need a definition, but since the shim is a DLL, this
+// would require loading the functions before using. To get around this, most PlatformShim functions are member
+// functions, so only the `get_platform_shim()` is needed to be loaded. As a consequence, all the member functions
+// need to be defined inline, so that both framework code and shim dlls can use them.
+
+inline void PlatformShim::redirect_all_paths(fs::path const& path) {
+    redirect_category(path, ManifestCategory::implicit_layer);
+    redirect_category(path, ManifestCategory::explicit_layer);
+    redirect_category(path, ManifestCategory::icd);
+}
+
+inline std::vector<std::string> parse_env_var_list(std::string const& var) {
+    std::vector<std::string> items;
+    int start = 0;
+    int len = 0;
+    for (size_t i = 0; i < var.size(); i++) {
+#if defined(WIN32)
+        if (var[i] == ';') {
+#elif defined(__linux__) || defined(__APPLE__)
+        if (var[i] == ':') {
+#endif
+            items.push_back(var.substr(start, len));
+            start = i + 1;
+            len = 0;
+        } else {
+            len++;
+        }
+    }
+    items.push_back(var.substr(start, len));
+
+    return items;
+}
+
+#if defined(WIN32)
+
+inline std::string category_path_name(ManifestCategory category) {
+    if (category == ManifestCategory::implicit_layer) return "ImplicitLayers";
+    if (category == ManifestCategory::explicit_layer)
+        return "ExplicitLayers";
+    else
+        return "Drivers";
+}
+
+inline const char* win_api_error_str(LSTATUS status) {
+    if (status == ERROR_INVALID_FUNCTION) return "ERROR_INVALID_FUNCTION";
+    if (status == ERROR_FILE_NOT_FOUND) return "ERROR_FILE_NOT_FOUND";
+    if (status == ERROR_PATH_NOT_FOUND) return "ERROR_PATH_NOT_FOUND";
+    if (status == ERROR_TOO_MANY_OPEN_FILES) return "ERROR_TOO_MANY_OPEN_FILES";
+    if (status == ERROR_ACCESS_DENIED) return "ERROR_ACCESS_DENIED";
+    if (status == ERROR_INVALID_HANDLE) return "ERROR_INVALID_HANDLE";
+    return "UNKNOWN ERROR";
+}
+
+inline void print_error_message(LSTATUS status, const char* function_name, std::string optional_message = "") {
+    LPVOID lpMsgBuf;
+    DWORD dw = GetLastError();
+
+    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, dw,
+                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
+
+    std::cerr << function_name << " failed with " << win_api_error_str(status) << ": "
+              << std::string(static_cast<LPTSTR>(lpMsgBuf));
+    if (optional_message != "") {
+        std::cerr << " | " << optional_message;
+    }
+    std::cerr << "\n";
+    LocalFree(lpMsgBuf);
+}
+
+inline std::string override_base_path(uint32_t random_base_path) {
+    return std::string("SOFTWARE\\LoaderRegressionTests_") + std::to_string(random_base_path);
+}
+
+inline std::string get_override_path(HKEY root_key, uint32_t random_base_path) {
+    std::string override_path = override_base_path(random_base_path);
+
+    if (root_key == HKEY_CURRENT_USER) {
+        override_path += "\\HKCU";
+    } else if (root_key == HKEY_LOCAL_MACHINE) {
+        override_path += "\\HKLM";
+    }
+    return override_path;
+}
+
+inline HKEY create_key(HKEY key_root, const char* key_path) {
+    DWORD dDisposition{};
+    HKEY key{};
+    LSTATUS out =
+        RegCreateKeyExA(key_root, key_path, NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &key, &dDisposition);
+    if (out != ERROR_SUCCESS) std::cerr << win_api_error_str(out) << " failed to create key " << key << " at " << key_path << "\n";
+    return key;
+}
+
+inline void close_key(HKEY& key) {
+    LSTATUS out = RegCloseKey(key);
+    if (out != ERROR_SUCCESS) std::cerr << win_api_error_str(out) << " failed to close key " << key << "\n";
+}
+
+inline void setup_override_key(HKEY root_key, uint32_t random_base_path) {
+    DWORD dDisposition{};
+    LSTATUS out;
+
+    auto override_path = get_override_path(root_key, random_base_path);
+    HKEY override_key;
+    out = RegCreateKeyExA(HKEY_CURRENT_USER, override_path.c_str(), NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL,
+                          &override_key, &dDisposition);
+    if (out != ERROR_SUCCESS)
+        std::cerr << win_api_error_str(out) << " failed to create key " << override_key << " with path " << override_path << "\n";
+
+    out = RegOverridePredefKey(root_key, override_key);
+    if (out != ERROR_SUCCESS) std::cerr << win_api_error_str(out) << " failed to override key " << override_key << "\n";
+
+    close_key(override_key);
+}
+inline void revert_override(HKEY root_key, uint32_t random_base_path) {
+    LSTATUS out = RegOverridePredefKey(root_key, NULL);
+    if (out != ERROR_SUCCESS) std::cerr << win_api_error_str(out) << " failed to revert override key " << root_key << "\n";
+
+    auto override_path = get_override_path(root_key, random_base_path);
+    out = RegDeleteTreeA(HKEY_CURRENT_USER, override_path.c_str());
+    if (out != ERROR_SUCCESS) print_error_message(out, "RegDeleteTreeA", std::string("Key") + override_path);
+}
+
+struct KeyWrapper {
+    explicit KeyWrapper(HKEY key) noexcept : key(key) {}
+    explicit KeyWrapper(HKEY key_root, const char* key_path) noexcept { key = create_key(key_root, key_path); }
+    ~KeyWrapper() noexcept {
+        if (key != NULL) close_key(key);
+    }
+    explicit KeyWrapper(KeyWrapper const&) = delete;
+    KeyWrapper& operator=(KeyWrapper const&) = delete;
+    explicit KeyWrapper(KeyWrapper&& other) : key(other.key) { other.key = NULL; };
+    KeyWrapper& operator=(KeyWrapper&& other) {
+        if (this != &other) {
+            if (key != NULL) close_key(key);
+            key = other.key;
+            other.key = NULL;
+        }
+        return *this;
+    };
+
+    HKEY get() const noexcept { return key; }
+    operator HKEY() { return key; }
+    operator HKEY() const { return key; }
+    operator HKEY&() { return key; }
+    operator HKEY const &() const { return key; }
+
+    HKEY key{};
+};
+
+inline void add_key_value(HKEY const& key, fs::path const& manifest_path, bool enabled = true) {
+    DWORD value = enabled ? 0 : 1;
+    LSTATUS out = RegSetValueEx(key, manifest_path.c_str(), 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value));
+    if (out != ERROR_SUCCESS) std::cerr << win_api_error_str(out) << " failed to set key value for " << manifest_path.str() << "\n";
+}
+
+inline void add_key_value_string(HKEY const& key, const char* name, const char* str) {
+    LSTATUS out = RegSetValueExA(key, name, 0, REG_SZ, reinterpret_cast<const BYTE*>(str), strlen(str));
+    if (out != ERROR_SUCCESS)
+        std::cerr << win_api_error_str(out) << " failed to set string value for " << name << ":" << str << "\n";
+}
+
+inline void remove_key_value(HKEY const& key, fs::path const& manifest_path) {
+    LSTATUS out = RegDeleteValueA(key, manifest_path.c_str());
+    if (out != ERROR_SUCCESS)
+        std::cerr << win_api_error_str(out) << " failed to delete key value for " << manifest_path.str() << "\n";
+}
+
+inline void clear_key_values(HKEY const& key) {
+    DWORD dwNumValues, dwValueNameLen;
+
+    LSTATUS out = RegQueryInfoKey(key, 0, 0, 0, 0, 0, 0, &dwNumValues, &dwValueNameLen, 0, 0, 0);
+    if (out != ERROR_SUCCESS) {
+        std::cerr << win_api_error_str(out) << "couldn't query enum " << key << " values\n";
+        return;
+    }
+    std::string tchValName(dwValueNameLen + 1, '\0');
+    for (DWORD i = 0; i < dwNumValues; i++) {
+        DWORD length = tchValName.size();
+        LPSTR lpstr = &tchValName[0];
+        out = RegEnumValue(key, i, lpstr, &length, 0, 0, 0, 0);
+        if (out != ERROR_SUCCESS) {
+            std::cerr << win_api_error_str(out) << "couldn't get enum value " << tchValName << "\n";
+            return;
+        }
+    }
+}
+
+inline void PlatformShim::setup_override(DebugMode debug_mode) {
+    std::random_device rd;
+    std::ranlux48 gen(rd());
+    std::uniform_int_distribution<uint32_t> dist(0, 2000000);
+    while (random_base_path == 0) {
+        uint32_t random_num = dist(gen);
+        auto override_path = get_override_path(HKEY_CURRENT_USER, random_num);
+        HKEY temp_key = NULL;
+        auto result = RegOpenKeyEx(HKEY_CURRENT_USER, override_path.c_str(), 0, KEY_READ, &temp_key);
+        if (result != ERROR_SUCCESS) {
+            // Didn't find it, use the random number
+            random_base_path = random_num;
+        } else {
+            // try a different random number that isn't being used
+            std::cout << "INFO: Encountered existing registry key, is the registry full of old LoaderRegressionTest keys?\n";
+        }
+    }
+    auto reg_base = override_base_path(random_base_path);
+    HKEY timestamp_key = create_key(HKEY_CURRENT_USER, reg_base.c_str());
+
+    std::time_t cur_time = std::time(nullptr);
+    auto* cur_time_text = std::ctime(&cur_time);
+    add_key_value_string(timestamp_key, "Timestamp", cur_time_text);
+
+    setup_override_key(HKEY_LOCAL_MACHINE, random_base_path);
+    setup_override_key(HKEY_CURRENT_USER, random_base_path);
+}
+inline void PlatformShim::clear_override(DebugMode debug_mode) {
+    if (debug_mode != DebugMode::no_delete) {
+        revert_override(HKEY_CURRENT_USER, random_base_path);
+        revert_override(HKEY_LOCAL_MACHINE, random_base_path);
+
+        LSTATUS out = RegDeleteKeyA(HKEY_CURRENT_USER, override_base_path(random_base_path).c_str());
+        if (out != ERROR_SUCCESS)
+            print_error_message(out, "RegDeleteKeyA", std::string("Key") + override_base_path(random_base_path).c_str());
+    }
+}
+inline void PlatformShim::reset(DebugMode debug_mode) {
+    KeyWrapper implicit_key{HKEY_LOCAL_MACHINE, "SOFTWARE\\Khronos\\Vulkan\\ImplicitLayers"};
+    KeyWrapper explicit_key{HKEY_LOCAL_MACHINE, "SOFTWARE\\Khronos\\Vulkan\\ExplicitLayers"};
+    KeyWrapper icd_key{HKEY_LOCAL_MACHINE, "SOFTWARE\\Khronos\\Vulkan\\Drivers"};
+    if (debug_mode != DebugMode::no_delete) {
+        clear_key_values(implicit_key);
+        clear_key_values(explicit_key);
+        clear_key_values(icd_key);
+    }
+}
+
+inline void PlatformShim::set_path(ManifestCategory category, fs::path const& path) {}
+
+inline void PlatformShim::add_manifest(ManifestCategory category, fs::path const& path) {
+    std::string reg_path = std::string("SOFTWARE\\Khronos\\Vulkan\\") + category_path_name(category);
+    KeyWrapper key{HKEY_LOCAL_MACHINE, reg_path.c_str()};
+    add_key_value(key, path);
+    if (category == ManifestCategory::icd) {
+        icd_paths.push_back(path);
+    }
+}
+inline void PlatformShim::add_dxgi_adapter(fs::path const& manifest_path, GpuType gpu_preference, uint32_t known_driver_index,
+                                           DXGI_ADAPTER_DESC1 desc1) {
+    dxgi_adapters.push_back(DXGIAdapter(manifest_path, gpu_preference, known_driver_index, desc1, next_adapter_handle++));
+}
+
+inline void PlatformShim::add_d3dkmt_adapter(SHIM_D3DKMT_ADAPTERINFO adapter, fs::path const& path) {
+    d3dkmt_adapters.push_back({adapter, path});
+}
+
+inline void PlatformShim::add_CM_Device_ID(std::wstring const& id, fs::path const& icd_path, fs::path const& layer_path) {
+    // append a null byte as separator if there is already id's in the list
+    if (CM_device_ID_list.size() != 0) {
+        CM_device_ID_list += L'\0';  // I'm sure this wont cause issues with std::string down the line... /s
+    }
+    CM_device_ID_list += id;
+    std::string id_str(id.length(), '\0');
+    std::wcstombs(&id_str[0], id.c_str(), id_str.length());
+
+    std::string device_path = std::string(pnp_registry_path) + "\\" + id_str;
+    CM_device_ID_registry_keys.emplace_back(HKEY_LOCAL_MACHINE, device_path.c_str());
+    HKEY id_key = CM_device_ID_registry_keys.back().key;
+    add_key_value_string(id_key, "VulkanDriverName", icd_path.c_str());
+    add_key_value_string(id_key, "VulkanLayerName", layer_path.c_str());
+    // TODO: decide how to handle 32 bit
+    // add_key_value_string(id_key, "VulkanDriverNameWoW", icd_path.c_str());
+    // add_key_value_string(id_key, "VulkanLayerName", layer_path.c_str());
+}
+
+inline HKEY GetRegistryKey() { return HKEY{}; }
+
+inline void PlatformShim::redirect_category(fs::path const& new_path, ManifestCategory search_category) {
+    // create_key(HKEY_LOCAL_MACHINE, "SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\0001");
+    // create_key(HKEY_LOCAL_MACHINE, "SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\0002");
+    switch (search_category) {
+        case (ManifestCategory::implicit_layer):
+            create_key(HKEY_CURRENT_USER, "SOFTWARE\\Khronos\\Vulkan\\ImplicitLayers");
+            create_key(HKEY_LOCAL_MACHINE, "SOFTWARE\\Khronos\\Vulkan\\ImplicitLayers");
+            create_key(HKEY_LOCAL_MACHINE, "SOFTWARE\\WOW6432Node\\Khronos\\Vulkan\\ImplicitLayers");
+            break;
+        case (ManifestCategory::explicit_layer):
+            create_key(HKEY_CURRENT_USER, "SOFTWARE\\Khronos\\Vulkan\\ExplicitLayers");
+            create_key(HKEY_LOCAL_MACHINE, "SOFTWARE\\Khronos\\Vulkan\\ExplicitLayers");
+            create_key(HKEY_LOCAL_MACHINE, "SOFTWARE\\WOW6432Node\\Khronos\\Vulkan\\ExplicitLayers");
+            break;
+        case (ManifestCategory::icd):
+            create_key(HKEY_LOCAL_MACHINE, "SOFTWARE\\Khronos\\Vulkan\\Drivers");
+            create_key(HKEY_LOCAL_MACHINE, "SOFTWARE\\WOW6432Node\\Khronos\\Vulkan\\Drivers");
+            break;
+    }
+}
+
+#elif defined(__linux__) || defined(__APPLE__)
+
+#include <sys/types.h>
+#include <dirent.h>
+#include <unistd.h>
+
+inline std::string category_path_name(ManifestCategory category) {
+    if (category == ManifestCategory::implicit_layer) return "implicit_layer.d";
+    if (category == ManifestCategory::explicit_layer)
+        return "explicit_layer.d";
+    else
+        return "icd.d";
+}
+
+inline void PlatformShim::setup_override(DebugMode debug_mode) {}
+inline void PlatformShim::clear_override(DebugMode debug_mode) {}
+inline void PlatformShim::reset(DebugMode debug_mode) { redirection_map.clear(); }
+
+inline void PlatformShim::add(fs::path const& path, fs::path const& new_path) { redirection_map[path.str()] = new_path; }
+inline void PlatformShim::remove(fs::path const& path) { redirection_map.erase(path.str()); }
+inline bool PlatformShim::is_fake_path(fs::path const& path) { return redirection_map.count(path.str()) > 0; }
+inline fs::path const& PlatformShim::get_fake_path(fs::path const& path) { return redirection_map.at(path.str()); }
+
+// void PlatformShim::set_implicit_layer_path(ManifestCategory category, fs::path const& path) {
+//     add(fs::path("/usr/local/etc/vulkan/implicit_layer.d"), path);
+
+//     add(fs::path("/usr/local/etc/vulkan/explicit_layer.d"), path);
+//     add(fs::path("/usr/local/etc/vulkan/icd.d"), path);
+// }
+
+inline void PlatformShim::add_manifest(ManifestCategory category, fs::path const& path) {}
+
+inline void PlatformShim::redirect_category(fs::path const& new_path, ManifestCategory category) {
+    // default paths
+    add(fs::path("/usr/local/etc/vulkan") / category_path_name(category), new_path);
+    add(fs::path("/usr/local/share/vulkan") / category_path_name(category), new_path);
+    add(fs::path("/etc/vulkan") / category_path_name(category), new_path);
+    add(fs::path("/usr/share/vulkan") / category_path_name(category), new_path);
+
+    std::vector<std::string> xdg_paths;
+    std::string xdg_data_dirs_var = get_env_var("XDG_DATA_DIRS");
+    if (xdg_data_dirs_var.size() > 0) {
+        xdg_paths = parse_env_var_list(xdg_data_dirs_var);
+    }
+    std::string xdg_config_dirs_var = get_env_var("XDG_CONFIG_DIRS");
+    if (xdg_config_dirs_var.size() > 0) {
+        auto paths = parse_env_var_list(xdg_config_dirs_var);
+        xdg_paths.insert(xdg_paths.begin(), paths.begin(), paths.end());
+    }
+    for (auto& path : xdg_paths) {
+        add(fs::path(path) / "vulkan" / category_path_name(category), new_path);
+    }
+
+    std::string home = get_env_var("HOME");
+    if (home.size() == 0) return;
+    add(fs::path(home) / ".local/share/vulkan" / category_path_name(category), new_path);
+}
+
+inline void PlatformShim::set_path(ManifestCategory category, fs::path const& path) {
+    if (category == ManifestCategory::implicit_layer) add(fs::path("/usr/local/etc/vulkan/implicit_layer.d"), path);
+    if (category == ManifestCategory::explicit_layer) add(fs::path("/usr/local/etc/vulkan/explicit_layer.d"), path);
+    if (category == ManifestCategory::icd) add(fs::path("/usr/local/etc/vulkan/icd.d"), path);
+}
+
+#endif

--- a/tests/framework/shim/windows_shim.cpp
+++ b/tests/framework/shim/windows_shim.cpp
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+// This needs to be defined first, or else we'll get redefinitions on NTSTATUS values
+#ifdef _WIN32
+#define UMDF_USING_NTSTATUS
+#include <ntstatus.h>
+#endif
+
+#include "shim.h"
+
+#include "detours.h"
+
+static PlatformShim platform_shim;
+
+extern "C" {
+
+static LibraryWrapper gdi32_dll;
+
+static PFN_LoaderEnumAdapters2 fpEnumAdapters2 = nullptr;
+static PFN_LoaderQueryAdapterInfo fpQueryAdapterInfo = nullptr;
+
+long ShimEnumAdapters2(LoaderEnumAdapters2 *adapters) {
+    if (adapters == nullptr) {
+        return STATUS_INVALID_PARAMETER;
+    }
+    if (platform_shim.d3dkmt_adapters.size() == 0) {
+        if (adapters->adapters != nullptr) adapters->adapter_count = 0;
+        return STATUS_SUCCESS;
+    }
+    if (adapters->adapters != nullptr) {
+        for (size_t i = 0; i < platform_shim.d3dkmt_adapters.size(); i++) {
+            adapters->adapters[i].handle = platform_shim.d3dkmt_adapters[i].info.hAdapter;
+            adapters->adapters[i].luid = platform_shim.d3dkmt_adapters[i].info.AdapterLuid;
+            adapters->adapters[i].source_count = platform_shim.d3dkmt_adapters[i].info.NumOfSources;
+            adapters->adapters[i].present_move_regions_preferred =
+                platform_shim.d3dkmt_adapters[i].info.bPresentMoveRegionsPreferred;
+        }
+        adapters->adapter_count = platform_shim.d3dkmt_adapters.size();
+    } else {
+        adapters->adapter_count = platform_shim.d3dkmt_adapters.size();
+    }
+    return STATUS_SUCCESS;
+}
+NTSTATUS APIENTRY ShimQueryAdapterInfo(const LoaderQueryAdapterInfo *query_info) {
+    if (query_info == nullptr || query_info->private_data == nullptr) {
+        return STATUS_INVALID_PARAMETER;
+    }
+    auto handle = query_info->handle;
+    auto it = std::find_if(platform_shim.d3dkmt_adapters.begin(), platform_shim.d3dkmt_adapters.end(),
+                           [handle](const D3DKMT_Adapter &adapter) { return handle == adapter.info.hAdapter; });
+    if (it == platform_shim.d3dkmt_adapters.end()) {
+        return STATUS_INVALID_PARAMETER;
+    }
+    auto &adapter = *it;
+
+    auto *reg_info = reinterpret_cast<LoaderQueryRegistryInfo *>(query_info->private_data);
+    reg_info->status = LOADER_QUERY_REGISTRY_STATUS_SUCCESS;
+    if (reg_info->output_value_size == 0) {
+        reg_info->output_value_size = it->path.size();
+    } else if (reg_info->output_value_size == it->path.size()) {
+        std::wstring path_wstr(1, L'\0');
+        path_wstr.assign(it->path.str().begin(), it->path.str().end());
+        wcscpy(&reg_info->output_string[0], path_wstr.c_str());
+    } else if (reg_info->output_value_size == it->path.size()) {
+        reg_info->status = LOADER_QUERY_REGISTRY_STATUS_BUFFER_OVERFLOW;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+// clang-format off
+static CONFIGRET(WINAPI *REAL_CM_Get_Device_ID_List_SizeW)(PULONG pulLen, PCWSTR pszFilter, ULONG ulFlags) = CM_Get_Device_ID_List_SizeW;
+static CONFIGRET(WINAPI *REAL_CM_Get_Device_ID_ListW)(PCWSTR pszFilter, PZZWSTR Buffer, ULONG BufferLen, ULONG ulFlags) = CM_Get_Device_ID_ListW;
+static CONFIGRET(WINAPI *REAL_CM_Locate_DevNodeW)(PDEVINST pdnDevInst, DEVINSTID_W pDeviceID, ULONG ulFlags) =  CM_Locate_DevNodeW;
+static CONFIGRET(WINAPI *REAL_CM_Get_DevNode_Status)(PULONG pulStatus, PULONG pulProblemNumber, DEVINST dnDevInst, ULONG ulFlags) =  CM_Get_DevNode_Status;
+static CONFIGRET(WINAPI *REAL_CM_Get_Device_IDW)(DEVINST dnDevInst, PWSTR Buffer, ULONG BufferLen, ULONG ulFlags) =  CM_Get_Device_IDW;
+static CONFIGRET(WINAPI *REAL_CM_Get_Child)(PDEVINST pdnDevInst, DEVINST dnDevInst, ULONG ulFlags) =  CM_Get_Child;
+static CONFIGRET(WINAPI *REAL_CM_Get_DevNode_Registry_PropertyW)(DEVINST dnDevInst, ULONG ulProperty, PULONG pulRegDataType, PVOID Buffer, PULONG pulLength, ULONG ulFlags) =  CM_Get_DevNode_Registry_PropertyW;
+static CONFIGRET(WINAPI *REAL_CM_Get_Sibling)(PDEVINST pdnDevInst, DEVINST dnDevInst, ULONG ulFlags) = CM_Get_Sibling;
+// clang-format on
+
+CONFIGRET WINAPI SHIM_CM_Get_Device_ID_List_SizeW(PULONG pulLen, PCWSTR pszFilter, ULONG ulFlags) {
+    if (pulLen == nullptr) {
+        return CR_INVALID_POINTER;
+    }
+    *pulLen = platform_shim.CM_device_ID_list.size();
+    return CR_SUCCESS;
+}
+CONFIGRET WINAPI SHIM_CM_Get_Device_ID_ListW(PCWSTR pszFilter, PZZWSTR Buffer, ULONG BufferLen, ULONG ulFlags) {
+    if (Buffer != NULL) {
+        if (BufferLen < platform_shim.CM_device_ID_list.size()) return CR_BUFFER_SMALL;
+        for (size_t i = 0; i < BufferLen; i++) {
+            Buffer[i] = platform_shim.CM_device_ID_list[i];
+        }
+    }
+    return CR_SUCCESS;
+}
+// TODO
+CONFIGRET WINAPI SHIM_CM_Locate_DevNodeW(PDEVINST pdnDevInst, DEVINSTID_W pDeviceID, ULONG ulFlags) { return CR_FAILURE; }
+// TODO
+CONFIGRET WINAPI SHIM_CM_Get_DevNode_Status(PULONG pulStatus, PULONG pulProblemNumber, DEVINST dnDevInst, ULONG ulFlags) {
+    return CR_FAILURE;
+}
+// TODO
+CONFIGRET WINAPI SHIM_CM_Get_Device_IDW(DEVINST dnDevInst, PWSTR Buffer, ULONG BufferLen, ULONG ulFlags) { return CR_FAILURE; }
+// TODO
+CONFIGRET WINAPI SHIM_CM_Get_Child(PDEVINST pdnDevInst, DEVINST dnDevInst, ULONG ulFlags) { return CR_FAILURE; }
+// TODO
+CONFIGRET WINAPI SHIM_CM_Get_DevNode_Registry_PropertyW(DEVINST dnDevInst, ULONG ulProperty, PULONG pulRegDataType, PVOID Buffer,
+                                                        PULONG pulLength, ULONG ulFlags) {
+    return CR_FAILURE;
+}
+// TODO
+CONFIGRET WINAPI SHIM_CM_Get_Sibling(PDEVINST pdnDevInst, DEVINST dnDevInst, ULONG ulFlags) { return CR_FAILURE; }
+
+static LibraryWrapper dxgi_module;
+typedef HRESULT(APIENTRY *PFN_CreateDXGIFactory1)(REFIID riid, void **ppFactory);
+
+PFN_CreateDXGIFactory1 RealCreateDXGIFactory1;
+
+
+
+HRESULT __stdcall ShimGetDesc1(IDXGIAdapter1 *pAdapter,
+                               /* [annotation][out] */
+                               _Out_ DXGI_ADAPTER_DESC1 *pDesc) {
+    if (pAdapter == nullptr || pDesc == nullptr) return DXGI_ERROR_INVALID_CALL;
+    auto it = platform_shim.dxgi_adapter_map.find(pAdapter);
+    if (it == platform_shim.dxgi_adapter_map.end()) {
+        return DXGI_ERROR_INVALID_CALL;
+    }
+    *pDesc = platform_shim.dxgi_adapters[it->second].desc1;
+    return S_OK;
+}
+ULONG __stdcall ShimIDXGIFactory1Release(IDXGIFactory1 *factory) {
+    if (factory != nullptr) {
+        if (factory->lpVtbl != nullptr) {
+            delete factory->lpVtbl;
+        }
+        delete factory;
+    }
+    return S_OK;
+}
+ULONG __stdcall ShimIDXGIFactory6Release(IDXGIFactory6 *factory) {
+    if (factory != nullptr) {
+        if (factory->lpVtbl != nullptr) {
+            delete factory->lpVtbl;
+        }
+        delete factory;
+    }
+    return S_OK;
+}
+
+ULONG __stdcall ShimRelease(IDXGIAdapter1 *pAdapter) {
+    if (pAdapter != nullptr) {
+        if (pAdapter->lpVtbl != nullptr) {
+            delete pAdapter->lpVtbl;
+        }
+        delete pAdapter;
+    }
+    return S_OK;
+}
+
+IDXGIAdapter1 *create_IDXGIAdapter1() {
+    IDXGIAdapter1Vtbl *vtbl = new IDXGIAdapter1Vtbl();
+    vtbl->GetDesc1 = ShimGetDesc1;
+    vtbl->Release = ShimRelease;
+    IDXGIAdapter1 *adapter = new IDXGIAdapter1();
+    adapter->lpVtbl = vtbl;
+    return adapter;
+}
+
+HRESULT __stdcall ShimEnumAdapters1_1(IDXGIFactory1 *This,
+                                      /* [in] */ UINT Adapter,
+                                      /* [annotation][out] */
+                                      _COM_Outptr_ IDXGIAdapter1 **ppAdapter) {
+    if (Adapter >= platform_shim.dxgi_adapters.size()) {
+        return DXGI_ERROR_INVALID_CALL;
+    }
+    auto *pAdapter = create_IDXGIAdapter1();
+    *ppAdapter = pAdapter;
+
+    platform_shim.dxgi_adapter_map[pAdapter] = Adapter;
+    return S_OK;
+}
+
+HRESULT __stdcall ShimEnumAdapters1_6(IDXGIFactory6 *This,
+                                      /* [in] */ UINT Adapter,
+                                      /* [annotation][out] */
+                                      _COM_Outptr_ IDXGIAdapter1 **ppAdapter) {
+    if (Adapter >= platform_shim.dxgi_adapters.size()) {
+        return DXGI_ERROR_INVALID_CALL;
+    }
+    auto *pAdapter = create_IDXGIAdapter1();
+    *ppAdapter = pAdapter;
+
+    platform_shim.dxgi_adapter_map[pAdapter] = Adapter;
+    return S_OK;
+}
+
+HRESULT __stdcall ShimEnumAdapterByGpuPreference(IDXGIFactory6 *This, _In_ UINT Adapter, _In_ DXGI_GPU_PREFERENCE GpuPreference,
+                                                 _In_ REFIID riid, _COM_Outptr_ void **ppvAdapter) {
+    if (Adapter >= platform_shim.dxgi_adapters.size()) {
+        return DXGI_ERROR_INVALID_CALL;
+    }
+    // loader always uses DXGI_GPU_PREFERENCE_UNSPECIFIED
+    // Update the shim if this isn't the case
+    assert(GpuPreference == DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_UNSPECIFIED &&
+           "Test shim assumes the GpuPreference is unspecified.");
+
+    auto *pAdapter = create_IDXGIAdapter1();
+    *ppvAdapter = pAdapter;
+    platform_shim.dxgi_adapter_map[pAdapter] = Adapter;
+    return S_OK;
+}
+
+IDXGIFactory1 *create_IDXGIFactory1() {
+    IDXGIFactory1Vtbl *vtbl = new IDXGIFactory1Vtbl();
+    vtbl->EnumAdapters1 = ShimEnumAdapters1_1;
+    vtbl->Release = ShimIDXGIFactory1Release;
+    IDXGIFactory1 *factory = new IDXGIFactory1();
+    factory->lpVtbl = vtbl;
+    return factory;
+}
+
+IDXGIFactory6 *create_IDXGIFactory6() {
+    IDXGIFactory6Vtbl *vtbl = new IDXGIFactory6Vtbl();
+    vtbl->EnumAdapters1 = ShimEnumAdapters1_6;
+    vtbl->EnumAdapterByGpuPreference = ShimEnumAdapterByGpuPreference;
+    vtbl->Release = ShimIDXGIFactory6Release;
+    IDXGIFactory6 *factory = new IDXGIFactory6();
+    factory->lpVtbl = vtbl;
+    return factory;
+}
+
+HRESULT __stdcall ShimCreateDXGIFactory1(REFIID riid, void **ppFactory) {
+    if (riid == IID_IDXGIFactory1) {
+        auto *factory = create_IDXGIFactory1();
+        *ppFactory = factory;
+        return S_OK;
+    }
+    if (riid == IID_IDXGIFactory6) {
+        auto *factory = create_IDXGIFactory6();
+        *ppFactory = factory;
+        return S_OK;
+    }
+    assert(false && "new riid, update shim code to handle");
+    return S_FALSE;
+}
+
+// Initialization
+void WINAPI DetourFunctions() {
+    if (!gdi32_dll) {
+        gdi32_dll = LibraryWrapper("gdi32.dll");
+        fpEnumAdapters2 = gdi32_dll.get_symbol<PFN_LoaderEnumAdapters2>("D3DKMTEnumAdapters2");
+        if (fpEnumAdapters2 == nullptr) {
+            std::cerr << "Failed to load D3DKMTEnumAdapters2\n";
+            return;
+        }
+        fpQueryAdapterInfo = gdi32_dll.get_symbol<PFN_LoaderQueryAdapterInfo>("D3DKMTQueryAdapterInfo");
+        if (fpQueryAdapterInfo == nullptr) {
+            std::cerr << "Failed to load D3DKMTQueryAdapterInfo\n";
+            return;
+        }
+    }
+    if (!dxgi_module) {
+        TCHAR systemPath[MAX_PATH] = "";
+        GetSystemDirectory(systemPath, MAX_PATH);
+        StringCchCat(systemPath, MAX_PATH, TEXT("\\dxgi.dll"));
+        dxgi_module = LibraryWrapper(systemPath);
+        RealCreateDXGIFactory1 = dxgi_module.get_symbol<PFN_CreateDXGIFactory1>("CreateDXGIFactory1");
+        if (RealCreateDXGIFactory1 == nullptr) {
+            std::cerr << "Failed to load CreateDXGIFactory1\n";
+        }
+    }
+
+    DetourRestoreAfterWith();
+
+    DetourTransactionBegin();
+    DetourUpdateThread(GetCurrentThread());
+    DetourAttach(&(PVOID &)fpEnumAdapters2, ShimEnumAdapters2);
+    DetourAttach(&(PVOID &)fpQueryAdapterInfo, ShimQueryAdapterInfo);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Device_ID_List_SizeW, SHIM_CM_Get_Device_ID_List_SizeW);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Device_ID_ListW, SHIM_CM_Get_Device_ID_ListW);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Device_ID_ListW, SHIM_CM_Get_Device_ID_ListW);
+    DetourAttach(&(PVOID &)REAL_CM_Locate_DevNodeW, SHIM_CM_Locate_DevNodeW);
+    DetourAttach(&(PVOID &)REAL_CM_Get_DevNode_Status, SHIM_CM_Get_DevNode_Status);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Device_IDW, SHIM_CM_Get_Device_IDW);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Child, SHIM_CM_Get_Child);
+    DetourAttach(&(PVOID &)REAL_CM_Get_DevNode_Registry_PropertyW, SHIM_CM_Get_DevNode_Registry_PropertyW);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Sibling, SHIM_CM_Get_Sibling);
+    DetourAttach(&(PVOID &)RealCreateDXGIFactory1, ShimCreateDXGIFactory1);
+    LONG error = DetourTransactionCommit();
+
+    if (error != NO_ERROR) {
+        std::cerr << "simple" << DETOURS_STRINGIFY(DETOURS_BITS) << ".dll:"
+                  << " Error detouring function(): " << error << "\n";
+    }
+}
+
+void DetachFunctions() {
+    DetourTransactionBegin();
+    DetourUpdateThread(GetCurrentThread());
+    DetourDetach(&(PVOID &)fpEnumAdapters2, ShimEnumAdapters2);
+    DetourDetach(&(PVOID &)fpQueryAdapterInfo, ShimQueryAdapterInfo);
+    DetourDetach(&(PVOID &)REAL_CM_Get_Device_ID_List_SizeW, SHIM_CM_Get_Device_ID_List_SizeW);
+    DetourDetach(&(PVOID &)REAL_CM_Get_Device_ID_ListW, SHIM_CM_Get_Device_ID_ListW);
+    DetourDetach(&(PVOID &)REAL_CM_Locate_DevNodeW, SHIM_CM_Locate_DevNodeW);
+    DetourDetach(&(PVOID &)REAL_CM_Get_DevNode_Status, SHIM_CM_Get_DevNode_Status);
+    DetourDetach(&(PVOID &)REAL_CM_Get_Device_IDW, SHIM_CM_Get_Device_IDW);
+    DetourDetach(&(PVOID &)REAL_CM_Get_Child, SHIM_CM_Get_Child);
+    DetourDetach(&(PVOID &)REAL_CM_Get_DevNode_Registry_PropertyW, SHIM_CM_Get_DevNode_Registry_PropertyW);
+    DetourDetach(&(PVOID &)REAL_CM_Get_Sibling, SHIM_CM_Get_Sibling);
+    DetourDetach(&(PVOID &)RealCreateDXGIFactory1, ShimCreateDXGIFactory1);
+    DetourTransactionCommit();
+}
+
+BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved) {
+    if (DetourIsHelperProcess()) {
+        return TRUE;
+    }
+
+    if (dwReason == DLL_PROCESS_ATTACH) {
+        DetourFunctions();
+    } else if (dwReason == DLL_PROCESS_DETACH) {
+        DetachFunctions();
+    }
+    return TRUE;
+}
+FRAMEWORK_EXPORT PlatformShim &get_platform_shim() {
+    platform_shim = PlatformShim();
+    return platform_shim;
+}
+}

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#include "test_environment.h"
+
+namespace detail {
+PlatformShimWrapper::PlatformShimWrapper(DebugMode debug_mode) : debug_mode(debug_mode) {
+#if defined(WIN32)
+    shim_library = LibraryWrapper(SHIM_LIBRARY_NAME);
+    auto get_platform_shim_func = shim_library.get_symbol<PFN_get_platform_shim>(GET_PLATFORM_SHIM_STR);
+    assert(get_platform_shim_func != NULL && "Must be able to get \"platform_shim\"");
+    platform_shim = &get_platform_shim_func();
+#elif defined(__linux__) || defined(__APPLE__)
+    platform_shim = &get_platform_shim();
+#endif
+    platform_shim->setup_override(debug_mode);
+    platform_shim->reset(debug_mode);
+}
+PlatformShimWrapper::~PlatformShimWrapper() {
+    platform_shim->reset(debug_mode);
+    platform_shim->clear_override(debug_mode);
+}
+
+TestICDHandle::TestICDHandle() {}
+TestICDHandle::TestICDHandle(fs::path const& icd_path) {
+    icd_library = LibraryWrapper(icd_path);
+    proc_addr_get_test_icd = icd_library.get_symbol<GetNewTestICDFunc>(GET_TEST_ICD_FUNC_STR);
+    proc_addr_get_new_test_icd = icd_library.get_symbol<GetNewTestICDFunc>(GET_NEW_TEST_ICD_FUNC_STR);
+}
+TestICD& TestICDHandle::get_test_icd() {
+    assert(proc_addr_get_test_icd != NULL && "symbol must be loaded before use");
+    return *proc_addr_get_test_icd();
+}
+TestICD& TestICDHandle::get_new_test_icd() {
+    assert(proc_addr_get_new_test_icd != NULL && "symbol must be loaded before use");
+    return *proc_addr_get_new_test_icd();
+}
+fs::path TestICDHandle::get_icd_full_path() { return icd_library.lib_path; }
+}  // namespace detail
+
+FrameworkEnvironment::FrameworkEnvironment(DebugMode debug_mode)
+    : platform_shim(debug_mode),
+      null_folder(FRAMEWORK_BUILD_DIRECTORY, "null_dir", debug_mode),
+      icd_folder(FRAMEWORK_BUILD_DIRECTORY, "icd_manifests", debug_mode),
+      explicit_layer_folder(FRAMEWORK_BUILD_DIRECTORY, "explicit_layer_manifests", debug_mode),
+      implicit_layer_folder(FRAMEWORK_BUILD_DIRECTORY, "implicit_layer_manifests", debug_mode),
+      vulkan_functions() {
+    platform_shim->redirect_all_paths(null_folder.location());
+
+    platform_shim->set_path(ManifestCategory::icd, icd_folder.location());
+    platform_shim->set_path(ManifestCategory::explicit_layer, explicit_layer_folder.location());
+    platform_shim->set_path(ManifestCategory::implicit_layer, implicit_layer_folder.location());
+}
+
+void FrameworkEnvironment::AddICD(TestICDDetails icd_details, const std::string& json_name) {
+    ManifestICD icd_manifest;
+    icd_manifest.lib_path = fs::fixup_backslashes_in_path(icd_details.icd_path);
+    icd_manifest.api_version = icd_details.api_version;
+    auto driver_loc = icd_folder.write(json_name, icd_manifest);
+    platform_shim->add_manifest(ManifestCategory::icd, driver_loc);
+}
+void FrameworkEnvironment::AddImplicitLayer(ManifestLayer layer_manifest, const std::string& json_name) {
+    auto layer_loc = implicit_layer_folder.write(json_name, layer_manifest);
+    platform_shim->add_manifest(ManifestCategory::implicit_layer, layer_loc);
+}
+void FrameworkEnvironment::AddExplicitLayer(ManifestLayer layer_manifest, const std::string& json_name) {
+    auto layer_loc = explicit_layer_folder.write(json_name, layer_manifest);
+    platform_shim->add_manifest(ManifestCategory::explicit_layer, layer_loc);
+}
+
+SingleICDShim::SingleICDShim(TestICDDetails icd_details, DebugMode debug_mode) : FrameworkEnvironment(debug_mode) {
+    icd_handle = detail::TestICDHandle(icd_details.icd_path);
+
+    AddICD(icd_details, "test_icd.json");
+}
+TestICD& SingleICDShim::get_test_icd() { return icd_handle.get_test_icd(); }
+TestICD& SingleICDShim::get_new_test_icd() { return icd_handle.get_new_test_icd(); }
+fs::path SingleICDShim::get_test_icd_path() { return icd_handle.get_icd_full_path(); }
+
+MultipleICDShim::MultipleICDShim(std::vector<TestICDDetails> icd_details_vector, DebugMode debug_mode)
+    : FrameworkEnvironment(debug_mode) {
+    uint32_t i = 0;
+    for (auto& test_icd_detail : icd_details_vector) {
+        fs::path new_driver_location = icd_folder.location() / fs::path(test_icd_detail.icd_path).stem() + "_" +
+                                       std::to_string(i) + fs::path(test_icd_detail.icd_path).extension();
+
+        fs::copy_file(test_icd_detail.icd_path, new_driver_location);
+
+        icds.push_back(detail::TestICDHandle(new_driver_location));
+        test_icd_detail.icd_path = new_driver_location.c_str();
+        AddICD(test_icd_detail, std::string("test_icd_") + std::to_string(i) + ".json");
+        i++;
+    }
+}
+TestICD& MultipleICDShim::get_test_icd(int index) { return icds[index].get_test_icd(); }
+TestICD& MultipleICDShim::get_new_test_icd(int index) { return icds[index].get_new_test_icd(); }
+fs::path MultipleICDShim::get_test_icd_path(int index) { return icds[index].get_icd_full_path(); }

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+/*
+ * The test_environment is what combines the icd, layer, and shim library into a single object that
+ * test fixtures can create and use. Responsible for loading the libraries and establishing the
+ * channels for tests to talk with the icd's and layers.
+*/
+#pragma once
+
+
+// Must include gtest first to guard against Xlib colliding due to redefinitions of "None" and "Bool"
+
+#ifdef _MSC_VER
+#pragma warning(push)
+/*
+    MSVC warnings 4251 and 4275 have to do with potential dll-interface mismatch
+    between library (gtest) and users. Since we build the gtest library
+    as part of the test build we know that the dll-interface will match and
+    can disable these warnings.
+ */
+#pragma warning(disable : 4251)
+#pragma warning(disable : 4275)
+#endif
+
+// GTest and Xlib collide due to redefinitions of "None" and "Bool"
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+#pragma push_macro("None")
+#pragma push_macro("Bool")
+#undef None
+#undef Bool
+#endif
+
+// Use the NDK's header on Android
+#include "gtest/gtest.h"
+
+#include "test_util.h"
+
+#include "shim/shim.h"
+
+#include "icd/physical_device.h"
+#include "icd/test_icd.h"
+
+namespace detail {
+struct PlatformShimWrapper {
+    PlatformShimWrapper(DebugMode debug_mode = DebugMode::none);
+    ~PlatformShimWrapper();
+    PlatformShimWrapper(PlatformShimWrapper const&) = delete;
+    PlatformShimWrapper& operator=(PlatformShimWrapper const&) = delete;
+
+    // Convenience
+    PlatformShim* operator->() { return platform_shim; }
+
+    LibraryWrapper shim_library;
+    PlatformShim* platform_shim;
+    DebugMode debug_mode = DebugMode::none;
+};
+
+struct TestICDHandle {
+    TestICDHandle();
+    TestICDHandle(fs::path const& icd_path);
+    TestICD& get_new_test_icd();
+    TestICD& get_test_icd();
+    fs::path get_icd_full_path();
+
+    // Must use statically
+    LibraryWrapper icd_library;
+    GetTestICDFunc proc_addr_get_test_icd;
+    GetNewTestICDFunc proc_addr_get_new_test_icd;
+};
+}  // namespace detail
+
+struct TestICDDetails {
+    TestICDDetails(const char* icd_path, uint32_t api_version = VK_MAKE_VERSION(1, 0, 0))
+        : icd_path(icd_path), api_version(api_version) {}
+    const char* icd_path = nullptr;
+    uint32_t api_version = VK_MAKE_VERSION(1, 0, 0);
+};
+struct FrameworkEnvironment {
+    FrameworkEnvironment(DebugMode debug_mode = DebugMode::none);
+
+    void AddICD(TestICDDetails icd_details, const std::string& json_name);
+    void AddImplicitLayer(ManifestLayer layer_manifest, const std::string& json_name);
+    void AddExplicitLayer(ManifestLayer layer_manifest, const std::string& json_name);
+
+    detail::PlatformShimWrapper platform_shim;
+    fs::FolderManager null_folder;
+    fs::FolderManager icd_folder;
+    fs::FolderManager explicit_layer_folder;
+    fs::FolderManager implicit_layer_folder;
+    VulkanFunctions vulkan_functions;
+};
+
+struct SingleICDShim : FrameworkEnvironment {
+    SingleICDShim(TestICDDetails icd_details, DebugMode debug_mode = DebugMode::none);
+
+    TestICD& get_test_icd();
+    TestICD& get_new_test_icd();
+
+    fs::path get_test_icd_path();
+
+    detail::TestICDHandle icd_handle;
+};
+
+struct MultipleICDShim : FrameworkEnvironment {
+    MultipleICDShim(std::vector<TestICDDetails> icd_details_vector, DebugMode debug_mode = DebugMode::none);
+
+    TestICD& get_test_icd(int index);
+    TestICD& get_new_test_icd(int index);
+    fs::path get_test_icd_path(int index);
+
+    std::vector<detail::TestICDHandle> icds;
+};

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -1,0 +1,564 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#include "test_util.h"
+
+#if defined(WIN32)
+bool set_env_var(std::string const& name, std::string const& value) { return SetEnvironmentVariableA(name.c_str(), value.c_str()); }
+bool remove_env_var(std::string const& name) { return SetEnvironmentVariableA(name.c_str(), nullptr); }
+#define ENV_VAR_BUFFER_SIZE 4096
+std::string get_env_var(std::string const& name) {
+    std::string value;
+    value.resize(ENV_VAR_BUFFER_SIZE);
+    DWORD in_size = 0;
+    DWORD ret = GetEnvironmentVariable(name.c_str(), (LPSTR)value.c_str(), ENV_VAR_BUFFER_SIZE);
+    if (0 == in_size) {
+        ret = GetLastError();
+        if (ERROR_ENVVAR_NOT_FOUND == ret) {
+            std::cerr << "Environment variable does not exist.\n";
+        }
+        return std::string();
+    } else if (ENV_VAR_BUFFER_SIZE < ret) {
+        std::cerr << "Not enough space to write environment variable" << name << "\n";
+    }
+    return value;
+}
+#elif defined(__linux__) || defined(__APPLE__)
+
+bool set_env_var(std::string const& name, std::string const& value) { return setenv(name.c_str(), value.c_str(), 1); }
+bool remove_env_var(std::string const& name) { return unsetenv(name.c_str()); }
+std::string get_env_var(std::string const& name) {
+    char* ret = getenv(name.c_str());
+    if (ret == nullptr) return std::string();
+    return ret;
+}
+#endif
+
+std::string ManifestICD::get_manifest_str() const {
+    std::string out;
+    out += "{\n";
+    out += "    \"file_format_version\": \"1.0.0\",\n";
+    out += "    \"ICD\": {\n";
+    out += "        \"library_path\": \"" + lib_path + "\",\n";
+    out += "        \"api_version\": \"" + version_to_string(api_version) + "\"\n";
+    out += "    }\n";
+    out += "}\n";
+    return out;
+}
+
+std::string ManifestLayer::LayerDescription::Extension::get_manifest_str() const {
+    std::string out;
+    out += "{ \"name\":\"" + name + "\",\n\t\t\t\"spec_version\":\"" + std::to_string(spec_version) + "\"";
+    if (entrypoints.size() > 0) {
+        out += ",\n\t\t\t\"entrypoints\": [";
+        for (size_t i = 0; i < entrypoints.size(); i++) {
+            if (i > 0) out += ", ";
+            out += "\"" + entrypoints.at(i) + "\"";
+        }
+        out += "]";
+    }
+    out += "\t\t\t}";
+    return out;
+}
+
+std::string ManifestLayer::LayerDescription::get_manifest_str() const {
+    std::string out;
+    out += "\t{\n";
+    out += "\t\t\"name\":\"" + name + "\",\n";
+    out += "\t\t\"type\":\"" + get_type_str(type) + "\",\n";
+    out += "\t\t\"library_path\": \"" + lib_path + "\",\n";
+    out += "\t\t\"api_version\": \"" + version_to_string(api_version) + "\",\n";
+    out += "\t\t\"implementation_version\":\"" + std::to_string(implementation_version) + "\",\n";
+    out += "\t\t\"description\": \"" + description + "\"";
+    if (functions.size() > 0) {
+        out += ",\n\t\t{";
+        for (size_t i = 0; i < functions.size(); i++) {
+            if (i > 0) out += ",";
+            out += "\n\t\t\t" + functions.at(i).get_manifest_str();
+        }
+        out += "\n\t\t}";
+    }
+    if (instance_extensions.size() > 0) {
+        out += ",\n\t\t{";
+        for (size_t i = 0; i < instance_extensions.size(); i++) {
+            if (i > 0) out += ",";
+            out += "\n\t\t\t" + instance_extensions.at(i).get_manifest_str();
+        }
+        out += "\n\t\t}";
+    }
+    if (device_extensions.size() > 0) {
+        out += ",\n\t\t{";
+        for (size_t i = 0; i < device_extensions.size(); i++) {
+            if (i > 0) out += ",";
+            out += "\n\t\t\t" + device_extensions.at(i).get_manifest_str();
+        }
+        out += "\n\t\t}";
+    }
+    if (enable_environment.size() > 0) {
+        out += ",\n\t\t{ \"" + enable_environment + "\": \"1\"";
+        out += "\n\t\t}";
+    }
+    if (disable_environment.size() > 0) {
+        out += ",\n\t\t{ \"" + disable_environment + "\": \"1\"";
+        out += "\n\t\t}";
+    }
+    if (component_layers.size() > 0) {
+        out += ",\n\t\t\"component_layers\": [";
+        for (size_t i = 0; i < component_layers.size(); i++) {
+            if (i > 0) out += ", ";
+            out += "\"" + component_layers.at(i) + "\"";
+        }
+        out += "]\n\t\t}";
+    }
+    if (pre_instance_functions.size() > 0) {
+        out += ",\n\t\t\"pre_instance_functions\": [";
+        for (size_t i = 0; i < pre_instance_functions.size(); i++) {
+            if (i > 0) out += ", ";
+            out += "\"" + pre_instance_functions.at(i) + "\"";
+        }
+        out += "]\n\t\t}";
+    }
+    out += "\n\t}";
+    return out;
+}
+
+VkLayerProperties ManifestLayer::LayerDescription::get_layer_properties() const {
+    VkLayerProperties properties{};
+    strncpy(properties.layerName, name.c_str(), 256);
+    strncpy(properties.description, description.c_str(), 256);
+    properties.implementationVersion = implementation_version;
+    properties.specVersion = api_version;
+    return properties;
+}
+
+std::string ManifestLayer::get_manifest_str() const {
+    std::string out;
+    out += "{\n";
+    out += "\t\"file_format_version\": \"1.0.0\",\n";
+    if (layers.size() == 1) {
+        out += "\t\"layer\": ";
+        out += layers.at(0).get_manifest_str() + "\n";
+    } else {
+        out += "\"\tlayers\": [";
+        for (size_t i = 0; i < layers.size(); i++) {
+            if (i > 0) out += ",";
+            out += "\n" + layers.at(0).get_manifest_str();
+        }
+        out += "\n]";
+    }
+    out += "}\n";
+    return out;
+}
+
+namespace fs {
+std::string make_native(std::string const& in_path) {
+    std::string out;
+#if defined(WIN32)
+    for (auto& c : in_path) {
+        if (c == '/')
+            out += "\\";
+        else
+            out += c;
+    }
+#elif defined(__linux__) || defined(APPLE)
+    for (size_t i = 0; i < in_path.size(); i++) {
+        if (i + 1 < in_path.size() && in_path[i] == '\\' && in_path[i + 1] == '\\') {
+            out += '/';
+            i++;
+        } else
+            out += in_path[i];
+    }
+#endif
+    return out;
+}
+
+// Json doesn't allow `\` in strings, it must be escaped. Thus we have to convert '\\' to '\\\\' in strings
+std::string fixup_backslashes_in_path(std::string const& in_path) {
+    std::string out;
+    for (auto& c : in_path) {
+        if (c == '\\')
+            out += "\\\\";
+        else
+            out += c;
+    }
+    return out;
+}
+
+path& path::operator+=(path const& in) {
+    contents += in.contents;
+    return *this;
+}
+path& path::operator+=(std::string const& in) {
+    contents += in;
+    return *this;
+}
+path& path::operator+=(const char* in) {
+    contents += std::string{in};
+    return *this;
+}
+path& path::operator/=(path const& in) {
+    if (contents.back() != path_separator && in.contents.front() != path_separator) contents += path_separator;
+    contents += in.contents;
+    return *this;
+}
+path& path::operator/=(std::string const& in) {
+    if (contents.back() != path_separator && in.front() != path_separator) contents += path_separator;
+    contents += in;
+    return *this;
+}
+path& path::operator/=(const char* in) {
+    std::string in_str{in};
+    if (contents.back() != path_separator && in_str.front() != path_separator) contents += path_separator;
+    contents += in_str;
+    return *this;
+}
+path path::operator+(path const& in) const {
+    path new_path = contents;
+    new_path += in;
+    return new_path;
+}
+path path::operator+(std::string const& in) const {
+    path new_path = contents;
+    new_path += in;
+    return new_path;
+}
+path path::operator+(const char* in) const {
+    path new_path(contents);
+    new_path += in;
+    return new_path;
+}
+
+path path::operator/(path const& in) const {
+    path new_path = contents;
+    new_path /= in;
+    return new_path;
+}
+path path::operator/(std::string const& in) const {
+    path new_path = contents;
+    new_path /= in;
+    return new_path;
+}
+path path::operator/(const char* in) const {
+    path new_path(contents);
+    new_path /= in;
+    return new_path;
+}
+
+path path::parent_path() const {
+    auto last_div = contents.rfind(path_separator);
+    if (last_div == std::string::npos) return "";
+    return path(contents.substr(0, last_div));
+}
+bool path::has_parent_path() const {
+    auto last_div = contents.rfind(path_separator);
+    return last_div != std::string::npos;
+}
+path path::filename() const {
+    auto last_div = contents.rfind(path_separator);
+    return path(contents.substr(last_div + 1, contents.size() - last_div + 1));
+}
+
+path path::extension() const {
+    auto last_div = contents.rfind(path_separator);
+    auto ext_div = contents.rfind('.');
+    // Make sure to not get the special `.` and `..`, as well as any filename that being with a dot, like .profile
+    if (last_div + 1 == ext_div || (last_div + 2 == ext_div && contents[last_div + 1] == '.')) return path("");
+    path temp = path(contents.substr(ext_div, contents.size() - ext_div + 1));
+
+    return path(contents.substr(ext_div, contents.size() - ext_div + 1));
+}
+
+path path::stem() const {
+    auto last_div = contents.rfind(path_separator);
+    auto ext_div = contents.rfind('.');
+    if (last_div + 1 == ext_div || (last_div + 2 == ext_div && contents[last_div + 1] == '.')) {
+        return path(contents.substr(last_div + 1, contents.size() - last_div + 1));
+    }
+    return path(contents.substr(last_div + 1, ext_div - last_div - 1));
+}
+
+path& path::replace_filename(path const& replacement) {
+    *this = parent_path() / replacement.str();
+    return *this;
+}
+
+// internal implementation helper for per-platform creating & destroying folders
+int create_folder(path const& path) {
+#if defined(WIN32)
+    return _mkdir(path.c_str());
+#else
+    mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    return 0;
+#endif
+}
+
+int delete_folder(path const& folder) {
+#if defined(WIN32)
+    // TODO
+    return 0;
+#else
+    DIR* dir = opendir(folder.c_str());
+    if (!dir) {
+        return 0;
+    }
+    int ret = 0;
+    dirent* file;
+    while (!ret && (file = readdir(dir))) {
+        int ret2 = -1;
+
+        /* Skip the names "." and ".." as we don't want to recurse on them. */
+        if (!strcmp(file->d_name, ".") || !strcmp(file->d_name, "..")) continue;
+
+        path file_path = folder / file->d_name;
+        struct stat statbuf;
+        if (!stat(file_path.c_str(), &statbuf)) {
+            if (S_ISDIR(statbuf.st_mode))
+                ret2 = delete_folder(file_path);
+            else
+                ret2 = unlink(file_path.c_str());
+        }
+
+        ret = ret2;
+    }
+    closedir(dir);
+
+    if (!ret) ret = rmdir(folder.c_str());
+    return ret;
+#endif
+}
+
+FolderManager::FolderManager(path root_path, std::string name, DebugMode debug) : debug(debug), folder(root_path / name) {
+    create_folder(folder);
+}
+FolderManager::~FolderManager() {
+    for (auto& file : files) {
+        if (debug >= DebugMode::log) std::cout << "Removing manifest " << file << " at " << (folder + file).str() << "\n";
+        if (debug != DebugMode::no_delete) {
+            std::remove((folder + file).c_str());
+        }
+    }
+    if (debug != DebugMode::no_delete) {
+        delete_folder(folder);
+    }
+    if (debug >= DebugMode::log) {
+        std::cout << "Deleting folder " << folder.str() << "\n";
+    }
+}
+path FolderManager::write(std::string const& name, ManifestICD const& icd_manifest) {
+    path out_path = folder / name;
+    auto found = std::find(files.begin(), files.end(), name);
+    if (found != files.end()) {
+        if (debug >= DebugMode::log) std::cout << "Writing icd manifest to " << name << "\n";
+    } else {
+        if (debug >= DebugMode::log) std::cout << "Creating icd manifest " << name << " at " << out_path.str() << "\n";
+        files.emplace_back(name);
+    }
+    auto file = std::ofstream(out_path.str());
+    file << icd_manifest.get_manifest_str() << std::endl;
+    return out_path;
+}
+path FolderManager::write(std::string const& name, ManifestLayer const& layer_manifest) {
+    path out_path = folder / name;
+    auto found = std::find(files.begin(), files.end(), name);
+    if (found != files.end()) {
+        if (debug >= DebugMode::log) std::cout << "Writing layer manifest to " << name << "\n";
+    } else {
+        if (debug >= DebugMode::log) std::cout << "Creating layer manifest " << name << " at " << out_path.str() << "\n";
+        files.emplace_back(name);
+    }
+    auto file = std::ofstream(out_path.str());
+    file << layer_manifest.get_manifest_str() << std::endl;
+    return out_path;
+}
+// close file handle, delete file, remove `name` from managed file list.
+void FolderManager::remove(std::string const& name) {
+    auto found = std::find(files.begin(), files.end(), name);
+    if (found != files.end()) {
+        if (debug >= DebugMode::log) std::cout << "Removing manifest " << name << " at " << (folder + name).str() << "\n";
+        if (debug != DebugMode::no_delete) {
+            std::remove((folder + name).c_str());
+            files.erase(found);
+        }
+    } else {
+        if (debug >= DebugMode::log) std::cout << "Couldn't remove manifest " << name << " at " << (folder + name).str() << ".\n";
+    }
+}
+
+}  // namespace fs
+
+VulkanFunctions::VulkanFunctions() : loader(FRAMEWORK_VULKAN_LIBRARY_PATH) {
+    // clang-format off
+    fp_vkGetInstanceProcAddr = loader.get_symbol<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr");
+    fp_vkEnumerateInstanceExtensionProperties = loader.get_symbol<PFN_vkEnumerateInstanceExtensionProperties>("vkEnumerateInstanceExtensionProperties");
+    fp_vkEnumerateInstanceLayerProperties = loader.get_symbol<PFN_vkEnumerateInstanceLayerProperties>("vkEnumerateInstanceLayerProperties");
+    fp_vkEnumerateInstanceVersion = loader.get_symbol<PFN_vkEnumerateInstanceVersion>("vkEnumerateInstanceVersion");
+    fp_vkCreateInstance = loader.get_symbol<PFN_vkCreateInstance>("vkCreateInstance");
+    fp_vkDestroyInstance = loader.get_symbol<PFN_vkDestroyInstance>("vkDestroyInstance");
+    fp_vkEnumeratePhysicalDevices = loader.get_symbol<PFN_vkEnumeratePhysicalDevices>("vkEnumeratePhysicalDevices");
+    fp_vkGetPhysicalDeviceFeatures = loader.get_symbol<PFN_vkGetPhysicalDeviceFeatures>("vkGetPhysicalDeviceFeatures");
+    fp_vkGetPhysicalDeviceFeatures2 = loader.get_symbol<PFN_vkGetPhysicalDeviceFeatures2>("vkGetPhysicalDeviceFeatures2");
+    fp_vkGetPhysicalDeviceFormatProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceFormatProperties>("vkGetPhysicalDeviceFormatProperties");
+    fp_vkGetPhysicalDeviceImageFormatProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceImageFormatProperties>("vkGetPhysicalDeviceImageFormatProperties");
+    fp_vkGetPhysicalDeviceProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceProperties>("vkGetPhysicalDeviceProperties");
+    fp_vkGetPhysicalDeviceProperties2 = loader.get_symbol<PFN_vkGetPhysicalDeviceProperties2>("vkGetPhysicalDeviceProperties2");
+    fp_vkGetPhysicalDeviceQueueFamilyProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceQueueFamilyProperties>("vkGetPhysicalDeviceQueueFamilyProperties");
+    fp_vkGetPhysicalDeviceQueueFamilyProperties2 = loader.get_symbol<PFN_vkGetPhysicalDeviceQueueFamilyProperties2>("vkGetPhysicalDeviceQueueFamilyProperties2");
+    fp_vkGetPhysicalDeviceMemoryProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceMemoryProperties>("vkGetPhysicalDeviceMemoryProperties");
+    fp_vkGetPhysicalDeviceFormatProperties2 = loader.get_symbol<PFN_vkGetPhysicalDeviceFormatProperties2>("vkGetPhysicalDeviceFormatProperties2");
+    fp_vkGetPhysicalDeviceMemoryProperties2 = loader.get_symbol<PFN_vkGetPhysicalDeviceMemoryProperties2>("vkGetPhysicalDeviceMemoryProperties2");
+    fp_vkGetPhysicalDeviceSurfaceSupportKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceSurfaceSupportKHR>("vkGetPhysicalDeviceSurfaceSupportKHR");
+    fp_vkGetPhysicalDeviceSurfaceFormatsKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceSurfaceFormatsKHR>("vkGetPhysicalDeviceSurfaceFormatsKHR");
+    fp_vkGetPhysicalDeviceSurfacePresentModesKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceSurfacePresentModesKHR>("vkGetPhysicalDeviceSurfacePresentModesKHR");
+    fp_vkGetPhysicalDeviceSurfaceCapabilitiesKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR>("vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
+    fp_vkEnumerateDeviceExtensionProperties = loader.get_symbol<PFN_vkEnumerateDeviceExtensionProperties>("vkEnumerateDeviceExtensionProperties");
+    fp_vkEnumerateDeviceLayerProperties = loader.get_symbol<PFN_vkEnumerateDeviceLayerProperties>("vkEnumerateDeviceLayerProperties");
+
+    fp_vkDestroySurfaceKHR = loader.get_symbol<PFN_vkDestroySurfaceKHR>("vkDestroySurfaceKHR");
+    fp_vkGetDeviceProcAddr = loader.get_symbol<PFN_vkGetDeviceProcAddr>("vkGetDeviceProcAddr");
+    fp_vkCreateDevice = loader.get_symbol<PFN_vkCreateDevice>("vkCreateDevice");
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    fp_vkCreateAndroidSurfaceKHR = loader.get_symbol<PFN_vkCreateAndroidSurfaceKHR>("vkCreateAndroidSurfaceKHR");
+#endif
+#ifdef VK_USE_PLATFORM_METAL_EXT
+    fp_vkCreateMetalSurfaceEXT = loader.get_symbol<PFN_vkCreateMetalSurfaceEXT>("vkCreateMetalSurfaceEXT")
+#endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    fp_vkCreateWaylandSurfaceKHR = loader.get_symbol<PFN_vkCreateWaylandSurfaceKHR>("vkCreateWaylandSurfaceKHR");
+#endif
+#ifdef VK_USE_PLATFORM_XCB_KHR
+    fp_vkCreateXcbSurfaceKHR = loader.get_symbol<PFN_vkCreateXcbSurfaceKHR>("vkCreateXcbSurfaceKHR");
+#endif
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+    fp_vkCreateXlibSurfaceKHR = loader.get_symbol<PFN_vkCreateXlibSurfaceKHR>("vkCreateXlibSurfaceKHR");
+#endif
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    fp_vkCreateWin32SurfaceKHR = loader.get_symbol<PFN_vkCreateWin32SurfaceKHR>("vkCreateWin32SurfaceKHR");
+#endif
+    fp_vkDestroyDevice = loader.get_symbol<PFN_vkDestroyDevice>("vkDestroyDevice");
+    fp_vkGetDeviceQueue = loader.get_symbol<PFN_vkGetDeviceQueue>("vkGetDeviceQueue");
+    // clang-format on
+}
+
+InstanceCreateInfo::InstanceCreateInfo() {
+    inst_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+}
+
+VkInstanceCreateInfo* InstanceCreateInfo::get() noexcept {
+    app_info.pApplicationName = app_name.c_str();
+    app_info.pEngineName = engine_name.c_str();
+    app_info.applicationVersion = app_version;
+    app_info.engineVersion = engine_version;
+    app_info.apiVersion = api_version;
+    inst_info.pApplicationInfo = &app_info;
+    inst_info.enabledLayerCount = static_cast<uint32_t>(enabled_layers.size());
+    inst_info.ppEnabledLayerNames = enabled_layers.data();
+    inst_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
+    inst_info.ppEnabledExtensionNames = enabled_extensions.data();
+    return &inst_info;
+}
+InstanceCreateInfo& InstanceCreateInfo::set_application_name(std::string app_name) {
+    this->app_name = app_name;
+    return *this;
+}
+InstanceCreateInfo& InstanceCreateInfo::set_engine_name(std::string engine_name) {
+    this->engine_name = engine_name;
+    return *this;
+}
+InstanceCreateInfo& InstanceCreateInfo::set_app_version(uint32_t app_version) {
+    this->app_version = app_version;
+    return *this;
+}
+InstanceCreateInfo& InstanceCreateInfo::set_engine_version(uint32_t engine_version) {
+    this->engine_version = engine_version;
+    return *this;
+}
+InstanceCreateInfo& InstanceCreateInfo::set_api_version(uint32_t api_version) {
+    this->api_version = api_version;
+    return *this;
+}
+InstanceCreateInfo& InstanceCreateInfo::add_layer(const char* layer_name) {
+    enabled_layers.push_back(layer_name);
+    return *this;
+}
+InstanceCreateInfo& InstanceCreateInfo::add_extension(const char* ext_name) {
+    enabled_extensions.push_back(ext_name);
+    return *this;
+}
+
+DeviceQueueCreateInfo::DeviceQueueCreateInfo() { queue.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO; }
+DeviceQueueCreateInfo& DeviceQueueCreateInfo::add_priority(float priority) {
+    priorities.push_back(priority);
+    return *this;
+}
+DeviceQueueCreateInfo& DeviceQueueCreateInfo::set_props(VkQueueFamilyProperties props) {
+    queue.queueCount = props.queueCount;
+    return *this;
+}
+
+VkDeviceCreateInfo* DeviceCreateInfo::get() noexcept {
+    dev.enabledLayerCount = static_cast<uint32_t>(enabled_layers.size());
+    dev.ppEnabledLayerNames = enabled_layers.data();
+    dev.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
+    dev.ppEnabledExtensionNames = enabled_extensions.data();
+    uint32_t index = 0;
+    for (auto& queue : queue_infos) queue.queueFamilyIndex = index++;
+
+    dev.queueCreateInfoCount = static_cast<uint32_t>(queue_infos.size());
+    dev.pQueueCreateInfos = queue_infos.data();
+    return &dev;
+}
+DeviceCreateInfo& DeviceCreateInfo::add_layer(const char* layer_name) {
+    enabled_layers.push_back(layer_name);
+
+    return *this;
+}
+DeviceCreateInfo& DeviceCreateInfo::add_extension(const char* ext_name) {
+    enabled_extensions.push_back(ext_name);
+
+    return *this;
+}
+DeviceCreateInfo& DeviceCreateInfo::add_device_queue(DeviceQueueCreateInfo queue_info_detail) {
+    queue_info_details.push_back(queue_info_detail);
+    return *this;
+}
+
+VkResult CreateInst(InstWrapper& inst, InstanceCreateInfo& inst_info) {
+    return inst.functions->fp_vkCreateInstance(inst_info.get(), nullptr, &inst.inst);
+}
+
+VkResult CreatePhysDevs(InstWrapper& inst, uint32_t phys_dev_count, std::vector<VkPhysicalDevice>& physical_devices) {
+    physical_devices.resize(phys_dev_count);
+    uint32_t physical_count = phys_dev_count;
+    return inst.functions->fp_vkEnumeratePhysicalDevices(inst.inst, &physical_count, physical_devices.data());
+}
+
+VkResult CreatePhysDev(InstWrapper& inst, VkPhysicalDevice& physical_device) {
+    uint32_t physical_count = 1;
+    return inst.functions->fp_vkEnumeratePhysicalDevices(inst.inst, &physical_count, &physical_device);
+}

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -1,0 +1,656 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+/*
+ * Contains all the utilities needed to make the framework and tests work.
+ * Contains:
+ * All the standard library includes and main platform specific includes
+ * Dll export macro
+ * Manifest ICD & Layer structs
+ * path abstraction class - modelled after C++17's filesystem::path
+ * FolderManager - manages the contents of a folder, cleaning up when needed
+ * per-platform library loading - mirrors the vk_loader_platform
+ * LibraryWrapper - RAII wrapper for a library
+ * DispatchableHandle - RAII wrapper for vulkan dispatchable handle objects
+ * ostream overload for VkResult - prettifies googletest output
+ * VulkanFunctions - loads vulkan functions for tests to use
+ * Instance & Device create info helpers
+ * InstWrapper & DeviceWrapper - for easier test writing
+ * operator == overloads for many vulkan structs - more concise tests
+*/
+#pragma once
+
+// Following items are needed for C++ to work with PRIxLEAST64
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
+#include <algorithm>
+#include <array>
+#include <iostream>
+#include <fstream>
+#include <ostream>
+#include <random>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <utility>
+
+#include <cassert>
+#include <cstring>
+#include <ctime>
+#include <stdio.h>
+#include <stdint.h>
+
+#if defined(WIN32)
+#include <direct.h>
+#include <windows.h>
+#elif defined(__linux__) || defined(__APPLE__)
+#include <dirent.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#endif
+
+#include <vulkan/vulkan.h>
+#include <vulkan/vk_icd.h>
+
+#include "framework_config.h"
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define FRAMEWORK_EXPORT __attribute__((visibility("default")))
+#elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
+#define FRAMEWORK_EXPORT __attribute__((visibility("default")))
+#elif defined(WIN32)
+#define FRAMEWORK_EXPORT __declspec(dllexport)
+#else
+#define FRAMEWORK_EXPORT
+#endif
+
+#if defined(WIN32)
+bool set_env_var(std::string const& name, std::string const& value);
+bool remove_env_var(std::string const& name);
+#define ENV_VAR_BUFFER_SIZE 4096
+std::string get_env_var(std::string const& name);
+
+#elif defined(__linux__) || defined(__APPLE__)
+bool set_env_var(std::string const& name, std::string const& value);
+bool remove_env_var(std::string const& name);
+std::string get_env_var(std::string const& name);
+#endif
+
+enum class DebugMode {
+    none,
+    log,       // log all folder and file creation & deletion
+    no_delete  // Will not delete create folders & files, but will report 'deleting them' to show when something *should* of been
+               // deleted
+};
+
+inline std::string version_to_string(uint32_t version) {
+    return std::to_string(VK_VERSION_MAJOR(version)) + "." + std::to_string(VK_VERSION_MINOR(version)) + "." +
+           std::to_string(VK_VERSION_PATCH(version));
+}
+
+struct ManifestICD {
+    uint32_t api_version = VK_MAKE_VERSION(1, 0, 0);
+    std::string lib_path;
+
+    std::string get_manifest_str() const;
+};
+
+struct ManifestLayer {
+    struct LayerDescription {
+        enum class Type { INSTANCE, GLOBAL, DEVICE };
+        std::string get_type_str(Type type) const {
+            if (type == Type::GLOBAL)
+                return "GLOBAL";
+            else if (type == Type::DEVICE)
+                return "DEVICE";
+            else  // default
+                return "INSTANCE";
+        }
+        struct FunctionOverride {
+            std::string vk_func;
+            std::string override_name;
+            std::string get_manifest_str() const { return std::string("{ \"") + vk_func + "\":\"" + override_name + "\" }"; }
+        };
+        struct Extension {
+            std::string name;
+            uint32_t spec_version = 0;
+            std::vector<std::string> entrypoints;
+            std::string get_manifest_str() const;
+        };
+        std::string name;
+        Type type = Type::INSTANCE;
+        std::string lib_path;
+        uint32_t api_version = VK_MAKE_VERSION(1, 0, 0);
+        uint32_t implementation_version = 0;
+        std::string description;
+        std::vector<FunctionOverride> functions;
+        std::vector<Extension> instance_extensions;
+        std::vector<Extension> device_extensions;
+        std::string enable_environment;
+        std::string disable_environment;
+        std::vector<std::string> component_layers;
+        std::vector<std::string> pre_instance_functions;
+
+        std::string get_manifest_str() const;
+        VkLayerProperties get_layer_properties() const;
+    };
+    uint32_t file_format_major = 1;
+    uint32_t file_format_minor = 1;
+    uint32_t file_format_patch = 2;
+    std::vector<LayerDescription> layers;
+
+    std::string get_manifest_str() const;
+};
+
+struct Extension {
+    std::string extensionName;
+    uint32_t specVersion = VK_MAKE_VERSION(1, 0, 0);
+
+    Extension(std::string extensionName, uint32_t specVersion = VK_MAKE_VERSION(1, 0, 0))
+        : extensionName(extensionName), specVersion(specVersion) {}
+
+    VkExtensionProperties get() const noexcept {
+        VkExtensionProperties props{};
+        std::strncpy(props.extensionName, extensionName.c_str(), VK_MAX_EXTENSION_NAME_SIZE);
+        props.specVersion = specVersion;
+        return props;
+    }
+};
+
+struct MockQueueFamilyProperties {
+    MockQueueFamilyProperties(VkQueueFamilyProperties properties, bool support_present = false)
+        : properties(properties), support_present(support_present) {}
+    VkQueueFamilyProperties properties{};
+    bool support_present = false;
+    VkQueueFamilyProperties get() const noexcept { return properties; }
+};
+
+namespace fs {
+std::string make_native(std::string const&);
+std::string fixup_backslashes_in_path(std::string const& in_path);
+struct path {
+   private:
+#if defined(WIN32)
+    static const char path_separator = '\\';
+#elif defined(__linux__) || defined(__APPLE__)
+    static const char path_separator = '/';
+#endif
+
+   public:
+    path() {}
+    path(std::string const& in) : contents(make_native(in)) {}
+    path(const char* in) : contents(make_native(std::string(in))) {}
+
+    // concat paths without directoryseperator
+    path& operator+=(path const& in);
+    path& operator+=(std::string const& in);
+    path& operator+=(const char* in);
+
+    // append paths with directoryseperator
+    path& operator/=(path const& in);
+    path& operator/=(std::string const& in);
+    path& operator/=(const char* in);
+
+    // concat paths without directory seperator
+    path operator+(path const& in) const;
+    path operator+(std::string const& in) const;
+    path operator+(const char* in) const;
+
+    // append paths with directory seperator
+    path operator/(path const& in) const;
+    path operator/(std::string const& in) const;
+    path operator/(const char* in) const;
+
+    // accesors
+    path parent_path() const;
+    bool has_parent_path() const;
+    path filename() const;
+    path extension() const;
+    path stem() const;
+
+    // modifiers
+    path& replace_filename(path const& replacement);
+
+    // get c style string
+    const char* c_str() const { return contents.c_str(); }
+    // get C++ style string
+    std::string const& str() const { return contents; }
+    std::string& str() { return contents; }
+    size_t size() const { return contents.size();};
+
+   private:
+    std::string contents;
+};
+
+class FolderManager {
+   public:
+    explicit FolderManager(path root_path, std::string name, DebugMode debug = DebugMode::none);
+    ~FolderManager();
+    path write(std::string const& name, ManifestICD const& icd_manifest);
+    path write(std::string const& name, ManifestLayer const& layer_manifest);
+
+    // close file handle, delete file, remove `name` from managed file list.
+    void remove(std::string const& name);
+
+    // location of the managed folder
+    path location() const { return folder; }
+
+    FolderManager(FolderManager const&) = delete;
+    FolderManager& operator=(FolderManager const&) = delete;
+
+   private:
+    DebugMode debug;
+    path folder;
+    std::vector<std::string> files;
+};
+
+inline void copy_file(path const& origin, path const& destination) {
+    std::ifstream src(origin.str(), std::ios::binary);
+    std::ofstream dst(destination.str(), std::ios::binary);
+    dst << src.rdbuf();
+}
+
+}  // namespace fs
+
+#if defined(WIN32)
+typedef HMODULE loader_platform_dl_handle;
+static loader_platform_dl_handle loader_platform_open_library(const char* lib_path) {
+    // Try loading the library the original way first.
+    loader_platform_dl_handle lib_handle = LoadLibrary(lib_path);
+    if (lib_handle == NULL && GetLastError() == ERROR_MOD_NOT_FOUND) {
+        // If that failed, then try loading it with broader search folders.
+        lib_handle = LoadLibraryEx(lib_path, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+    }
+    return lib_handle;
+}
+static char* loader_platform_open_library_error(const char* libPath) {
+    static char errorMsg[164];
+    (void)snprintf(errorMsg, 163, "Failed to open dynamic library \"%s\" with error %lu", libPath, GetLastError());
+    return errorMsg;
+}
+static void loader_platform_close_library(loader_platform_dl_handle library) { FreeLibrary(library); }
+static void* loader_platform_get_proc_address(loader_platform_dl_handle library, const char* name) {
+    assert(library);
+    assert(name);
+    return (void*)GetProcAddress(library, name);
+}
+static char* loader_platform_get_proc_address_error(const char* name) {
+    static char errorMsg[120];
+    (void)snprintf(errorMsg, 119, "Failed to find function \"%s\" in dynamic library", name);
+    return errorMsg;
+}
+
+#elif defined(__linux__) || defined(__APPLE__)
+
+typedef void* loader_platform_dl_handle;
+static inline loader_platform_dl_handle loader_platform_open_library(const char* libPath) {
+    return dlopen(libPath, RTLD_LAZY | RTLD_LOCAL);
+}
+static inline const char* loader_platform_open_library_error(const char* libPath) { return dlerror(); }
+static inline void loader_platform_close_library(loader_platform_dl_handle library) { dlclose(library); }
+static inline void* loader_platform_get_proc_address(loader_platform_dl_handle library, const char* name) {
+    assert(library);
+    assert(name);
+    return dlsym(library, name);
+}
+static inline const char* loader_platform_get_proc_address_error(const char* name) { return dlerror(); }
+#endif
+
+struct LibraryWrapper {
+    explicit LibraryWrapper() noexcept {}
+    explicit LibraryWrapper(fs::path const& lib_path) noexcept : lib_path(lib_path) {
+        lib_handle = loader_platform_open_library(lib_path.c_str());
+        if (lib_handle == NULL) {
+            fprintf(stderr, "Unable to open library %s: %s\n", lib_path.c_str(),
+                    loader_platform_open_library_error(lib_path.c_str()));
+            assert(lib_handle != NULL && "Must be able to open library");
+        }
+    }
+    ~LibraryWrapper() noexcept {
+        if (lib_handle != NULL) {
+            loader_platform_close_library(lib_handle);
+            lib_handle = nullptr;
+        }
+    }
+    LibraryWrapper(LibraryWrapper const& wrapper) = delete;
+    LibraryWrapper& operator=(LibraryWrapper const& wrapper) = delete;
+    LibraryWrapper(LibraryWrapper&& wrapper) noexcept : lib_handle(wrapper.lib_handle), lib_path(wrapper.lib_path) { wrapper.lib_handle = nullptr; }
+    LibraryWrapper& operator=(LibraryWrapper&& wrapper) noexcept {
+        if (this != &wrapper) {
+            if (lib_handle != nullptr) {
+                loader_platform_close_library(lib_handle);
+            }
+            lib_handle = wrapper.lib_handle;
+            lib_path = wrapper.lib_path;
+            wrapper.lib_handle = nullptr;
+        }
+        return *this;
+    }
+    template <typename T>
+    T get_symbol(const char* symbol_name) const {
+        assert(lib_handle != NULL && "Cannot get symbol with null library handle");
+        T symbol = reinterpret_cast<T>(loader_platform_get_proc_address(lib_handle, symbol_name));
+        if (symbol == NULL) {
+            fprintf(stderr, "Unable to open symbol %s: %s\n", symbol_name, loader_platform_get_proc_address_error(symbol_name));
+            assert(symbol != NULL && "Must be able to get symbol");
+        }
+        return symbol;
+    }
+
+    explicit operator bool() const noexcept { return lib_handle != nullptr; }
+
+    loader_platform_dl_handle lib_handle = nullptr;
+    fs::path lib_path;
+};
+
+template <typename T>
+struct FRAMEWORK_EXPORT DispatchableHandle {
+    DispatchableHandle() {
+        auto ptr_handle = new VK_LOADER_DATA;
+        set_loader_magic_value(ptr_handle);
+        handle = reinterpret_cast<T>(ptr_handle);
+    }
+    ~DispatchableHandle() {
+        delete reinterpret_cast<VK_LOADER_DATA*>(handle);
+        handle = nullptr;
+    }
+    DispatchableHandle(DispatchableHandle const&) = delete;
+    DispatchableHandle& operator=(DispatchableHandle const&) = delete;
+    DispatchableHandle(DispatchableHandle&& other) noexcept : handle(other.handle) { other.handle = nullptr; }
+    DispatchableHandle& operator=(DispatchableHandle&& other) noexcept {
+        if (this != &other) {
+            delete reinterpret_cast<VK_LOADER_DATA*>(handle);
+            handle = other.handle;
+            other.handle = nullptr;
+        }
+        return *this;
+    }
+    bool operator==(T base_handle) { return base_handle == handle; }
+    bool operator!=(T base_handle) { return base_handle != handle; }
+
+    T handle = nullptr;
+};
+
+// Stream operator for VkResult so GTEST will print out error codes as strings (automatically)
+inline std::ostream& operator<<(std::ostream& os, const VkResult& result) {
+    switch (result) {
+        case (VK_SUCCESS):
+            return os << "VK_SUCCESS";
+        case (VK_NOT_READY):
+            return os << "VK_NOT_READY";
+        case (VK_TIMEOUT):
+            return os << "VK_TIMEOUT";
+        case (VK_EVENT_SET):
+            return os << "VK_EVENT_SET";
+        case (VK_EVENT_RESET):
+            return os << "VK_EVENT_RESET";
+        case (VK_INCOMPLETE):
+            return os << "VK_INCOMPLETE";
+        case (VK_ERROR_OUT_OF_HOST_MEMORY):
+            return os << "VK_ERROR_OUT_OF_HOST_MEMORY";
+        case (VK_ERROR_OUT_OF_DEVICE_MEMORY):
+            return os << "VK_ERROR_OUT_OF_DEVICE_MEMORY";
+        case (VK_ERROR_INITIALIZATION_FAILED):
+            return os << "VK_ERROR_INITIALIZATION_FAILED";
+        case (VK_ERROR_DEVICE_LOST):
+            return os << "VK_ERROR_DEVICE_LOST";
+        case (VK_ERROR_MEMORY_MAP_FAILED):
+            return os << "VK_ERROR_MEMORY_MAP_FAILED";
+        case (VK_ERROR_LAYER_NOT_PRESENT):
+            return os << "VK_ERROR_LAYER_NOT_PRESENT";
+        case (VK_ERROR_EXTENSION_NOT_PRESENT):
+            return os << "VK_ERROR_EXTENSION_NOT_PRESENT";
+        case (VK_ERROR_FEATURE_NOT_PRESENT):
+            return os << "VK_ERROR_FEATURE_NOT_PRESENT";
+        case (VK_ERROR_INCOMPATIBLE_DRIVER):
+            return os << "VK_ERROR_INCOMPATIBLE_DRIVER";
+        case (VK_ERROR_TOO_MANY_OBJECTS):
+            return os << "VK_ERROR_TOO_MANY_OBJECTS";
+        case (VK_ERROR_FORMAT_NOT_SUPPORTED):
+            return os << "VK_ERROR_FORMAT_NOT_SUPPORTED";
+        case (VK_ERROR_FRAGMENTED_POOL):
+            return os << "VK_ERROR_FRAGMENTED_POOL";
+        case (VK_ERROR_UNKNOWN):
+            return os << "VK_ERROR_UNKNOWN";
+        case (VK_ERROR_OUT_OF_POOL_MEMORY):
+            return os << "VK_ERROR_OUT_OF_POOL_MEMORY";
+        case (VK_ERROR_INVALID_EXTERNAL_HANDLE):
+            return os << "VK_ERROR_INVALID_EXTERNAL_HANDLE";
+        case (VK_ERROR_FRAGMENTATION):
+            return os << "VK_ERROR_FRAGMENTATION";
+        case (VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS):
+            return os << "VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS";
+        case (VK_ERROR_SURFACE_LOST_KHR):
+            return os << "VK_ERROR_SURFACE_LOST_KHR";
+        case (VK_ERROR_NATIVE_WINDOW_IN_USE_KHR):
+            return os << "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR";
+        case (VK_SUBOPTIMAL_KHR):
+            return os << "VK_SUBOPTIMAL_KHR";
+        case (VK_ERROR_OUT_OF_DATE_KHR):
+            return os << "VK_ERROR_OUT_OF_DATE_KHR";
+        case (VK_ERROR_INCOMPATIBLE_DISPLAY_KHR):
+            return os << "VK_ERROR_INCOMPATIBLE_DISPLAY_KHR";
+        case (VK_ERROR_VALIDATION_FAILED_EXT):
+            return os << "VK_ERROR_VALIDATION_FAILED_EXT";
+        case (VK_ERROR_INVALID_SHADER_NV):
+            return os << "VK_ERROR_INVALID_SHADER_NV";
+        case (VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT):
+            return os << "VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT";
+        case (VK_ERROR_NOT_PERMITTED_EXT):
+            return os << "VK_ERROR_NOT_PERMITTED_EXT";
+        case (VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT):
+            return os << "VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT";
+        case (VK_THREAD_IDLE_KHR):
+            return os << "VK_THREAD_IDLE_KHR";
+        case (VK_THREAD_DONE_KHR):
+            return os << "VK_THREAD_DONE_KHR";
+        case (VK_OPERATION_DEFERRED_KHR):
+            return os << "VK_OPERATION_DEFERRED_KHR";
+        case (VK_OPERATION_NOT_DEFERRED_KHR):
+            return os << "VK_OPERATION_NOT_DEFERRED_KHR";
+        case (VK_PIPELINE_COMPILE_REQUIRED_EXT):
+            return os << "VK_PIPELINE_COMPILE_REQUIRED_EXT";
+        case (VK_RESULT_MAX_ENUM):
+            return os << "VK_RESULT_MAX_ENUM";
+    }
+    return os << static_cast<int32_t>(result);
+}
+
+struct VulkanFunctions {
+    LibraryWrapper loader;
+
+    // Pre-Instance
+    PFN_vkGetInstanceProcAddr fp_vkGetInstanceProcAddr = nullptr;
+    PFN_vkEnumerateInstanceExtensionProperties fp_vkEnumerateInstanceExtensionProperties = nullptr;
+    PFN_vkEnumerateInstanceLayerProperties fp_vkEnumerateInstanceLayerProperties = nullptr;
+    PFN_vkEnumerateInstanceVersion fp_vkEnumerateInstanceVersion = nullptr;
+    PFN_vkCreateInstance fp_vkCreateInstance = nullptr;
+
+    // Instance
+    PFN_vkDestroyInstance fp_vkDestroyInstance = nullptr;
+    PFN_vkEnumeratePhysicalDevices fp_vkEnumeratePhysicalDevices = nullptr;
+    PFN_vkGetPhysicalDeviceFeatures fp_vkGetPhysicalDeviceFeatures = nullptr;
+    PFN_vkGetPhysicalDeviceFeatures2 fp_vkGetPhysicalDeviceFeatures2 = nullptr;
+    PFN_vkGetPhysicalDeviceFormatProperties fp_vkGetPhysicalDeviceFormatProperties = nullptr;
+    PFN_vkGetPhysicalDeviceImageFormatProperties fp_vkGetPhysicalDeviceImageFormatProperties = nullptr;
+    PFN_vkGetPhysicalDeviceProperties fp_vkGetPhysicalDeviceProperties = nullptr;
+    PFN_vkGetPhysicalDeviceProperties2 fp_vkGetPhysicalDeviceProperties2 = nullptr;
+    PFN_vkGetPhysicalDeviceQueueFamilyProperties fp_vkGetPhysicalDeviceQueueFamilyProperties = nullptr;
+    PFN_vkGetPhysicalDeviceQueueFamilyProperties2 fp_vkGetPhysicalDeviceQueueFamilyProperties2 = nullptr;
+    PFN_vkGetPhysicalDeviceMemoryProperties fp_vkGetPhysicalDeviceMemoryProperties = nullptr;
+    PFN_vkGetPhysicalDeviceFormatProperties2 fp_vkGetPhysicalDeviceFormatProperties2 = nullptr;
+    PFN_vkGetPhysicalDeviceMemoryProperties2 fp_vkGetPhysicalDeviceMemoryProperties2 = nullptr;
+    PFN_vkGetPhysicalDeviceSurfaceSupportKHR fp_vkGetPhysicalDeviceSurfaceSupportKHR = nullptr;
+    PFN_vkGetPhysicalDeviceSurfaceFormatsKHR fp_vkGetPhysicalDeviceSurfaceFormatsKHR = nullptr;
+    PFN_vkGetPhysicalDeviceSurfacePresentModesKHR fp_vkGetPhysicalDeviceSurfacePresentModesKHR = nullptr;
+    PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR fp_vkGetPhysicalDeviceSurfaceCapabilitiesKHR = nullptr;
+    PFN_vkEnumerateDeviceExtensionProperties fp_vkEnumerateDeviceExtensionProperties = nullptr;
+    PFN_vkEnumerateDeviceLayerProperties fp_vkEnumerateDeviceLayerProperties = nullptr;
+
+    PFN_vkGetDeviceProcAddr fp_vkGetDeviceProcAddr = nullptr;
+    PFN_vkCreateDevice fp_vkCreateDevice = nullptr;
+
+// WSI
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    PFN_vkCreateAndroidSurfaceKHR fp_vkCreateAndroidSurfaceKHR;
+#endif
+#ifdef VK_USE_PLATFORM_METAL_EXT
+    PFN_vkCreateMetalSurfaceEXT fp_vkCreateMetalSurfaceEXT;
+#endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    PFN_vkCreateWaylandSurfaceKHR fp_vkCreateWaylandSurfaceKHR;
+#endif
+#ifdef VK_USE_PLATFORM_XCB_KHR
+    PFN_vkCreateXcbSurfaceKHR fp_vkCreateXcbSurfaceKHR;
+#endif
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+    PFN_vkCreateXlibSurfaceKHR fp_vkCreateXlibSurfaceKHR;
+#endif
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    PFN_vkCreateWin32SurfaceKHR fp_vkCreateWin32SurfaceKHR;
+#endif
+    PFN_vkDestroySurfaceKHR fp_vkDestroySurfaceKHR = nullptr;
+
+    // device functions
+    PFN_vkDestroyDevice fp_vkDestroyDevice = nullptr;
+    PFN_vkGetDeviceQueue fp_vkGetDeviceQueue = nullptr;
+
+    VulkanFunctions();
+};
+
+struct InstanceCreateInfo {
+    VkInstanceCreateInfo inst_info{};
+    VkApplicationInfo app_info{};
+    std::string app_name;
+    std::string engine_name;
+    uint32_t app_version = 0;
+    uint32_t engine_version = 0;
+    uint32_t api_version = VK_MAKE_VERSION(1, 0, 0);
+    std::vector<const char*> enabled_layers;
+    std::vector<const char*> enabled_extensions;
+
+    InstanceCreateInfo();
+
+    VkInstanceCreateInfo* get() noexcept;
+    InstanceCreateInfo& set_application_name(std::string app_name);
+    InstanceCreateInfo& set_engine_name(std::string engine_name);
+    InstanceCreateInfo& set_app_version(uint32_t app_version);
+    InstanceCreateInfo& set_engine_version(uint32_t engine_version);
+    InstanceCreateInfo& set_api_version(uint32_t api_version);
+    InstanceCreateInfo& add_layer(const char* layer_name);
+    InstanceCreateInfo& add_extension(const char* ext_name);
+};
+
+struct DeviceQueueCreateInfo {
+    VkDeviceQueueCreateInfo queue{};
+    std::vector<float> priorities;
+    DeviceQueueCreateInfo();
+    DeviceQueueCreateInfo& add_priority(float priority);
+    DeviceQueueCreateInfo& set_props(VkQueueFamilyProperties props);
+};
+
+struct DeviceCreateInfo {
+    VkDeviceCreateInfo dev{};
+    std::vector<const char*> enabled_extensions;
+    std::vector<const char*> enabled_layers;
+    std::vector<DeviceQueueCreateInfo> queue_info_details;
+    std::vector<VkDeviceQueueCreateInfo> queue_infos;
+
+    VkDeviceCreateInfo* get() noexcept;
+    DeviceCreateInfo& add_layer(const char* layer_name);
+    DeviceCreateInfo& add_extension(const char* ext_name);
+    DeviceCreateInfo& add_device_queue(DeviceQueueCreateInfo queue_info_detail);
+};
+
+struct InstWrapper {
+    InstWrapper(VulkanFunctions& functions) noexcept : functions(&functions) {}
+    InstWrapper(VulkanFunctions& functions, VkInstance inst) noexcept : functions(&functions), inst(inst) {}
+    ~InstWrapper() {
+        if (inst != VK_NULL_HANDLE) functions->fp_vkDestroyInstance(inst, nullptr);
+    }
+
+    // Immoveable object
+    InstWrapper(InstWrapper const&) = delete;
+    InstWrapper& operator=(InstWrapper const&) = delete;
+    InstWrapper(InstWrapper&&) = delete;
+    InstWrapper& operator=(InstWrapper&&) = delete;
+
+    // Convenience
+    operator VkInstance() { return inst; }
+    VulkanFunctions* operator->() { return functions; }
+
+    VulkanFunctions* functions = nullptr;
+    VkInstance inst = VK_NULL_HANDLE;
+};
+
+VkResult CreateInst(InstWrapper& inst, InstanceCreateInfo& inst_info);
+VkResult CreatePhysDevs(InstWrapper& inst, uint32_t phys_dev_count, std::vector<VkPhysicalDevice>& physical_devices);
+VkResult CreatePhysDev(InstWrapper& inst, VkPhysicalDevice& physical_device);
+
+struct DeviceWrapper {
+    DeviceWrapper(){};
+    DeviceWrapper(VulkanFunctions& functions, VkDevice dev) : functions(&functions), dev(dev){};
+    ~DeviceWrapper() { functions->fp_vkDestroyDevice(dev, nullptr); }
+
+    // Immoveable object
+    DeviceWrapper(DeviceWrapper const&) = delete;
+    DeviceWrapper& operator=(DeviceWrapper const&) = delete;
+    DeviceWrapper(DeviceWrapper&&) = delete;
+    DeviceWrapper& operator=(DeviceWrapper&&) = delete;
+
+    // Convenience
+    operator VkDevice() { return dev; }
+    VulkanFunctions* operator->() { return functions; }
+
+    VulkanFunctions* functions = nullptr;
+    VkDevice dev = VK_NULL_HANDLE;
+};
+
+inline bool operator==(const VkExtent3D& a, const VkExtent3D& b) {
+    return a.width == b.width && a.height == b.height && a.depth == b.depth;
+}
+inline bool operator!=(const VkExtent3D& a, const VkExtent3D& b) { return !(a == b); }
+
+inline bool operator==(const VkQueueFamilyProperties& a, const VkQueueFamilyProperties& b) {
+    return a.minImageTransferGranularity == b.minImageTransferGranularity && a.queueCount == b.queueCount &&
+           a.queueFlags == b.queueFlags && a.timestampValidBits == b.timestampValidBits;
+}
+inline bool operator!=(const VkQueueFamilyProperties& a, const VkQueueFamilyProperties& b) { return !(a == b); }
+
+inline bool operator==(const VkLayerProperties& a, const VkLayerProperties& b) {
+    return strncmp(a.layerName, b.layerName, 256) == 0 && strncmp(a.description, b.description, 256) == 0 &&
+           a.implementationVersion == b.implementationVersion && a.specVersion == b.specVersion;
+}
+inline bool operator!=(const VkLayerProperties& a, const VkLayerProperties& b) { return !(a == b); }
+
+inline bool operator==(const VkExtensionProperties& a, const VkExtensionProperties& b) {
+    return strncmp(a.extensionName, b.extensionName, 256) == 0 && a.specVersion == b.specVersion;
+}
+inline bool operator!=(const VkExtensionProperties& a, const VkExtensionProperties& b) { return !(a == b); }

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#include "test_environment.h"
+
+class RegressionTests : public ::testing::Test {
+   protected:
+    virtual void SetUp() {
+        env = std::unique_ptr<SingleICDShim>(
+            new SingleICDShim(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_MAKE_VERSION(1, 0, 0))));
+    }
+
+    virtual void TearDown() { env.reset(); }
+    std::unique_ptr<SingleICDShim> env;
+};
+
+TEST_F(RegressionTests, CreateInstance_BasicRun) {
+    auto& driver = env->get_test_icd();
+    driver.SetICDAPIVersion(VK_MAKE_VERSION(1, 0, 0));
+    driver.SetMinICDInterfaceVersion(5);
+
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+}
+
+TEST_F(RegressionTests, CreateInstance_DestroyInstanceNullHandle) {
+    env->vulkan_functions.fp_vkDestroyInstance(VK_NULL_HANDLE, nullptr);
+}
+
+TEST_F(RegressionTests, CreateInstance_DestroyDeviceNullHandle) {
+    env->vulkan_functions.fp_vkDestroyDevice(VK_NULL_HANDLE, nullptr);
+}
+
+TEST_F(RegressionTests, CreateInstance_ExtensionNotPresent) {
+    auto& driver = env->get_test_icd();
+    {
+        VkInstance inst = VK_NULL_HANDLE;
+        auto inst_info = driver.GetVkInstanceCreateInfo();
+        inst_info.add_extension("VK_EXT_validation_features");  // test icd won't report this as supported
+        ASSERT_EQ(VK_ERROR_EXTENSION_NOT_PRESENT,
+                  env->vulkan_functions.fp_vkCreateInstance(inst_info.get(), VK_NULL_HANDLE, &inst));
+    }
+    {
+        VkInstance inst = VK_NULL_HANDLE;
+        auto inst_info = driver.GetVkInstanceCreateInfo();
+        inst_info.add_extension("Non_existant_extension");  // unknown instance extension
+        ASSERT_EQ(VK_ERROR_EXTENSION_NOT_PRESENT,
+                  env->vulkan_functions.fp_vkCreateInstance(inst_info.get(), VK_NULL_HANDLE, &inst));
+    }
+}
+
+TEST_F(RegressionTests, EnumeratePhysicalDevices_OneCall) {
+    auto& driver = env->get_test_icd();
+    driver.SetMinICDInterfaceVersion(5);
+
+    driver.physical_devices.emplace_back("physical_device_0");
+    driver.physical_devices.emplace_back("physical_device_1");
+    driver.physical_devices.emplace_back("physical_device_2");
+    driver.physical_devices.emplace_back("physical_device_3");
+
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    uint32_t physical_count = driver.physical_devices.size();
+    uint32_t returned_physical_count = driver.physical_devices.size();
+    std::vector<VkPhysicalDevice> physical_device_handles = std::vector<VkPhysicalDevice>(physical_count);
+    ASSERT_EQ(VK_SUCCESS, inst->fp_vkEnumeratePhysicalDevices(inst, &returned_physical_count, physical_device_handles.data()));
+    ASSERT_EQ(physical_count, returned_physical_count);
+}
+
+TEST_F(RegressionTests, EnumeratePhysicalDevices_TwoCall) {
+    auto& driver = env->get_test_icd();
+    driver.SetMinICDInterfaceVersion(5);
+
+    driver.physical_devices.emplace_back("physical_device_0");
+    driver.physical_devices.emplace_back("physical_device_1");
+
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    uint32_t physical_count = driver.physical_devices.size();
+    uint32_t returned_physical_count = 0;
+    ASSERT_EQ(VK_SUCCESS, inst->fp_vkEnumeratePhysicalDevices(inst.inst, &returned_physical_count, nullptr));
+    ASSERT_EQ(physical_count, returned_physical_count);
+
+    std::unique_ptr<VkPhysicalDevice[]> physical_device_handles(new VkPhysicalDevice[physical_count]);
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkEnumeratePhysicalDevices(inst.inst, &returned_physical_count,
+                                                                              physical_device_handles.get()));
+    ASSERT_EQ(physical_count, returned_physical_count);
+}
+
+TEST_F(RegressionTests, EnumeratePhysicalDevices_MatchOneAndTwoCallNumbers) {
+    auto& driver = env->get_test_icd();
+    driver.SetMinICDInterfaceVersion(5);
+
+    driver.physical_devices.emplace_back("physical_device_0");
+    driver.physical_devices.emplace_back("physical_device_1");
+    driver.physical_devices.emplace_back("physical_device_2");
+
+    InstWrapper inst1{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst1, inst_create_info), VK_SUCCESS);
+
+    uint32_t physical_count_one_call = driver.physical_devices.size();
+    uint32_t returned_physical_count_one_call = driver.physical_devices.size();
+    std::unique_ptr<VkPhysicalDevice[]> physical_device_handles_one_call(new VkPhysicalDevice[physical_count_one_call]);
+    ASSERT_EQ(VK_SUCCESS, inst1->fp_vkEnumeratePhysicalDevices(inst1, &returned_physical_count_one_call,
+                                                               physical_device_handles_one_call.get()));
+    ASSERT_EQ(physical_count_one_call, returned_physical_count_one_call);
+
+    InstWrapper inst2{env->vulkan_functions};
+    ASSERT_EQ(CreateInst(inst2, inst_create_info), VK_SUCCESS);
+
+    uint32_t physical_count = driver.physical_devices.size();
+    uint32_t returned_physical_count = 0;
+    ASSERT_EQ(VK_SUCCESS, inst2->fp_vkEnumeratePhysicalDevices(inst2, &returned_physical_count, nullptr));
+    ASSERT_EQ(physical_count, returned_physical_count);
+
+    std::unique_ptr<VkPhysicalDevice[]> physical_device_handles(new VkPhysicalDevice[physical_count]);
+    ASSERT_EQ(VK_SUCCESS, inst2->fp_vkEnumeratePhysicalDevices(inst2, &returned_physical_count, physical_device_handles.get()));
+    ASSERT_EQ(physical_count, returned_physical_count);
+
+    ASSERT_EQ(returned_physical_count, returned_physical_count);
+}
+
+TEST_F(RegressionTests, EnumeratePhysicalDevices_TwoCallIncomplete) {
+    auto& driver = env->get_test_icd();
+    driver.SetMinICDInterfaceVersion(5);
+
+    driver.physical_devices.emplace_back("physical_device_0");
+    driver.physical_devices.emplace_back("physical_device_1");
+
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    uint32_t physical_count = 0;
+    ASSERT_EQ(VK_SUCCESS, inst->fp_vkEnumeratePhysicalDevices(inst, &physical_count, nullptr));
+    ASSERT_EQ(physical_count, driver.physical_devices.size());
+
+    std::unique_ptr<VkPhysicalDevice[]> physical(new VkPhysicalDevice[physical_count]);
+
+    // Remove one from the physical device count so we can get the VK_INCOMPLETE message
+    physical_count = 1;
+
+    ASSERT_EQ(VK_INCOMPLETE, inst->fp_vkEnumeratePhysicalDevices(inst, &physical_count, physical.get()));
+    ASSERT_EQ(physical_count, 1);
+}
+
+TEST_F(RegressionTests, CreateDevice_ExtensionNotPresent) {
+    auto& driver = env->get_test_icd();
+
+    MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
+
+    driver.physical_devices.emplace_back("physical_device_0");
+    driver.physical_devices.back().queue_family_properties.push_back(family_props);
+
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    VkPhysicalDevice phys_dev;
+    ASSERT_EQ(CreatePhysDev(inst, phys_dev), VK_SUCCESS);
+
+    uint32_t familyCount = 0;
+    inst->fp_vkGetPhysicalDeviceQueueFamilyProperties(phys_dev, &familyCount, nullptr);
+    ASSERT_EQ(familyCount, 1);
+
+    VkQueueFamilyProperties families;
+    inst->fp_vkGetPhysicalDeviceQueueFamilyProperties(phys_dev, &familyCount, &families);
+    ASSERT_EQ(familyCount, 1);
+    ASSERT_EQ(families, family_props.properties);
+
+    DeviceCreateInfo dev_create_info;
+    dev_create_info.add_extension("NotPresent");
+    DeviceQueueCreateInfo queue_info;
+    queue_info.add_priority(0.0f);
+    dev_create_info.add_device_queue(queue_info);
+
+    VkDevice device;
+    ASSERT_EQ(VK_ERROR_EXTENSION_NOT_PRESENT, inst->fp_vkCreateDevice(phys_dev, dev_create_info.get(), nullptr, &device));
+}
+
+TEST_F(RegressionTests, CreateDevice_LayersNotPresent) {
+    auto& driver = env->get_test_icd();
+
+    MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
+
+    driver.physical_devices.emplace_back("physical_device_0");
+    driver.physical_devices.back().queue_family_properties.push_back(family_props);
+
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    VkPhysicalDevice phys_dev;
+    ASSERT_EQ(CreatePhysDev(inst, phys_dev), VK_SUCCESS);
+
+    uint32_t familyCount = 0;
+    inst->fp_vkGetPhysicalDeviceQueueFamilyProperties(phys_dev, &familyCount, nullptr);
+    ASSERT_EQ(familyCount, 1);
+
+    VkQueueFamilyProperties families;
+    inst->fp_vkGetPhysicalDeviceQueueFamilyProperties(phys_dev, &familyCount, &families);
+    ASSERT_EQ(familyCount, 1);
+    ASSERT_EQ(families, family_props.properties);
+
+    DeviceCreateInfo dev_create_info;
+    dev_create_info.add_layer("NotPresent");
+    DeviceQueueCreateInfo queue_info;
+    queue_info.add_priority(0.0f);
+    dev_create_info.add_device_queue(queue_info);
+
+    VkDevice device;
+    ASSERT_EQ(VK_SUCCESS, inst->fp_vkCreateDevice(phys_dev, dev_create_info.get(), nullptr, &device));
+}
+
+TEST_F(RegressionTests, EnumerateInstanceExtensionProperties_PropertyCountLessThanAvailable) {
+    uint32_t extension_count = 0;
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkEnumerateInstanceExtensionProperties("", &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 2); //return debug report & debug utils
+    extension_count = 1;  // artificially remove one extension
+
+    std::array<VkExtensionProperties, 2> extensions;
+    ASSERT_EQ(VK_INCOMPLETE,
+              env->vulkan_functions.fp_vkEnumerateInstanceExtensionProperties("", &extension_count, extensions.data()));
+    ASSERT_EQ(extension_count, 1);
+    // loader always adds the debug report & debug utils extensions
+    ASSERT_EQ(strcmp(extensions[0].extensionName, "VK_EXT_debug_report"), 0);
+}
+
+
+TEST_F(RegressionTests, EnumerateInstanceExtensionProperties_FilterUnkownInstanceExtensions) {
+    Extension first_ext{"FirstTestExtension"};
+    Extension second_ext{"SecondTestExtension"};
+    env->get_new_test_icd().AddInstanceExtensions({first_ext, second_ext});
+
+    uint32_t extension_count = 0;
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkEnumerateInstanceExtensionProperties("", &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 2); //return debug report & debug utils
+
+    std::array<VkExtensionProperties, 2> extensions;
+    ASSERT_EQ(VK_SUCCESS,
+              env->vulkan_functions.fp_vkEnumerateInstanceExtensionProperties("", &extension_count, extensions.data()));
+    ASSERT_EQ(extension_count, 2);
+    // loader always adds the debug report & debug utils extensions
+    ASSERT_EQ(strcmp(extensions[0].extensionName, "VK_EXT_debug_report"), 0);
+    ASSERT_EQ(strcmp(extensions[1].extensionName, "VK_EXT_debug_utils"), 0);
+}
+
+TEST_F(RegressionTests, EnumerateInstanceExtensionProperties_DisableUnknownInstanceExtensionFiltering) {
+    Extension first_ext{"FirstTestExtension"};
+    Extension second_ext{"SecondTestExtension"};
+    env->get_new_test_icd().AddInstanceExtensions({first_ext, second_ext});
+
+    set_env_var("VK_LOADER_DISABLE_INST_EXT_FILTER","1");
+
+    uint32_t extension_count = 0;
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkEnumerateInstanceExtensionProperties("", &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 4);
+
+    std::array<VkExtensionProperties, 4> extensions;
+    ASSERT_EQ(VK_SUCCESS,
+              env->vulkan_functions.fp_vkEnumerateInstanceExtensionProperties("", &extension_count, extensions.data()));
+    ASSERT_EQ(extension_count, 4);
+
+    ASSERT_EQ(extensions[0], first_ext.get());
+    ASSERT_EQ(extensions[1], second_ext.get());
+    //Loader always adds these two extensions
+    ASSERT_EQ(strcmp(extensions[2].extensionName, "VK_EXT_debug_report"), 0);
+    ASSERT_EQ(strcmp(extensions[3].extensionName, "VK_EXT_debug_utils"), 0);
+}

--- a/tests/loader_testing_main.cpp
+++ b/tests/loader_testing_main.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#include "test_environment.h"
+
+int main(int argc, char** argv) {
+#if defined(_WIN32)
+    // Avoid "Abort, Retry, Ignore" dialog boxes
+    _set_error_mode(_OUT_TO_STDERR);
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+#endif
+
+    ::testing::InitGoogleTest(&argc, argv);
+
+    int result = RUN_ALL_TESTS();
+    return result;
+}

--- a/tests/loader_validation_tests.cpp
+++ b/tests/loader_validation_tests.cpp
@@ -284,8 +284,8 @@ struct AllocTrack {
 // However, we have to globally define it so the allocation callback functions work properly.
 std::vector<AllocTrack> g_allocated_vector;
 bool g_intentional_fail_enabled = false;
-uint32_t g_intenional_fail_index = 0;
-uint32_t g_intenional_fail_count = 0;
+uint32_t g_intentional_fail_index = 0;
+uint32_t g_intentional_fail_count = 0;
 
 void FreeAllocTracker() { g_allocated_vector.clear(); }
 
@@ -296,12 +296,12 @@ void InitAllocTracker(size_t size, uint32_t intentional_fail_index = UINT32_MAX)
     g_allocated_vector.resize(size);
     if (intentional_fail_index != UINT32_MAX) {
         g_intentional_fail_enabled = true;
-        g_intenional_fail_index = intentional_fail_index;
-        g_intenional_fail_count = 0;
+        g_intentional_fail_index = intentional_fail_index;
+        g_intentional_fail_count = 0;
     } else {
         g_intentional_fail_enabled = false;
-        g_intenional_fail_index = 0;
-        g_intenional_fail_count = 0;
+        g_intentional_fail_index = 0;
+        g_intentional_fail_count = 0;
     }
 }
 
@@ -334,7 +334,7 @@ bool IsAllocTrackerEmpty() {
 VKAPI_ATTR void *VKAPI_CALL AllocCallbackFunc(void *pUserData, size_t size, size_t alignment,
                                               VkSystemAllocationScope allocationScope) {
     if (g_intentional_fail_enabled) {
-        if (++g_intenional_fail_count >= g_intenional_fail_index) {
+        if (++g_intentional_fail_count >= g_intentional_fail_index) {
             return nullptr;
         }
     }
@@ -432,7 +432,7 @@ void test_create_device(VkPhysicalDevice physical) {
 // Test groups:
 // LX = lunar exchange
 // LVLGH = loader and validation github
-// LVLGL = lodaer and validation gitlab
+// LVLGL = loader and validation gitlab
 
 TEST(LX435, InstanceCreateInfoConst) {
     VkInstanceCreateInfo const info = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO, nullptr, 0, nullptr, 0, nullptr, 0, nullptr};
@@ -1591,7 +1591,7 @@ TEST(EnumeratePhysicalDeviceGroupsKHR, OneCall) {
 }
 
 // Used by run_loader_tests.sh to test for the expected usage of the
-// vkEnumeratePhysicalDeviceGroupsKHR call in a two call fasion (once with NULL data
+// vkEnumeratePhysicalDeviceGroupsKHR call in a two call fashion (once with NULL data
 // to get count, and then again with data).
 TEST(EnumeratePhysicalDeviceGroupsKHR, TwoCall) {
     VkInstance instance = VK_NULL_HANDLE;

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#include "test_environment.h"
+
+struct ICDSetup {
+    ICDSetup(const char* icd_path, const char* manifest_name)
+        : driver_store(FRAMEWORK_BUILD_DIRECTORY, "version_test_manifests") {
+        ManifestICD icd_manifest;
+        icd_manifest.lib_path = icd_path;
+        icd_manifest.api_version = VK_MAKE_VERSION(1, 0, 0);
+        driver_store.write(manifest_name, icd_manifest);
+
+        set_env_var("VK_ICD_FILENAMES", (driver_store.location() / manifest_name).str());
+
+        driver_wrapper = LibraryWrapper(fs::path(icd_path));
+        get_new_test_icd = driver_wrapper.get_symbol<GetNewTestICDFunc>(GET_NEW_TEST_ICD_FUNC_STR);
+    }
+    ~ICDSetup() { remove_env_var("VK_ICD_FILENAMES"); }
+    fs::FolderManager driver_store;
+    LibraryWrapper driver_wrapper;
+    GetNewTestICDFunc get_new_test_icd;
+    VulkanFunctions vulkan_functions;
+};
+
+// Don't support vk_icdNegotiateLoaderICDInterfaceVersion
+// Loader calls vk_icdGetInstanceProcAddr second
+// does not support vk_icdGetInstanceProcAddr
+// must export vkGetInstanceProcAddr, vkCreateInstance, vkEnumerateInstanceExtensionProperties
+TEST(DriverNone, version_0) {
+    ICDSetup setup(TEST_ICD_PATH_EXPORT_NONE, "test_icd_export_none.json");
+    auto* driver = setup.get_new_test_icd();
+
+    InstWrapper inst{setup.vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    ASSERT_EQ(driver->called_vk_icd_gipa, CalledICDGIPA::vk_gipa);
+}
+
+// Don't support vk_icdNegotiateLoaderICDInterfaceVersion
+// the loader calls vk_icdGetInstanceProcAddr first
+TEST(DriverICDGIPA, version_1) {
+    ICDSetup setup(TEST_ICD_PATH_EXPORT_ICD_GIPA, "test_icd_export_icd_gipa.json");
+    auto* driver = setup.get_new_test_icd();
+
+    InstWrapper inst{setup.vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    ASSERT_EQ(driver->called_vk_icd_gipa, CalledICDGIPA::vk_icd_gipa);
+}
+
+// support vk_icdNegotiateLoaderICDInterfaceVersion but not vk_icdGetInstanceProcAddr
+// should assert that `interface_vers == 0` due to version mismatch, only checkable in Debug Mode
+TEST(DriverNegotiateInterfaceVersionDeathTest, version_negotiate_interface_version) {
+    // may be needed to surpress debug assert popups on windows
+    //::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    ICDSetup setup(TEST_ICD_PATH_EXPORT_NEGOTIATE_INTERFACE_VERSION, "test_icd_export_negotiate_interface_version.json");
+
+    InstWrapper inst{setup.vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+#if !defined(NDEBUG)
+#if defined(WIN32)
+    ASSERT_DEATH(CreateInst(inst, inst_create_info), "");
+#else
+    ASSERT_DEATH(CreateInst(inst, inst_create_info), "interface_vers == 0");
+#endif
+#else
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+#endif
+}
+
+// export vk_icdNegotiateLoaderICDInterfaceVersion and vk_icdGetInstanceProcAddr
+TEST(DriverNegotiateInterfaceVersionAndICDGIPA, version_2) {
+    ICDSetup setup(TEST_ICD_PATH_VERSION_2, "test_icd_version_2.json");
+    auto* driver = setup.get_new_test_icd();
+
+    InstWrapper inst{setup.vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    ASSERT_EQ(driver->called_vk_icd_gipa, CalledICDGIPA::vk_icd_gipa);
+}
+
+class ICDInterfaceVersion2Plus : public ::testing::Test {
+   protected:
+    virtual void SetUp() { env = std::unique_ptr<SingleICDShim>(new SingleICDShim(TEST_ICD_PATH_VERSION_2)); }
+
+    virtual void TearDown() { env.reset(); }
+    std::unique_ptr<SingleICDShim> env;
+};
+
+TEST_F(ICDInterfaceVersion2Plus, vk_icdNegotiateLoaderICDInterfaceVersion) {
+    auto& driver = env->get_test_icd();
+
+    for (uint32_t i = 0; i <= 6; i++) {
+        for (uint32_t j = i; j <= 6; j++) {
+            driver.min_icd_interface_version = i;
+            driver.max_icd_interface_version = j;
+            InstWrapper inst{env->vulkan_functions};
+            InstanceCreateInfo inst_create_info;
+            EXPECT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+        }
+    }
+}
+
+TEST_F(ICDInterfaceVersion2Plus, version_3) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+    {
+        driver.min_icd_interface_version = 2;
+        driver.enable_icd_wsi = true;
+        InstWrapper inst{env->vulkan_functions};
+        InstanceCreateInfo inst_create_info;
+        ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+        ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
+    }
+    {
+        driver.min_icd_interface_version = 3;
+        driver.enable_icd_wsi = false;
+        InstWrapper inst{env->vulkan_functions};
+        InstanceCreateInfo inst_create_info;
+        ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+        ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
+    }
+    {
+        driver.min_icd_interface_version = 3;
+        driver.enable_icd_wsi = true;
+        InstWrapper inst{env->vulkan_functions};
+        InstanceCreateInfo inst_create_info;
+        ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+        ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::is_using);
+    }
+}
+
+TEST_F(ICDInterfaceVersion2Plus, version_4) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+}
+
+TEST_F(ICDInterfaceVersion2Plus, l4_icd4) {
+    // ICD must fail with VK_ERROR_INCOMPATIBLE_DRIVER for all vkCreateInstance calls with apiVersion set to > Vulkan 1.0
+    // because both the loader and ICD support interface version <= 4. Otherwise, the ICD should behave as normal.
+}
+TEST_F(ICDInterfaceVersion2Plus, l4_icd5) {
+    // ICD must fail with VK_ERROR_INCOMPATIBLE_DRIVER for all vkCreateInstance calls with apiVersion set to > Vulkan 1.0
+    // because the loader is still at interface version <= 4. Otherwise, the ICD should behave as normal.
+}
+TEST_F(ICDInterfaceVersion2Plus, l5_icd4) {
+    // Loader will fail with VK_ERROR_INCOMPATIBLE_DRIVER if it can't handle the apiVersion. ICD may pass for all apiVersions,
+    // but since its interface is <= 4, it is best if it assumes it needs to do the work of rejecting anything > Vulkan 1.0 and
+    // fail with VK_ERROR_INCOMPATIBLE_DRIVER. Otherwise, the ICD should behave as normal.
+}
+TEST_F(ICDInterfaceVersion2Plus, l5_icd5) {
+    // Loader will fail with VK_ERROR_INCOMPATIBLE_DRIVER if it can't handle the apiVersion, and ICDs should fail with
+    // VK_ERROR_INCOMPATIBLE_DRIVER only if they can not support the specified apiVersion. Otherwise, the ICD should behave as
+    // normal.
+}
+
+class ICDInterfaceVersion2PlusEnumerateAdapterPhysicalDevices : public ::testing::Test {
+   protected:
+    virtual void SetUp() {
+        env = std::unique_ptr<SingleICDShim>(
+            new SingleICDShim(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES));
+    }
+
+    virtual void TearDown() { env.reset(); }
+    std::unique_ptr<SingleICDShim> env;
+};
+
+// Need more work to shim dxgi for this test to work
+#if defined(WIN32)
+// Version 6 provides a mechanism to allow the loader to sort physical devices.
+// The loader will only attempt to sort physical devices on an ICD if version 6 of the interface is supported.
+// This version provides the vk_icdEnumerateAdapterPhysicalDevices function.
+TEST_F(ICDInterfaceVersion2Plus, version_5) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_1");
+    driver.physical_devices.emplace_back("physical_device_0");
+    uint32_t physical_count = driver.physical_devices.size();
+    uint32_t returned_physical_count = driver.physical_devices.size();
+    std::vector<VkPhysicalDevice> physical_device_handles = std::vector<VkPhysicalDevice>(physical_count);
+
+    driver.min_icd_interface_version = 5;
+
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkEnumeratePhysicalDevices(inst.inst, &returned_physical_count,
+                                                                              physical_device_handles.data()));
+    ASSERT_EQ(physical_count, returned_physical_count);
+    ASSERT_EQ(driver.called_enumerate_adapter_physical_devices, CalledEnumerateAdapterPhysicalDevices::not_called);
+}
+TEST_F(ICDInterfaceVersion2PlusEnumerateAdapterPhysicalDevices, version_6) {
+    // Version 6 provides a mechanism to allow the loader to sort physical devices.
+    // The loader will only attempt to sort physical devices on an ICD if version 6 of the interface is supported.
+    // This version provides the vk_icdEnumerateAdapterPhysicalDevices function.
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_1");
+    driver.physical_devices.emplace_back("physical_device_0");
+    uint32_t physical_count = driver.physical_devices.size();
+    uint32_t returned_physical_count = driver.physical_devices.size();
+    std::vector<VkPhysicalDevice> physical_device_handles = std::vector<VkPhysicalDevice>(physical_count);
+
+    driver.min_icd_interface_version = 6;
+
+    uint32_t driver_index = 2; //which drive this test pretends to be
+    auto& known_driver = known_driver_list.at(2);
+    DXGI_ADAPTER_DESC1 desc1{};
+    wcsncpy(&desc1.Description[0], L"TestDriver1", 128);
+    desc1.VendorId = known_driver.vendor_id;
+    desc1.AdapterLuid;
+    desc1.Flags = DXGI_ADAPTER_FLAG_NONE;
+    env->platform_shim->add_dxgi_adapter(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES, GpuType::discrete, driver_index, desc1);
+
+
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkEnumeratePhysicalDevices(inst.inst, &returned_physical_count, nullptr));
+    ASSERT_EQ(physical_count, returned_physical_count);
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkEnumeratePhysicalDevices(inst.inst, &returned_physical_count,
+                                                                              physical_device_handles.data()));
+    ASSERT_EQ(physical_count, returned_physical_count);
+    ASSERT_EQ(driver.called_enumerate_adapter_physical_devices, CalledEnumerateAdapterPhysicalDevices::called);
+}
+
+TEST_F(ICDInterfaceVersion2PlusEnumerateAdapterPhysicalDevices, EnumAdapters2) {
+
+InstWrapper inst{env->vulkan_functions};
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_1");
+    driver.physical_devices.emplace_back("physical_device_0");
+    uint32_t physical_count = driver.physical_devices.size();
+    uint32_t returned_physical_count = driver.physical_devices.size();
+    std::vector<VkPhysicalDevice> physical_device_handles = std::vector<VkPhysicalDevice>(physical_count);
+
+    SHIM_D3DKMT_ADAPTERINFO d3dkmt_adapter_info{};
+    d3dkmt_adapter_info.hAdapter = 0; //
+    d3dkmt_adapter_info.AdapterLuid = _LUID{10, 1000};
+    d3dkmt_adapter_info.NumOfSources = 1;
+    d3dkmt_adapter_info.bPresentMoveRegionsPreferred = true;
+
+    env->platform_shim->add_d3dkmt_adapter(d3dkmt_adapter_info, env->get_test_icd_path());
+
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkEnumeratePhysicalDevices(inst.inst, &returned_physical_count, nullptr));
+    ASSERT_EQ(physical_count, returned_physical_count);
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkEnumeratePhysicalDevices(inst.inst, &returned_physical_count,
+                                                                              physical_device_handles.data()));
+    ASSERT_EQ(physical_count, returned_physical_count);
+}
+#endif  // defined(WIN32)
+
+TEST(MultipleICDConfig, Basic) {
+    MultipleICDShim env(
+        {TestICDDetails(TEST_ICD_PATH_VERSION_2), TestICDDetails(TEST_ICD_PATH_VERSION_2), TestICDDetails(TEST_ICD_PATH_VERSION_2)},
+        DebugMode::none);
+
+    env.get_test_icd(0).physical_devices.emplace_back("physical_device_0");
+    env.get_test_icd(1).physical_devices.emplace_back("physical_device_1");
+    env.get_test_icd(2).physical_devices.emplace_back("physical_device_2");
+
+    env.get_test_icd(0).physical_devices.at(0).properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+    env.get_test_icd(1).physical_devices.at(0).properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+    env.get_test_icd(2).physical_devices.at(0).properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_CPU;
+
+    strcpy(env.get_test_icd(0).physical_devices.at(0).properties.deviceName, "dev0");
+    strcpy(env.get_test_icd(1).physical_devices.at(0).properties.deviceName, "dev1");
+    strcpy(env.get_test_icd(2).physical_devices.at(0).properties.deviceName, "dev2");
+
+    InstWrapper inst{env.vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    std::array<VkPhysicalDevice, 3> phys_devs_array;
+    uint32_t phys_dev_count = 3;
+    ASSERT_EQ(env.vulkan_functions.fp_vkEnumeratePhysicalDevices(inst, &phys_dev_count, phys_devs_array.data()), VK_SUCCESS);
+    ASSERT_EQ(phys_dev_count, 3);
+    ASSERT_EQ(env.get_test_icd(0).physical_devices.at(0).properties.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
+    ASSERT_EQ(env.get_test_icd(1).physical_devices.at(0).properties.deviceType, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU);
+    ASSERT_EQ(env.get_test_icd(2).physical_devices.at(0).properties.deviceType, VK_PHYSICAL_DEVICE_TYPE_CPU);
+}
+
+TEST(MultipleDriverConfig, DifferentICDInterfaceVersions) {
+    MultipleICDShim env({TestICDDetails(TEST_ICD_PATH_EXPORT_ICD_GIPA), TestICDDetails(TEST_ICD_PATH_VERSION_2),
+                            TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)},
+                           DebugMode::none);
+
+    TestICD& icd0 = env.get_test_icd(0);
+    icd0.physical_devices.emplace_back("physical_device_0");
+    icd0.max_icd_interface_version = 1;
+
+    TestICD& icd1 = env.get_test_icd(1);
+    icd1.physical_devices.emplace_back("physical_device_1");
+    icd1.min_icd_interface_version = 2;
+    icd1.max_icd_interface_version = 5;
+
+    InstWrapper inst{env.vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    std::array<VkPhysicalDevice, 2> phys_devs_array;
+    uint32_t phys_dev_count = 2;
+    ASSERT_EQ(env.vulkan_functions.fp_vkEnumeratePhysicalDevices(inst, &phys_dev_count, phys_devs_array.data()), VK_SUCCESS);
+    ASSERT_EQ(phys_dev_count, 2);
+}

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#include "test_environment.h"
+
+#if defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XCB_KHR)
+#include <X11/Xutil.h>
+#endif
+
+class RegressionTests : public ::testing::Test {
+   protected:
+    virtual void SetUp() { env = std::unique_ptr<SingleICDShim>(new SingleICDShim(TestICDDetails(TEST_ICD_PATH_VERSION_2))); }
+
+    virtual void TearDown() { env.reset(); }
+    std::unique_ptr<SingleICDShim> env;
+
+    int width = 100;
+    int height = 100;
+};
+
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+
+// MS-Windows event handling function:
+LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) { return DefWindowProcA(hWnd, uMsg, wParam, lParam); }
+
+TEST_F(RegressionTests, CreateSurfaceWin32) {
+    auto& driver = env->get_test_icd();
+    driver.SetICDAPIVersion(VK_MAKE_VERSION(1, 0, 0));
+    driver.SetMinICDInterfaceVersion(5);
+    driver.AddInstanceExtension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
+    driver.AddInstanceExtension(Extension(VK_KHR_WIN32_SURFACE_EXTENSION_NAME));
+    driver.enable_icd_wsi = true;
+
+    InstWrapper inst{env->vulkan_functions};
+    auto inst_create_info = driver.GetVkInstanceCreateInfo();
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    WNDCLASSEX win_class;
+    const char* app_short_name = "loader_surface_test";
+    HINSTANCE h_instance = GetModuleHandle(nullptr);  // Windows Instance
+    HWND h_wnd = nullptr;                             // window handle
+
+    // Initialize the window class structure:
+    win_class.cbSize = sizeof(WNDCLASSEX);
+    win_class.style = CS_HREDRAW | CS_VREDRAW;
+    win_class.lpfnWndProc = WndProc;
+    win_class.cbClsExtra = 0;
+    win_class.cbWndExtra = 0;
+    win_class.hInstance = h_instance;
+    win_class.hIcon = LoadIconA(nullptr, IDI_APPLICATION);
+    win_class.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    win_class.hbrBackground = (HBRUSH)GetStockObject(WHITE_BRUSH);
+    win_class.lpszMenuName = nullptr;
+    win_class.lpszClassName = app_short_name;
+    win_class.hIconSm = LoadIconA(nullptr, IDI_WINLOGO);
+
+    // Register window class:
+    EXPECT_TRUE(RegisterClassExA(&win_class) != NULL);
+
+    // Create window with the registered class:
+    RECT wr = {0, 0, width, height};
+    AdjustWindowRect(&wr, WS_OVERLAPPEDWINDOW, FALSE);
+    h_wnd = CreateWindowExA(0,
+                            app_short_name,  // class name
+                            app_short_name,  // app name
+                            // WS_VISIBLE | WS_SYSMENU |
+                            WS_OVERLAPPEDWINDOW,  // window style
+                            width, height,        // x/y coords
+                            wr.right - wr.left,   // width
+                            wr.bottom - wr.top,   // height
+                            nullptr,              // handle to parent
+                            nullptr,              // handle to menu
+                            h_instance,           // hInstance
+                            nullptr);             // no extra parameters
+    EXPECT_TRUE(h_wnd != nullptr);
+
+    VkSurfaceKHR surface{};
+    VkWin32SurfaceCreateInfoKHR surf_create_info{};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+    surf_create_info.hwnd = h_wnd;
+    surf_create_info.hinstance = h_instance;
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkCreateWin32SurfaceKHR(inst, &surf_create_info, nullptr, &surface));
+    ASSERT_TRUE(surface != VK_NULL_HANDLE);
+    //    ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
+
+    env->vulkan_functions.fp_vkDestroySurfaceKHR(inst, surface, nullptr);
+    DestroyWindow(h_wnd);
+}
+
+#endif
+
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+TEST_F(RegressionTests, CreateSurfaceXCB) {
+    auto& driver = env->get_test_icd();
+    driver.SetICDAPIVersion(VK_MAKE_VERSION(1, 0, 0));
+    driver.SetMinICDInterfaceVersion(5);
+    driver.AddInstanceExtension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
+    driver.AddInstanceExtension(Extension(VK_KHR_XCB_SURFACE_EXTENSION_NAME));
+    driver.enable_icd_wsi = true;
+
+    InstWrapper inst{env->vulkan_functions};
+    auto inst_create_info = driver.GetVkInstanceCreateInfo();
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    xcb_connection_t* xcb_connection;
+    xcb_screen_t* xcb_screen;
+    xcb_window_t xcb_window;
+
+    //--Init Connection--
+    const xcb_setup_t* setup;
+    xcb_screen_iterator_t iter;
+    int scr;
+
+    // API guarantees non-null xcb_connection
+    xcb_connection = xcb_connect(nullptr, &scr);
+    int conn_error = xcb_connection_has_error(xcb_connection);
+    ASSERT_EQ(conn_error, 0);
+
+    setup = xcb_get_setup(xcb_connection);
+    iter = xcb_setup_roots_iterator(setup);
+    while (scr-- > 0) {
+        xcb_screen_next(&iter);
+    }
+
+    xcb_screen = iter.data;
+
+    xcb_window = xcb_generate_id(xcb_connection);
+    xcb_create_window(xcb_connection, XCB_COPY_FROM_PARENT, xcb_window, xcb_screen->root, 0, 0, width, height, 0,
+                      XCB_WINDOW_CLASS_INPUT_OUTPUT, xcb_screen->root_visual, 0, nullptr);
+
+    xcb_intern_atom_cookie_t cookie = xcb_intern_atom(xcb_connection, 1, 12, "WM_PROTOCOLS");
+    xcb_intern_atom_reply_t* reply = xcb_intern_atom_reply(xcb_connection, cookie, 0);
+    free(reply);
+
+    VkXcbSurfaceCreateInfoKHR xcb_createInfo;
+    xcb_createInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
+    xcb_createInfo.pNext = nullptr;
+    xcb_createInfo.flags = 0;
+    xcb_createInfo.connection = xcb_connection;
+    xcb_createInfo.window = xcb_window;
+
+    VkSurfaceKHR surface{};
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkCreateXcbSurfaceKHR(inst, &xcb_createInfo, nullptr, &surface));
+    ASSERT_TRUE(surface != VK_NULL_HANDLE);
+
+    env->vulkan_functions.fp_vkDestroySurfaceKHR(inst, surface, nullptr);
+
+    xcb_destroy_window(xcb_connection, xcb_window);
+    xcb_disconnect(xcb_connection);
+}
+#endif
+
+#if defined(VK_USE_PLATFORM_XLIB_KHR)
+TEST_F(RegressionTests, CreateSurfaceXLIB) {
+    auto& driver = env->get_test_icd();
+    driver.SetICDAPIVersion(VK_MAKE_VERSION(1, 0, 0));
+    driver.SetMinICDInterfaceVersion(5);
+    driver.AddInstanceExtension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
+    driver.AddInstanceExtension(Extension(VK_KHR_XLIB_SURFACE_EXTENSION_NAME));
+    driver.enable_icd_wsi = true;
+
+    InstWrapper inst{env->vulkan_functions};
+    auto inst_create_info = driver.GetVkInstanceCreateInfo();
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    Display* xlib_display;
+    Window xlib_window;
+
+    long visualMask = VisualScreenMask;
+    int numberOfVisuals;
+
+    xlib_display = XOpenDisplay(nullptr);
+    ASSERT_NE(xlib_display, nullptr);
+
+    XVisualInfo vInfoTemplate = {};
+    vInfoTemplate.screen = DefaultScreen(xlib_display);
+    XVisualInfo* visualInfo = XGetVisualInfo(xlib_display, visualMask, &vInfoTemplate, &numberOfVisuals);
+    xlib_window = XCreateWindow(xlib_display, RootWindow(xlib_display, vInfoTemplate.screen), 0, 0, width, height, 0,
+                                visualInfo->depth, InputOutput, visualInfo->visual, 0, nullptr);
+
+    XSync(xlib_display, false);
+    XFree(visualInfo);
+
+    VkXlibSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = nullptr;
+    createInfo.flags = 0;
+    createInfo.dpy = xlib_display;
+    createInfo.window = xlib_window;
+
+    VkSurfaceKHR surface;
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkCreateXlibSurfaceKHR(inst, &createInfo, nullptr, &surface));
+    ASSERT_TRUE(surface != VK_NULL_HANDLE);
+
+    env->vulkan_functions.fp_vkDestroySurfaceKHR(inst, surface, nullptr);
+
+    XDestroyWindow(xlib_display, xlib_window);
+    XCloseDisplay(xlib_display);
+}
+#endif
+
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+
+struct WaylandState {
+    wl_display* display{};
+    wl_registry* registry{};
+    wl_compositor* compositor{};
+    wl_surface* surface{};
+};
+
+static void wayland_registry_global(void* data, struct wl_registry* registry, uint32_t id, const char* interface,
+                                    uint32_t version) {
+    WaylandState* wayland = static_cast<WaylandState*>(data);
+    if (strcmp(interface, "wl_compositor") == 0) {
+        wayland->compositor = (struct wl_compositor*)wl_registry_bind(registry, id, &wl_compositor_interface, 1);
+        wayland->surface = wl_compositor_create_surface(wayland->compositor);
+    }
+}
+static void wayland_registry_global_remove(void* data, struct wl_registry* registry, uint32_t id) {}
+static const struct wl_registry_listener wayland_registry_listener = {wayland_registry_global, wayland_registry_global_remove};
+
+TEST_F(RegressionTests, CreateSurfaceWayland) {
+    auto& driver = env->get_test_icd();
+    driver.SetICDAPIVersion(VK_MAKE_VERSION(1, 0, 0));
+    driver.SetMinICDInterfaceVersion(5);
+    driver.AddInstanceExtension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
+    driver.AddInstanceExtension(Extension(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME));
+    driver.enable_icd_wsi = true;
+
+    InstWrapper inst{env->vulkan_functions};
+    auto inst_create_info = driver.GetVkInstanceCreateInfo();
+    ASSERT_EQ(CreateInst(inst, inst_create_info), VK_SUCCESS);
+
+    WaylandState wayland;
+
+    wayland.display = wl_display_connect(nullptr);
+    ASSERT_NE(wayland.display, nullptr);
+    wayland.registry = wl_display_get_registry(wayland.display);
+    wl_registry_add_listener(wl_display_get_registry(wayland.display), &wayland_registry_listener, static_cast<void*>(&wayland));
+    wl_display_roundtrip(wayland.display);
+    wl_registry_destroy(wayland.registry);
+
+    VkWaylandSurfaceCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+    createInfo.pNext = nullptr;
+    createInfo.flags = 0;
+    createInfo.display = wayland.display;
+    createInfo.surface = wayland.surface;
+
+    VkSurfaceKHR surface;
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.fp_vkCreateWaylandSurfaceKHR(inst, &createInfo, nullptr, &surface));
+    ASSERT_TRUE(surface != VK_NULL_HANDLE);
+
+    env->vulkan_functions.fp_vkDestroySurfaceKHR(inst, surface, nullptr);
+
+    wl_display_disconnect(wayland.display);
+}
+#endif


### PR DESCRIPTION
This PR is a draft: It is meant to gather feedback on the various designs, features, and limitations this test framework offers.

The test framework adds the necessary infrastructure to enable broad testing of the Vulkan-Loader codebase by allowing control over many of the system wide inputs that the loader uses, such as implicit layers and system wide driver lookup. Existing tests were inadequate due to their limited options for  controlling how the loader operates. 

Majority of changes are in `tests/framework` with some notable exceptions:
* loader/loader.c - Addition of crtdbg.h headers in debug mode to disable assert popups
* loader/CMakeLists.txt - Fix Debug mode using mixed CRT's, necessary to disable assert popups
* external/* - Added Detours library on Windows only when testing is enabled
* external/* - Added automated test dependency downloading using DownloadProject.cmake