### PR TITLE
Enable regression tests in Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
               run: git clone --branch release-1.8.1 https://github.com/google/googletest.git external/googletest
 
             - name: Generate build files
-              run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -Cexternal/helper.cmake
+              run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -DBUILD_TESTS=On -Cexternal/helper.cmake
               env:
                 CC: ${{matrix.cc}}
                 CXX: ${{matrix.cxx}}
@@ -97,11 +97,11 @@ jobs:
               run: git clone --branch v4.0.1 https://github.com/microsoft/Detours.git external/detours
 
             - name: Generate build files
-              run: cmake -S. -Bbuild -A${{matrix.arch}} "-Cexternal/helper.cmake"
+              run: cmake -S. -Bbuild -A${{matrix.arch}} -DBUILD_TESTS=On "-Cexternal/helper.cmake"
               if: matrix.os != 'windows-2016'
 
             - name: Generate build files
-              run: cmake -S. -Bbuild -A${{matrix.arch}} "-DCMAKE_SYSTEM_VERSION=10.0.17763.0" "-Cexternal/helper.cmake"
+              run: cmake -S. -Bbuild -A${{matrix.arch}}  -DBUILD_TESTS=On "-DCMAKE_SYSTEM_VERSION=10.0.17763.0" "-Cexternal/helper.cmake"
               if: matrix.os == 'windows-2016'
 
             - name: Build the loader

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,8 @@ jobs:
               run: make -C build
 
             - name: Run regression tests
-              run: ./build/tests/test_regression
+              working-directory: ./build
+              run: ctest --output-on-failure
 
             - name: Verify generated source files
               run: python scripts/generate_source.py --verify external/Vulkan-Headers/registry
@@ -105,6 +106,10 @@ jobs:
 
             - name: Build the loader
               run: cmake --build ./build --config ${{matrix.config}}
+
+            - name: Run regression tests
+              working-directory: ./build
+              run: ctest --output-on-failure
 
             - name: Verify generated source files
               run: python scripts/generate_source.py --verify external/Vulkan-Headers/registry

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@
 # ~~~
 
 add_executable(vk_loader_validation_tests loader_validation_tests.cpp)
-add_test(NAME vk_loader_validation_tests COMMAND vk_loader_validation_tests)
+#add_test(NAME vk_loader_validation_tests COMMAND vk_loader_validation_tests)
 
 set_target_properties(vk_loader_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
 if(UNIX)
@@ -139,10 +139,12 @@ add_subdirectory(layers)
 
 option(TEST_USE_ADDRESS_SANITIZER "Linux only: Advanced memory checking" OFF)
 
+include(GoogleTest)
 add_subdirectory(framework)
 
 add_executable(test_regression loader_testing_main.cpp loader_regression_tests.cpp loader_version_tests.cpp)
 target_link_libraries(test_regression PRIVATE testing_dependencies)
+gtest_discover_tests(test_regression)
 
 add_executable(test_wsi loader_testing_main.cpp loader_wsi_tests.cpp)
 target_link_libraries(test_wsi PRIVATE testing_dependencies)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,28 +112,28 @@ endif()
 target_link_libraries(vk_loader_validation_tests "${LOADER_LIB}" gtest gtest_main)
 
 # Copy loader and googletest (gtest) libs to test dir so the test executable can find them.
-if(WIN32)
-    file(COPY vk_loader_validation_tests.vcxproj.user DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
-    if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
-        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIG>/gtest_main$<$<CONFIG:Debug>:d>.dll
-                            GTEST_COPY_SRC1)
-        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIG>/gtest$<$<CONFIG:Debug>:d>.dll
-                            GTEST_COPY_SRC2)
-        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG> GTEST_COPY_DEST)
-    else()
-        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/gtest_main$<$<CONFIG:Debug>:d>.dll GTEST_COPY_SRC1)
-        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/gtest$<$<CONFIG:Debug>:d>.dll GTEST_COPY_SRC2)
-        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR} GTEST_COPY_DEST)
-    endif()
-    add_custom_command(TARGET vk_loader_validation_tests POST_BUILD
-                       COMMAND ${CMAKE_COMMAND} -E copy ${GTEST_COPY_SRC1} ${GTEST_COPY_DEST}
-                       COMMAND ${CMAKE_COMMAND} -E copy ${GTEST_COPY_SRC2} ${GTEST_COPY_DEST})
-    # Copy the loader shared lib (if built) to the test application directory so the test app finds it.
-    if(TARGET vulkan)
-        add_custom_command(TARGET vk_loader_validation_tests POST_BUILD
-                           COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:vulkan> $<TARGET_FILE_DIR:vk_loader_validation_tests>)
-    endif()
-endif()
+#if(WIN32)
+#    file(COPY vk_loader_validation_tests.vcxproj.user DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+#    if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
+#        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIG>/gtest_main$<$<CONFIG:Debug>:d>.dll
+#                            GTEST_COPY_SRC1)
+#        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIG>/gtest$<$<CONFIG:Debug>:d>.dll
+#                            GTEST_COPY_SRC2)
+#        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG> GTEST_COPY_DEST)
+#    else()
+#        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/gtest_main$<$<CONFIG:Debug>:d>.dll GTEST_COPY_SRC1)
+#        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/gtest$<$<CONFIG:Debug>:d>.dll GTEST_COPY_SRC2)
+#        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR} GTEST_COPY_DEST)
+#    endif()
+#    add_custom_command(TARGET vk_loader_validation_tests POST_BUILD
+#                       COMMAND ${CMAKE_COMMAND} -E copy ${GTEST_COPY_SRC1} ${GTEST_COPY_DEST}
+#                       COMMAND ${CMAKE_COMMAND} -E copy ${GTEST_COPY_SRC2} ${GTEST_COPY_DEST})
+#    # Copy the loader shared lib (if built) to the test application directory so the test app finds it.
+#    if(TARGET vulkan)
+#        add_custom_command(TARGET vk_loader_validation_tests POST_BUILD
+#                           COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:vulkan> $<TARGET_FILE_DIR:vk_loader_validation_tests>)
+#    endif()
+#endif()
 
 add_subdirectory(layers)
 
@@ -144,7 +144,6 @@ add_subdirectory(framework)
 
 add_executable(test_regression loader_testing_main.cpp loader_regression_tests.cpp loader_version_tests.cpp)
 target_link_libraries(test_regression PRIVATE testing_dependencies)
-gtest_discover_tests(test_regression)
 
 add_executable(test_wsi loader_testing_main.cpp loader_wsi_tests.cpp)
 target_link_libraries(test_wsi PRIVATE testing_dependencies)
@@ -176,3 +175,6 @@ if(WIN32)
                            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:vulkan> $<TARGET_FILE_DIR:test_regression>)
     endif()
 endif()
+
+#must happen after the dll's get copied over
+gtest_discover_tests(test_regression)

--- a/tests/framework/icd/CMakeLists.txt
+++ b/tests/framework/icd/CMakeLists.txt
@@ -56,3 +56,12 @@ target_compile_definitions(test_icd_version_2_export_icd_enumerate_adapter_physi
 add_library(test_icd_version_2_export_icd_gpdpa SHARED ${TEST_ICD_SOURCES})
 target_link_libraries(test_icd_version_2_export_icd_gpdpa PRIVATE test_icd_deps)
 target_compile_definitions(test_icd_version_2_export_icd_gpdpa PRIVATE TEST_ICD_EXPORT_ICD_GPDPA=1 ${TEST_ICD_VERSION_2_DEFINES})
+
+if (WIN32)
+    target_sources(test_icd_export_none PRIVATE export_definitions/test_icd_0.def)
+    target_sources(test_icd_export_icd_gipa PRIVATE export_definitions/test_icd_gipa.def)
+    target_sources(test_icd_export_negotiate_interface_version PRIVATE export_definitions/test_icd_negotiate_version.def)
+    target_sources(test_icd_version_2 PRIVATE export_definitions/test_icd_2.def)
+    target_sources(test_icd_version_2_export_icd_enumerate_adapter_physical_devices PRIVATE export_definitions/test_icd_2_enum_adapter.def)
+    target_sources(test_icd_version_2_export_icd_gpdpa PRIVATE export_definitions/test_icd_2_gpdpa.def)
+endif()

--- a/tests/framework/icd/export_definitions/test_icd_0.def
+++ b/tests/framework/icd/export_definitions/test_icd_0.def
@@ -1,0 +1,5 @@
+LIBRARY test_icd_export_none
+EXPORTS
+    vkGetInstanceProcAddr
+    vkCreateInstance
+    vkEnumerateInstanceExtensionProperties

--- a/tests/framework/icd/export_definitions/test_icd_2.def
+++ b/tests/framework/icd/export_definitions/test_icd_2.def
@@ -1,0 +1,4 @@
+LIBRARY test_icd_version_2
+EXPORTS
+    vk_icdGetInstanceProcAddr
+    vk_icdNegotiateLoaderICDInterfaceVersion

--- a/tests/framework/icd/export_definitions/test_icd_2_enum_adapter.def
+++ b/tests/framework/icd/export_definitions/test_icd_2_enum_adapter.def
@@ -1,0 +1,5 @@
+LIBRARY test_icd_version_2_export_icd_enumerate_adapter_physical_devices
+EXPORTS
+    vk_icdGetInstanceProcAddr
+    vk_icdNegotiateLoaderICDInterfaceVersion
+    vk_icdEnumerateAdapterPhysicalDevices

--- a/tests/framework/icd/export_definitions/test_icd_2_gpdpa.def
+++ b/tests/framework/icd/export_definitions/test_icd_2_gpdpa.def
@@ -1,0 +1,5 @@
+LIBRARY test_icd_version_2_export_icd_gpdpa
+EXPORTS
+    vk_icdGetInstanceProcAddr
+    vk_icdNegotiateLoaderICDInterfaceVersion
+    vk_icdGetPhysicalDeviceProcAddr

--- a/tests/framework/icd/export_definitions/test_icd_gipa.def
+++ b/tests/framework/icd/export_definitions/test_icd_gipa.def
@@ -1,0 +1,3 @@
+LIBRARY test_icd_export_icd_gipa
+EXPORTS
+    vk_icdGetInstanceProcAddr

--- a/tests/framework/icd/export_definitions/test_icd_negotiate_version.def
+++ b/tests/framework/icd/export_definitions/test_icd_negotiate_version.def
@@ -1,0 +1,3 @@
+LIBRARY test_icd_export_negotiate_interface_version
+EXPORTS
+    vk_icdNegotiateLoaderICDInterfaceVersion


### PR DESCRIPTION
This enables the regression tests for Windows. Doing so unearthed an issue with 32 bit builds that caused exported names to be mangled even with `extern "C"`. The second commit fixes it by adding .def files.