### PR TITLE
loader: Disable -Wimplicit-fallthrough in GN.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -44,6 +44,7 @@ config("vulkan_internal_config") {
     cflags = [
       "-Wno-conversion",
       "-Wno-extra-semi",
+      "-Wno-implicit-fallthrough",
       "-Wno-sign-compare",
       "-Wno-unreachable-code",
       "-Wno-unused-function",


### PR DESCRIPTION
This flag was recently enabled by default in Chrome and ANGLE
and other projects inherit these build settings. Explicitly
dsiable this warning until it is enabled in the non-GN build.

Change-Id: I8f353f8abc3f7857481ff9cc774aff3618eaf35a

@charles-lunarg @MarkY-LunarG PTAL