### PR TITLE
loader: Silence erroneous implicit layer warning

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4952,7 +4952,7 @@ void loaderScanForImplicitLayers(struct loader_instance *inst, struct loader_lay
                 continue;
             }
 
-            res = loaderAddLayerProperties(inst, instance_layers, json, true, file_str);
+            res = loaderAddLayerProperties(inst, instance_layers, json, false, file_str);
 
             loader_instance_heap_free(inst, file_str);
             manifest_files.filename_list[i] = NULL;


### PR DESCRIPTION
When the override layer or an implicit meta layer is detected, the loader will
go and find all of the explicit layers because the override/meta layer might
require them. During that process `loaderAddLayerProperties` is called. It was
accidentally called with `is_implicit = true`, which causes the loader to interpret the manifest files as if they were implicit, generating
many erroneous warnings.

Fixes #582

Change-Id: I8bc6bfa0d2a81159ebc33406e18ebf2099355768