### PR TITLE
Change no driver result error

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -625,10 +625,8 @@ bool loaderGetDeviceRegistryEntry(const struct loader_instance *inst, char **reg
     char *manifest_path = NULL;
     bool found = false;
 
-    if (NULL == total_size || NULL == reg_data) {
-        *result = VK_ERROR_INITIALIZATION_FAILED;
-        return false;
-    }
+    assert(reg_data != NULL && "loaderGetDeviceRegistryEntry: reg_data is a NULL pointer");
+    assert(total_size != NULL && "loaderGetDeviceRegistryEntry: total_size is a NULL pointer");
 
     CONFIGRET status = CM_Open_DevNode_Key(dev_id, KEY_QUERY_VALUE, 0, RegDisposition_OpenExisting, &hkrKey, CM_REGISTRY_SOFTWARE);
     if (status != CR_SUCCESS) {
@@ -730,10 +728,7 @@ VkResult loaderGetDeviceRegistryFiles(const struct loader_instance *inst, char *
     VkResult result = VK_SUCCESS;
     bool found = false;
 
-    if (NULL == reg_data) {
-        result = VK_ERROR_INITIALIZATION_FAILED;
-        return result;
-    }
+    assert(reg_data != NULL && "loaderGetDeviceRegistryFiles: reg_data is NULL");
 
     // if after obtaining the DeviceNameSize, new device is added start over
     do {
@@ -906,10 +901,7 @@ VkResult loaderGetRegistryFiles(const struct loader_instance *inst, char *locati
     IDXGIFactory1 *dxgi_factory = NULL;
     bool is_driver = !strcmp(location, VK_DRIVERS_INFO_REGISTRY_LOC);
 
-    if (NULL == reg_data) {
-        result = VK_ERROR_INITIALIZATION_FAILED;
-        goto out;
-    }
+    assert(reg_data != NULL && "loaderGetRegistryFiles: reg_data is a NULL pointer");
 
     if (is_driver) {
         HRESULT hres = fpCreateDXGIFactory1(&IID_IDXGIFactory1, (void **)&dxgi_factory);
@@ -3802,11 +3794,8 @@ static inline VkResult CheckAndAdjustDataFileList(const struct loader_instance *
 static VkResult AddIfManifestFile(const struct loader_instance *inst, const char *file_name, struct loader_data_files *out_files) {
     VkResult vk_result = VK_SUCCESS;
 
-    if (NULL == file_name || NULL == out_files) {
-        loader_log(inst, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0, "AddIfManfistFile: Received NULL pointer");
-        vk_result = VK_ERROR_INITIALIZATION_FAILED;
-        goto out;
-    }
+    assert(NULL != file_name && "AddIfManifestFile: Received NULL pointer for file_name");
+    assert(NULL != out_files && "AddIfManifestFile: Received NULL pointer for out_files");
 
     // Look for files ending with ".json" suffix
     size_t name_len = strlen(file_name);
@@ -3826,7 +3815,7 @@ static VkResult AddIfManifestFile(const struct loader_instance *inst, const char
     out_files->filename_list[out_files->count] =
         loader_instance_heap_alloc(inst, strlen(file_name) + 1, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
     if (out_files->filename_list[out_files->count] == NULL) {
-        loader_log(inst, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0, "AddIfManfistFile: Failed to allocate space for manifest file %d list",
+        loader_log(inst, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0, "AddIfManifestFile: Failed to allocate space for manifest file %d list",
                    out_files->count);
         vk_result = VK_ERROR_OUT_OF_HOST_MEMORY;
         goto out;

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -482,9 +482,18 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
     // Scan/discover all ICD libraries
     memset(&ptr_instance->icd_tramp_list, 0, sizeof(ptr_instance->icd_tramp_list));
     res = loader_icd_scan(ptr_instance, &ptr_instance->icd_tramp_list);
-    if (res != VK_SUCCESS) {
+    if (res == VK_SUCCESS && ptr_instance->icd_tramp_list.count == 0) {
+        // No drivers found
+        res = VK_ERROR_INCOMPATIBLE_DRIVER;
         goto out;
     }
+    if (res != VK_SUCCESS) {
+        if (res != VK_ERROR_OUT_OF_HOST_MEMORY && ptr_instance->icd_tramp_list.count == 0) {
+            res = VK_ERROR_INCOMPATIBLE_DRIVER;
+        }
+        goto out;
+    }
+
 
     // Get extensions from all ICD's, merge so no duplicates, then validate
     res = loader_get_icd_loader_instance_extensions(ptr_instance, &ptr_instance->icd_tramp_list, &ptr_instance->ext_list);


### PR DESCRIPTION
ReadDataFilesInRegistry would return VK_ERROR_INITIALIZATION_FAILED in several cases
which could cause the loader to short cirtuit and return that value when no drivers were
found in the registry. This is inconsistent with the later check of the size of the list
of manifest, which if it is 0 returns VK_ERROR_INCOMPATABLE_DRIVER. This commit changes
the instances of INIT_FAILED into INCOMPATABLE_DRIVER where relevant.

The addition of `AddManifestFile` (and change of `AddIfManifestFile`) are used in an upcoming PR which only needs the adding logic and not the json checking, thus I pulled out the common bits into a new function. 