### PR TITLE
Enable Windows CI regression tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
               run: git clone --branch release-1.8.1 https://github.com/google/googletest.git external/googletest
 
             - name: Generate build files
-              run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -Cexternal/helper.cmake
+              run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -DBUILD_TESTS=On -Cexternal/helper.cmake
               env:
                 CC: ${{matrix.cc}}
                 CXX: ${{matrix.cxx}}
@@ -97,11 +97,11 @@ jobs:
               run: git clone --branch v4.0.1 https://github.com/microsoft/Detours.git external/detours
 
             - name: Generate build files
-              run: cmake -S. -Bbuild -A${{matrix.arch}} "-Cexternal/helper.cmake"
+              run: cmake -S. -Bbuild -A${{matrix.arch}} -DBUILD_TESTS=On "-Cexternal/helper.cmake"
               if: matrix.os != 'windows-2016'
 
             - name: Generate build files
-              run: cmake -S. -Bbuild -A${{matrix.arch}} "-DCMAKE_SYSTEM_VERSION=10.0.17763.0" "-Cexternal/helper.cmake"
+              run: cmake -S. -Bbuild -A${{matrix.arch}}  -DBUILD_TESTS=On "-DCMAKE_SYSTEM_VERSION=10.0.17763.0" "-Cexternal/helper.cmake"
               if: matrix.os == 'windows-2016'
 
             - name: Build the loader

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,8 @@ jobs:
               run: make -C build
 
             - name: Run regression tests
-              run: ./build/tests/test_regression
+              working-directory: ./build
+              run: ctest --output-on-failure
 
             - name: Verify generated source files
               run: python scripts/generate_source.py --verify external/Vulkan-Headers/registry
@@ -105,6 +106,10 @@ jobs:
 
             - name: Build the loader
               run: cmake --build ./build --config ${{matrix.config}}
+
+            - name: Run regression tests
+              working-directory: ./build
+              run: ctest --output-on-failure
 
             - name: Verify generated source files
               run: python scripts/generate_source.py --verify external/Vulkan-Headers/registry

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,6 @@
 # ~~~
 
 add_executable(vk_loader_validation_tests loader_validation_tests.cpp)
-add_test(NAME vk_loader_validation_tests COMMAND vk_loader_validation_tests)
 
 set_target_properties(vk_loader_validation_tests PROPERTIES COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
 if(UNIX)
@@ -111,34 +110,11 @@ endif()
 
 target_link_libraries(vk_loader_validation_tests "${LOADER_LIB}" gtest gtest_main)
 
-# Copy loader and googletest (gtest) libs to test dir so the test executable can find them.
-if(WIN32)
-    file(COPY vk_loader_validation_tests.vcxproj.user DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
-    if(CMAKE_GENERATOR MATCHES "^Visual Studio.*")
-        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIG>/gtest_main$<$<CONFIG:Debug>:d>.dll
-                            GTEST_COPY_SRC1)
-        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/$<CONFIG>/gtest$<$<CONFIG:Debug>:d>.dll
-                            GTEST_COPY_SRC2)
-        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG> GTEST_COPY_DEST)
-    else()
-        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/gtest_main$<$<CONFIG:Debug>:d>.dll GTEST_COPY_SRC1)
-        file(TO_NATIVE_PATH ${PROJECT_BINARY_DIR}/external/googletest/googletest/gtest$<$<CONFIG:Debug>:d>.dll GTEST_COPY_SRC2)
-        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR} GTEST_COPY_DEST)
-    endif()
-    add_custom_command(TARGET vk_loader_validation_tests POST_BUILD
-                       COMMAND ${CMAKE_COMMAND} -E copy ${GTEST_COPY_SRC1} ${GTEST_COPY_DEST}
-                       COMMAND ${CMAKE_COMMAND} -E copy ${GTEST_COPY_SRC2} ${GTEST_COPY_DEST})
-    # Copy the loader shared lib (if built) to the test application directory so the test app finds it.
-    if(TARGET vulkan)
-        add_custom_command(TARGET vk_loader_validation_tests POST_BUILD
-                           COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:vulkan> $<TARGET_FILE_DIR:vk_loader_validation_tests>)
-    endif()
-endif()
-
 add_subdirectory(layers)
 
 option(TEST_USE_ADDRESS_SANITIZER "Linux only: Advanced memory checking" OFF)
 
+include(GoogleTest)
 add_subdirectory(framework)
 
 add_executable(test_regression loader_testing_main.cpp loader_regression_tests.cpp loader_version_tests.cpp)
@@ -174,3 +150,6 @@ if(WIN32)
                            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:vulkan> $<TARGET_FILE_DIR:test_regression>)
     endif()
 endif()
+
+#must happen after the dll's get copied over
+gtest_discover_tests(test_regression)

--- a/tests/framework/icd/CMakeLists.txt
+++ b/tests/framework/icd/CMakeLists.txt
@@ -56,3 +56,12 @@ target_compile_definitions(test_icd_version_2_export_icd_enumerate_adapter_physi
 add_library(test_icd_version_2_export_icd_gpdpa SHARED ${TEST_ICD_SOURCES})
 target_link_libraries(test_icd_version_2_export_icd_gpdpa PRIVATE test_icd_deps)
 target_compile_definitions(test_icd_version_2_export_icd_gpdpa PRIVATE TEST_ICD_EXPORT_ICD_GPDPA=1 ${TEST_ICD_VERSION_2_DEFINES})
+
+if (WIN32)
+    target_sources(test_icd_export_none PRIVATE export_definitions/test_icd_0.def)
+    target_sources(test_icd_export_icd_gipa PRIVATE export_definitions/test_icd_gipa.def)
+    target_sources(test_icd_export_negotiate_interface_version PRIVATE export_definitions/test_icd_negotiate_version.def)
+    target_sources(test_icd_version_2 PRIVATE export_definitions/test_icd_2.def)
+    target_sources(test_icd_version_2_export_icd_enumerate_adapter_physical_devices PRIVATE export_definitions/test_icd_2_enum_adapter.def)
+    target_sources(test_icd_version_2_export_icd_gpdpa PRIVATE export_definitions/test_icd_2_gpdpa.def)
+endif()

--- a/tests/framework/icd/export_definitions/test_icd_0.def
+++ b/tests/framework/icd/export_definitions/test_icd_0.def
@@ -1,0 +1,5 @@
+LIBRARY test_icd_export_none
+EXPORTS
+    vkGetInstanceProcAddr
+    vkCreateInstance
+    vkEnumerateInstanceExtensionProperties

--- a/tests/framework/icd/export_definitions/test_icd_2.def
+++ b/tests/framework/icd/export_definitions/test_icd_2.def
@@ -1,0 +1,4 @@
+LIBRARY test_icd_version_2
+EXPORTS
+    vk_icdGetInstanceProcAddr
+    vk_icdNegotiateLoaderICDInterfaceVersion

--- a/tests/framework/icd/export_definitions/test_icd_2_enum_adapter.def
+++ b/tests/framework/icd/export_definitions/test_icd_2_enum_adapter.def
@@ -1,0 +1,5 @@
+LIBRARY test_icd_version_2_export_icd_enumerate_adapter_physical_devices
+EXPORTS
+    vk_icdGetInstanceProcAddr
+    vk_icdNegotiateLoaderICDInterfaceVersion
+    vk_icdEnumerateAdapterPhysicalDevices

--- a/tests/framework/icd/export_definitions/test_icd_2_gpdpa.def
+++ b/tests/framework/icd/export_definitions/test_icd_2_gpdpa.def
@@ -1,0 +1,5 @@
+LIBRARY test_icd_version_2_export_icd_gpdpa
+EXPORTS
+    vk_icdGetInstanceProcAddr
+    vk_icdNegotiateLoaderICDInterfaceVersion
+    vk_icdGetPhysicalDeviceProcAddr

--- a/tests/framework/icd/export_definitions/test_icd_gipa.def
+++ b/tests/framework/icd/export_definitions/test_icd_gipa.def
@@ -1,0 +1,3 @@
+LIBRARY test_icd_export_icd_gipa
+EXPORTS
+    vk_icdGetInstanceProcAddr

--- a/tests/framework/icd/export_definitions/test_icd_negotiate_version.def
+++ b/tests/framework/icd/export_definitions/test_icd_negotiate_version.def
@@ -1,0 +1,6 @@
+LIBRARY test_icd_export_negotiate_interface_version
+EXPORTS
+    vkGetInstanceProcAddr
+    vkCreateInstance
+    vkEnumerateInstanceExtensionProperties
+    vk_icdNegotiateLoaderICDInterfaceVersion

--- a/tests/framework/icd/physical_device.h
+++ b/tests/framework/icd/physical_device.h
@@ -32,6 +32,7 @@
 struct PhysicalDevice {
     PhysicalDevice() {}
     PhysicalDevice(std::string name) : deviceName(name) {}
+    PhysicalDevice(const char* name) : deviceName(name) {}
     PhysicalDevice& set_properties(VkPhysicalDeviceProperties properties) {
         this->properties = properties;
         return *this;

--- a/tests/framework/shim/shim.h
+++ b/tests/framework/shim/shim.h
@@ -110,6 +110,10 @@ struct PlatformShim {
 
 // platform specific shim interface
 #if defined(WIN32)
+    // Control Platform Elevation Level
+    unsigned long elevation_level = SECURITY_MANDATORY_LOW_RID;
+    void set_elevation_level(unsigned long new_elevation_level) { elevation_level = new_elevation_level; }
+
     void add_dxgi_adapter(fs::path const& manifest_path, GpuType gpu_preference, uint32_t known_driver_index,
                           DXGI_ADAPTER_DESC1 desc1);
     void add_d3dkmt_adapter(SHIM_D3DKMT_ADAPTERINFO adapter, fs::path const& path);

--- a/tests/framework/shim/shim.h
+++ b/tests/framework/shim/shim.h
@@ -198,32 +198,6 @@ inline std::string category_path_name(ManifestCategory category) {
         return "Drivers";
 }
 
-inline const char* win_api_error_str(LSTATUS status) {
-    if (status == ERROR_INVALID_FUNCTION) return "ERROR_INVALID_FUNCTION";
-    if (status == ERROR_FILE_NOT_FOUND) return "ERROR_FILE_NOT_FOUND";
-    if (status == ERROR_PATH_NOT_FOUND) return "ERROR_PATH_NOT_FOUND";
-    if (status == ERROR_TOO_MANY_OPEN_FILES) return "ERROR_TOO_MANY_OPEN_FILES";
-    if (status == ERROR_ACCESS_DENIED) return "ERROR_ACCESS_DENIED";
-    if (status == ERROR_INVALID_HANDLE) return "ERROR_INVALID_HANDLE";
-    return "UNKNOWN ERROR";
-}
-
-inline void print_error_message(LSTATUS status, const char* function_name, std::string optional_message = "") {
-    LPVOID lpMsgBuf;
-    DWORD dw = GetLastError();
-
-    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, dw,
-                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
-
-    std::cerr << function_name << " failed with " << win_api_error_str(status) << ": "
-              << std::string(static_cast<LPTSTR>(lpMsgBuf));
-    if (optional_message != "") {
-        std::cerr << " | " << optional_message;
-    }
-    std::cerr << "\n";
-    LocalFree(lpMsgBuf);
-}
-
 inline std::string override_base_path(uint32_t random_base_path) {
     return std::string("SOFTWARE\\LoaderRegressionTests_") + std::to_string(random_base_path);
 }

--- a/tests/framework/shim/windows_shim.cpp
+++ b/tests/framework/shim/windows_shim.cpp
@@ -44,7 +44,7 @@ static LibraryWrapper gdi32_dll;
 static PFN_LoaderEnumAdapters2 fpEnumAdapters2 = nullptr;
 static PFN_LoaderQueryAdapterInfo fpQueryAdapterInfo = nullptr;
 
-long ShimEnumAdapters2(LoaderEnumAdapters2 *adapters) {
+NTSTATUS APIENTRY ShimEnumAdapters2(LoaderEnumAdapters2 *adapters) {
     if (adapters == nullptr) {
         return STATUS_INVALID_PARAMETER;
     }

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -105,10 +105,10 @@ MultipleICDShim::MultipleICDShim(std::vector<TestICDDetails> icd_details_vector,
     : FrameworkEnvironment(debug_mode) {
     uint32_t i = 0;
     for (auto& test_icd_detail : icd_details_vector) {
-        fs::path new_driver_location = icd_folder.location() / fs::path(test_icd_detail.icd_path).stem() + "_" +
+        fs::path new_driver_name = fs::path(test_icd_detail.icd_path).stem() + "_" +
                                        std::to_string(i) + fs::path(test_icd_detail.icd_path).extension();
 
-        fs::copy_file(test_icd_detail.icd_path, new_driver_location);
+        auto new_driver_location = icd_folder.copy_file(test_icd_detail.icd_path, new_driver_name.str());
 
         icds.push_back(detail::TestICDHandle(new_driver_location));
         test_icd_detail.icd_path = new_driver_location.c_str();

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -95,6 +95,22 @@ void FrameworkEnvironment::AddExplicitLayer(ManifestLayer layer_manifest, const 
     platform_shim->add_manifest(ManifestCategory::explicit_layer, layer_loc);
 }
 
+EnvVarICDOverrideShim::EnvVarICDOverrideShim(DebugMode debug_mode) : FrameworkEnvironment(debug_mode) {}
+
+void EnvVarICDOverrideShim::SetEnvOverrideICD(const char* icd_path, const char* manifest_name) {
+    ManifestICD icd_manifest;
+    icd_manifest.lib_path = icd_path;
+    icd_manifest.api_version = VK_MAKE_VERSION(1, 0, 0);
+
+    icd_folder.write(manifest_name, icd_manifest);
+    set_env_var("VK_ICD_FILENAMES", (icd_folder.location() / manifest_name).str());
+
+    driver_wrapper = LibraryWrapper(fs::path(icd_path));
+
+    get_new_test_icd = driver_wrapper.get_symbol<GetNewTestICDFunc>(GET_NEW_TEST_ICD_FUNC_STR);
+
+}
+
 SingleICDShim::SingleICDShim(TestICDDetails icd_details, DebugMode debug_mode) : FrameworkEnvironment(debug_mode) {
     icd_handle = detail::TestICDHandle(icd_details.icd_path);
 

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -39,6 +39,9 @@ PlatformShimWrapper::PlatformShimWrapper(DebugMode debug_mode) : debug_mode(debu
 #endif
     platform_shim->setup_override(debug_mode);
     platform_shim->reset(debug_mode);
+
+    // leave it permanently on at full blast
+    set_env_var("VK_LOADER_DEBUG", "all");
 }
 PlatformShimWrapper::~PlatformShimWrapper() {
     platform_shim->reset(debug_mode);

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -115,6 +115,16 @@ struct FrameworkEnvironment {
     VulkanFunctions vulkan_functions;
 };
 
+struct EnvVarICDOverrideShim : FrameworkEnvironment {
+    EnvVarICDOverrideShim(DebugMode debug_mode = DebugMode::none);
+
+    void SetEnvOverrideICD(const char* icd_path, const char* manifest_name);
+
+    LibraryWrapper driver_wrapper;
+    GetNewTestICDFunc get_new_test_icd;
+};
+
+
 struct SingleICDShim : FrameworkEnvironment {
     SingleICDShim(TestICDDetails icd_details, DebugMode debug_mode = DebugMode::none);
 


### PR DESCRIPTION
In addition to enabling regressions test in Github Actions, this PR fixes several aspects of the test framework that either did not work or due to how github actions runs, failed there. 
Such as:
* 32 bit MSVC mangling names even with `extern "C"` - solution is using .def files for the TestICD DLL's.
* CI runs jobs with elevated permissions, thus disabling env-var's being used (known loader behavior for security reasons). Fix is to shim the elevated permissions check and force it to what the test requires.
* Missing _stdcalll in ShimEnumAdapters2
* Cleanup of copied files wasn't happening, nor were the folders being deleted. Leaving state around like this causes hard to track down bugs.

Additionally more error handling logic was added to various shim functionality as the current level leaves much to be desired when issues do arise. 
VK_LOADER_DEBUG=all is now set during tests, as they prove extremely useful in understanding what the test is doing internally. Normally, these messages will be hidden by ctest which only prints the messages if the test failed.