### PR TITLE
loader: Accept layer manifest version 1.2.0

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3557,8 +3557,9 @@ out:
 }
 
 static inline bool isValidLayerJsonVersion(const layer_json_version *layer_json) {
-    // Supported versions are: 1.0.0, 1.0.1, and 1.1.0 - 1.1.2.
-    if ((layer_json->major == 1 && layer_json->minor == 1 && layer_json->patch < 3) ||
+    // Supported versions are: 1.0.0, 1.0.1, 1.1.0 - 1.1.2, and 1.2.0.
+    if ((layer_json->major == 1 && layer_json->minor == 2 && layer_json->patch < 1) ||
+        (layer_json->major == 1 && layer_json->minor == 1 && layer_json->patch < 3) ||
         (layer_json->major == 1 && layer_json->minor == 0 && layer_json->patch < 2)) {
         return true;
     }


### PR DESCRIPTION
This change only prevents the loader from warning on the new version.

Set as a draft as this may not be necessary depending on whether there will be a version bump or not.

Change-Id: If8c0aedb2e0052d5b6eb6f72fc4e7ad70b58d8a7