### PR TITLE
windows: update the loader copyright date

### DIFF
--- a/loader/loader.rc
+++ b/loader/loader.rc
@@ -86,7 +86,7 @@ BEGIN
         BEGIN
             VALUE "FileDescription", VER_FILE_DESCRIPTION_STR
             VALUE "FileVersion", VER_FILE_VERSION_STR
-            VALUE "LegalCopyright", "Copyright (C) 2015-2020"
+            VALUE "LegalCopyright", "Copyright (C) 2015-2021"
             VALUE "ProductName", "Vulkan Runtime"
             VALUE "ProductVersion", VER_FILE_VERSION_STR
         END


### PR DESCRIPTION
The date, specified in loader/loader.rc, was incorrectly set to 2020.