### PR TITLE
Add missing root Makefile for build-qnx folder

### DIFF
--- a/build-qnx/Makefile
+++ b/build-qnx/Makefile
@@ -1,0 +1,2 @@
+LIST=OS
+include recurse.mk

--- a/build-qnx/common.mk
+++ b/build-qnx/common.mk
@@ -34,7 +34,7 @@ CCFLAGS += -Wno-stringop-overflow -Wimplicit-fallthrough=0 -fvisibility=hidden
 CCFLAGS += -Wpointer-arith -fPIC
 
 # Enable this if required
-# CCFLAGS += -DVK_ENABLE_BETA_EXTENSIONS
+CCFLAGS += -DVK_ENABLE_BETA_EXTENSIONS
 
 CXXFLAGS += $(CCFLAGS)
 


### PR DESCRIPTION
Hi,

I forgot to force addition of Makefile in the build-qnx folder. Also enable Beta extensions by default, because generated files are using beta extensions.

Thanks.