### PR TITLE
Many small fixes that clang-tidy detected

### DIFF
--- a/loader/allocation.c
+++ b/loader/allocation.c
@@ -39,6 +39,7 @@ void *loader_instance_heap_alloc(const struct loader_instance *instance, size_t 
         pMemory = instance->alloc_callbacks.pfnAllocation(instance->alloc_callbacks.pUserData, size, sizeof(uint64_t), alloc_scope);
     } else {
 #endif
+        assert(size > 0 && "The behavior of malloc undefined if size is zero");
         pMemory = malloc(size);
     }
 
@@ -91,6 +92,7 @@ void *loader_device_heap_alloc(const struct loader_device *device, size_t size, 
         pMemory = device->alloc_callbacks.pfnAllocation(device->alloc_callbacks.pUserData, size, sizeof(uint64_t), alloc_scope);
     } else {
 #endif
+        assert(size > 0 && "The behavior of malloc undefined if size is zero");
         pMemory = malloc(size);
     }
     return pMemory;

--- a/loader/extension_manual.c
+++ b/loader/extension_manual.c
@@ -160,6 +160,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_ReleaseDisplayEXT(VkPhysicalDevice phy
                    "ICD \"%s\" associated with VkPhysicalDevice does not support vkReleaseDisplayEXT - Consequently, the call is "
                    "invalid because it should not be possible to acquire a display on this device",
                    icd_term->scanned_icd->lib_name);
+        abort();
     }
     return icd_term->dispatch.ReleaseDisplayEXT(phys_dev_term->phys_dev, display);
 }
@@ -241,6 +242,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfacePresentModes2E
     if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfacePresentModes2EXT) {
         loader_log(icd_term->this_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD associated with VkPhysicalDevice does not support GetPhysicalDeviceSurfacePresentModes2EXT");
+        abort();
     }
     VkIcdSurface *icd_surface = (VkIcdSurface *)(pSurfaceInfo->surface);
     uint8_t icd_index = phys_dev_term->icd_index;

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4981,7 +4981,6 @@ VkResult loader_create_device_chain(const VkPhysicalDevice pd, const VkDeviceCre
 
                     // Replace the old struct in the pNext chain with this one.
                     pPrev->pNext = (VkBaseOutStructure *)temp_struct;
-                    pNext = (VkBaseOutStructure *)temp_struct;
                 }
                 break;
             }
@@ -5656,7 +5655,6 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
 
                     // Replace the old struct in the pNext chain with this one.
                     pPrev->pNext = (VkBaseOutStructure *)temp_struct;
-                    pNext = (VkBaseOutStructure *)temp_struct;
                 }
                 break;
             }

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -6543,6 +6543,13 @@ VkResult setup_loader_term_phys_dev_groups(struct loader_instance *inst) {
         total_count += cur_icd_group_count;
     }
 
+    if (total_count == 0) {
+        loader_log(inst, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, 0,
+                   "setupLoaderTermPhysDevGroups:  Did not detect any GPU Groups"
+                   " in the current config");
+        goto out;
+    }
+
     // Create an array for the new physical device groups, which will be stored
     // in the instance for the Terminator code.
     new_phys_dev_groups = (VkPhysicalDeviceGroupProperties **)loader_instance_heap_alloc(

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -6396,6 +6396,7 @@ terminator_EnumerateInstanceExtensionProperties(const VkEnumerateInstanceExtensi
 
     memset(&local_ext_list, 0, sizeof(local_ext_list));
     memset(&instance_layers, 0, sizeof(instance_layers));
+    memset(&icd_tramp_list, 0, sizeof(icd_tramp_list));
 
     // Get layer libraries if needed
     if (pLayerName && strlen(pLayerName) != 0) {
@@ -6418,7 +6419,6 @@ terminator_EnumerateInstanceExtensionProperties(const VkEnumerateInstanceExtensi
         loader_preload_icds();
 
         // Scan/discover all ICD libraries
-        memset(&icd_tramp_list, 0, sizeof(icd_tramp_list));
         res = loader_icd_scan(NULL, &icd_tramp_list);
         // EnumerateInstanceExtensionProperties can't return anything other than OOM or VK_ERROR_LAYER_NOT_PRESENT
         if ((VK_SUCCESS != res && icd_tramp_list.count > 0) || res == VK_ERROR_OUT_OF_HOST_MEMORY) {

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4329,12 +4329,12 @@ bool loader_phys_dev_ext_gpa(struct loader_instance *inst, const char *funcName,
     idx = murmurhash(funcName, strlen(funcName), seed) % MAX_NUM_UNKNOWN_EXTS;
     if (perform_checking && !loader_name_in_phys_dev_ext_table(inst, &idx, funcName)) {
         uint32_t i;
-        bool added = false;
 
         // Only need to add first one to get index in Instance.  Others will use
         // the same index.
-        if (!added && loader_add_phys_dev_ext_table(inst, &idx, funcName)) {
-            added = true;
+        if (!loader_add_phys_dev_ext_table(inst, &idx, funcName)) {
+            // couldn't perform the above function due to insufficient memory available
+            goto out;
         }
 
         // Setup the ICD function pointers

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -6235,11 +6235,13 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateDeviceExtensionProperties(VkP
         if (res != VK_SUCCESS) {
             goto out;
         }
-        icd_props_list = loader_instance_heap_alloc(icd_term->this_instance, sizeof(VkExtensionProperties) * icd_ext_count,
-                                                    VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-        if (NULL == icd_props_list) {
-            res = VK_ERROR_OUT_OF_HOST_MEMORY;
-            goto out;
+        if (icd_ext_count > 0) {
+            icd_props_list = loader_instance_heap_alloc(icd_term->this_instance, sizeof(VkExtensionProperties) * icd_ext_count,
+                                                        VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
+            if (NULL == icd_props_list) {
+                res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                goto out;
+            }
         }
     }
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1911,7 +1911,6 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
     {                                                                      \
         var = cJSON_GetObjectItem(node, #var);                             \
         if (var == NULL) {                                                 \
-            layer_node = layer_node->next;                                 \
             loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,                    \
                        "Didn't find required layer object %s in manifest " \
                        "JSON file, skipping this layer",                   \
@@ -1923,7 +1922,6 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
     {                                                                          \
         item = cJSON_GetObjectItem(node, #var);                                \
         if (item == NULL) {                                                    \
-            layer_node = layer_node->next;                                     \
             loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,                        \
                        "Didn't find required layer value %s in manifest JSON " \
                        "file, skipping this layer",                            \
@@ -1932,7 +1930,6 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
         }                                                                      \
         temp = cJSON_Print(inst, item);                                        \
         if (temp == NULL) {                                                    \
-            layer_node = layer_node->next;                                     \
             loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,                        \
                        "Problem accessing layer value %s in manifest JSON "    \
                        "file, skipping this layer",                            \
@@ -1953,8 +1950,7 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
 
     // Add list entry
     if (!strcmp(type, "DEVICE")) {
-        loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0, "Device layers are deprecated skipping this layer");
-        layer_node = layer_node->next;
+        loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0, "Device layers are deprecated. Skipping this layer");
         goto out;
     }
 
@@ -1962,7 +1958,6 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
     // layers that must work with older loaders
     if (!strcmp(type, "INSTANCE") || !strcmp(type, "GLOBAL")) {
         if (layer_instance_list == NULL) {
-            layer_node = layer_node->next;
             goto out;
         }
         props = loader_get_next_layer_property_slot(inst, layer_instance_list);
@@ -1976,7 +1971,6 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
             props->type_flags |= VK_LAYER_TYPE_FLAG_EXPLICIT_LAYER;
         }
     } else {
-        layer_node = layer_node->next;
         goto out;
     }
 
@@ -2063,7 +2057,6 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
 
         temp = cJSON_Print(inst, library_path);
         if (NULL == temp) {
-            layer_node = layer_node->next;
             loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
                        "Problem accessing layer value library_path in manifest JSON file, skipping this layer");
             result = VK_ERROR_OUT_OF_HOST_MEMORY;
@@ -2228,7 +2221,6 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
         if (!disable_environment || !disable_environment->child) {
             loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
                        "Didn't find required layer child value disable_environment in manifest JSON file, skipping this layer");
-            layer_node = layer_node->next;
             goto out;
         }
         strncpy(props->disable_env_var.name, disable_environment->child->string, sizeof(props->disable_env_var.name));

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4991,21 +4991,21 @@ VkResult loader_create_device_chain(const VkPhysicalDevice pd, const VkDeviceCre
             pNext = pNext->pNext;
         }
     }
-
-    layer_device_link_info = loader_stack_alloc(sizeof(VkLayerDeviceLink) * dev->expanded_activated_layer_list.count);
-    if (!layer_device_link_info) {
-        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "loader_create_device_chain: Failed to alloc Device objects for layer. Skipping Layer.");
-        return VK_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
-    activated_layer_names = loader_stack_alloc(sizeof(char *) * inst->expanded_activated_layer_list.count);
-    if (!activated_layer_names) {
-        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "loader_create_instance_chain: Failed to alloc activated layer names array");
-        return VK_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
     if (dev->expanded_activated_layer_list.count > 0) {
+        layer_device_link_info = loader_stack_alloc(sizeof(VkLayerDeviceLink) * dev->expanded_activated_layer_list.count);
+        if (!layer_device_link_info) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+                       "loader_create_device_chain: Failed to alloc Device objects for layer. Skipping Layer.");
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        activated_layer_names = loader_stack_alloc(sizeof(char *) * inst->expanded_activated_layer_list.count);
+        if (!activated_layer_names) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+                       "loader_create_instance_chain: Failed to alloc activated layer names array");
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
         chain_info.sType = VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO;
         chain_info.function = VK_LAYER_LINK_INFO;
         chain_info.u.pLayerInfo = NULL;

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4105,7 +4105,7 @@ static bool loader_name_in_dev_ext_table(struct loader_instance *inst, uint32_t 
     // search the list of secondary locations (shallow search, not deep search)
     for (uint32_t i = 0; i < inst->dev_ext_disp_hash[*idx].list.count; i++) {
         alt_idx = inst->dev_ext_disp_hash[*idx].list.index[i];
-        if (!strcmp(inst->dev_ext_disp_hash[*idx].func_name, funcName)) {
+        if (inst->dev_ext_disp_hash[*idx].func_name && !strcmp(inst->dev_ext_disp_hash[*idx].func_name, funcName)) {
             *idx = alt_idx;
             return true;
         }
@@ -4266,7 +4266,7 @@ static bool loader_name_in_phys_dev_ext_table(struct loader_instance *inst, uint
     // search the list of secondary locations (shallow search, not deep search)
     for (uint32_t i = 0; i < inst->phys_dev_ext_disp_hash[*idx].list.count; i++) {
         alt_idx = inst->phys_dev_ext_disp_hash[*idx].list.index[i];
-        if (!strcmp(inst->phys_dev_ext_disp_hash[*idx].func_name, funcName)) {
+        if (inst->phys_dev_ext_disp_hash[*idx].func_name && !strcmp(inst->phys_dev_ext_disp_hash[*idx].func_name, funcName)) {
             *idx = alt_idx;
             return true;
         }

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -6447,7 +6447,7 @@ terminator_EnumerateInstanceExtensionProperties(const VkEnumerateInstanceExtensi
     }
 
 out:
-
+    loader_destroy_generic_list(NULL, (struct loader_generic_list *)&icd_tramp_list);
     loader_destroy_generic_list(NULL, (struct loader_generic_list *)&local_ext_list);
     loader_delete_layer_list_and_properties(NULL, &instance_layers);
     return res;
@@ -6812,7 +6812,6 @@ out:
             }
             loader_instance_heap_free(inst, new_phys_dev_groups);
         }
-        total_count = 0;
     } else {
         // Free everything that didn't carry over to the new array of
         // physical device groups

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3617,7 +3617,6 @@ void loader_scan_for_layers(struct loader_instance *inst, struct loader_layer_li
     if (manifest_files.count == 0 && total_count == 0) {
         goto out;
     } else {
-        total_count += manifest_files.count;
         for (uint32_t i = 0; i < manifest_files.count; i++) {
             file_str = manifest_files.filename_list[i];
             if (file_str == NULL) {

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -230,14 +230,14 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceSupportKHR(VkP
     if (NULL == pSupported) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "NULL pointer passed into vkGetPhysicalDeviceSurfaceSupportKHR for pSupported!\n");
-        assert(false && "GetPhysicalDeviceSurfaceSupportKHR: Error, null pSupported");
+        abort();
     }
     *pSupported = false;
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfaceSupportKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetPhysicalDeviceSurfaceSupportKHR!\n");
-        assert(false && "loader: null GetPhysicalDeviceSurfaceSupportKHR ICD pointer");
+        abort();
     }
 
     VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
@@ -277,13 +277,13 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilitiesKH
     if (NULL == pSurfaceCapabilities) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "NULL pointer passed into vkGetPhysicalDeviceSurfaceCapabilitiesKHR for pSurfaceCapabilities!\n");
-        assert(false && "GetPhysicalDeviceSurfaceCapabilitiesKHR: Error, null pSurfaceCapabilities");
+        abort();
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfaceCapabilitiesKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetPhysicalDeviceSurfaceCapabilitiesKHR!\n");
-        assert(false && "loader: null GetPhysicalDeviceSurfaceCapabilitiesKHR ICD pointer");
+        abort();
     }
 
     VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
@@ -325,13 +325,13 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormatsKHR(VkP
     if (NULL == pSurfaceFormatCount) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "NULL pointer passed into vkGetPhysicalDeviceSurfaceFormatsKHR for pSurfaceFormatCount!\n");
-        assert(false && "GetPhysicalDeviceSurfaceFormatsKHR(: Error, null pSurfaceFormatCount");
+        abort();
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfaceFormatsKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetPhysicalDeviceSurfaceCapabilitiesKHR!\n");
-        assert(false && "loader: null GetPhysicalDeviceSurfaceFormatsKHR ICD pointer");
+        abort();
     }
 
     VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
@@ -375,13 +375,13 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfacePresentModesKH
     if (NULL == pPresentModeCount) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "NULL pointer passed into vkGetPhysicalDeviceSurfacePresentModesKHR for pPresentModeCount!\n");
-        assert(false && "GetPhysicalDeviceSurfacePresentModesKHR(: Error, null pPresentModeCount");
+        abort();
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfacePresentModesKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetPhysicalDeviceSurfacePresentModesKHR!\n");
-        assert(false && "loader: null GetPhysicalDeviceSurfacePresentModesKHR ICD pointer");
+        abort();
     }
 
     VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
@@ -592,7 +592,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceWin32PresentationSupp
     if (NULL == icd_term->dispatch.GetPhysicalDeviceWin32PresentationSupportKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetPhysicalDeviceWin32PresentationSupportKHR!\n");
-        assert(false && "loader: null GetPhysicalDeviceWin32PresentationSupportKHR ICD pointer");
+        abort();
     }
 
     return icd_term->dispatch.GetPhysicalDeviceWin32PresentationSupportKHR(phys_dev_term->phys_dev, queueFamilyIndex);
@@ -706,7 +706,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceWaylandPresentationSu
     if (NULL == icd_term->dispatch.GetPhysicalDeviceWaylandPresentationSupportKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetPhysicalDeviceWaylandPresentationSupportKHR!\n");
-        assert(false && "loader: null GetPhysicalDeviceWaylandPresentationSupportKHR ICD pointer");
+        abort();
     }
 
     return icd_term->dispatch.GetPhysicalDeviceWaylandPresentationSupportKHR(phys_dev_term->phys_dev, queueFamilyIndex, display);
@@ -822,7 +822,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceXcbPresentationSuppor
     if (NULL == icd_term->dispatch.GetPhysicalDeviceXcbPresentationSupportKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetPhysicalDeviceXcbPresentationSupportKHR!\n");
-        assert(false && "loader: null GetPhysicalDeviceXcbPresentationSupportKHR ICD pointer");
+        abort();
     }
 
     return icd_term->dispatch.GetPhysicalDeviceXcbPresentationSupportKHR(phys_dev_term->phys_dev, queueFamilyIndex, connection,
@@ -937,7 +937,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceXlibPresentationSuppo
     if (NULL == icd_term->dispatch.GetPhysicalDeviceXlibPresentationSupportKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetPhysicalDeviceXlibPresentationSupportKHR!\n");
-        assert(false && "loader: null GetPhysicalDeviceXlibPresentationSupportKHR ICD pointer");
+        abort();
     }
 
     return icd_term->dispatch.GetPhysicalDeviceXlibPresentationSupportKHR(phys_dev_term->phys_dev, queueFamilyIndex, dpy, visualID);
@@ -1055,7 +1055,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceDirectFBPresentationS
     if (NULL == icd_term->dispatch.GetPhysicalDeviceDirectFBPresentationSupportEXT) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetPhysicalDeviceDirectFBPresentationSupportEXT!\n");
-        assert(false && "loader: null GetPhysicalDeviceDirectFBPresentationSupportEXT ICD pointer");
+        abort();
     }
 
     return icd_term->dispatch.GetPhysicalDeviceDirectFBPresentationSupportEXT(phys_dev_term->phys_dev, queueFamilyIndex, dfb);
@@ -1549,7 +1549,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceScreenPresentationSup
     if (NULL == icd_term->dispatch.GetPhysicalDeviceScreenPresentationSupportQNX) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetPhysicalDeviceScreenPresentationSupportQNX!\n");
-        assert(false && "loader: null GetPhysicalDeviceScreenPresentationSupportQNX ICD pointer");
+        abort();
     }
 
     return icd_term->dispatch.GetPhysicalDeviceScreenPresentationSupportQNX(phys_dev_term->phys_dev, queueFamilyIndex, window);
@@ -1643,7 +1643,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayPlaneSupportedDisplaysKHR(Vk
     if (NULL == icd_term->dispatch.GetDisplayPlaneSupportedDisplaysKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetDisplayPlaneSupportedDisplaysKHR!\n");
-        assert(false && "loader: null GetDisplayPlaneSupportedDisplaysKHR ICD pointer");
+        abort();
     }
 
     return icd_term->dispatch.GetDisplayPlaneSupportedDisplaysKHR(phys_dev_term->phys_dev, planeIndex, pDisplayCount, pDisplays);
@@ -1675,7 +1675,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayModePropertiesKHR(VkPhysical
     if (NULL == icd_term->dispatch.GetDisplayModePropertiesKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetDisplayModePropertiesKHR!\n");
-        assert(false && "loader: null GetDisplayModePropertiesKHR ICD pointer");
+        abort();
     }
 
     return icd_term->dispatch.GetDisplayModePropertiesKHR(phys_dev_term->phys_dev, display, pPropertyCount, pProperties);
@@ -1708,7 +1708,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDisplayModeKHR(VkPhysicalDevice 
     if (NULL == icd_term->dispatch.CreateDisplayModeKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkCreateDisplayModeKHR!\n");
-        assert(false && "loader: null CreateDisplayModeKHR ICD pointer");
+        abort();
     }
 
     return icd_term->dispatch.CreateDisplayModeKHR(phys_dev_term->phys_dev, display, pCreateInfo, pAllocator, pMode);
@@ -1740,7 +1740,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayPlaneCapabilitiesKHR(VkPhysi
     if (NULL == icd_term->dispatch.GetDisplayPlaneCapabilitiesKHR) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device is not exporting vkGetDisplayPlaneCapabilitiesKHR!\n");
-        assert(false && "loader: null GetDisplayPlaneCapabilitiesKHR ICD pointer");
+        abort();
     }
 
     return icd_term->dispatch.GetDisplayPlaneCapabilitiesKHR(phys_dev_term->phys_dev, mode, planeIndex, pCapabilities);
@@ -1909,6 +1909,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDevicePresentRectanglesKHR(
     if (NULL == icd_term->dispatch.GetPhysicalDevicePresentRectanglesKHR) {
         loader_log(icd_term->this_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD associated with VkPhysicalDevice does not support GetPhysicalDevicePresentRectanglesKHX");
+        abort();
     }
     VkIcdSurface *icd_surface = (VkIcdSurface *)(surface);
     uint8_t icd_index = phys_dev_term->icd_index;

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -223,7 +223,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceSupportKHR(VkP
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_surface extension not enabled.  vkGetPhysicalDeviceSurfaceSupportKHR not executed!\n");
+                   "VK_KHR_surface extension not enabled. vkGetPhysicalDeviceSurfaceSupportKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -270,7 +270,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilitiesKH
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_surface extension not enabled.  vkGetPhysicalDeviceSurfaceCapabilitiesKHR not executed!\n");
+                   "VK_KHR_surface extension not enabled. vkGetPhysicalDeviceSurfaceCapabilitiesKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -318,7 +318,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormatsKHR(VkP
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_surface extension not enabled.  vkGetPhysicalDeviceSurfaceFormatsKHR not executed!\n");
+                   "VK_KHR_surface extension not enabled. vkGetPhysicalDeviceSurfaceFormatsKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -368,7 +368,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfacePresentModesKH
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_surface extension not enabled.  vkGetPhysicalDeviceSurfacePresentModesKHR not executed!\n");
+                   "VK_KHR_surface extension not enabled. vkGetPhysicalDeviceSurfacePresentModesKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -515,7 +515,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateWin32SurfaceKHR(VkInstance insta
     struct loader_instance *ptr_instance = loader_get_instance(instance);
     if (!ptr_instance->wsi_win32_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_win32_surface extension not enabled.  vkCreateWin32SurfaceKHR not executed!\n");
+                   "VK_KHR_win32_surface extension not enabled. vkCreateWin32SurfaceKHR not executed!\n");
         vkRes = VK_ERROR_EXTENSION_NOT_PRESENT;
         goto out;
     }
@@ -585,7 +585,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceWin32PresentationSupp
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_win32_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_win32_surface extension not enabled.  vkGetPhysicalDeviceWin32PresentationSupportKHR not executed!\n");
+                   "VK_KHR_win32_surface extension not enabled. vkGetPhysicalDeviceWin32PresentationSupportKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -626,7 +626,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateWaylandSurfaceKHR(VkInstance ins
     struct loader_instance *ptr_instance = loader_get_instance(instance);
     if (!ptr_instance->wsi_wayland_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_wayland_surface extension not enabled.  vkCreateWaylandSurfaceKHR not executed!\n");
+                   "VK_KHR_wayland_surface extension not enabled. vkCreateWaylandSurfaceKHR not executed!\n");
         vkRes = VK_ERROR_EXTENSION_NOT_PRESENT;
         goto out;
     }
@@ -699,7 +699,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceWaylandPresentationSu
     if (!ptr_instance->wsi_wayland_surface_enabled) {
         loader_log(
             ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-            "VK_KHR_wayland_surface extension not enabled.  vkGetPhysicalDeviceWaylandPresentationSupportKHR not executed!\n");
+            "VK_KHR_wayland_surface extension not enabled. vkGetPhysicalDeviceWaylandPresentationSupportKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -741,7 +741,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateXcbSurfaceKHR(VkInstance instanc
     struct loader_instance *ptr_instance = loader_get_instance(instance);
     if (!ptr_instance->wsi_xcb_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_xcb_surface extension not enabled.  vkCreateXcbSurfaceKHR not executed!\n");
+                   "VK_KHR_xcb_surface extension not enabled. vkCreateXcbSurfaceKHR not executed!\n");
         vkRes = VK_ERROR_EXTENSION_NOT_PRESENT;
         goto out;
     }
@@ -815,7 +815,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceXcbPresentationSuppor
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_xcb_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_xcb_surface extension not enabled.  vkGetPhysicalDeviceXcbPresentationSupportKHR not executed!\n");
+                   "VK_KHR_xcb_surface extension not enabled. vkGetPhysicalDeviceXcbPresentationSupportKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -858,7 +858,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateXlibSurfaceKHR(VkInstance instan
     struct loader_instance *ptr_instance = loader_get_instance(instance);
     if (!ptr_instance->wsi_xlib_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_xlib_surface extension not enabled.  vkCreateXlibSurfaceKHR not executed!\n");
+                   "VK_KHR_xlib_surface extension not enabled. vkCreateXlibSurfaceKHR not executed!\n");
         vkRes = VK_ERROR_EXTENSION_NOT_PRESENT;
         goto out;
     }
@@ -930,7 +930,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceXlibPresentationSuppo
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_xlib_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_xlib_surface extension not enabled.  vkGetPhysicalDeviceXlibPresentationSupportKHR not executed!\n");
+                   "VK_KHR_xlib_surface extension not enabled. vkGetPhysicalDeviceXlibPresentationSupportKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -974,7 +974,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDirectFBSurfaceEXT(VkInstance in
     struct loader_instance *ptr_instance = loader_get_instance(instance);
     if (!ptr_instance->wsi_directfb_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_EXT_directfb_surface extension not enabled.  vkCreateDirectFBSurfaceEXT not executed!\n");
+                   "VK_EXT_directfb_surface extension not enabled. vkCreateDirectFBSurfaceEXT not executed!\n");
         vkRes = VK_ERROR_EXTENSION_NOT_PRESENT;
         goto out;
     }
@@ -1048,7 +1048,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceDirectFBPresentationS
     if (!ptr_instance->wsi_directfb_surface_enabled) {
         loader_log(
             ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-            "VK_EXT_directfb_surface extension not enabled.  vkGetPhysicalDeviceWaylandPresentationSupportKHR not executed!\n");
+            "VK_EXT_directfb_surface extension not enabled. vkGetPhysicalDeviceWaylandPresentationSupportKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -1087,7 +1087,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateAndroidSurfaceKHR(VkInstance ins
     struct loader_instance *ptr_instance = loader_get_instance(instance);
     if (!ptr_instance->wsi_display_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_display extension not enabled.  vkCreateAndroidSurfaceKHR not executed!\n");
+                   "VK_KHR_display extension not enabled. vkCreateAndroidSurfaceKHR not executed!\n");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
@@ -1205,7 +1205,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateMacOSSurfaceMVK(VkInstance insta
     struct loader_instance *ptr_instance = loader_get_instance(instance);
     if (!ptr_instance->wsi_macos_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_MVK_macos_surface extension not enabled.  vkCreateMacOSSurfaceMVK not executed!\n");
+                   "VK_MVK_macos_surface extension not enabled. vkCreateMacOSSurfaceMVK not executed!\n");
         vkRes = VK_ERROR_EXTENSION_NOT_PRESENT;
         goto out;
     }
@@ -1279,7 +1279,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateIOSSurfaceMVK(VkInstance instanc
     struct loader_instance *ptr_instance = loader_get_instance(instance);
     if (!ptr_instance->wsi_ios_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_MVK_ios_surface extension not enabled.  vkCreateIOSSurfaceMVK not executed!\n");
+                   "VK_MVK_ios_surface extension not enabled. vkCreateIOSSurfaceMVK not executed!\n");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
@@ -1328,7 +1328,7 @@ terminator_CreateStreamDescriptorSurfaceGGP(VkInstance instance, const VkStreamD
     struct loader_instance *ptr_instance = loader_get_instance(instance);
     if (!ptr_instance->wsi_ggp_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_GGP_stream_descriptor_surface extension not enabled.  vkCreateStreamDescriptorSurfaceGGP not executed!\n");
+                   "VK_GGP_stream_descriptor_surface extension not enabled. vkCreateStreamDescriptorSurfaceGGP not executed!\n");
         vkRes = VK_ERROR_EXTENSION_NOT_PRESENT;
         goto out;
     }
@@ -1470,7 +1470,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateScreenSurfaceQNX(VkInstance inst
     struct loader_instance *ptr_instance = loader_get_instance(instance);
     if (!ptr_instance->wsi_screen_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_QNX_screen_surface extension not enabled.  vkCreateScreenSurfaceQNX not executed!\n");
+                   "VK_QNX_screen_surface extension not enabled. vkCreateScreenSurfaceQNX not executed!\n");
         vkRes = VK_ERROR_EXTENSION_NOT_PRESENT;
         goto out;
     }
@@ -1542,7 +1542,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceScreenPresentationSup
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_screen_surface_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_QNX_screen_surface extension not enabled.  vkGetPhysicalDeviceScreenPresentationSupportQNX not executed!\n");
+                   "VK_QNX_screen_surface extension not enabled. vkGetPhysicalDeviceScreenPresentationSupportQNX not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -1576,7 +1576,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceDisplayPropertiesKHR(
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_display_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_display extension not enabled.  vkGetPhysicalDeviceDisplayPropertiesKHR not executed!\n");
+                   "VK_KHR_display extension not enabled. vkGetPhysicalDeviceDisplayPropertiesKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -1606,7 +1606,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceDisplayPlanePropertie
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_display_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_display extension not enabled.  vkGetPhysicalDeviceDisplayPlanePropertiesKHR not executed!\n");
+                   "VK_KHR_display extension not enabled. vkGetPhysicalDeviceDisplayPlanePropertiesKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -1636,7 +1636,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayPlaneSupportedDisplaysKHR(Vk
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_display_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_display extension not enabled.  vkGetDisplayPlaneSupportedDisplaysKHR not executed!\n");
+                   "VK_KHR_display extension not enabled. vkGetDisplayPlaneSupportedDisplaysKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -1668,7 +1668,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayModePropertiesKHR(VkPhysical
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_display_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_display extension not enabled.  vkGetDisplayModePropertiesKHR not executed!\n");
+                   "VK_KHR_display extension not enabled. vkGetDisplayModePropertiesKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -1701,7 +1701,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDisplayModeKHR(VkPhysicalDevice 
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_display_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_display extension not enabled.  vkCreateDisplayModeKHR not executed!\n");
+                   "VK_KHR_display extension not enabled. vkCreateDisplayModeKHR not executed!\n");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
@@ -1733,7 +1733,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayPlaneCapabilitiesKHR(VkPhysi
     struct loader_instance *ptr_instance = (struct loader_instance *)icd_term->this_instance;
     if (!ptr_instance->wsi_display_enabled) {
         loader_log(ptr_instance, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_display extension not enabled.  vkGetDisplayPlaneCapabilitiesKHR not executed!\n");
+                   "VK_KHR_display extension not enabled. vkGetDisplayPlaneCapabilitiesKHR not executed!\n");
         return VK_SUCCESS;
     }
 
@@ -1769,7 +1769,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDisplayPlaneSurfaceKHR(VkInstanc
 
     if (!inst->wsi_display_enabled) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_surface extension not enabled.  vkCreateDisplayPlaneSurfaceKHR not executed!\n");
+                   "VK_KHR_surface extension not enabled. vkCreateDisplayPlaneSurfaceKHR not executed!\n");
         vkRes = VK_ERROR_EXTENSION_NOT_PRESENT;
         goto out;
     }


### PR DESCRIPTION
Fixes include:
* Explicitly calling abort or assert instead of crashing when the loader intends to crash, documenting desired behavior
* Assert against `malloc`'s of size 0, as that is undefined behavior
* Remove redundant stores - several places where assignment was not doing anything
* Guard against passing `NULL` into `strcmp`
* Assert `instance != NULL` at the beginning of functions to remove multiple individual checks.