### PR TITLE
copyrights: updated copyrights on MIT files

### DIFF
--- a/loader/cJSON.c
+++ b/loader/cJSON.c
@@ -1,8 +1,8 @@
 /*
   Copyright (c) 2009 Dave Gamble
-  Copyright (c) 2015-2016 The Khronos Group Inc.
-  Copyright (c) 2015-2016 Valve Corporation
-  Copyright (c) 2015-2016 LunarG, Inc.
+  Copyright (c) 2015-2017 The Khronos Group Inc.
+  Copyright (c) 2015-2017 Valve Corporation
+  Copyright (c) 2015-2017 LunarG, Inc.
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/loader/cJSON.h
+++ b/loader/cJSON.h
@@ -1,8 +1,8 @@
 /*
   Copyright (c) 2009 Dave Gamble
-  Copyright (c) 2015-2016 The Khronos Group Inc.
-  Copyright (c) 2015-2016 Valve Corporation
-  Copyright (c) 2015-2016 LunarG, Inc.
+  Copyright (c) 2015-2017 The Khronos Group Inc.
+  Copyright (c) 2015-2017 Valve Corporation
+  Copyright (c) 2015-2017 LunarG, Inc.
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/loader/murmurhash.c
+++ b/loader/murmurhash.c
@@ -3,9 +3,9 @@
  * `murmurhash.h' - murmurhash
  *
  * copyright (c) 2014 joseph werle <joseph.werle@gmail.com>
- * Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (c) 2015-2017 The Khronos Group Inc.
+ * Copyright (c) 2015-2017 Valve Corporation
+ * Copyright (c) 2015-2017 LunarG, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and/or associated documentation files (the "Materials"), to


### PR DESCRIPTION
During SDK testing we identified that the runtime copyrights
were out-of-date.  The loader runtime includes two separate
MIT copyrights, each attributed to a pair of source files,
one initiated by Dave Gamble and one by joseph werle.

I examined these files to discover that the last LunarG change to
three out of the four was actually in 2017, not 2016.  This
date should be attributed to Khronos, Valve, and LunarG.

By updating the copyright notice in these files, we ensure that
the license registry remains up-to-date.

Note that no real content changed (which is why the copyrights are not
being updated to 2021).