### PR TITLE
Match null queue check for vkGetDeviceQueue

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -864,7 +864,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceQueue(VkDevice device, uint3
     disp = loader_get_dispatch(device);
 
     disp->GetDeviceQueue(device, queueNodeIndex, queueIndex, pQueue);
-    if (pQueue != NULL) {
+    if (pQueue != NULL && *pQueue != NULL) {
         loader_set_dispatch(*pQueue, disp);
     }
 }


### PR DESCRIPTION
Hey @lenny-lunarg ... so I think we never actually solved #384 wrong (and it took my almost a year to finally remember to get back to this :disappointed: )

So looking at [InvalidGetDeviceQueue](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/6eaf131c0cd70cc6e7808a5358bf2c90ae4e171d/tests/vklayertests_others.cpp#L9938-L9947)

These tests still segfault. The issue is we did it wrong in #385 

but since then I see the code in `vkGetDeviceQueue2` is now

```
if (pQueue != NULL && *pQueue != NULL) {
```

Which I agree is the correct code, now this PR is just to add it to `vkGetDeviceQueue` which now having the `InvalidGetDeviceQueue` tests, I can verify that it doesn't crash with this PR

cc @ncesario-lunarg 
