### PR TITLE
loader: Dont return OOM on function load failure

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4200,7 +4200,7 @@ static VkResult ReadManifestsFromD3DAdapters(const struct loader_instance *inst,
     PFN_LoaderQueryAdapterInfo fpLoaderQueryAdapterInfo =
         (PFN_LoaderQueryAdapterInfo)GetProcAddress(GetModuleHandle("gdi32.dll"), "D3DKMTQueryAdapterInfo");
     if (fpLoaderEnumAdapters2 == NULL || fpLoaderQueryAdapterInfo == NULL) {
-        result = VK_ERROR_OUT_OF_HOST_MEMORY;
+        result = VK_ERROR_INCOMPATIBLE_DRIVER;
         goto out;
     }
 


### PR DESCRIPTION
Win7 does not support D3DKMTEnumAdapters2, as such when the loader goes to
query it, it gets NULL back. Except, instead of just erroring out, it would
return VK_ERROR_OUT_OF_HOST_MEMORY. Problem was that change
73296a04678a07fc4fb1eef50cf4fe2778f059f8
starts checking for OOM, and finding one when running in Win7. This change
alters that behavior so that it doesn't report an OOM when one hasn't occurred.

Fixes #621 