### PR TITLE
loader: Make use of a generated header version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,5 @@
 # Generated source files will always have LF (unix) line endings on checkout.
 loader/generated/*.c text eol=lf
 loader/generated/*.h text eol=lf
+loader/generated/*.cmake text eol=lf
+

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -264,11 +264,8 @@ else()
         add_library(vulkan SHARED ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS})
     endif()
     add_dependencies(vulkan loader_asm_gen_files)
-    set_target_properties(vulkan
-                          PROPERTIES SOVERSION
-                                     "1"
-                                     VERSION
-                                     "${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}")
+    # set version based on VK_HEADER_VERSION used to generate the code
+    include(generated/loader_generated_header_version.cmake)
     target_link_libraries(vulkan ${CMAKE_DL_LIBS} m)
     if (NOT ANDROID)
         target_link_libraries(vulkan pthread)

--- a/loader/generated/loader_generated_header_version.cmake
+++ b/loader/generated/loader_generated_header_version.cmake
@@ -1,0 +1,32 @@
+# *** THIS FILE IS GENERATED - DO NOT EDIT ***
+# See loader_generated_header_version_generator.py for modifications
+
+############################################################################
+#
+# Copyright (c) 2021 The Khronos Group Inc.
+# Copyright (c) 2021 Valve Corporation
+# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Charles Giessen <charles@lunarg.com>
+#
+############################################################################
+
+set_target_properties(vulkan
+                      PROPERTIES SOVERSION
+                      "1"
+                      VERSION
+                      "1.2.187")
+

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -45,7 +45,8 @@ def main(argv):
                                             'vk_layer_dispatch_table.h',
                                             'vk_loader_extensions.h',
                                             'vk_loader_extensions.c',
-                                            'vk_object_types.h']]
+                                            'vk_object_types.h',
+                                            'loader_generated_header_version.cmake']]
 
     repo_dir = common_codegen.repo_relative('loader/generated')
 

--- a/scripts/loader_generated_header_version_generator.py
+++ b/scripts/loader_generated_header_version_generator.py
@@ -1,0 +1,148 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2021 The Khronos Group Inc.
+# Copyright (c) 2021 Valve Corporation
+# Copyright (c) 2021 LunarG, Inc.
+# Copyright (c) 2021 Google Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Charles Giessen <charles@lunarg.com>
+
+import os,re,sys
+import xml.etree.ElementTree as etree
+from generator import *
+from collections import namedtuple
+from common_codegen import *
+
+#
+# LoaderGenerateHeaderVersionGeneratorOptions - subclass of GeneratorOptions.
+class LoaderGenerateHeaderVersionGeneratorOptions(GeneratorOptions):
+    def __init__(self,
+                 conventions = None,
+                 filename = None,
+                 directory = '.',
+                 genpath = None,
+                 apiname = None,
+                 profile = None,
+                 versions = '.*',
+                 emitversions = '.*',
+                 defaultExtensions = None,
+                 addExtensions = None,
+                 removeExtensions = None,
+                 emitExtensions = None,
+                 sortProcedure = regSortFeatures,
+                 prefixText = "",
+                 genFuncPointers = True,
+                 protectFile = True,
+                 protectFeature = True,
+                 apicall = '',
+                 apientry = '',
+                 apientryp = '',
+                 alignFuncParam = 0,
+                 library_name = '',
+                 expandEnumerants = True):
+        GeneratorOptions.__init__(self,
+                conventions = conventions,
+                filename = filename,
+                directory = directory,
+                genpath = genpath,
+                apiname = apiname,
+                profile = profile,
+                versions = versions,
+                emitversions = emitversions,
+                defaultExtensions = defaultExtensions,
+                addExtensions = addExtensions,
+                removeExtensions = removeExtensions,
+                emitExtensions = emitExtensions,
+                sortProcedure = sortProcedure)
+        self.prefixText       = prefixText
+        self.genFuncPointers  = genFuncPointers
+        self.protectFile      = protectFile
+        self.protectFeature   = protectFeature
+        self.apicall          = apicall
+        self.apientry         = apientry
+        self.apientryp        = apientryp
+        self.alignFuncParam   = alignFuncParam
+        self.library_name     = library_name
+#
+# LoaderGenerateHeaderVersion - subclass of OutputGenerator. Outputs cmake file containing vulkan version used when generating files
+class LoaderGenerateHeaderVersion(OutputGenerator):
+    """Generate helper file based on XML element attributes"""
+    def __init__(self,
+                 errFile = sys.stderr,
+                 warnFile = sys.stderr,
+                 diagFile = sys.stdout):
+        OutputGenerator.__init__(self, errFile, warnFile, diagFile)
+
+    #
+    # Called once at the beginning of each run
+    def beginFile(self, genOpts):
+        OutputGenerator.beginFile(self, genOpts)
+        # User-supplied prefix text, if any (list of strings)
+        self.library_name = genOpts.library_name
+
+        header_version = ''
+        for elem in self.registry.reg.find('types').findall('type'):
+            if elem.get('category') == 'define':
+                if elem.get('name') == 'VK_HEADER_VERSION':
+                    header_version = re.findall("[0-9]+", ''.join(elem.itertext()))[0]
+                    break
+
+        # File Comment
+        file_comment = '# *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
+        file_comment += '# See loader_generated_header_version_generator.py for modifications\n'
+        write(file_comment, file=self.outFile)
+        # Copyright Notice
+        copyright = ''
+        copyright += '############################################################################\n'
+        copyright += '#\n'
+        copyright += '# Copyright (c) 2021 The Khronos Group Inc.\n'
+        copyright += '# Copyright (c) 2021 Valve Corporation\n'
+        copyright += '# Copyright (c) 2021 LunarG, Inc.\n'
+        copyright += '# Copyright (c) 2021 Google Inc.\n'
+        copyright += '#\n'
+        copyright += '# Licensed under the Apache License, Version 2.0 (the "License");\n'
+        copyright += '# you may not use this file except in compliance with the License.\n'
+        copyright += '# You may obtain a copy of the License at\n'
+        copyright += '#\n'
+        copyright += '#     http://www.apache.org/licenses/LICENSE-2.0\n'
+        copyright += '#\n'
+        copyright += '# Unless required by applicable law or agreed to in writing, software\n'
+        copyright += '# distributed under the License is distributed on an "AS IS" BASIS,\n'
+        copyright += '# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
+        copyright += '# See the License for the specific language governing permissions and\n'
+        copyright += '# limitations under the License.\n'
+        copyright += '#\n'
+        copyright += '# Author: Charles Giessen <charles@lunarg.com>\n'
+        copyright += '#\n'
+        copyright += '############################################################################\n'
+        write(copyright, file=self.outFile)
+        set_prop_str = ''
+        set_prop_str += 'set_target_properties(vulkan\n'
+        set_prop_str += '                      PROPERTIES SOVERSION\n'
+        set_prop_str += '                      "1"\n'
+        set_prop_str += '                      VERSION\n'
+        set_prop_str += '                      "1.2.' + header_version + '")'
+        write(set_prop_str, file=self.outFile)
+
+    #
+    # Write generated file content to output file
+    def endFile(self):
+        dest_file = ''
+        # Remove blank lines at EOF
+        if dest_file.endswith('\n'):
+            dest_file = dest_file[:-1]
+        write(dest_file, file=self.outFile)
+        # Finish processing in superclass
+        OutputGenerator.endFile(self)

--- a/scripts/loader_genvk.py
+++ b/scripts/loader_genvk.py
@@ -239,6 +239,30 @@ def makeGenOpts(args):
             helper_file_type  = 'object_types_header')
         ]
 
+    # Loader Generated Header Version Options for loader_generated_header_version.cmake
+    genOpts['loader_generated_header_version.cmake'] = [
+          LoaderGenerateHeaderVersion,
+          LoaderGenerateHeaderVersionGeneratorOptions(
+            conventions       = conventions,
+            filename          = 'loader_generated_header_version.cmake',
+            directory         = directory,
+            genpath           = None,
+            apiname           = 'vulkan',
+            profile           = None,
+            versions          = featuresPat,
+            emitversions      = featuresPat,
+            defaultExtensions = 'vulkan',
+            addExtensions     = addExtensionsPat,
+            removeExtensions  = removeExtensionsPat,
+            emitExtensions    = emitExtensionsPat,
+            prefixText        = prefixStrings + vkPrefixStrings,
+            apicall           = 'VKAPI_ATTR ',
+            apientry          = 'VKAPI_CALL ',
+            apientryp         = 'VKAPI_PTR *',
+            alignFuncParam    = 48,
+            expandEnumerants  = False)
+        ]
+
 # Create an API generator and corresponding generator options based on
 # the requested target and command line options.
 # This is encapsulated in a function so it can be profiled and/or timed.
@@ -357,6 +381,8 @@ if __name__ == '__main__':
     from dispatch_table_helper_generator import DispatchTableHelperOutputGenerator, DispatchTableHelperOutputGeneratorOptions
     from helper_file_generator import HelperFileOutputGenerator, HelperFileOutputGeneratorOptions
     from loader_extension_generator import LoaderExtensionOutputGenerator, LoaderExtensionGeneratorOptions
+    from loader_generated_header_version_generator import LoaderGenerateHeaderVersion, LoaderGenerateHeaderVersionGeneratorOptions
+
     # Temporary workaround for vkconventions python2 compatibility
     import abc; abc.ABC = abc.ABCMeta('ABC', (object,), {})
     from vkconventions import VulkanConventions


### PR DESCRIPTION
This changes the loader to always set the version to the one which was used when
generating the source files that are checked into the repo, instead of using the
version gotten from the Vulkan-Headers as it might be out of sync.

Fixes #141

Change-Id: Id0955ddfd10e35e0f358f5a77799d8baa4992b04