### PR TITLE
Loader shared lib: back to default cmake prefix

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -229,21 +229,14 @@ if(WIN32)
                 $<TARGET_OBJECTS:loader-unknown-chain>
                 ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-1.def
                 ${CMAKE_CURRENT_SOURCE_DIR}/loader.rc)
-    if(MSVC)
+
+    # when adding the suffix the import and runtime library names must be consistent
+    # mingw: libvulkan-1.dll.a / libvulkan-1.dll
+    # msvc: vulkan-1.lib / vulkan-1.dll
     set_target_properties(vulkan
                           PROPERTIES
-                          #LINK_FLAGS_DEBUG "/ignore:4098"
-                                     OUTPUT_NAME
-                                     vulkan-1
-                                     PREFIX
-                                     "")
-    else()
-    set_target_properties(vulkan
-                          PROPERTIES
-                          LIBRARY_OUTPUT_NAME vulkan
-                          RUNTIME_OUTPUT_NAME vulkan-1
-                          ARCHIVE_OUTPUT_NAME vulkan)
-    endif()
+                          OUTPUT_NAME vulkan-1)
+
     target_link_libraries(vulkan Vulkan::Headers)
 
     if(MSVC AND ENABLE_WIN10_ONECORE)


### PR DESCRIPTION
#595 restores the default lib prefix for mingw (libvulkan-1.dll instead of vulkan-1.dl) and basically reverts #523
but it changes the import lib name (libvulkan.dll.a instead of libvulkan-1.dll.a) and  breaks cmake detection in FindVulkan
(find_library looks for libvulkan-1.dll.a under mingw)
now we go back to using the default cmake prefix which is equivalent to the #595 prefix prior to #523
without the broken import lib name

cc @Biswa96