### PR TITLE
Report a warning if the number of GPUs doesn't match

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -708,6 +708,13 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDevices(VkInstan
 
     count = inst->phys_dev_count_tramp;
 
+    if (inst->phys_dev_count_tramp != inst->total_gpu_count) {
+        loader_log(inst, VK_DEBUG_REPORT_WARNING_BIT_EXT, 0,
+                   "vkEnumeratePhysicalDevices: One or more layers modified physical devices!"
+                   "Count returned by ICDs = %d, count returned above layers = %d",
+                   inst->total_gpu_count, inst->phys_dev_count_tramp);
+    }
+
     // Wrap the PhysDev object for loader usage, return wrapped objects
     if (NULL != pPhysicalDevices) {
         if (inst->phys_dev_count_tramp > *pPhysicalDeviceCount) {


### PR DESCRIPTION
We've encountered situations where a layer removes physical devices
from the list which can cause issues on some systems if it's done
incorrectly.  For now, simply throw a warning if the loader determines
that a layer has removed devices.

NOTE: In the long-run, I think we should define a policy which states
that layers can re-order devices, but not add or remove.  If a layer
wants to add, it should become an ICD.