### PR TITLE
QNX build: Use headers in the external folder prior to the system Vulkan headers

### DIFF
--- a/build-qnx/common.mk
+++ b/build-qnx/common.mk
@@ -10,6 +10,7 @@ endef
 ICD_ROOT=$(CURDIR)/../../../..
 
 EXTRA_INCVPATH+=$(ICD_ROOT)/build_qnx
+EXTRA_INCVPATH+=$(ICD_ROOT)/external/Vulkan-Headers/include
 
 EXTRA_SRCVPATH+=$(ICD_ROOT)/loader
 EXTRA_SRCVPATH+=$(ICD_ROOT)/loader/generated


### PR DESCRIPTION
This is a small fix for QNX build which adds external folder for Vulkan headers prior to the system headers.
