### PR TITLE
scripts: Switch from mkpath to makedirs

### DIFF
--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -242,7 +242,6 @@ from __future__ import print_function
 
 import argparse
 import json
-import distutils.dir_util
 import os.path
 import subprocess
 import sys
@@ -274,6 +273,12 @@ def on_rm_error( func, path, exc_info):
     """
     os.chmod( path, stat.S_IWRITE )
     os.unlink( path )
+
+def make_or_exist_dirs(path):
+    "Wrapper for os.makedirs that tolerates the directory already existing"
+    # Could use os.makedirs(path, exist_ok=True) if we drop python2
+    if not os.path.isdir(path):
+        os.makedirs(path)
 
 def command_output(cmd, directory, fail_ok=False):
     """Runs a command in a directory and returns its standard output stream.
@@ -346,7 +351,7 @@ class GoodRepo(object):
     def Clone(self, retries=10, retry_seconds=60):
         print('Cloning {n} into {d}'.format(n=self.name, d=self.repo_dir))
         for retry in range(retries):
-            distutils.dir_util.mkpath(self.repo_dir)
+            make_or_exist_dirs(self.repo_dir)
             try:
                 command_output(['git', 'clone', self.url, '.'], self.repo_dir)
                 # If we get here, we didn't raise an error
@@ -426,7 +431,7 @@ class GoodRepo(object):
             shutil.rmtree(self.install_dir)
 
         # Create and change to build directory
-        distutils.dir_util.mkpath(self.build_dir)
+        make_or_exist_dirs(self.build_dir)
         os.chdir(self.build_dir)
 
         cmake_cmd = [
@@ -665,7 +670,7 @@ def main():
     save_cwd = os.getcwd()
 
     # Create working "top" directory if needed
-    distutils.dir_util.mkpath(args.dir)
+    make_or_exist_dirs(args.dir)
     abs_top_dir = os.path.abspath(args.dir)
 
     repos = GetGoodRepos(args)


### PR DESCRIPTION
distutils.dir_util.mkpath will not re-create a directory if it has been removed with shutil.rmtree because it caches the filesystem under the hood. This was causing the clone retry to fail on the second iteration every time it got there.

Switch to using os.makedirs for equivalent functionality without the cache.

More context from Vulkan-Loader CI build 400:

```
Checking out Vulkan-Headers in C:\j\w3\32-bit\Release\Vulkan-Loader\Vulkan-ValidationLayers\external\Vulkan-Headers
Cloning Vulkan-Headers into C:\j\w3\32-bit\Release\Vulkan-Loader\Vulkan-ValidationLayers\external\Vulkan-Headers
*** Error ***
stderr contents:
b"Cloning into '.'...\nfatal: unable to access 'https://github.com/KhronosGroup/Vulkan-Headers.git/': OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443 \n"
Error cloning on iteration 1/10: Failed to run ['git', 'clone', 'https://github.com/KhronosGroup/Vulkan-Headers.git', '.'] in C:\j\w3\32-bit\Release\Vulkan-Loader\Vulkan-ValidationLayers\external\Vulkan-Headers
Waiting 60 seconds before trying again
Removing old tree C:\j\w3\32-bit\Release\Vulkan-Loader\Vulkan-ValidationLayers\external\Vulkan-Headers
----stderr---------------------------------------------------
Your CMake version is 3.10.2. Update to at least 3.16 to enable precompiled headers to speed up incremental builds
Traceback (most recent call last):
  File "scripts\update_deps.py", line 727, in <module>
    main()
  File "scripts\update_deps.py", line 713, in main
    repo.Checkout()
  File "scripts\update_deps.py", line 393, in Checkout
    self.Clone()
  File "scripts\update_deps.py", line 351, in Clone
    command_output(['git', 'clone', self.url, '.'], self.repo_dir)
  File "scripts\update_deps.py", line 288, in command_output
    cmd, cwd=directory, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "C:\Program Files\Python37\lib\subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "C:\Program Files\Python37\lib\subprocess.py", line 1178, in _execute_child
    startupinfo)
NotADirectoryError: [WinError 267] The directory name is invalid
-------------------------------------------------------------
```

Related python bug (TLDR use os.makedirs instead)
https://bugs.python.org/issue10948