### PR TITLE
Update loader to include handle validation

### DIFF
--- a/loader/extension_manual.c
+++ b/loader/extension_manual.c
@@ -49,6 +49,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceExternalImageFormatPropertiesNV(
     VkExternalImageFormatPropertiesNV *pExternalImageFormatProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceExternalImageFormatPropertiesNV: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceExternalImageFormatPropertiesNV-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
 
     return disp->GetPhysicalDeviceExternalImageFormatPropertiesNV(unwrapped_phys_dev, format, type, tiling, usage, flags,
@@ -89,6 +95,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysic
                                                                         VkSurfaceCapabilities2EXT *pSurfaceCapabilities) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceExternalImageFormatPropertiesNV: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceSurfaceCapabilities2EXT-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceSurfaceCapabilities2EXT(unwrapped_phys_dev, surface, pSurfaceCapabilities);
 }
@@ -148,6 +160,11 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2E
 VKAPI_ATTR VkResult VKAPI_CALL ReleaseDisplayEXT(VkPhysicalDevice physicalDevice, VkDisplayKHR display) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkReleaseDisplayEXT: Invalid physicalDevice [VUID-vkReleaseDisplayEXT-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->ReleaseDisplayEXT(unwrapped_phys_dev, display);
 }
@@ -172,6 +189,11 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_ReleaseDisplayEXT(VkPhysicalDevice phy
 VKAPI_ATTR VkResult VKAPI_CALL AcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, Display *dpy, VkDisplayKHR display) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkAcquireXlibDisplayEXT: Invalid physicalDevice [VUID-vkAcquireXlibDisplayEXT-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->AcquireXlibDisplayEXT(unwrapped_phys_dev, dpy, display);
 }
@@ -198,6 +220,11 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(VkPhysicalDevice physica
                                                         VkDisplayKHR *pDisplay) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetRandROutputDisplayEXT: Invalid physicalDevice [VUID-vkGetRandROutputDisplayEXT-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetRandROutputDisplayEXT(unwrapped_phys_dev, dpy, rrOutput, pDisplay);
 }
@@ -231,6 +258,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModes2EXT(VkPhysic
                                                                         VkPresentModeKHR *pPresentModes) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceSurfacePresentModes2EXT: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceSurfacePresentModes2EXT-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceSurfacePresentModes2EXT(unwrapped_phys_dev, pSurfaceInfo, pPresentModeCount, pPresentModes);
 }
@@ -264,6 +297,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModes2EXT(VkDevice de
                                                                      const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,
                                                                      VkDeviceGroupPresentModeFlagsKHR *pModes) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeviceGroupSurfacePresentModes2EXT: Invalid device "
+                   "[VUID-vkGetDeviceGroupSurfacePresentModes2EXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetDeviceGroupSurfacePresentModes2EXT(device, pSurfaceInfo, pModes);
 }
 
@@ -296,6 +335,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevi
                                                                   VkPhysicalDeviceToolPropertiesEXT *pToolProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceToolPropertiesEXT: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceToolPropertiesEXT-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceToolPropertiesEXT(unwrapped_phys_dev, pToolCount, pToolProperties);
 }

--- a/loader/generated/vk_dispatch_table_helper.h
+++ b/loader/generated/vk_dispatch_table_helper.h
@@ -3,9 +3,9 @@
 // See dispatch_helper_generator.py for modifications
 
 /*
- * Copyright (c) 2015-2017 The Khronos Group Inc.
- * Copyright (c) 2015-2017 Valve Corporation
- * Copyright (c) 2015-2017 LunarG, Inc.
+ * Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -344,6 +344,8 @@ static VKAPI_ATTR void VKAPI_CALL StubCmdSetRayTracingPipelineStackSizeKHR(VkCom
 
 static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDispatchTable *table, PFN_vkGetDeviceProcAddr gpa) {
     memset(table, 0, sizeof(*table));
+    table->magic = DEVICE_DISP_TABLE_MAGIC_NUMBER;
+
     // Device function pointers
     table->GetDeviceProcAddr = gpa;
     table->DestroyDevice = (PFN_vkDestroyDevice) gpa(device, "vkDestroyDevice");
@@ -1062,6 +1064,7 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
 
 static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa) {
     memset(table, 0, sizeof(*table));
+
     // Instance function pointers
     table->DestroyInstance = (PFN_vkDestroyInstance) gpa(instance, "vkDestroyInstance");
     table->EnumeratePhysicalDevices = (PFN_vkEnumeratePhysicalDevices) gpa(instance, "vkEnumeratePhysicalDevices");

--- a/loader/generated/vk_layer_dispatch_table.h
+++ b/loader/generated/vk_layer_dispatch_table.h
@@ -2,9 +2,9 @@
 // See loader_extension_generator.py for modifications
 
 /*
- * Copyright (c) 2015-2017 The Khronos Group Inc.
- * Copyright (c) 2015-2017 Valve Corporation
- * Copyright (c) 2015-2017 LunarG, Inc.
+ * Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -275,7 +275,9 @@ typedef struct VkLayerInstanceDispatchTable_ {
 } VkLayerInstanceDispatchTable;
 
 // Device function pointer dispatch table
+#define DEVICE_DISP_TABLE_MAGIC_NUMBER 0x10ADED040410ADEDUL
 typedef struct VkLayerDispatchTable_ {
+    uint64_t magic; // Should be DEVICE_DISP_TABLE_MAGIC_NUMBER
 
     // ---- Core 1_0 commands
     PFN_vkGetDeviceProcAddr GetDeviceProcAddr;

--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -2,9 +2,9 @@
 // See loader_extension_generator.py for modifications
 
 /*
- * Copyright (c) 2015-2017 The Khronos Group Inc.
- * Copyright (c) 2015-2017 Valve Corporation
- * Copyright (c) 2015-2017 LunarG, Inc.
+ * Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -326,6 +326,7 @@ VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_icd_term *icd_t
 VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_dispatch_table *dev_table, PFN_vkGetDeviceProcAddr gpa,
                                                              VkDevice dev) {
     VkLayerDispatchTable *table = &dev_table->core_dispatch;
+    table->magic = DEVICE_DISP_TABLE_MAGIC_NUMBER;
     for (uint32_t i = 0; i < MAX_NUM_UNKNOWN_EXTS; i++) dev_table->ext_dispatch.dev_ext[i] = (PFN_vkDevExt)vkDevExtError;
 
     // ---- Core 1_0 commands
@@ -492,6 +493,7 @@ VKAPI_ATTR void VKAPI_CALL loader_init_device_extension_dispatch_table(struct lo
                                                                        VkInstance inst,
                                                                        VkDevice dev) {
     VkLayerDispatchTable *table = &dev_table->core_dispatch;
+    table->magic = DEVICE_DISP_TABLE_MAGIC_NUMBER;
 
     // ---- VK_KHR_swapchain extension commands
     table->CreateSwapchainKHR = (PFN_vkCreateSwapchainKHR)gdpa(dev, "vkCreateSwapchainKHR");
@@ -2132,6 +2134,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoCapabilitiesKHR(
     VkVideoCapabilitiesKHR*                     pCapabilities) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceVideoCapabilitiesKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceVideoCapabilitiesKHR(unwrapped_phys_dev, pVideoProfile, pCapabilities);
 }
@@ -2158,6 +2166,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoFormatPropertiesKHR(
     VkVideoFormatPropertiesKHR*                 pVideoFormatProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceVideoFormatPropertiesKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceVideoFormatPropertiesKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceVideoFormatPropertiesKHR(unwrapped_phys_dev, pVideoFormatInfo, pVideoFormatPropertyCount, pVideoFormatProperties);
 }
@@ -2184,6 +2198,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkVideoSessionKHR*                          pVideoSession) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateVideoSessionKHR: Invalid device "
+                   "[VUID-vkCreateVideoSessionKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateVideoSessionKHR(device, pCreateInfo, pAllocator, pVideoSession);
 }
 
@@ -2194,6 +2214,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionKHR(
     VkVideoSessionKHR                           videoSession,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyVideoSessionKHR: Invalid device "
+                   "[VUID-vkDestroyVideoSessionKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyVideoSessionKHR(device, videoSession, pAllocator);
 }
 
@@ -2205,6 +2231,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetVideoSessionMemoryRequirementsKHR(
     uint32_t*                                   pVideoSessionMemoryRequirementsCount,
     VkVideoGetMemoryPropertiesKHR*              pVideoSessionMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetVideoSessionMemoryRequirementsKHR: Invalid device "
+                   "[VUID-vkGetVideoSessionMemoryRequirementsKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetVideoSessionMemoryRequirementsKHR(device, videoSession, pVideoSessionMemoryRequirementsCount, pVideoSessionMemoryRequirements);
 }
 
@@ -2216,6 +2248,12 @@ VKAPI_ATTR VkResult VKAPI_CALL BindVideoSessionMemoryKHR(
     uint32_t                                    videoSessionBindMemoryCount,
     const VkVideoBindMemoryKHR*                 pVideoSessionBindMemories) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkBindVideoSessionMemoryKHR: Invalid device "
+                   "[VUID-vkBindVideoSessionMemoryKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->BindVideoSessionMemoryKHR(device, videoSession, videoSessionBindMemoryCount, pVideoSessionBindMemories);
 }
 
@@ -2227,6 +2265,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionParametersKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkVideoSessionParametersKHR*                pVideoSessionParameters) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateVideoSessionParametersKHR: Invalid device "
+                   "[VUID-vkCreateVideoSessionParametersKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateVideoSessionParametersKHR(device, pCreateInfo, pAllocator, pVideoSessionParameters);
 }
 
@@ -2237,6 +2281,12 @@ VKAPI_ATTR VkResult VKAPI_CALL UpdateVideoSessionParametersKHR(
     VkVideoSessionParametersKHR                 videoSessionParameters,
     const VkVideoSessionParametersUpdateInfoKHR* pUpdateInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkUpdateVideoSessionParametersKHR: Invalid device "
+                   "[VUID-vkUpdateVideoSessionParametersKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->UpdateVideoSessionParametersKHR(device, videoSessionParameters, pUpdateInfo);
 }
 
@@ -2247,6 +2297,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionParametersKHR(
     VkVideoSessionParametersKHR                 videoSessionParameters,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyVideoSessionParametersKHR: Invalid device "
+                   "[VUID-vkDestroyVideoSessionParametersKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyVideoSessionParametersKHR(device, videoSessionParameters, pAllocator);
 }
 
@@ -2256,6 +2312,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginVideoCodingKHR(
     VkCommandBuffer                             commandBuffer,
     const VkVideoBeginCodingInfoKHR*            pBeginInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBeginVideoCodingKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdBeginVideoCodingKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBeginVideoCodingKHR(commandBuffer, pBeginInfo);
 }
 
@@ -2265,6 +2327,12 @@ VKAPI_ATTR void VKAPI_CALL CmdEndVideoCodingKHR(
     VkCommandBuffer                             commandBuffer,
     const VkVideoEndCodingInfoKHR*              pEndCodingInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdEndVideoCodingKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdEndVideoCodingKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdEndVideoCodingKHR(commandBuffer, pEndCodingInfo);
 }
 
@@ -2274,6 +2342,12 @@ VKAPI_ATTR void VKAPI_CALL CmdControlVideoCodingKHR(
     VkCommandBuffer                             commandBuffer,
     const VkVideoCodingControlInfoKHR*          pCodingControlInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdControlVideoCodingKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdControlVideoCodingKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdControlVideoCodingKHR(commandBuffer, pCodingControlInfo);
 }
 
@@ -2286,6 +2360,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDecodeVideoKHR(
     VkCommandBuffer                             commandBuffer,
     const VkVideoDecodeInfoKHR*                 pFrameInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDecodeVideoKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdDecodeVideoKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDecodeVideoKHR(commandBuffer, pFrameInfo);
 }
 
@@ -2297,12 +2377,24 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderingKHR(
     VkCommandBuffer                             commandBuffer,
     const VkRenderingInfoKHR*                   pRenderingInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBeginRenderingKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdBeginRenderingKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBeginRenderingKHR(commandBuffer, pRenderingInfo);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdEndRenderingKHR(
     VkCommandBuffer                             commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdEndRenderingKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdEndRenderingKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdEndRenderingKHR(commandBuffer);
 }
 
@@ -2316,6 +2408,12 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceGroupPeerMemoryFeaturesKHR(
     uint32_t                                    remoteDeviceIndex,
     VkPeerMemoryFeatureFlags*                   pPeerMemoryFeatures) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeviceGroupPeerMemoryFeaturesKHR: Invalid device "
+                   "[VUID-vkGetDeviceGroupPeerMemoryFeaturesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures);
 }
 
@@ -2323,6 +2421,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMaskKHR(
     VkCommandBuffer                             commandBuffer,
     uint32_t                                    deviceMask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetDeviceMaskKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdSetDeviceMaskKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetDeviceMaskKHR(commandBuffer, deviceMask);
 }
 
@@ -2335,6 +2439,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBaseKHR(
     uint32_t                                    groupCountY,
     uint32_t                                    groupCountZ) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDispatchBaseKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdDispatchBaseKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 }
 
@@ -2346,6 +2456,12 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPoolKHR(
     VkCommandPool                               commandPool,
     VkCommandPoolTrimFlags                      flags) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkTrimCommandPoolKHR: Invalid device "
+                   "[VUID-vkTrimCommandPoolKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->TrimCommandPoolKHR(device, commandPool, flags);
 }
 
@@ -2358,6 +2474,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleKHR(
     const VkMemoryGetWin32HandleInfoKHR*        pGetWin32HandleInfo,
     HANDLE*                                     pHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetMemoryWin32HandleKHR: Invalid device "
+                   "[VUID-vkGetMemoryWin32HandleKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetMemoryWin32HandleKHR(device, pGetWin32HandleInfo, pHandle);
 }
 
@@ -2369,6 +2491,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandlePropertiesKHR(
     HANDLE                                      handle,
     VkMemoryWin32HandlePropertiesKHR*           pMemoryWin32HandleProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetMemoryWin32HandlePropertiesKHR: Invalid device "
+                   "[VUID-vkGetMemoryWin32HandlePropertiesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetMemoryWin32HandlePropertiesKHR(device, handleType, handle, pMemoryWin32HandleProperties);
 }
 
@@ -2381,6 +2509,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHR(
     const VkMemoryGetFdInfoKHR*                 pGetFdInfo,
     int*                                        pFd) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetMemoryFdKHR: Invalid device "
+                   "[VUID-vkGetMemoryFdKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetMemoryFdKHR(device, pGetFdInfo, pFd);
 }
 
@@ -2390,6 +2524,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdPropertiesKHR(
     int                                         fd,
     VkMemoryFdPropertiesKHR*                    pMemoryFdProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetMemoryFdPropertiesKHR: Invalid device "
+                   "[VUID-vkGetMemoryFdPropertiesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties);
 }
 
@@ -2401,6 +2541,12 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreWin32HandleKHR(
     VkDevice                                    device,
     const VkImportSemaphoreWin32HandleInfoKHR*  pImportSemaphoreWin32HandleInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkImportSemaphoreWin32HandleKHR: Invalid device "
+                   "[VUID-vkImportSemaphoreWin32HandleKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->ImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo);
 }
 
@@ -2411,6 +2557,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreWin32HandleKHR(
     const VkSemaphoreGetWin32HandleInfoKHR*     pGetWin32HandleInfo,
     HANDLE*                                     pHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetSemaphoreWin32HandleKHR: Invalid device "
+                   "[VUID-vkGetSemaphoreWin32HandleKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetSemaphoreWin32HandleKHR(device, pGetWin32HandleInfo, pHandle);
 }
 
@@ -2422,6 +2574,12 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreFdKHR(
     VkDevice                                    device,
     const VkImportSemaphoreFdInfoKHR*           pImportSemaphoreFdInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkImportSemaphoreFdKHR: Invalid device "
+                   "[VUID-vkImportSemaphoreFdKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->ImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo);
 }
 
@@ -2430,6 +2588,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreFdKHR(
     const VkSemaphoreGetFdInfoKHR*              pGetFdInfo,
     int*                                        pFd) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetSemaphoreFdKHR: Invalid device "
+                   "[VUID-vkGetSemaphoreFdKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetSemaphoreFdKHR(device, pGetFdInfo, pFd);
 }
 
@@ -2444,6 +2608,12 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetKHR(
     uint32_t                                    descriptorWriteCount,
     const VkWriteDescriptorSet*                 pDescriptorWrites) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdPushDescriptorSetKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdPushDescriptorSetKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
 }
 
@@ -2454,6 +2624,12 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplateKHR(
     uint32_t                                    set,
     const void*                                 pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdPushDescriptorSetWithTemplateKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdPushDescriptorSetWithTemplateKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set, pData);
 }
 
@@ -2466,6 +2642,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateDescriptorUpdateTemplateKHR: Invalid device "
+                   "[VUID-vkCreateDescriptorUpdateTemplateKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
 }
 
@@ -2474,6 +2656,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
     VkDescriptorUpdateTemplate                  descriptorUpdateTemplate,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyDescriptorUpdateTemplateKHR: Invalid device "
+                   "[VUID-vkDestroyDescriptorUpdateTemplateKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
 }
 
@@ -2483,6 +2671,12 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplateKHR(
     VkDescriptorUpdateTemplate                  descriptorUpdateTemplate,
     const void*                                 pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkUpdateDescriptorSetWithTemplateKHR: Invalid device "
+                   "[VUID-vkUpdateDescriptorSetWithTemplateKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->UpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData);
 }
 
@@ -2495,6 +2689,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
     const VkAllocationCallbacks*                pAllocator,
     VkRenderPass*                               pRenderPass) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateRenderPass2KHR: Invalid device "
+                   "[VUID-vkCreateRenderPass2KHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass);
 }
 
@@ -2503,6 +2703,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2KHR(
     const VkRenderPassBeginInfo*                pRenderPassBegin,
     const VkSubpassBeginInfo*                   pSubpassBeginInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBeginRenderPass2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdBeginRenderPass2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
 }
 
@@ -2511,6 +2717,12 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2KHR(
     const VkSubpassBeginInfo*                   pSubpassBeginInfo,
     const VkSubpassEndInfo*                     pSubpassEndInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdNextSubpass2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdNextSubpass2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
 }
 
@@ -2518,6 +2730,12 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkSubpassEndInfo*                     pSubpassEndInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdEndRenderPass2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdEndRenderPass2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
 }
 
@@ -2528,6 +2746,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainStatusKHR(
     VkDevice                                    device,
     VkSwapchainKHR                              swapchain) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetSwapchainStatusKHR: Invalid device "
+                   "[VUID-vkGetSwapchainStatusKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetSwapchainStatusKHR(device, swapchain);
 }
 
@@ -2539,6 +2763,12 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceWin32HandleKHR(
     VkDevice                                    device,
     const VkImportFenceWin32HandleInfoKHR*      pImportFenceWin32HandleInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkImportFenceWin32HandleKHR: Invalid device "
+                   "[VUID-vkImportFenceWin32HandleKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->ImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo);
 }
 
@@ -2549,6 +2779,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceWin32HandleKHR(
     const VkFenceGetWin32HandleInfoKHR*         pGetWin32HandleInfo,
     HANDLE*                                     pHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetFenceWin32HandleKHR: Invalid device "
+                   "[VUID-vkGetFenceWin32HandleKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetFenceWin32HandleKHR(device, pGetWin32HandleInfo, pHandle);
 }
 
@@ -2560,6 +2796,12 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceFdKHR(
     VkDevice                                    device,
     const VkImportFenceFdInfoKHR*               pImportFenceFdInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkImportFenceFdKHR: Invalid device "
+                   "[VUID-vkImportFenceFdKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->ImportFenceFdKHR(device, pImportFenceFdInfo);
 }
 
@@ -2568,6 +2810,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceFdKHR(
     const VkFenceGetFdInfoKHR*                  pGetFdInfo,
     int*                                        pFd) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetFenceFdKHR: Invalid device "
+                   "[VUID-vkGetFenceFdKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetFenceFdKHR(device, pGetFdInfo, pFd);
 }
 
@@ -2582,6 +2830,12 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceQueueFamilyPerformanceQuer
     VkPerformanceCounterDescriptionKHR*         pCounterDescriptions) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR: Invalid physicalDevice "
+                   "[VUID-vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(unwrapped_phys_dev, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions);
 }
@@ -2607,6 +2861,12 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR
     uint32_t*                                   pNumPasses) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     disp->GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(unwrapped_phys_dev, pPerformanceQueryCreateInfo, pNumPasses);
 }
@@ -2628,12 +2888,24 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireProfilingLockKHR(
     VkDevice                                    device,
     const VkAcquireProfilingLockInfoKHR*        pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkAcquireProfilingLockKHR: Invalid device "
+                   "[VUID-vkAcquireProfilingLockKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->AcquireProfilingLockKHR(device, pInfo);
 }
 
 VKAPI_ATTR void VKAPI_CALL ReleaseProfilingLockKHR(
     VkDevice                                    device) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkReleaseProfilingLockKHR: Invalid device "
+                   "[VUID-vkReleaseProfilingLockKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->ReleaseProfilingLockKHR(device);
 }
 
@@ -2645,6 +2917,12 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2KHR(
     const VkImageMemoryRequirementsInfo2*       pInfo,
     VkMemoryRequirements2*                      pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetImageMemoryRequirements2KHR: Invalid device "
+                   "[VUID-vkGetImageMemoryRequirements2KHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetImageMemoryRequirements2KHR(device, pInfo, pMemoryRequirements);
 }
 
@@ -2653,6 +2931,12 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2KHR(
     const VkBufferMemoryRequirementsInfo2*      pInfo,
     VkMemoryRequirements2*                      pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetBufferMemoryRequirements2KHR: Invalid device "
+                   "[VUID-vkGetBufferMemoryRequirements2KHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetBufferMemoryRequirements2KHR(device, pInfo, pMemoryRequirements);
 }
 
@@ -2662,6 +2946,12 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2KHR(
     uint32_t*                                   pSparseMemoryRequirementCount,
     VkSparseImageMemoryRequirements2*           pSparseMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetImageSparseMemoryRequirements2KHR: Invalid device "
+                   "[VUID-vkGetImageSparseMemoryRequirements2KHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetImageSparseMemoryRequirements2KHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 }
 
@@ -2674,6 +2964,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSamplerYcbcrConversion*                   pYcbcrConversion) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateSamplerYcbcrConversionKHR: Invalid device "
+                   "[VUID-vkCreateSamplerYcbcrConversionKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion);
 }
 
@@ -2682,6 +2978,12 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
     VkSamplerYcbcrConversion                    ycbcrConversion,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroySamplerYcbcrConversionKHR: Invalid device "
+                   "[VUID-vkDestroySamplerYcbcrConversionKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
 }
 
@@ -2693,6 +2995,12 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(
     uint32_t                                    bindInfoCount,
     const VkBindBufferMemoryInfo*               pBindInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkBindBufferMemory2KHR: Invalid device "
+                   "[VUID-vkBindBufferMemory2KHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->BindBufferMemory2KHR(device, bindInfoCount, pBindInfos);
 }
 
@@ -2701,6 +3009,12 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2KHR(
     uint32_t                                    bindInfoCount,
     const VkBindImageMemoryInfo*                pBindInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkBindImageMemory2KHR: Invalid device "
+                   "[VUID-vkBindImageMemory2KHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->BindImageMemory2KHR(device, bindInfoCount, pBindInfos);
 }
 
@@ -2712,6 +3026,12 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupportKHR(
     const VkDescriptorSetLayoutCreateInfo*      pCreateInfo,
     VkDescriptorSetLayoutSupport*               pSupport) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDescriptorSetLayoutSupportKHR: Invalid device "
+                   "[VUID-vkGetDescriptorSetLayoutSupportKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetDescriptorSetLayoutSupportKHR(device, pCreateInfo, pSupport);
 }
 
@@ -2727,6 +3047,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountKHR(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDrawIndirectCountKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdDrawIndirectCountKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
 
@@ -2739,6 +3065,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountKHR(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDrawIndexedIndirectCountKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdDrawIndexedIndirectCountKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
 
@@ -2750,6 +3082,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValueKHR(
     VkSemaphore                                 semaphore,
     uint64_t*                                   pValue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetSemaphoreCounterValueKHR: Invalid device "
+                   "[VUID-vkGetSemaphoreCounterValueKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetSemaphoreCounterValueKHR(device, semaphore, pValue);
 }
 
@@ -2758,6 +3096,12 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphoresKHR(
     const VkSemaphoreWaitInfo*                  pWaitInfo,
     uint64_t                                    timeout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkWaitSemaphoresKHR: Invalid device "
+                   "[VUID-vkWaitSemaphoresKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->WaitSemaphoresKHR(device, pWaitInfo, timeout);
 }
 
@@ -2765,6 +3109,12 @@ VKAPI_ATTR VkResult VKAPI_CALL SignalSemaphoreKHR(
     VkDevice                                    device,
     const VkSemaphoreSignalInfo*                pSignalInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkSignalSemaphoreKHR: Invalid device "
+                   "[VUID-vkSignalSemaphoreKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->SignalSemaphoreKHR(device, pSignalInfo);
 }
 
@@ -2777,6 +3127,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceFragmentShadingRatesKHR(
     VkPhysicalDeviceFragmentShadingRateKHR*     pFragmentShadingRates) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceFragmentShadingRatesKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceFragmentShadingRatesKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceFragmentShadingRatesKHR(unwrapped_phys_dev, pFragmentShadingRateCount, pFragmentShadingRates);
 }
@@ -2799,6 +3155,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateKHR(
     const VkExtent2D*                           pFragmentSize,
     const VkFragmentShadingRateCombinerOpKHR    combinerOps[2]) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetFragmentShadingRateKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdSetFragmentShadingRateKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetFragmentShadingRateKHR(commandBuffer, pFragmentSize, combinerOps);
 }
 
@@ -2811,6 +3173,12 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitForPresentKHR(
     uint64_t                                    presentId,
     uint64_t                                    timeout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkWaitForPresentKHR: Invalid device "
+                   "[VUID-vkWaitForPresentKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->WaitForPresentKHR(device, swapchain, presentId, timeout);
 }
 
@@ -2821,6 +3189,12 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressKHR(
     VkDevice                                    device,
     const VkBufferDeviceAddressInfo*            pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetBufferDeviceAddressKHR: Invalid device "
+                   "[VUID-vkGetBufferDeviceAddressKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetBufferDeviceAddressKHR(device, pInfo);
 }
 
@@ -2828,6 +3202,12 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetBufferOpaqueCaptureAddressKHR(
     VkDevice                                    device,
     const VkBufferDeviceAddressInfo*            pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetBufferOpaqueCaptureAddressKHR: Invalid device "
+                   "[VUID-vkGetBufferOpaqueCaptureAddressKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetBufferOpaqueCaptureAddressKHR(device, pInfo);
 }
 
@@ -2835,6 +3215,12 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetDeviceMemoryOpaqueCaptureAddressKHR(
     VkDevice                                    device,
     const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeviceMemoryOpaqueCaptureAddressKHR: Invalid device "
+                   "[VUID-vkGetDeviceMemoryOpaqueCaptureAddressKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetDeviceMemoryOpaqueCaptureAddressKHR(device, pInfo);
 }
 
@@ -2846,6 +3232,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDeferredOperationKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkDeferredOperationKHR*                     pDeferredOperation) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateDeferredOperationKHR: Invalid device "
+                   "[VUID-vkCreateDeferredOperationKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateDeferredOperationKHR(device, pAllocator, pDeferredOperation);
 }
 
@@ -2854,6 +3246,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyDeferredOperationKHR(
     VkDeferredOperationKHR                      operation,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyDeferredOperationKHR: Invalid device "
+                   "[VUID-vkDestroyDeferredOperationKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyDeferredOperationKHR(device, operation, pAllocator);
 }
 
@@ -2861,6 +3259,12 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetDeferredOperationMaxConcurrencyKHR(
     VkDevice                                    device,
     VkDeferredOperationKHR                      operation) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeferredOperationMaxConcurrencyKHR: Invalid device "
+                   "[VUID-vkGetDeferredOperationMaxConcurrencyKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetDeferredOperationMaxConcurrencyKHR(device, operation);
 }
 
@@ -2868,6 +3272,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeferredOperationResultKHR(
     VkDevice                                    device,
     VkDeferredOperationKHR                      operation) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeferredOperationResultKHR: Invalid device "
+                   "[VUID-vkGetDeferredOperationResultKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetDeferredOperationResultKHR(device, operation);
 }
 
@@ -2875,6 +3285,12 @@ VKAPI_ATTR VkResult VKAPI_CALL DeferredOperationJoinKHR(
     VkDevice                                    device,
     VkDeferredOperationKHR                      operation) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDeferredOperationJoinKHR: Invalid device "
+                   "[VUID-vkDeferredOperationJoinKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->DeferredOperationJoinKHR(device, operation);
 }
 
@@ -2887,6 +3303,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutablePropertiesKHR(
     uint32_t*                                   pExecutableCount,
     VkPipelineExecutablePropertiesKHR*          pProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPipelineExecutablePropertiesKHR: Invalid device "
+                   "[VUID-vkGetPipelineExecutablePropertiesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties);
 }
 
@@ -2896,6 +3318,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableStatisticsKHR(
     uint32_t*                                   pStatisticCount,
     VkPipelineExecutableStatisticKHR*           pStatistics) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPipelineExecutableStatisticsKHR: Invalid device "
+                   "[VUID-vkGetPipelineExecutableStatisticsKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics);
 }
 
@@ -2905,6 +3333,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableInternalRepresentationsKHR(
     uint32_t*                                   pInternalRepresentationCount,
     VkPipelineExecutableInternalRepresentationKHR* pInternalRepresentations) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPipelineExecutableInternalRepresentationsKHR: Invalid device "
+                   "[VUID-vkGetPipelineExecutableInternalRepresentationsKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations);
 }
 
@@ -2916,6 +3350,12 @@ VKAPI_ATTR void VKAPI_CALL CmdEncodeVideoKHR(
     VkCommandBuffer                             commandBuffer,
     const VkVideoEncodeInfoKHR*                 pEncodeInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdEncodeVideoKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdEncodeVideoKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdEncodeVideoKHR(commandBuffer, pEncodeInfo);
 }
 
@@ -2928,6 +3368,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent2KHR(
     VkEvent                                     event,
     const VkDependencyInfoKHR*                  pDependencyInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetEvent2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdSetEvent2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetEvent2KHR(commandBuffer, event, pDependencyInfo);
 }
 
@@ -2936,6 +3382,12 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent2KHR(
     VkEvent                                     event,
     VkPipelineStageFlags2KHR                    stageMask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdResetEvent2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdResetEvent2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdResetEvent2KHR(commandBuffer, event, stageMask);
 }
 
@@ -2945,6 +3397,12 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents2KHR(
     const VkEvent*                              pEvents,
     const VkDependencyInfoKHR*                  pDependencyInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdWaitEvents2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdWaitEvents2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos);
 }
 
@@ -2952,6 +3410,12 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkDependencyInfoKHR*                  pDependencyInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdPipelineBarrier2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdPipelineBarrier2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo);
 }
 
@@ -2961,6 +3425,12 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2KHR(
     VkQueryPool                                 queryPool,
     uint32_t                                    query) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdWriteTimestamp2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdWriteTimestamp2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
 }
 
@@ -2970,6 +3440,12 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(
     const VkSubmitInfo2KHR*                     pSubmits,
     VkFence                                     fence) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkQueueSubmit2KHR: Invalid queue "
+                   "[VUID-vkQueueSubmit2KHR-queue-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->QueueSubmit2KHR(queue, submitCount, pSubmits, fence);
 }
 
@@ -2980,6 +3456,12 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarker2AMD(
     VkDeviceSize                                dstOffset,
     uint32_t                                    marker) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdWriteBufferMarker2AMD: Invalid commandBuffer "
+                   "[VUID-vkCmdWriteBufferMarker2AMD-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker);
 }
 
@@ -2988,6 +3470,12 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointData2NV(
     uint32_t*                                   pCheckpointDataCount,
     VkCheckpointData2NV*                        pCheckpointData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetQueueCheckpointData2NV: Invalid queue "
+                   "[VUID-vkGetQueueCheckpointData2NV-queue-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetQueueCheckpointData2NV(queue, pCheckpointDataCount, pCheckpointData);
 }
 
@@ -2998,6 +3486,12 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkCopyBufferInfo2KHR*                 pCopyBufferInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdCopyBuffer2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdCopyBuffer2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo);
 }
 
@@ -3005,6 +3499,12 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkCopyImageInfo2KHR*                  pCopyImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdCopyImage2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdCopyImage2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdCopyImage2KHR(commandBuffer, pCopyImageInfo);
 }
 
@@ -3012,6 +3512,12 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkCopyBufferToImageInfo2KHR*          pCopyBufferToImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdCopyBufferToImage2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdCopyBufferToImage2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo);
 }
 
@@ -3019,6 +3525,12 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkCopyImageToBufferInfo2KHR*          pCopyImageToBufferInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdCopyImageToBuffer2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdCopyImageToBuffer2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo);
 }
 
@@ -3026,6 +3538,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkBlitImageInfo2KHR*                  pBlitImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBlitImage2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdBlitImage2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBlitImage2KHR(commandBuffer, pBlitImageInfo);
 }
 
@@ -3033,6 +3551,12 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkResolveImageInfo2KHR*               pResolveImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdResolveImage2KHR: Invalid commandBuffer "
+                   "[VUID-vkCmdResolveImage2KHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdResolveImage2KHR(commandBuffer, pResolveImageInfo);
 }
 
@@ -3044,6 +3568,12 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirementsKHR(
     const VkDeviceBufferMemoryRequirementsKHR*  pInfo,
     VkMemoryRequirements2*                      pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeviceBufferMemoryRequirementsKHR: Invalid device "
+                   "[VUID-vkGetDeviceBufferMemoryRequirementsKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetDeviceBufferMemoryRequirementsKHR(device, pInfo, pMemoryRequirements);
 }
 
@@ -3052,6 +3582,12 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirementsKHR(
     const VkDeviceImageMemoryRequirementsKHR*   pInfo,
     VkMemoryRequirements2*                      pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeviceImageMemoryRequirementsKHR: Invalid device "
+                   "[VUID-vkGetDeviceImageMemoryRequirementsKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetDeviceImageMemoryRequirementsKHR(device, pInfo, pMemoryRequirements);
 }
 
@@ -3061,6 +3597,12 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSparseMemoryRequirementsKHR(
     uint32_t*                                   pSparseMemoryRequirementCount,
     VkSparseImageMemoryRequirements2*           pSparseMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeviceImageSparseMemoryRequirementsKHR: Invalid device "
+                   "[VUID-vkGetDeviceImageSparseMemoryRequirementsKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetDeviceImageSparseMemoryRequirementsKHR(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 }
 
@@ -3071,6 +3613,12 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
     VkDevice                                    device,
     const VkDebugMarkerObjectTagInfoEXT*        pTagInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDebugMarkerSetObjectTagEXT: Invalid device "
+                   "[VUID-vkDebugMarkerSetObjectTagEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     VkDebugMarkerObjectTagInfoEXT local_tag_info;
     memcpy(&local_tag_info, pTagInfo, sizeof(VkDebugMarkerObjectTagInfoEXT));
     // If this is a physical device, we have to replace it with the proper one for the next call.
@@ -3113,6 +3661,12 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(
     VkDevice                                    device,
     const VkDebugMarkerObjectNameInfoEXT*       pNameInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDebugMarkerSetObjectNameEXT: Invalid device "
+                   "[VUID-vkDebugMarkerSetObjectNameEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     VkDebugMarkerObjectNameInfoEXT local_name_info;
     memcpy(&local_name_info, pNameInfo, sizeof(VkDebugMarkerObjectNameInfoEXT));
     // If this is a physical device, we have to replace it with the proper one for the next call.
@@ -3155,12 +3709,24 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerBeginEXT(
     VkCommandBuffer                             commandBuffer,
     const VkDebugMarkerMarkerInfoEXT*           pMarkerInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDebugMarkerBeginEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdDebugMarkerBeginEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerEndEXT(
     VkCommandBuffer                             commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDebugMarkerEndEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdDebugMarkerEndEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDebugMarkerEndEXT(commandBuffer);
 }
 
@@ -3168,6 +3734,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerInsertEXT(
     VkCommandBuffer                             commandBuffer,
     const VkDebugMarkerMarkerInfoEXT*           pMarkerInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDebugMarkerInsertEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdDebugMarkerInsertEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo);
 }
 
@@ -3182,6 +3754,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBindTransformFeedbackBuffersEXT(
     const VkDeviceSize*                         pOffsets,
     const VkDeviceSize*                         pSizes) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBindTransformFeedbackBuffersEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdBindTransformFeedbackBuffersEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes);
 }
 
@@ -3192,6 +3770,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginTransformFeedbackEXT(
     const VkBuffer*                             pCounterBuffers,
     const VkDeviceSize*                         pCounterBufferOffsets) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBeginTransformFeedbackEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdBeginTransformFeedbackEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
 }
 
@@ -3202,6 +3786,12 @@ VKAPI_ATTR void VKAPI_CALL CmdEndTransformFeedbackEXT(
     const VkBuffer*                             pCounterBuffers,
     const VkDeviceSize*                         pCounterBufferOffsets) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdEndTransformFeedbackEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdEndTransformFeedbackEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
 }
 
@@ -3212,6 +3802,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQueryIndexedEXT(
     VkQueryControlFlags                         flags,
     uint32_t                                    index) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBeginQueryIndexedEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdBeginQueryIndexedEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index);
 }
 
@@ -3221,6 +3817,12 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQueryIndexedEXT(
     uint32_t                                    query,
     uint32_t                                    index) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdEndQueryIndexedEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdEndQueryIndexedEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index);
 }
 
@@ -3233,6 +3835,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectByteCountEXT(
     uint32_t                                    counterOffset,
     uint32_t                                    vertexStride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDrawIndirectByteCountEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride);
 }
 
@@ -3245,6 +3853,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCuModuleNVX(
     const VkAllocationCallbacks*                pAllocator,
     VkCuModuleNVX*                              pModule) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateCuModuleNVX: Invalid device "
+                   "[VUID-vkCreateCuModuleNVX-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateCuModuleNVX(device, pCreateInfo, pAllocator, pModule);
 }
 
@@ -3254,6 +3868,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCuFunctionNVX(
     const VkAllocationCallbacks*                pAllocator,
     VkCuFunctionNVX*                            pFunction) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateCuFunctionNVX: Invalid device "
+                   "[VUID-vkCreateCuFunctionNVX-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateCuFunctionNVX(device, pCreateInfo, pAllocator, pFunction);
 }
 
@@ -3262,6 +3882,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyCuModuleNVX(
     VkCuModuleNVX                               module,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyCuModuleNVX: Invalid device "
+                   "[VUID-vkDestroyCuModuleNVX-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyCuModuleNVX(device, module, pAllocator);
 }
 
@@ -3270,6 +3896,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyCuFunctionNVX(
     VkCuFunctionNVX                             function,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyCuFunctionNVX: Invalid device "
+                   "[VUID-vkDestroyCuFunctionNVX-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyCuFunctionNVX(device, function, pAllocator);
 }
 
@@ -3277,6 +3909,12 @@ VKAPI_ATTR void VKAPI_CALL CmdCuLaunchKernelNVX(
     VkCommandBuffer                             commandBuffer,
     const VkCuLaunchInfoNVX*                    pLaunchInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdCuLaunchKernelNVX: Invalid commandBuffer "
+                   "[VUID-vkCmdCuLaunchKernelNVX-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdCuLaunchKernelNVX(commandBuffer, pLaunchInfo);
 }
 
@@ -3287,6 +3925,12 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetImageViewHandleNVX(
     VkDevice                                    device,
     const VkImageViewHandleInfoNVX*             pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetImageViewHandleNVX: Invalid device "
+                   "[VUID-vkGetImageViewHandleNVX-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetImageViewHandleNVX(device, pInfo);
 }
 
@@ -3295,6 +3939,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageViewAddressNVX(
     VkImageView                                 imageView,
     VkImageViewAddressPropertiesNVX*            pProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetImageViewAddressNVX: Invalid device "
+                   "[VUID-vkGetImageViewAddressNVX-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetImageViewAddressNVX(device, imageView, pProperties);
 }
 
@@ -3310,6 +3960,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDrawIndirectCountAMD: Invalid commandBuffer "
+                   "[VUID-vkCmdDrawIndirectCountAMD-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
 
@@ -3322,6 +3978,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountAMD(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDrawIndexedIndirectCountAMD: Invalid commandBuffer "
+                   "[VUID-vkCmdDrawIndexedIndirectCountAMD-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
 
@@ -3336,6 +3998,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetShaderInfoAMD(
     size_t*                                     pInfoSize,
     void*                                       pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetShaderInfoAMD: Invalid device "
+                   "[VUID-vkGetShaderInfoAMD-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo);
 }
 
@@ -3349,6 +4017,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleNV(
     VkExternalMemoryHandleTypeFlagsNV           handleType,
     HANDLE*                                     pHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetMemoryWin32HandleNV: Invalid device "
+                   "[VUID-vkGetMemoryWin32HandleNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetMemoryWin32HandleNV(device, memory, handleType, pHandle);
 }
 
@@ -3362,8 +4036,15 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
     const VkViSurfaceCreateInfoNN*              pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
+    struct loader_instance *inst = loader_get_instance(instance);
+    if (NULL == inst) {
+        loader_log(
+            NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+            "vkCreateViSurfaceNN: Invalid instance [VUID-vkCreateViSurfaceNN-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 #error("Not implemented. Likely needs to be manually generated!");
-    return disp->CreateViSurfaceNN(instance, pCreateInfo, pAllocator, pSurface);
+    return inst->disp->CreateViSurfaceNN(instance, pCreateInfo, pAllocator, pSurface);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateViSurfaceNN(
@@ -3371,6 +4052,13 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateViSurfaceNN(
     const VkViSurfaceCreateInfoNN*              pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
+    struct loader_instance *inst = loader_get_instance(instance);
+    if (NULL == inst) {
+        loader_log(
+            NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+            "vkCreateViSurfaceNN: Invalid instance [VUID-vkCreateViSurfaceNN-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 #error("Not implemented. Likely needs to be manually generated!");
 }
 
@@ -3382,12 +4070,24 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
     VkCommandBuffer                             commandBuffer,
     const VkConditionalRenderingBeginInfoEXT*   pConditionalRenderingBegin) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBeginConditionalRenderingEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdBeginConditionalRenderingEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdEndConditionalRenderingEXT(
     VkCommandBuffer                             commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdEndConditionalRenderingEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdEndConditionalRenderingEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdEndConditionalRenderingEXT(commandBuffer);
 }
 
@@ -3400,6 +4100,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingNV(
     uint32_t                                    viewportCount,
     const VkViewportWScalingNV*                 pViewportWScalings) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetViewportWScalingNV: Invalid commandBuffer "
+                   "[VUID-vkCmdSetViewportWScalingNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings);
 }
 
@@ -3411,6 +4117,12 @@ VKAPI_ATTR VkResult VKAPI_CALL DisplayPowerControlEXT(
     VkDisplayKHR                                display,
     const VkDisplayPowerInfoEXT*                pDisplayPowerInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDisplayPowerControlEXT: Invalid device "
+                   "[VUID-vkDisplayPowerControlEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->DisplayPowerControlEXT(device, display, pDisplayPowerInfo);
 }
 
@@ -3420,6 +4132,12 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkFence*                                    pFence) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkRegisterDeviceEventEXT: Invalid device "
+                   "[VUID-vkRegisterDeviceEventEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->RegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence);
 }
 
@@ -3430,6 +4148,12 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkFence*                                    pFence) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkRegisterDisplayEventEXT: Invalid device "
+                   "[VUID-vkRegisterDisplayEventEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->RegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence);
 }
 
@@ -3439,6 +4163,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainCounterEXT(
     VkSurfaceCounterFlagBitsEXT                 counter,
     uint64_t*                                   pCounterValue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetSwapchainCounterEXT: Invalid device "
+                   "[VUID-vkGetSwapchainCounterEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetSwapchainCounterEXT(device, swapchain, counter, pCounterValue);
 }
 
@@ -3450,6 +4180,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRefreshCycleDurationGOOGLE(
     VkSwapchainKHR                              swapchain,
     VkRefreshCycleDurationGOOGLE*               pDisplayTimingProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetRefreshCycleDurationGOOGLE: Invalid device "
+                   "[VUID-vkGetRefreshCycleDurationGOOGLE-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties);
 }
 
@@ -3459,6 +4195,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPastPresentationTimingGOOGLE(
     uint32_t*                                   pPresentationTimingCount,
     VkPastPresentationTimingGOOGLE*             pPresentationTimings) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPastPresentationTimingGOOGLE: Invalid device "
+                   "[VUID-vkGetPastPresentationTimingGOOGLE-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings);
 }
 
@@ -3471,6 +4213,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEXT(
     uint32_t                                    discardRectangleCount,
     const VkRect2D*                             pDiscardRectangles) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetDiscardRectangleEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetDiscardRectangleEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles);
 }
 
@@ -3483,6 +4231,12 @@ VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(
     const VkSwapchainKHR*                       pSwapchains,
     const VkHdrMetadataEXT*                     pMetadata) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkSetHdrMetadataEXT: Invalid device "
+                   "[VUID-vkSetHdrMetadataEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->SetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata);
 }
 
@@ -3493,6 +4247,12 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
     VkDevice                                    device,
     const VkDebugUtilsObjectNameInfoEXT*        pNameInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkSetDebugUtilsObjectNameEXT: Invalid device "
+                   "[VUID-vkSetDebugUtilsObjectNameEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     VkDebugUtilsObjectNameInfoEXT local_name_info;
     memcpy(&local_name_info, pNameInfo, sizeof(VkDebugUtilsObjectNameInfoEXT));
     // If this is a physical device, we have to replace it with the proper one for the next call.
@@ -3539,6 +4299,12 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectTagEXT(
     VkDevice                                    device,
     const VkDebugUtilsObjectTagInfoEXT*         pTagInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkSetDebugUtilsObjectTagEXT: Invalid device "
+                   "[VUID-vkSetDebugUtilsObjectTagEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     VkDebugUtilsObjectTagInfoEXT local_tag_info;
     memcpy(&local_tag_info, pTagInfo, sizeof(VkDebugUtilsObjectTagInfoEXT));
     // If this is a physical device, we have to replace it with the proper one for the next call.
@@ -3585,6 +4351,12 @@ VKAPI_ATTR void VKAPI_CALL QueueBeginDebugUtilsLabelEXT(
     VkQueue                                     queue,
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkQueueBeginDebugUtilsLabelEXT: Invalid queue "
+                   "[VUID-vkQueueBeginDebugUtilsLabelEXT-queue-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     if (disp->QueueBeginDebugUtilsLabelEXT != NULL) {
         disp->QueueBeginDebugUtilsLabelEXT(queue, pLabelInfo);
     }
@@ -3604,6 +4376,12 @@ VKAPI_ATTR void VKAPI_CALL terminator_QueueBeginDebugUtilsLabelEXT(
 VKAPI_ATTR void VKAPI_CALL QueueEndDebugUtilsLabelEXT(
     VkQueue                                     queue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkQueueEndDebugUtilsLabelEXT: Invalid queue "
+                   "[VUID-vkQueueEndDebugUtilsLabelEXT-queue-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     if (disp->QueueEndDebugUtilsLabelEXT != NULL) {
         disp->QueueEndDebugUtilsLabelEXT(queue);
     }
@@ -3623,6 +4401,12 @@ VKAPI_ATTR void VKAPI_CALL QueueInsertDebugUtilsLabelEXT(
     VkQueue                                     queue,
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkQueueInsertDebugUtilsLabelEXT: Invalid queue "
+                   "[VUID-vkQueueInsertDebugUtilsLabelEXT-queue-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     if (disp->QueueInsertDebugUtilsLabelEXT != NULL) {
         disp->QueueInsertDebugUtilsLabelEXT(queue, pLabelInfo);
     }
@@ -3643,6 +4427,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginDebugUtilsLabelEXT(
     VkCommandBuffer                             commandBuffer,
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBeginDebugUtilsLabelEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdBeginDebugUtilsLabelEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     if (disp->CmdBeginDebugUtilsLabelEXT != NULL) {
         disp->CmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
     }
@@ -3662,6 +4452,12 @@ VKAPI_ATTR void VKAPI_CALL terminator_CmdBeginDebugUtilsLabelEXT(
 VKAPI_ATTR void VKAPI_CALL CmdEndDebugUtilsLabelEXT(
     VkCommandBuffer                             commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdEndDebugUtilsLabelEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     if (disp->CmdEndDebugUtilsLabelEXT != NULL) {
         disp->CmdEndDebugUtilsLabelEXT(commandBuffer);
     }
@@ -3681,6 +4477,12 @@ VKAPI_ATTR void VKAPI_CALL CmdInsertDebugUtilsLabelEXT(
     VkCommandBuffer                             commandBuffer,
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdInsertDebugUtilsLabelEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdInsertDebugUtilsLabelEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     if (disp->CmdInsertDebugUtilsLabelEXT != NULL) {
         disp->CmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
     }
@@ -3706,6 +4508,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAndroidHardwareBufferPropertiesANDROID(
     const struct AHardwareBuffer*               buffer,
     VkAndroidHardwareBufferPropertiesANDROID*   pProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetAndroidHardwareBufferPropertiesANDROID: Invalid device "
+                   "[VUID-vkGetAndroidHardwareBufferPropertiesANDROID-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetAndroidHardwareBufferPropertiesANDROID(device, buffer, pProperties);
 }
 
@@ -3716,6 +4524,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryAndroidHardwareBufferANDROID(
     const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo,
     struct AHardwareBuffer**                    pBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetMemoryAndroidHardwareBufferANDROID: Invalid device "
+                   "[VUID-vkGetMemoryAndroidHardwareBufferANDROID-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetMemoryAndroidHardwareBufferANDROID(device, pInfo, pBuffer);
 }
 
@@ -3727,6 +4541,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEXT(
     VkCommandBuffer                             commandBuffer,
     const VkSampleLocationsInfoEXT*             pSampleLocationsInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetSampleLocationsEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetSampleLocationsEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo);
 }
 
@@ -3736,6 +4556,12 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMultisamplePropertiesEXT(
     VkMultisamplePropertiesEXT*                 pMultisampleProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceMultisamplePropertiesEXT: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceMultisamplePropertiesEXT-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     disp->GetPhysicalDeviceMultisamplePropertiesEXT(unwrapped_phys_dev, samples, pMultisampleProperties);
 }
@@ -3761,6 +4587,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageDrmFormatModifierPropertiesEXT(
     VkImage                                     image,
     VkImageDrmFormatModifierPropertiesEXT*      pProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetImageDrmFormatModifierPropertiesEXT: Invalid device "
+                   "[VUID-vkGetImageDrmFormatModifierPropertiesEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetImageDrmFormatModifierPropertiesEXT(device, image, pProperties);
 }
 
@@ -3773,6 +4605,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkValidationCacheEXT*                       pValidationCache) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateValidationCacheEXT: Invalid device "
+                   "[VUID-vkCreateValidationCacheEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache);
 }
 
@@ -3781,6 +4619,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
     VkValidationCacheEXT                        validationCache,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyValidationCacheEXT: Invalid device "
+                   "[VUID-vkDestroyValidationCacheEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyValidationCacheEXT(device, validationCache, pAllocator);
 }
 
@@ -3790,6 +4634,12 @@ VKAPI_ATTR VkResult VKAPI_CALL MergeValidationCachesEXT(
     uint32_t                                    srcCacheCount,
     const VkValidationCacheEXT*                 pSrcCaches) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkMergeValidationCachesEXT: Invalid device "
+                   "[VUID-vkMergeValidationCachesEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->MergeValidationCachesEXT(device, dstCache, srcCacheCount, pSrcCaches);
 }
 
@@ -3799,6 +4649,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetValidationCacheDataEXT(
     size_t*                                     pDataSize,
     void*                                       pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetValidationCacheDataEXT: Invalid device "
+                   "[VUID-vkGetValidationCacheDataEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetValidationCacheDataEXT(device, validationCache, pDataSize, pData);
 }
 
@@ -3810,6 +4666,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadingRateImageNV(
     VkImageView                                 imageView,
     VkImageLayout                               imageLayout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBindShadingRateImageNV: Invalid commandBuffer "
+                   "[VUID-vkCmdBindShadingRateImageNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
 }
 
@@ -3819,6 +4681,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportShadingRatePaletteNV(
     uint32_t                                    viewportCount,
     const VkShadingRatePaletteNV*               pShadingRatePalettes) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetViewportShadingRatePaletteNV: Invalid commandBuffer "
+                   "[VUID-vkCmdSetViewportShadingRatePaletteNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes);
 }
 
@@ -3828,6 +4696,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoarseSampleOrderNV(
     uint32_t                                    customSampleOrderCount,
     const VkCoarseSampleOrderCustomNV*          pCustomSampleOrders) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetCoarseSampleOrderNV: Invalid commandBuffer "
+                   "[VUID-vkCmdSetCoarseSampleOrderNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders);
 }
 
@@ -3840,6 +4714,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureNV(
     const VkAllocationCallbacks*                pAllocator,
     VkAccelerationStructureNV*                  pAccelerationStructure) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateAccelerationStructureNV: Invalid device "
+                   "[VUID-vkCreateAccelerationStructureNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure);
 }
 
@@ -3848,6 +4728,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
     VkAccelerationStructureNV                   accelerationStructure,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyAccelerationStructureNV: Invalid device "
+                   "[VUID-vkDestroyAccelerationStructureNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyAccelerationStructureNV(device, accelerationStructure, pAllocator);
 }
 
@@ -3856,6 +4742,12 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureMemoryRequirementsNV(
     const VkAccelerationStructureMemoryRequirementsInfoNV* pInfo,
     VkMemoryRequirements2KHR*                   pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetAccelerationStructureMemoryRequirementsNV: Invalid device "
+                   "[VUID-vkGetAccelerationStructureMemoryRequirementsNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetAccelerationStructureMemoryRequirementsNV(device, pInfo, pMemoryRequirements);
 }
 
@@ -3864,6 +4756,12 @@ VKAPI_ATTR VkResult VKAPI_CALL BindAccelerationStructureMemoryNV(
     uint32_t                                    bindInfoCount,
     const VkBindAccelerationStructureMemoryInfoNV* pBindInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkBindAccelerationStructureMemoryNV: Invalid device "
+                   "[VUID-vkBindAccelerationStructureMemoryNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->BindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos);
 }
 
@@ -3878,6 +4776,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructureNV(
     VkBuffer                                    scratch,
     VkDeviceSize                                scratchOffset) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBuildAccelerationStructureNV: Invalid commandBuffer "
+                   "[VUID-vkCmdBuildAccelerationStructureNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset);
 }
 
@@ -3887,6 +4791,12 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureNV(
     VkAccelerationStructureNV                   src,
     VkCopyAccelerationStructureModeKHR          mode) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdCopyAccelerationStructureNV: Invalid commandBuffer "
+                   "[VUID-vkCmdCopyAccelerationStructureNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode);
 }
 
@@ -3907,6 +4817,12 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysNV(
     uint32_t                                    height,
     uint32_t                                    depth) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdTraceRaysNV: Invalid commandBuffer "
+                   "[VUID-vkCmdTraceRaysNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
 }
 
@@ -3918,6 +4834,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(
     const VkAllocationCallbacks*                pAllocator,
     VkPipeline*                                 pPipelines) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateRayTracingPipelinesNV: Invalid device "
+                   "[VUID-vkCreateRayTracingPipelinesNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
 }
 
@@ -3929,6 +4851,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesKHR(
     size_t                                      dataSize,
     void*                                       pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetRayTracingShaderGroupHandlesKHR: Invalid device "
+                   "[VUID-vkGetRayTracingShaderGroupHandlesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
 }
 
@@ -3940,6 +4868,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesNV(
     size_t                                      dataSize,
     void*                                       pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetRayTracingShaderGroupHandlesNV: Invalid device "
+                   "[VUID-vkGetRayTracingShaderGroupHandlesNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData);
 }
 
@@ -3949,6 +4883,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAccelerationStructureHandleNV(
     size_t                                      dataSize,
     void*                                       pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetAccelerationStructureHandleNV: Invalid device "
+                   "[VUID-vkGetAccelerationStructureHandleNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData);
 }
 
@@ -3960,6 +4900,12 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesNV(
     VkQueryPool                                 queryPool,
     uint32_t                                    firstQuery) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdWriteAccelerationStructuresPropertiesNV: Invalid commandBuffer "
+                   "[VUID-vkCmdWriteAccelerationStructuresPropertiesNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
 }
 
@@ -3968,6 +4914,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CompileDeferredNV(
     VkPipeline                                  pipeline,
     uint32_t                                    shader) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCompileDeferredNV: Invalid device "
+                   "[VUID-vkCompileDeferredNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CompileDeferredNV(device, pipeline, shader);
 }
 
@@ -3980,6 +4932,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryHostPointerPropertiesEXT(
     const void*                                 pHostPointer,
     VkMemoryHostPointerPropertiesEXT*           pMemoryHostPointerProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetMemoryHostPointerPropertiesEXT: Invalid device "
+                   "[VUID-vkGetMemoryHostPointerPropertiesEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties);
 }
 
@@ -3993,6 +4951,12 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarkerAMD(
     VkDeviceSize                                dstOffset,
     uint32_t                                    marker) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdWriteBufferMarkerAMD: Invalid commandBuffer "
+                   "[VUID-vkCmdWriteBufferMarkerAMD-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
 }
 
@@ -4005,6 +4969,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCalibrateableTimeDomainsEXT(
     VkTimeDomainEXT*                            pTimeDomains) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceCalibrateableTimeDomainsEXT-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceCalibrateableTimeDomainsEXT(unwrapped_phys_dev, pTimeDomainCount, pTimeDomains);
 }
@@ -4029,6 +4999,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetCalibratedTimestampsEXT(
     uint64_t*                                   pTimestamps,
     uint64_t*                                   pMaxDeviation) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetCalibratedTimestampsEXT: Invalid device "
+                   "[VUID-vkGetCalibratedTimestampsEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation);
 }
 
@@ -4040,6 +5016,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksNV(
     uint32_t                                    taskCount,
     uint32_t                                    firstTask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDrawMeshTasksNV: Invalid commandBuffer "
+                   "[VUID-vkCmdDrawMeshTasksNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask);
 }
 
@@ -4050,6 +5032,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectNV(
     uint32_t                                    drawCount,
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDrawMeshTasksIndirectNV: Invalid commandBuffer "
+                   "[VUID-vkCmdDrawMeshTasksIndirectNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
 }
 
@@ -4062,6 +5050,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountNV(
     uint32_t                                    maxDrawCount,
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDrawMeshTasksIndirectCountNV: Invalid commandBuffer "
+                   "[VUID-vkCmdDrawMeshTasksIndirectCountNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
 
@@ -4074,6 +5068,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorNV(
     uint32_t                                    exclusiveScissorCount,
     const VkRect2D*                             pExclusiveScissors) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetExclusiveScissorNV: Invalid commandBuffer "
+                   "[VUID-vkCmdSetExclusiveScissorNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors);
 }
 
@@ -4084,6 +5084,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCheckpointNV(
     VkCommandBuffer                             commandBuffer,
     const void*                                 pCheckpointMarker) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetCheckpointNV: Invalid commandBuffer "
+                   "[VUID-vkCmdSetCheckpointNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetCheckpointNV(commandBuffer, pCheckpointMarker);
 }
 
@@ -4092,6 +5098,12 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointDataNV(
     uint32_t*                                   pCheckpointDataCount,
     VkCheckpointDataNV*                         pCheckpointData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetQueueCheckpointDataNV: Invalid queue "
+                   "[VUID-vkGetQueueCheckpointDataNV-queue-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetQueueCheckpointDataNV(queue, pCheckpointDataCount, pCheckpointData);
 }
 
@@ -4102,12 +5114,24 @@ VKAPI_ATTR VkResult VKAPI_CALL InitializePerformanceApiINTEL(
     VkDevice                                    device,
     const VkInitializePerformanceApiInfoINTEL*  pInitializeInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkInitializePerformanceApiINTEL: Invalid device "
+                   "[VUID-vkInitializePerformanceApiINTEL-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->InitializePerformanceApiINTEL(device, pInitializeInfo);
 }
 
 VKAPI_ATTR void VKAPI_CALL UninitializePerformanceApiINTEL(
     VkDevice                                    device) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkUninitializePerformanceApiINTEL: Invalid device "
+                   "[VUID-vkUninitializePerformanceApiINTEL-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->UninitializePerformanceApiINTEL(device);
 }
 
@@ -4115,6 +5139,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceMarkerINTEL(
     VkCommandBuffer                             commandBuffer,
     const VkPerformanceMarkerInfoINTEL*         pMarkerInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetPerformanceMarkerINTEL: Invalid commandBuffer "
+                   "[VUID-vkCmdSetPerformanceMarkerINTEL-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo);
 }
 
@@ -4122,6 +5152,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceStreamMarkerINTEL(
     VkCommandBuffer                             commandBuffer,
     const VkPerformanceStreamMarkerInfoINTEL*   pMarkerInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetPerformanceStreamMarkerINTEL: Invalid commandBuffer "
+                   "[VUID-vkCmdSetPerformanceStreamMarkerINTEL-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo);
 }
 
@@ -4129,6 +5165,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceOverrideINTEL(
     VkCommandBuffer                             commandBuffer,
     const VkPerformanceOverrideInfoINTEL*       pOverrideInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetPerformanceOverrideINTEL: Invalid commandBuffer "
+                   "[VUID-vkCmdSetPerformanceOverrideINTEL-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo);
 }
 
@@ -4137,6 +5179,12 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquirePerformanceConfigurationINTEL(
     const VkPerformanceConfigurationAcquireInfoINTEL* pAcquireInfo,
     VkPerformanceConfigurationINTEL*            pConfiguration) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkAcquirePerformanceConfigurationINTEL: Invalid device "
+                   "[VUID-vkAcquirePerformanceConfigurationINTEL-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->AcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration);
 }
 
@@ -4144,6 +5192,12 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleasePerformanceConfigurationINTEL(
     VkDevice                                    device,
     VkPerformanceConfigurationINTEL             configuration) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkReleasePerformanceConfigurationINTEL: Invalid device "
+                   "[VUID-vkReleasePerformanceConfigurationINTEL-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->ReleasePerformanceConfigurationINTEL(device, configuration);
 }
 
@@ -4151,6 +5205,12 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSetPerformanceConfigurationINTEL(
     VkQueue                                     queue,
     VkPerformanceConfigurationINTEL             configuration) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkQueueSetPerformanceConfigurationINTEL: Invalid queue "
+                   "[VUID-vkQueueSetPerformanceConfigurationINTEL-queue-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->QueueSetPerformanceConfigurationINTEL(queue, configuration);
 }
 
@@ -4159,6 +5219,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPerformanceParameterINTEL(
     VkPerformanceParameterTypeINTEL             parameter,
     VkPerformanceValueINTEL*                    pValue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPerformanceParameterINTEL: Invalid device "
+                   "[VUID-vkGetPerformanceParameterINTEL-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetPerformanceParameterINTEL(device, parameter, pValue);
 }
 
@@ -4170,6 +5236,12 @@ VKAPI_ATTR void VKAPI_CALL SetLocalDimmingAMD(
     VkSwapchainKHR                              swapChain,
     VkBool32                                    localDimmingEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkSetLocalDimmingAMD: Invalid device "
+                   "[VUID-vkSetLocalDimmingAMD-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->SetLocalDimmingAMD(device, swapChain, localDimmingEnable);
 }
 
@@ -4180,6 +5252,12 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
     VkDevice                                    device,
     const VkBufferDeviceAddressInfo*            pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetBufferDeviceAddressEXT: Invalid device "
+                   "[VUID-vkGetBufferDeviceAddressEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetBufferDeviceAddressEXT(device, pInfo);
 }
 
@@ -4192,6 +5270,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesNV(
     VkCooperativeMatrixPropertiesNV*            pProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceCooperativeMatrixPropertiesNV-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceCooperativeMatrixPropertiesNV(unwrapped_phys_dev, pPropertyCount, pProperties);
 }
@@ -4218,6 +5302,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSupportedFramebufferMixedSamples
     VkFramebufferMixedSamplesCombinationNV*     pCombinations) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(unwrapped_phys_dev, pCombinationCount, pCombinations);
 }
@@ -4243,6 +5333,12 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireFullScreenExclusiveModeEXT(
     VkDevice                                    device,
     VkSwapchainKHR                              swapchain) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkAcquireFullScreenExclusiveModeEXT: Invalid device "
+                   "[VUID-vkAcquireFullScreenExclusiveModeEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->AcquireFullScreenExclusiveModeEXT(device, swapchain);
 }
 
@@ -4252,6 +5348,12 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseFullScreenExclusiveModeEXT(
     VkDevice                                    device,
     VkSwapchainKHR                              swapchain) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkReleaseFullScreenExclusiveModeEXT: Invalid device "
+                   "[VUID-vkReleaseFullScreenExclusiveModeEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->ReleaseFullScreenExclusiveModeEXT(device, swapchain);
 }
 
@@ -4264,6 +5366,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleEXT(
     uint32_t                                    lineStippleFactor,
     uint16_t                                    lineStipplePattern) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetLineStippleEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetLineStippleEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern);
 }
 
@@ -4276,6 +5384,12 @@ VKAPI_ATTR void VKAPI_CALL ResetQueryPoolEXT(
     uint32_t                                    firstQuery,
     uint32_t                                    queryCount) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkResetQueryPoolEXT: Invalid device "
+                   "[VUID-vkResetQueryPoolEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->ResetQueryPoolEXT(device, queryPool, firstQuery, queryCount);
 }
 
@@ -4286,6 +5400,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCullModeEXT(
     VkCommandBuffer                             commandBuffer,
     VkCullModeFlags                             cullMode) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetCullModeEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetCullModeEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetCullModeEXT(commandBuffer, cullMode);
 }
 
@@ -4293,6 +5413,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFrontFaceEXT(
     VkCommandBuffer                             commandBuffer,
     VkFrontFace                                 frontFace) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetFrontFaceEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetFrontFaceEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetFrontFaceEXT(commandBuffer, frontFace);
 }
 
@@ -4300,6 +5426,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveTopologyEXT(
     VkCommandBuffer                             commandBuffer,
     VkPrimitiveTopology                         primitiveTopology) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetPrimitiveTopologyEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetPrimitiveTopologyEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology);
 }
 
@@ -4308,6 +5440,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWithCountEXT(
     uint32_t                                    viewportCount,
     const VkViewport*                           pViewports) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetViewportWithCountEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetViewportWithCountEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetViewportWithCountEXT(commandBuffer, viewportCount, pViewports);
 }
 
@@ -4316,6 +5454,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissorWithCountEXT(
     uint32_t                                    scissorCount,
     const VkRect2D*                             pScissors) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetScissorWithCountEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetScissorWithCountEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetScissorWithCountEXT(commandBuffer, scissorCount, pScissors);
 }
 
@@ -4328,6 +5472,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers2EXT(
     const VkDeviceSize*                         pSizes,
     const VkDeviceSize*                         pStrides) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBindVertexBuffers2EXT: Invalid commandBuffer "
+                   "[VUID-vkCmdBindVertexBuffers2EXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides);
 }
 
@@ -4335,6 +5485,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthTestEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    depthTestEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetDepthTestEnableEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetDepthTestEnableEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable);
 }
 
@@ -4342,6 +5498,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthWriteEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    depthWriteEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetDepthWriteEnableEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetDepthWriteEnableEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable);
 }
 
@@ -4349,6 +5511,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthCompareOpEXT(
     VkCommandBuffer                             commandBuffer,
     VkCompareOp                                 depthCompareOp) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetDepthCompareOpEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetDepthCompareOpEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp);
 }
 
@@ -4356,6 +5524,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBoundsTestEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    depthBoundsTestEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetDepthBoundsTestEnableEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetDepthBoundsTestEnableEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable);
 }
 
@@ -4363,6 +5537,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilTestEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    stencilTestEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetStencilTestEnableEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetStencilTestEnableEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable);
 }
 
@@ -4374,6 +5554,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilOpEXT(
     VkStencilOp                                 depthFailOp,
     VkCompareOp                                 compareOp) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetStencilOpEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetStencilOpEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
 }
 
@@ -4385,6 +5571,12 @@ VKAPI_ATTR void VKAPI_CALL GetGeneratedCommandsMemoryRequirementsNV(
     const VkGeneratedCommandsMemoryRequirementsInfoNV* pInfo,
     VkMemoryRequirements2*                      pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetGeneratedCommandsMemoryRequirementsNV: Invalid device "
+                   "[VUID-vkGetGeneratedCommandsMemoryRequirementsNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetGeneratedCommandsMemoryRequirementsNV(device, pInfo, pMemoryRequirements);
 }
 
@@ -4392,6 +5584,12 @@ VKAPI_ATTR void VKAPI_CALL CmdPreprocessGeneratedCommandsNV(
     VkCommandBuffer                             commandBuffer,
     const VkGeneratedCommandsInfoNV*            pGeneratedCommandsInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdPreprocessGeneratedCommandsNV: Invalid commandBuffer "
+                   "[VUID-vkCmdPreprocessGeneratedCommandsNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdPreprocessGeneratedCommandsNV(commandBuffer, pGeneratedCommandsInfo);
 }
 
@@ -4400,6 +5598,12 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteGeneratedCommandsNV(
     VkBool32                                    isPreprocessed,
     const VkGeneratedCommandsInfoNV*            pGeneratedCommandsInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdExecuteGeneratedCommandsNV: Invalid commandBuffer "
+                   "[VUID-vkCmdExecuteGeneratedCommandsNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, pGeneratedCommandsInfo);
 }
 
@@ -4409,6 +5613,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipelineShaderGroupNV(
     VkPipeline                                  pipeline,
     uint32_t                                    groupIndex) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBindPipelineShaderGroupNV: Invalid commandBuffer "
+                   "[VUID-vkCmdBindPipelineShaderGroupNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex);
 }
 
@@ -4418,6 +5628,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNV(
     const VkAllocationCallbacks*                pAllocator,
     VkIndirectCommandsLayoutNV*                 pIndirectCommandsLayout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateIndirectCommandsLayoutNV: Invalid device "
+                   "[VUID-vkCreateIndirectCommandsLayoutNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout);
 }
 
@@ -4426,6 +5642,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNV(
     VkIndirectCommandsLayoutNV                  indirectCommandsLayout,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyIndirectCommandsLayoutNV: Invalid device "
+                   "[VUID-vkDestroyIndirectCommandsLayoutNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, pAllocator);
 }
 
@@ -4438,6 +5660,12 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireDrmDisplayEXT(
     VkDisplayKHR                                display) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkAcquireDrmDisplayEXT: Invalid physicalDevice "
+                   "[VUID-vkAcquireDrmDisplayEXT-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->AcquireDrmDisplayEXT(unwrapped_phys_dev, drmFd, display);
 }
@@ -4462,6 +5690,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDrmDisplayEXT(
     VkDisplayKHR*                               display) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDrmDisplayEXT: Invalid physicalDevice "
+                   "[VUID-vkGetDrmDisplayEXT-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetDrmDisplayEXT(unwrapped_phys_dev, drmFd, connectorId, display);
 }
@@ -4489,6 +5723,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlotEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkPrivateDataSlotEXT*                       pPrivateDataSlot) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreatePrivateDataSlotEXT: Invalid device "
+                   "[VUID-vkCreatePrivateDataSlotEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot);
 }
 
@@ -4497,6 +5737,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlotEXT(
     VkPrivateDataSlotEXT                        privateDataSlot,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyPrivateDataSlotEXT: Invalid device "
+                   "[VUID-vkDestroyPrivateDataSlotEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyPrivateDataSlotEXT(device, privateDataSlot, pAllocator);
 }
 
@@ -4507,6 +5753,12 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateDataEXT(
     VkPrivateDataSlotEXT                        privateDataSlot,
     uint64_t                                    data) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkSetPrivateDataEXT: Invalid device "
+                   "[VUID-vkSetPrivateDataEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->SetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data);
 }
 
@@ -4517,6 +5769,12 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateDataEXT(
     VkPrivateDataSlotEXT                        privateDataSlot,
     uint64_t*                                   pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPrivateDataEXT: Invalid device "
+                   "[VUID-vkGetPrivateDataEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, pData);
 }
 
@@ -4528,6 +5786,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateEnumNV(
     VkFragmentShadingRateNV                     shadingRate,
     const VkFragmentShadingRateCombinerOpKHR    combinerOps[2]) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetFragmentShadingRateEnumNV: Invalid commandBuffer "
+                   "[VUID-vkCmdSetFragmentShadingRateEnumNV-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, combinerOps);
 }
 
@@ -4540,6 +5804,12 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireWinrtDisplayNV(
     VkDisplayKHR                                display) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkAcquireWinrtDisplayNV: Invalid physicalDevice "
+                   "[VUID-vkAcquireWinrtDisplayNV-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->AcquireWinrtDisplayNV(unwrapped_phys_dev, display);
 }
@@ -4564,6 +5834,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetWinrtDisplayNV(
     VkDisplayKHR*                               pDisplay) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetWinrtDisplayNV: Invalid physicalDevice "
+                   "[VUID-vkGetWinrtDisplayNV-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetWinrtDisplayNV(unwrapped_phys_dev, deviceRelativeId, pDisplay);
 }
@@ -4592,6 +5868,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetVertexInputEXT(
     uint32_t                                    vertexAttributeDescriptionCount,
     const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetVertexInputEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetVertexInputEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, pVertexBindingDescriptions, vertexAttributeDescriptionCount, pVertexAttributeDescriptions);
 }
 
@@ -4604,6 +5886,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandleFUCHSIA(
     const VkMemoryGetZirconHandleInfoFUCHSIA*   pGetZirconHandleInfo,
     zx_handle_t*                                pZirconHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetMemoryZirconHandleFUCHSIA: Invalid device "
+                   "[VUID-vkGetMemoryZirconHandleFUCHSIA-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetMemoryZirconHandleFUCHSIA(device, pGetZirconHandleInfo, pZirconHandle);
 }
 
@@ -4615,6 +5903,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandlePropertiesFUCHSIA(
     zx_handle_t                                 zirconHandle,
     VkMemoryZirconHandlePropertiesFUCHSIA*      pMemoryZirconHandleProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetMemoryZirconHandlePropertiesFUCHSIA: Invalid device "
+                   "[VUID-vkGetMemoryZirconHandlePropertiesFUCHSIA-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetMemoryZirconHandlePropertiesFUCHSIA(device, handleType, zirconHandle, pMemoryZirconHandleProperties);
 }
 
@@ -4627,6 +5921,12 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreZirconHandleFUCHSIA(
     VkDevice                                    device,
     const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkImportSemaphoreZirconHandleFUCHSIA: Invalid device "
+                   "[VUID-vkImportSemaphoreZirconHandleFUCHSIA-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->ImportSemaphoreZirconHandleFUCHSIA(device, pImportSemaphoreZirconHandleInfo);
 }
 
@@ -4637,6 +5937,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreZirconHandleFUCHSIA(
     const VkSemaphoreGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo,
     zx_handle_t*                                pZirconHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetSemaphoreZirconHandleFUCHSIA: Invalid device "
+                   "[VUID-vkGetSemaphoreZirconHandleFUCHSIA-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetSemaphoreZirconHandleFUCHSIA(device, pGetZirconHandleInfo, pZirconHandle);
 }
 
@@ -4651,6 +5957,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferCollectionFUCHSIA(
     const VkAllocationCallbacks*                pAllocator,
     VkBufferCollectionFUCHSIA*                  pCollection) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateBufferCollectionFUCHSIA: Invalid device "
+                   "[VUID-vkCreateBufferCollectionFUCHSIA-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateBufferCollectionFUCHSIA(device, pCreateInfo, pAllocator, pCollection);
 }
 
@@ -4661,6 +5973,12 @@ VKAPI_ATTR VkResult VKAPI_CALL SetBufferCollectionImageConstraintsFUCHSIA(
     VkBufferCollectionFUCHSIA                   collection,
     const VkImageConstraintsInfoFUCHSIA*        pImageConstraintsInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkSetBufferCollectionImageConstraintsFUCHSIA: Invalid device "
+                   "[VUID-vkSetBufferCollectionImageConstraintsFUCHSIA-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->SetBufferCollectionImageConstraintsFUCHSIA(device, collection, pImageConstraintsInfo);
 }
 
@@ -4671,6 +5989,12 @@ VKAPI_ATTR VkResult VKAPI_CALL SetBufferCollectionBufferConstraintsFUCHSIA(
     VkBufferCollectionFUCHSIA                   collection,
     const VkBufferConstraintsInfoFUCHSIA*       pBufferConstraintsInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkSetBufferCollectionBufferConstraintsFUCHSIA: Invalid device "
+                   "[VUID-vkSetBufferCollectionBufferConstraintsFUCHSIA-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->SetBufferCollectionBufferConstraintsFUCHSIA(device, collection, pBufferConstraintsInfo);
 }
 
@@ -4681,6 +6005,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferCollectionFUCHSIA(
     VkBufferCollectionFUCHSIA                   collection,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyBufferCollectionFUCHSIA: Invalid device "
+                   "[VUID-vkDestroyBufferCollectionFUCHSIA-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyBufferCollectionFUCHSIA(device, collection, pAllocator);
 }
 
@@ -4691,6 +6021,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetBufferCollectionPropertiesFUCHSIA(
     VkBufferCollectionFUCHSIA                   collection,
     VkBufferCollectionPropertiesFUCHSIA*        pProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetBufferCollectionPropertiesFUCHSIA: Invalid device "
+                   "[VUID-vkGetBufferCollectionPropertiesFUCHSIA-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetBufferCollectionPropertiesFUCHSIA(device, collection, pProperties);
 }
 
@@ -4703,12 +6039,24 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(
     VkRenderPass                                renderpass,
     VkExtent2D*                                 pMaxWorkgroupSize) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI: Invalid device "
+                   "[VUID-vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(device, renderpass, pMaxWorkgroupSize);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdSubpassShadingHUAWEI(
     VkCommandBuffer                             commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSubpassShadingHUAWEI: Invalid commandBuffer "
+                   "[VUID-vkCmdSubpassShadingHUAWEI-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSubpassShadingHUAWEI(commandBuffer);
 }
 
@@ -4720,6 +6068,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBindInvocationMaskHUAWEI(
     VkImageView                                 imageView,
     VkImageLayout                               imageLayout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBindInvocationMaskHUAWEI: Invalid commandBuffer "
+                   "[VUID-vkCmdBindInvocationMaskHUAWEI-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBindInvocationMaskHUAWEI(commandBuffer, imageView, imageLayout);
 }
 
@@ -4731,6 +6085,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryRemoteAddressNV(
     const VkMemoryGetRemoteAddressInfoNV*       pMemoryGetRemoteAddressInfo,
     VkRemoteAddressNV*                          pAddress) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetMemoryRemoteAddressNV: Invalid device "
+                   "[VUID-vkGetMemoryRemoteAddressNV-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetMemoryRemoteAddressNV(device, pMemoryGetRemoteAddressInfo, pAddress);
 }
 
@@ -4741,6 +6101,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPatchControlPointsEXT(
     VkCommandBuffer                             commandBuffer,
     uint32_t                                    patchControlPoints) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetPatchControlPointsEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetPatchControlPointsEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints);
 }
 
@@ -4748,6 +6114,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizerDiscardEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    rasterizerDiscardEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetRasterizerDiscardEnableEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetRasterizerDiscardEnableEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable);
 }
 
@@ -4755,6 +6127,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBiasEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    depthBiasEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetDepthBiasEnableEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetDepthBiasEnableEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable);
 }
 
@@ -4762,6 +6140,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLogicOpEXT(
     VkCommandBuffer                             commandBuffer,
     VkLogicOp                                   logicOp) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetLogicOpEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetLogicOpEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetLogicOpEXT(commandBuffer, logicOp);
 }
 
@@ -4769,6 +6153,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveRestartEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    primitiveRestartEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetPrimitiveRestartEnableEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetPrimitiveRestartEnableEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable);
 }
 
@@ -4780,6 +6170,12 @@ VKAPI_ATTR void                                    VKAPI_CALL CmdSetColorWriteEn
     uint32_t                                    attachmentCount,
     const VkBool32*                             pColorWriteEnables) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetColorWriteEnableEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdSetColorWriteEnableEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, pColorWriteEnables);
 }
 
@@ -4794,6 +6190,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiEXT(
     uint32_t                                    firstInstance,
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDrawMultiEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdDrawMultiEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawMultiEXT(commandBuffer, drawCount, pVertexInfo, instanceCount, firstInstance, stride);
 }
 
@@ -4806,6 +6208,12 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiIndexedEXT(
     uint32_t                                    stride,
     const int32_t*                              pVertexOffset) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdDrawMultiIndexedEXT: Invalid commandBuffer "
+                   "[VUID-vkCmdDrawMultiIndexedEXT-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawMultiIndexedEXT(commandBuffer, drawCount, pIndexInfo, instanceCount, firstInstance, stride, pVertexOffset);
 }
 
@@ -4817,6 +6225,12 @@ VKAPI_ATTR void VKAPI_CALL SetDeviceMemoryPriorityEXT(
     VkDeviceMemory                              memory,
     float                                       priority) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkSetDeviceMemoryPriorityEXT: Invalid device "
+                   "[VUID-vkSetDeviceMemoryPriorityEXT-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->SetDeviceMemoryPriorityEXT(device, memory, priority);
 }
 
@@ -4829,6 +6243,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkAccelerationStructureKHR*                 pAccelerationStructure) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateAccelerationStructureKHR: Invalid device "
+                   "[VUID-vkCreateAccelerationStructureKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure);
 }
 
@@ -4837,6 +6257,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureKHR(
     VkAccelerationStructureKHR                  accelerationStructure,
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroyAccelerationStructureKHR: Invalid device "
+                   "[VUID-vkDestroyAccelerationStructureKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyAccelerationStructureKHR(device, accelerationStructure, pAllocator);
 }
 
@@ -4846,6 +6272,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresKHR(
     const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBuildAccelerationStructuresKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdBuildAccelerationStructuresKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
 }
 
@@ -4857,6 +6289,12 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresIndirectKHR(
     const uint32_t*                             pIndirectStrides,
     const uint32_t* const*                      ppMaxPrimitiveCounts) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdBuildAccelerationStructuresIndirectKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdBuildAccelerationStructuresIndirectKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts);
 }
 
@@ -4867,6 +6305,12 @@ VKAPI_ATTR VkResult VKAPI_CALL BuildAccelerationStructuresKHR(
     const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkBuildAccelerationStructuresKHR: Invalid device "
+                   "[VUID-vkBuildAccelerationStructuresKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->BuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos);
 }
 
@@ -4875,6 +6319,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureKHR(
     VkDeferredOperationKHR                      deferredOperation,
     const VkCopyAccelerationStructureInfoKHR*   pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCopyAccelerationStructureKHR: Invalid device "
+                   "[VUID-vkCopyAccelerationStructureKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CopyAccelerationStructureKHR(device, deferredOperation, pInfo);
 }
 
@@ -4883,6 +6333,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureToMemoryKHR(
     VkDeferredOperationKHR                      deferredOperation,
     const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCopyAccelerationStructureToMemoryKHR: Invalid device "
+                   "[VUID-vkCopyAccelerationStructureToMemoryKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo);
 }
 
@@ -4891,6 +6347,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToAccelerationStructureKHR(
     VkDeferredOperationKHR                      deferredOperation,
     const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCopyMemoryToAccelerationStructureKHR: Invalid device "
+                   "[VUID-vkCopyMemoryToAccelerationStructureKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo);
 }
 
@@ -4903,6 +6365,12 @@ VKAPI_ATTR VkResult VKAPI_CALL WriteAccelerationStructuresPropertiesKHR(
     void*                                       pData,
     size_t                                      stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkWriteAccelerationStructuresPropertiesKHR: Invalid device "
+                   "[VUID-vkWriteAccelerationStructuresPropertiesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->WriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride);
 }
 
@@ -4910,6 +6378,12 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureKHR(
     VkCommandBuffer                             commandBuffer,
     const VkCopyAccelerationStructureInfoKHR*   pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdCopyAccelerationStructureKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdCopyAccelerationStructureKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdCopyAccelerationStructureKHR(commandBuffer, pInfo);
 }
 
@@ -4917,6 +6391,12 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureToMemoryKHR(
     VkCommandBuffer                             commandBuffer,
     const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdCopyAccelerationStructureToMemoryKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdCopyAccelerationStructureToMemoryKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo);
 }
 
@@ -4924,6 +6404,12 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMemoryToAccelerationStructureKHR(
     VkCommandBuffer                             commandBuffer,
     const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdCopyMemoryToAccelerationStructureKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdCopyMemoryToAccelerationStructureKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo);
 }
 
@@ -4931,6 +6417,12 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetAccelerationStructureDeviceAddressKHR(
     VkDevice                                    device,
     const VkAccelerationStructureDeviceAddressInfoKHR* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetAccelerationStructureDeviceAddressKHR: Invalid device "
+                   "[VUID-vkGetAccelerationStructureDeviceAddressKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetAccelerationStructureDeviceAddressKHR(device, pInfo);
 }
 
@@ -4942,6 +6434,12 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesKHR(
     VkQueryPool                                 queryPool,
     uint32_t                                    firstQuery) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdWriteAccelerationStructuresPropertiesKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
 }
 
@@ -4950,6 +6448,12 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceAccelerationStructureCompatibilityKHR(
     const VkAccelerationStructureVersionInfoKHR* pVersionInfo,
     VkAccelerationStructureCompatibilityKHR*    pCompatibility) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeviceAccelerationStructureCompatibilityKHR: Invalid device "
+                   "[VUID-vkGetDeviceAccelerationStructureCompatibilityKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetDeviceAccelerationStructureCompatibilityKHR(device, pVersionInfo, pCompatibility);
 }
 
@@ -4960,6 +6464,12 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureBuildSizesKHR(
     const uint32_t*                             pMaxPrimitiveCounts,
     VkAccelerationStructureBuildSizesInfoKHR*   pSizeInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetAccelerationStructureBuildSizesKHR: Invalid device "
+                   "[VUID-vkGetAccelerationStructureBuildSizesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo);
 }
 
@@ -4976,6 +6486,12 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysKHR(
     uint32_t                                    height,
     uint32_t                                    depth) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdTraceRaysKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdTraceRaysKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth);
 }
 
@@ -4988,6 +6504,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkPipeline*                                 pPipelines) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateRayTracingPipelinesKHR: Invalid device "
+                   "[VUID-vkCreateRayTracingPipelinesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
 }
 
@@ -4999,6 +6521,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingCaptureReplayShaderGroupHandlesKHR(
     size_t                                      dataSize,
     void*                                       pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetRayTracingCaptureReplayShaderGroupHandlesKHR: Invalid device "
+                   "[VUID-vkGetRayTracingCaptureReplayShaderGroupHandlesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
 }
 
@@ -5010,6 +6538,12 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysIndirectKHR(
     const VkStridedDeviceAddressRegionKHR*      pCallableShaderBindingTable,
     VkDeviceAddress                             indirectDeviceAddress) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdTraceRaysIndirectKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable, pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress);
 }
 
@@ -5019,6 +6553,12 @@ VKAPI_ATTR VkDeviceSize VKAPI_CALL GetRayTracingShaderGroupStackSizeKHR(
     uint32_t                                    group,
     VkShaderGroupShaderKHR                      groupShader) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetRayTracingShaderGroupStackSizeKHR: Invalid device "
+                   "[VUID-vkGetRayTracingShaderGroupStackSizeKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader);
 }
 
@@ -5026,6 +6566,12 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRayTracingPipelineStackSizeKHR(
     VkCommandBuffer                             commandBuffer,
     uint32_t                                    pipelineStackSize) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCmdSetRayTracingPipelineStackSizeKHR: Invalid commandBuffer "
+                   "[VUID-vkCmdSetRayTracingPipelineStackSizeKHR-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize);
 }
 

--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -2,9 +2,9 @@
 // See loader_extension_generator.py for modifications
 
 /*
- * Copyright (c) 2015-2017 The Khronos Group Inc.
- * Copyright (c) 2015-2017 Valve Corporation
- * Copyright (c) 2015-2017 LunarG, Inc.
+ * Copyright (c) 2015-2021 The Khronos Group Inc.
+ * Copyright (c) 2015-2021 Valve Corporation
+ * Copyright (c) 2015-2021 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -226,9 +226,13 @@ struct loader_instance_dispatch_table {
     PFN_PhysDevExt phys_dev_ext[MAX_NUM_UNKNOWN_EXTS];
 };
 
+// Unique magic number identifier for the loader.
+#define LOADER_MAGIC_NUMBER 0x10ADED010110ADEDUL
+
 // Per instance structure
 struct loader_instance {
     struct loader_instance_dispatch_table *disp;  // must be first entry in structure
+    uint64_t magic;                               // Should be LOADER_MAGIC_NUMBER
 
     // Vulkan API version the app is intending to use.
     uint16_t app_api_major_version;
@@ -342,11 +346,15 @@ struct loader_instance {
 // trampoline code wraps the VkPhysicalDevice this means all loader trampoline
 // code that passes a VkPhysicalDevice should unwrap it.
 
+// Unique identifier for physical devices
+#define PHYS_TRAMP_MAGIC_NUMBER 0x10ADED020210ADEDUL
+
 // Per enumerated PhysicalDevice structure, used to wrap in trampoline code and
 // also same structure used to wrap in terminator code
 struct loader_physical_device_tramp {
     struct loader_instance_dispatch_table *disp;  // must be first entry in structure
     struct loader_instance *this_instance;
+    uint64_t magic;             // Should be PHYS_TRAMP_MAGIC_NUMBER
     VkPhysicalDevice phys_dev;  // object from layers/loader terminator
 };
 

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -57,7 +57,12 @@ LOADER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkI
             return NULL;
         }
         struct loader_instance *ptr_instance = loader_get_instance(instance);
-        if (ptr_instance == NULL) return NULL;
+        // If we've gotten here and the pointer is NULL, it's invalid
+        if (ptr_instance == NULL) {
+            loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                       "vkGetInstanceProcAddr: Invalid instance [VUID-vkGetInstanceProcAddr-instance-parameter]");
+            abort(); /* Intentionally fail so user can correct issue. */
+        }
         // Return trampoline code for non-global entrypoints including any extensions.
         // Device extensions are returned if a layer or ICD supports the extension.
         // Instance extensions are returned if the extension is enabled and the
@@ -288,6 +293,14 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t *pApiVersion) {
     LOADER_PLATFORM_THREAD_ONCE(&once_init, loader_initialize);
 
+    if (NULL == pApiVersion) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkEnumerateInstanceVersion: \'pApiVersion\' must not be NULL "
+                   "(VUVUID-vkEnumerateInstanceVersion-pApiVersion-parameter");
+        // NOTE: This seems silly, but it's the only allowable failure
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
     // We know we need to call at least the terminator
     VkResult res = VK_SUCCESS;
     VkEnumerateInstanceVersionChain chain_tail = {
@@ -384,6 +397,50 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
 
     LOADER_PLATFORM_THREAD_ONCE(&once_init, loader_initialize);
 
+    if (pCreateInfo == NULL) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateInstance: \'pCreateInfo\' is NULL (VUID-vkCreateInstance-pCreateInfo-parameter)");
+        goto out;
+    }
+    if (pCreateInfo->sType != VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateInstance: \'pCreateInfo\' struct type invalid (VUID-VkInstanceCreateInfo-sType-sType");
+        goto out;
+    }
+    // NOTE: Can't test VUID-VkInstanceCreateInfo-pNext-pNext since Debug Utils extends the pNext struct
+    if (pCreateInfo->flags != 0) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateInstance: \'pCreateInfo\' \'flags\' must be 0 (VUID-VkInstanceCreateInfo-flags-zerobitmask");
+        goto out;
+    }
+    if (pCreateInfo->pApplicationInfo != NULL) {
+        bool failed = false;
+        if (pCreateInfo->pApplicationInfo->sType != VK_STRUCTURE_TYPE_APPLICATION_INFO) {
+            loader_log(
+                NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                "vkCreateInstance: \'pCreateInfo\' \'pApplicationInfo\' \'sType\' invalid (VUID-VkApplicationInfo-sType-sType");
+            failed = true;
+        }
+        if (pCreateInfo->pApplicationInfo->pNext != NULL) {
+            loader_log(
+                NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                "vkCreateInstance: \'pCreateInfo\' \'pApplicationInfo\' \'pNext\' is not NULL (VUID-VkApplicationInfo-pNext-pNext");
+            failed = true;
+        }
+        if (failed) {
+            loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                       "vkCreateInstance: \'pCreateInfo\' \'pApplicationInfo\' must be NULL or point to a valid VkApplicationInfo "
+                       "(VUID-VkInstanceCreateInfo-pApplicationInfo-parameter");
+            goto out;
+        }
+    }
+
+    if (pInstance == NULL) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateInstance \'pInstance\' not valid (VUID-vkCreateInstance-pInstance-parameter)");
+        goto out;
+    }
+
 #if (DEBUG_DISABLE_APP_ALLOCATORS == 1)
     {
 #else
@@ -408,6 +465,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
     if (pAllocator) {
         ptr_instance->alloc_callbacks = *pAllocator;
     }
+    ptr_instance->magic = LOADER_MAGIC_NUMBER;
 
     // Save the application version
     if (NULL == pCreateInfo || NULL == pCreateInfo->pApplicationInfo || 0 == pCreateInfo->pApplicationInfo->apiVersion) {
@@ -532,13 +590,13 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         debug_utils_CreateInstance(ptr_instance, &ici);
         extensions_create_instance(ptr_instance, &ici);
 
-        *pInstance = created_instance;
+        *pInstance = (VkInstance)ptr_instance;
 
         // Finally have the layers in place and everyone has seen
         // the CreateInstance command go by. This allows the layer's
         // GetInstanceProcAddr functions to return valid extension functions
         // if enabled.
-        loader_activate_instance_layer_extensions(ptr_instance, *pInstance);
+        loader_activate_instance_layer_extensions(ptr_instance, created_instance);
     }
 
 out:
@@ -603,12 +661,15 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
     if (instance == VK_NULL_HANDLE) {
         return;
     }
-
-    disp = loader_get_instance_layer_dispatch(instance);
-
     loader_platform_thread_lock_mutex(&loader_lock);
 
     ptr_instance = loader_get_instance(instance);
+    if (ptr_instance == NULL) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyInstance: Invalid instance [VUID-vkDestroyInstance-instance-parameter]");
+        loader_platform_thread_unlock_mutex(&loader_lock);
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     if (pAllocator) {
         ptr_instance->alloc_callbacks = *pAllocator;
@@ -630,7 +691,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
         }
     }
 
-    disp->DestroyInstance(instance, pAllocator);
+    disp = loader_get_instance_layer_dispatch(instance);
+    disp->DestroyInstance(ptr_instance->instance, pAllocator);
 
     if (NULL != ptr_instance->expanded_activated_layer_list.list) {
         loader_deactivate_layers(ptr_instance, NULL, &ptr_instance->expanded_activated_layer_list);
@@ -684,13 +746,15 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDevices(VkInstan
 
     inst = loader_get_instance(instance);
     if (NULL == inst) {
-        res = VK_ERROR_INITIALIZATION_FAILED;
-        goto out;
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkEnumeratePhysicalDevices: Invalid instance [VUID-vkEnumeratePhysicalDevices-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
     }
 
     if (NULL == pPhysicalDeviceCount) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "vkEnumeratePhysicalDevices: Received NULL pointer for physical device count return value.");
+                   "vkEnumeratePhysicalDevices: Received NULL pointer for physical device count return value. "
+                   "[VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter]");
         res = VK_ERROR_INITIALIZATION_FAILED;
         goto out;
     }
@@ -698,7 +762,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDevices(VkInstan
     // Setup the trampoline loader physical devices.  This will actually
     // call down and setup the terminator loader physical devices during the
     // process.
-    VkResult setup_res = setup_loader_tramp_phys_devs(instance);
+    VkResult setup_res = setup_loader_tramp_phys_devs(inst);
     if (setup_res != VK_SUCCESS && setup_res != VK_INCOMPLETE) {
         res = setup_res;
         goto out;
@@ -740,6 +804,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFeatures(VkPhysicalD
                                                                      VkPhysicalDeviceFeatures *pFeatures) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(
+            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            "vkGetPhysicalDeviceFeatures: Invalid physicalDevice [VUID-vkGetPhysicalDeviceFeatures-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     disp->GetPhysicalDeviceFeatures(unwrapped_phys_dev, pFeatures);
 }
@@ -747,9 +817,15 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFeatures(VkPhysicalD
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                              VkFormatProperties *pFormatInfo) {
     const VkLayerInstanceDispatchTable *disp;
-    VkPhysicalDevice unwrapped_pd = loader_unwrap_physical_device(physicalDevice);
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceFormatProperties: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceFormatProperties-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
-    disp->GetPhysicalDeviceFormatProperties(unwrapped_pd, format, pFormatInfo);
+    disp->GetPhysicalDeviceFormatProperties(unwrapped_phys_dev, format, pFormatInfo);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceImageFormatProperties(
@@ -757,6 +833,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceImageFormatPrope
     VkImageCreateFlags flags, VkImageFormatProperties *pImageFormatProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceImageFormatProperties: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceImageFormatProperties-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceImageFormatProperties(unwrapped_phys_dev, format, type, tiling, usage, flags,
                                                         pImageFormatProperties);
@@ -766,6 +848,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceProperties(VkPhysica
                                                                        VkPhysicalDeviceProperties *pProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(
+            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            "vkGetPhysicalDeviceProperties: Invalid physicalDevice [VUID-vkGetPhysicalDeviceProperties-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     disp->GetPhysicalDeviceProperties(unwrapped_phys_dev, pProperties);
 }
@@ -775,6 +863,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceQueueFamilyPropertie
                                                                                   VkQueueFamilyProperties *pQueueProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceQueueFamilyProperties: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceQueueFamilyProperties-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     disp->GetPhysicalDeviceQueueFamilyProperties(unwrapped_phys_dev, pQueueFamilyPropertyCount, pQueueProperties);
 }
@@ -783,12 +877,23 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceMemoryProperties(VkP
                                                                              VkPhysicalDeviceMemoryProperties *pMemoryProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceMemoryProperties: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceMemoryProperties-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     disp->GetPhysicalDeviceMemoryProperties(unwrapped_phys_dev, pMemoryProperties);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
                                                             const VkAllocationCallbacks *pAllocator, VkDevice *pDevice) {
+    if (VK_NULL_HANDLE == loader_unwrap_physical_device(physicalDevice)) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateDevice: Invalid physicalDevice [VUID-vkCreateDevice-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     loader_platform_thread_lock_mutex(&loader_lock);
     VkResult res = loader_layer_create_device(NULL, physicalDevice, pCreateInfo, pAllocator, pDevice, NULL, NULL);
     loader_platform_thread_unlock_mutex(&loader_lock);
@@ -802,6 +907,10 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, const 
         return;
     }
     disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyDevice: Invalid device [VUID-vkDestroyDevice-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     loader_platform_thread_lock_mutex(&loader_lock);
 
@@ -817,6 +926,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionPropertie
     struct loader_physical_device_tramp *phys_dev;
     const VkLayerInstanceDispatchTable *disp;
     phys_dev = (struct loader_physical_device_tramp *)physicalDevice;
+    if (VK_NULL_HANDLE == physicalDevice || PHYS_TRAMP_MAGIC_NUMBER != phys_dev->magic) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkEnumerateDeviceExtensionProperties: Invalid physicalDevice "
+                   "[VUID-vkEnumerateDeviceExtensionProperties-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     loader_platform_thread_lock_mutex(&loader_lock);
 
@@ -846,6 +961,14 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(Vk
     // down the chain
 
     phys_dev = (struct loader_physical_device_tramp *)physicalDevice;
+    if (VK_NULL_HANDLE == physicalDevice || PHYS_TRAMP_MAGIC_NUMBER != phys_dev->magic) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkEnumerateDeviceLayerProperties: Invalid physicalDevice "
+                   "[VUID-vkEnumerateDeviceLayerProperties-physicalDevice-parameter]");
+        loader_platform_thread_unlock_mutex(&loader_lock);
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
+
     const struct loader_instance *inst = phys_dev->this_instance;
 
     uint32_t count = inst->app_activated_layer_list.count;
@@ -873,9 +996,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(Vk
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceQueue(VkDevice device, uint32_t queueNodeIndex, uint32_t queueIndex,
                                                           VkQueue *pQueue) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkGetDeviceQueue: Invalid device [VUID-vkGetDeviceQueue-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->GetDeviceQueue(device, queueNodeIndex, queueIndex, pQueue);
     if (pQueue != NULL && *pQueue != NULL) {
@@ -885,123 +1010,157 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceQueue(VkDevice device, uint3
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
                                                            VkFence fence) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(queue);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkQueueSubmit: Invalid queue [VUID-vkQueueSubmit-queue-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->QueueSubmit(queue, submitCount, pSubmits, fence);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueueWaitIdle(VkQueue queue) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(queue);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkQueueWaitIdle: Invalid queue [VUID-vkQueueWaitIdle-queue-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->QueueWaitIdle(queue);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkDeviceWaitIdle(VkDevice device) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDeviceWaitIdle: Invalid device [VUID-vkDeviceWaitIdle-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->DeviceWaitIdle(device);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
                                                               const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkAllocateMemory: Invalid device [VUID-vkAllocateMemory-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->AllocateMemory(device, pAllocateInfo, pAllocator, pMemory);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkFreeMemory(VkDevice device, VkDeviceMemory mem,
                                                       const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkFreeMemory: Invalid device [VUID-vkFreeMemory-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->FreeMemory(device, mem, pAllocator);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkMapMemory(VkDevice device, VkDeviceMemory mem, VkDeviceSize offset,
                                                          VkDeviceSize size, VkFlags flags, void **ppData) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkMapMemory: Invalid device [VUID-vkMapMemory-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->MapMemory(device, mem, offset, size, flags, ppData);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkUnmapMemory(VkDevice device, VkDeviceMemory mem) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkUnmapMemory: Invalid device [VUID-vkUnmapMemory-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->UnmapMemory(device, mem);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkFlushMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                                        const VkMappedMemoryRange *pMemoryRanges) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkFlushMappedMemoryRanges: Invalid device [VUID-vkFlushMappedMemoryRanges-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->FlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkInvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                                             const VkMappedMemoryRange *pMemoryRanges) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkInvalidateMappedMemoryRanges: Invalid device [VUID-vkInvalidateMappedMemoryRanges-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->InvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory memory,
                                                                      VkDeviceSize *pCommittedMemoryInBytes) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetDeviceMemoryCommitment: Invalid device [VUID-vkGetDeviceMemoryCommitment-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->GetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory mem,
                                                                 VkDeviceSize offset) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkBindBufferMemory: Invalid device [VUID-vkBindBufferMemory-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->BindBufferMemory(device, buffer, mem, offset);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem,
                                                                VkDeviceSize offset) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkBindImageMemory: Invalid device [VUID-vkBindImageMemory-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->BindImageMemory(device, image, mem, offset);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetBufferMemoryRequirements(VkDevice device, VkBuffer buffer,
                                                                        VkMemoryRequirements *pMemoryRequirements) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetBufferMemoryRequirements: Invalid device [VUID-vkGetBufferMemoryRequirements-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->GetBufferMemoryRequirements(device, buffer, pMemoryRequirements);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetImageMemoryRequirements(VkDevice device, VkImage image,
                                                                       VkMemoryRequirements *pMemoryRequirements) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetImageMemoryRequirements: Invalid device [VUID-vkGetImageMemoryRequirements-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->GetImageMemoryRequirements(device, image, pMemoryRequirements);
 }
@@ -1009,9 +1168,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetImageMemoryRequirements(VkDevice d
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL
 vkGetImageSparseMemoryRequirements(VkDevice device, VkImage image, uint32_t *pSparseMemoryRequirementCount,
                                    VkSparseImageMemoryRequirements *pSparseMemoryRequirements) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetImageSparseMemoryRequirements: Invalid device [VUID-vkGetImageSparseMemoryRequirements-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->GetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 }
@@ -1021,136 +1183,174 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceSparseImageFormatPro
     VkImageTiling tiling, uint32_t *pPropertyCount, VkSparseImageFormatProperties *pProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
-    disp = loader_get_instance_layer_dispatch(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceSparseImageFormatProperties: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceSparseImageFormatProperties-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
+    disp = loader_get_instance_layer_dispatch(physicalDevice);
     disp->GetPhysicalDeviceSparseImageFormatProperties(unwrapped_phys_dev, format, type, samples, usage, tiling, pPropertyCount,
                                                        pProperties);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueueBindSparse(VkQueue queue, uint32_t bindInfoCount,
                                                                const VkBindSparseInfo *pBindInfo, VkFence fence) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(queue);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkQueueBindSparse: Invalid queue [VUID-vkQueueBindSparse-queue-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->QueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateFence(VkDevice device, const VkFenceCreateInfo *pCreateInfo,
                                                            const VkAllocationCallbacks *pAllocator, VkFence *pFence) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateFence: Invalid device [VUID-vkCreateFence-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateFence(device, pCreateInfo, pAllocator, pFence);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyFence: Invalid device [VUID-vkDestroyFence-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyFence(device, fence, pAllocator);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkResetFences: Invalid device [VUID-vkResetFences-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->ResetFences(device, fenceCount, pFences);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetFenceStatus(VkDevice device, VkFence fence) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkGetFenceStatus: Invalid device [VUID-vkGetFenceStatus-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->GetFenceStatus(device, fence);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences,
                                                              VkBool32 waitAll, uint64_t timeout) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkWaitForFences: Invalid device [VUID-vkWaitForFences-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->WaitForFences(device, fenceCount, pFences, waitAll, timeout);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo *pCreateInfo,
                                                                const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateSemaphore: Invalid device [VUID-vkCreateSemaphore-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroySemaphore(VkDevice device, VkSemaphore semaphore,
                                                             const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroySemaphore: Invalid device [VUID-vkDestroySemaphore-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroySemaphore(device, semaphore, pAllocator);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateEvent(VkDevice device, const VkEventCreateInfo *pCreateInfo,
                                                            const VkAllocationCallbacks *pAllocator, VkEvent *pEvent) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateEvent: Invalid device [VUID-vkCreateEvent-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateEvent(device, pCreateInfo, pAllocator, pEvent);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyEvent: Invalid device [VUID-vkDestroyEvent-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyEvent(device, event, pAllocator);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetEventStatus(VkDevice device, VkEvent event) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkGetEventStatus: Invalid device [VUID-vkGetEventStatus-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->GetEventStatus(device, event);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkSetEvent(VkDevice device, VkEvent event) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkSetEvent: Invalid device [VUID-vkSetEvent-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->SetEvent(device, event);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetEvent(VkDevice device, VkEvent event) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkResetEvent: Invalid device [VUID-vkResetEvent-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->ResetEvent(device, event);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
                                                                const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateQueryPool: Invalid device [VUID-vkCreateQueryPool-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyQueryPool(VkDevice device, VkQueryPool queryPool,
                                                             const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyQueryPool: Invalid device [VUID-vkDestroyQueryPool-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyQueryPool(device, queryPool, pAllocator);
 }
@@ -1158,62 +1358,79 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyQueryPool(VkDevice device, VkQ
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery,
                                                                    uint32_t queryCount, size_t dataSize, void *pData,
                                                                    VkDeviceSize stride, VkQueryResultFlags flags) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetQueryPoolResults: Invalid device [VUID-vkGetQueryPoolResults-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->GetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
                                                             const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateBuffer: Invalid device [VUID-vkCreateBuffer-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyBuffer(VkDevice device, VkBuffer buffer,
                                                          const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyBuffer: Invalid device [VUID-vkDestroyBuffer-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyBuffer(device, buffer, pAllocator);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateBufferView(VkDevice device, const VkBufferViewCreateInfo *pCreateInfo,
                                                                 const VkAllocationCallbacks *pAllocator, VkBufferView *pView) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateBufferView: Invalid device [VUID-vkCreateBufferView-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateBufferView(device, pCreateInfo, pAllocator, pView);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyBufferView(VkDevice device, VkBufferView bufferView,
                                                              const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyBufferView: Invalid device [VUID-vkDestroyBufferView-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyBufferView(device, bufferView, pAllocator);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
                                                            const VkAllocationCallbacks *pAllocator, VkImage *pImage) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateImage: Invalid device [VUID-vkCreateImage-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateImage(device, pCreateInfo, pAllocator, pImage);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyImage: Invalid device [VUID-vkDestroyImage-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyImage(device, image, pAllocator);
 }
@@ -1221,27 +1438,35 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyImage(VkDevice device, VkImage
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetImageSubresourceLayout(VkDevice device, VkImage image,
                                                                      const VkImageSubresource *pSubresource,
                                                                      VkSubresourceLayout *pLayout) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetImageSubresourceLayout: Invalid device [VUID-vkGetImageSubresourceLayout-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->GetImageSubresourceLayout(device, image, pSubresource, pLayout);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
                                                                const VkAllocationCallbacks *pAllocator, VkImageView *pView) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateImageView: Invalid device [VUID-vkCreateImageView-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateImageView(device, pCreateInfo, pAllocator, pView);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyImageView(VkDevice device, VkImageView imageView,
                                                             const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyImageView: Invalid device [VUID-vkDestroyImageView-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyImageView(device, imageView, pAllocator);
 }
@@ -1249,18 +1474,24 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyImageView(VkDevice device, VkI
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                                                   const VkAllocationCallbacks *pAllocator,
                                                                   VkShaderModule *pShader) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateShaderModule: Invalid device [VUID-vkCreateShaderModule-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateShaderModule(device, pCreateInfo, pAllocator, pShader);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyShaderModule(VkDevice device, VkShaderModule shaderModule,
                                                                const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyShaderModule: Invalid device [VUID-vkDestroyShaderModule-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyShaderModule(device, shaderModule, pAllocator);
 }
@@ -1268,36 +1499,48 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyShaderModule(VkDevice device, 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo *pCreateInfo,
                                                                    const VkAllocationCallbacks *pAllocator,
                                                                    VkPipelineCache *pPipelineCache) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreatePipelineCache: Invalid device [VUID-vkCreatePipelineCache-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyPipelineCache(VkDevice device, VkPipelineCache pipelineCache,
                                                                 const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyPipelineCache: Invalid device [VUID-vkDestroyPipelineCache-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyPipelineCache(device, pipelineCache, pAllocator);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPipelineCacheData(VkDevice device, VkPipelineCache pipelineCache,
                                                                     size_t *pDataSize, void *pData) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPipelineCacheData: Invalid device [VUID-vkGetPipelineCacheData-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->GetPipelineCacheData(device, pipelineCache, pDataSize, pData);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkMergePipelineCaches(VkDevice device, VkPipelineCache dstCache,
                                                                    uint32_t srcCacheCount, const VkPipelineCache *pSrcCaches) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkMergePipelineCaches: Invalid device [VUID-vkMergePipelineCaches-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->MergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches);
 }
@@ -1307,9 +1550,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateGraphicsPipelines(VkDevice 
                                                                        const VkGraphicsPipelineCreateInfo *pCreateInfos,
                                                                        const VkAllocationCallbacks *pAllocator,
                                                                        VkPipeline *pPipelines) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateGraphicsPipelines: Invalid device [VUID-vkCreateGraphicsPipelines-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
 }
@@ -1319,18 +1565,23 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateComputePipelines(VkDevice d
                                                                       const VkComputePipelineCreateInfo *pCreateInfos,
                                                                       const VkAllocationCallbacks *pAllocator,
                                                                       VkPipeline *pPipelines) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateComputePipelines: Invalid device [VUID-vkCreateComputePipelines-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyPipeline(VkDevice device, VkPipeline pipeline,
                                                            const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyPipeline: Invalid device [VUID-vkDestroyPipeline-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyPipeline(device, pipeline, pAllocator);
 }
@@ -1338,36 +1589,46 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyPipeline(VkDevice device, VkPi
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
                                                                     const VkAllocationCallbacks *pAllocator,
                                                                     VkPipelineLayout *pPipelineLayout) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreatePipelineLayout: Invalid device [VUID-vkCreatePipelineLayout-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyPipelineLayout(VkDevice device, VkPipelineLayout pipelineLayout,
                                                                  const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyPipelineLayout: Invalid device [VUID-vkDestroyPipelineLayout-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyPipelineLayout(device, pipelineLayout, pAllocator);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,
                                                              const VkAllocationCallbacks *pAllocator, VkSampler *pSampler) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateSampler: Invalid device [VUID-vkCreateSampler-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateSampler(device, pCreateInfo, pAllocator, pSampler);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroySampler(VkDevice device, VkSampler sampler,
                                                           const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroySampler: Invalid device [VUID-vkDestroySampler-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroySampler(device, sampler, pAllocator);
 }
@@ -1376,18 +1637,24 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDescriptorSetLayout(VkDevic
                                                                          const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
                                                                          const VkAllocationCallbacks *pAllocator,
                                                                          VkDescriptorSetLayout *pSetLayout) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateDescriptorSetLayout: Invalid device [VUID-vkCreateDescriptorSetLayout-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDescriptorSetLayout(VkDevice device, VkDescriptorSetLayout descriptorSetLayout,
                                                                       const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyDescriptorSetLayout: Invalid device [VUID-vkDestroyDescriptorSetLayout-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator);
 }
@@ -1395,27 +1662,36 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDescriptorSetLayout(VkDevice d
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo *pCreateInfo,
                                                                     const VkAllocationCallbacks *pAllocator,
                                                                     VkDescriptorPool *pDescriptorPool) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateDescriptorPool: Invalid device [VUID-vkCreateDescriptorPool-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
                                                                  const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyDescriptorPool: Invalid device [VUID-vkDestroyDescriptorPool-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyDescriptorPool(device, descriptorPool, pAllocator);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
                                                                    VkDescriptorPoolResetFlags flags) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkResetDescriptorPool: Invalid device [VUID-vkResetDescriptorPool-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->ResetDescriptorPool(device, descriptorPool, flags);
 }
@@ -1423,9 +1699,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetDescriptorPool(VkDevice devi
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAllocateDescriptorSets(VkDevice device,
                                                                       const VkDescriptorSetAllocateInfo *pAllocateInfo,
                                                                       VkDescriptorSet *pDescriptorSets) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkAllocateDescriptorSets: Invalid device [VUID-vkAllocateDescriptorSets-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->AllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets);
 }
@@ -1433,9 +1712,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAllocateDescriptorSets(VkDevice d
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool,
                                                                   uint32_t descriptorSetCount,
                                                                   const VkDescriptorSet *pDescriptorSets) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkFreeDescriptorSets: Invalid device [VUID-vkFreeDescriptorSets-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->FreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets);
 }
@@ -1444,9 +1726,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkUpdateDescriptorSets(VkDevice device,
                                                                 const VkWriteDescriptorSet *pDescriptorWrites,
                                                                 uint32_t descriptorCopyCount,
                                                                 const VkCopyDescriptorSet *pDescriptorCopies) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkUpdateDescriptorSets: Invalid device [VUID-vkUpdateDescriptorSets-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->UpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies);
 }
@@ -1454,18 +1739,24 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkUpdateDescriptorSets(VkDevice device,
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo *pCreateInfo,
                                                                  const VkAllocationCallbacks *pAllocator,
                                                                  VkFramebuffer *pFramebuffer) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateFramebuffer: Invalid device [VUID-vkCreateFramebuffer-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer,
                                                               const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyFramebuffer: Invalid device [VUID-vkDestroyFramebuffer-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyFramebuffer(device, framebuffer, pAllocator);
 }
@@ -1473,27 +1764,36 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyFramebuffer(VkDevice device, V
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
                                                                 const VkAllocationCallbacks *pAllocator,
                                                                 VkRenderPass *pRenderPass) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateRenderPass: Invalid device [VUID-vkCreateRenderPass-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyRenderPass(VkDevice device, VkRenderPass renderPass,
                                                              const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyRenderPass: Invalid device [VUID-vkDestroyRenderPass-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyRenderPass(device, renderPass, pAllocator);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetRenderAreaGranularity(VkDevice device, VkRenderPass renderPass,
                                                                     VkExtent2D *pGranularity) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetRenderAreaGranularity: Invalid device [VUID-vkGetRenderAreaGranularity-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->GetRenderAreaGranularity(device, renderPass, pGranularity);
 }
@@ -1501,27 +1801,36 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetRenderAreaGranularity(VkDevice dev
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
                                                                  const VkAllocationCallbacks *pAllocator,
                                                                  VkCommandPool *pCommandPool) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateCommandPool: Invalid device [VUID-vkCreateCommandPool-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->CreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyCommandPool(VkDevice device, VkCommandPool commandPool,
                                                               const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyCommandPool: Invalid device [VUID-vkDestroyCommandPool-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->DestroyCommandPool(device, commandPool, pAllocator);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetCommandPool(VkDevice device, VkCommandPool commandPool,
                                                                 VkCommandPoolResetFlags flags) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkResetCommandPool: Invalid device [VUID-vkResetCommandPool-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->ResetCommandPool(device, commandPool, flags);
 }
@@ -1529,10 +1838,13 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetCommandPool(VkDevice device,
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAllocateCommandBuffers(VkDevice device,
                                                                       const VkCommandBufferAllocateInfo *pAllocateInfo,
                                                                       VkCommandBuffer *pCommandBuffers) {
-    const VkLayerDispatchTable *disp;
     VkResult res;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkAllocateCommandBuffers: Invalid device [VUID-vkAllocateCommandBuffers-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     res = disp->AllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers);
     if (res == VK_SUCCESS) {
@@ -1548,9 +1860,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAllocateCommandBuffers(VkDevice d
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkFreeCommandBuffers(VkDevice device, VkCommandPool commandPool,
                                                               uint32_t commandBufferCount, const VkCommandBuffer *pCommandBuffers) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkFreeCommandBuffers: Invalid device [VUID-vkFreeCommandBuffers-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->FreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
 }
@@ -1560,110 +1875,151 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkBeginCommandBuffer(VkCommandBuffe
     const VkLayerDispatchTable *disp;
 
     disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkBeginCommandBuffer: Invalid commandBuffer [VUID-vkBeginCommandBuffer-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->BeginCommandBuffer(commandBuffer, pBeginInfo);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEndCommandBuffer(VkCommandBuffer commandBuffer) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkEndCommandBuffer: Invalid commandBuffer [VUID-vkEndCommandBuffer-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->EndCommandBuffer(commandBuffer);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkResetCommandBuffer: Invalid commandBuffer [VUID-vkResetCommandBuffer-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     return disp->ResetCommandBuffer(commandBuffer, flags);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                            VkPipeline pipeline) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdBindPipeline: Invalid commandBuffer [VUID-vkCmdBindPipeline-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                           uint32_t viewportCount, const VkViewport *pViewports) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdSetViewport: Invalid commandBuffer [VUID-vkCmdSetViewport-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetScissor(VkCommandBuffer commandBuffer, uint32_t firstScissor,
                                                          uint32_t scissorCount, const VkRect2D *pScissors) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdSetScissor: Invalid commandBuffer [VUID-vkCmdSetScissor-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdSetLineWidth: Invalid commandBuffer [VUID-vkCmdSetLineWidth-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdSetLineWidth(commandBuffer, lineWidth);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetDepthBias(VkCommandBuffer commandBuffer, float depthBiasConstantFactor,
                                                            float depthBiasClamp, float depthBiasSlopeFactor) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdSetDepthBias: Invalid commandBuffer [VUID-vkCmdSetDepthBias-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetBlendConstants(VkCommandBuffer commandBuffer, const float blendConstants[4]) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdSetBlendConstants: Invalid commandBuffer [VUID-vkCmdSetBlendConstants-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdSetBlendConstants(commandBuffer, blendConstants);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetDepthBounds(VkCommandBuffer commandBuffer, float minDepthBounds,
                                                              float maxDepthBounds) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdSetDepthBounds: Invalid commandBuffer [VUID-vkCmdSetDepthBounds-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetStencilCompareMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                                     uint32_t compareMask) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdSetStencilCompareMask: Invalid commandBuffer [VUID-vkCmdSetStencilCompareMask-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdSetStencilCompareMask(commandBuffer, faceMask, compareMask);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                                   uint32_t writeMask) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdSetStencilWriteMask: Invalid commandBuffer [VUID-vkCmdSetStencilWriteMask-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdSetStencilWriteMask(commandBuffer, faceMask, writeMask);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                                   uint32_t reference) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdSetStencilReference: Invalid commandBuffer [VUID-vkCmdSetStencilReference-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdSetStencilReference(commandBuffer, faceMask, reference);
 }
@@ -1673,9 +2029,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBindDescriptorSets(VkCommandBuffer
                                                                  uint32_t firstSet, uint32_t descriptorSetCount,
                                                                  const VkDescriptorSet *pDescriptorSets,
                                                                  uint32_t dynamicOffsetCount, const uint32_t *pDynamicOffsets) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdBindDescriptorSets: Invalid commandBuffer [VUID-vkCmdBindDescriptorSets-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets,
                                 dynamicOffsetCount, pDynamicOffsets);
@@ -1683,9 +2042,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBindDescriptorSets(VkCommandBuffer
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                               VkIndexType indexType) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdBindIndexBuffer: Invalid commandBuffer [VUID-vkCmdBindIndexBuffer-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
 }
@@ -1693,18 +2055,23 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBindIndexBuffer(VkCommandBuffer co
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding,
                                                                 uint32_t bindingCount, const VkBuffer *pBuffers,
                                                                 const VkDeviceSize *pOffsets) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdBindVertexBuffers: Invalid commandBuffer [VUID-vkCmdBindVertexBuffers-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
                                                    uint32_t firstVertex, uint32_t firstInstance) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCmdDraw: Invalid commandBuffer [VUID-vkCmdDraw-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
 }
@@ -1712,53 +2079,71 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDraw(VkCommandBuffer commandBuffer
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount,
                                                           uint32_t instanceCount, uint32_t firstIndex, int32_t vertexOffset,
                                                           uint32_t firstInstance) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdDrawIndexed: Invalid commandBuffer [VUID-vkCmdDrawIndexed-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                            uint32_t drawCount, uint32_t stride) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdDrawIndirect: Invalid commandBuffer [VUID-vkCmdDrawIndirect-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                                   VkDeviceSize offset, uint32_t drawCount, uint32_t stride) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdDrawIndexedIndirect: Invalid commandBuffer [VUID-vkCmdDrawIndexedIndirect-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdDispatch: Invalid commandBuffer [VUID-vkCmdDispatch-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdDispatch(commandBuffer, x, y, z);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                                VkDeviceSize offset) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdDispatchIndirect: Invalid commandBuffer [VUID-vkCmdDispatchIndirect-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdDispatchIndirect(commandBuffer, buffer, offset);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
                                                          uint32_t regionCount, const VkBufferCopy *pRegions) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdCopyBuffer: Invalid commandBuffer [VUID-vkCmdCopyBuffer-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
 }
@@ -1767,9 +2152,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyImage(VkCommandBuffer commandB
                                                         VkImageLayout srcImageLayout, VkImage dstImage,
                                                         VkImageLayout dstImageLayout, uint32_t regionCount,
                                                         const VkImageCopy *pRegions) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdCopyImage: Invalid commandBuffer [VUID-vkCmdCopyImage-devcommandBufferice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
 }
@@ -1778,9 +2166,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBlitImage(VkCommandBuffer commandB
                                                         VkImageLayout srcImageLayout, VkImage dstImage,
                                                         VkImageLayout dstImageLayout, uint32_t regionCount,
                                                         const VkImageBlit *pRegions, VkFilter filter) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdBlitImage: Invalid commandBuffer [VUID-vkCmdBlitImage-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
 }
@@ -1788,9 +2179,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBlitImage(VkCommandBuffer commandB
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                                 VkImageLayout dstImageLayout, uint32_t regionCount,
                                                                 const VkBufferImageCopy *pRegions) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdCopyBufferToImage: Invalid commandBuffer [VUID-vkCmdCopyBufferToImage-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
 }
@@ -1798,27 +2192,36 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyBufferToImage(VkCommandBuffer 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage,
                                                                 VkImageLayout srcImageLayout, VkBuffer dstBuffer,
                                                                 uint32_t regionCount, const VkBufferImageCopy *pRegions) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdCopyImageToBuffer: Invalid commandBuffer [VUID-vkCmdCopyImageToBuffer-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer,
                                                            VkDeviceSize dstOffset, VkDeviceSize dataSize, const void *pData) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdUpdateBuffer: Invalid commandBuffer [VUID-vkCmdUpdateBuffer-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                          VkDeviceSize size, uint32_t data) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdFillBuffer: Invalid commandBuffer [VUID-vkCmdFillBuffer-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
 }
@@ -1826,9 +2229,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdFillBuffer(VkCommandBuffer command
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image,
                                                               VkImageLayout imageLayout, const VkClearColorValue *pColor,
                                                               uint32_t rangeCount, const VkImageSubresourceRange *pRanges) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdClearColorImage: Invalid commandBuffer [VUID-vkCmdClearColorImage-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
 }
@@ -1837,9 +2243,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdClearDepthStencilImage(VkCommandBu
                                                                      VkImageLayout imageLayout,
                                                                      const VkClearDepthStencilValue *pDepthStencil,
                                                                      uint32_t rangeCount, const VkImageSubresourceRange *pRanges) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdClearDepthStencilImage: Invalid commandBuffer [VUID-vkCmdClearDepthStencilImage-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
 }
@@ -1847,9 +2256,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdClearDepthStencilImage(VkCommandBu
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                                const VkClearAttachment *pAttachments, uint32_t rectCount,
                                                                const VkClearRect *pRects) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdClearAttachments: Invalid commandBuffer [VUID-vkCmdClearAttachments-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects);
 }
@@ -1858,27 +2270,36 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdResolveImage(VkCommandBuffer comma
                                                            VkImageLayout srcImageLayout, VkImage dstImage,
                                                            VkImageLayout dstImageLayout, uint32_t regionCount,
                                                            const VkImageResolve *pRegions) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdResolveImage: Invalid commandBuffer [VUID-vkCmdResolveImage-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event,
                                                        VkPipelineStageFlags stageMask) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdSetEvent: Invalid commandBuffer [VUID-vkCmdSetEvent-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdSetEvent(commandBuffer, event, stageMask);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event,
                                                          VkPipelineStageFlags stageMask) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdResetEvent: Invalid commandBuffer [VUID-vkCmdResetEvent-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdResetEvent(commandBuffer, event, stageMask);
 }
@@ -1890,9 +2311,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdWaitEvents(VkCommandBuffer command
                                                          const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                                          uint32_t imageMemoryBarrierCount,
                                                          const VkImageMemoryBarrier *pImageMemoryBarriers) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdWaitEvents: Invalid commandBuffer [VUID-vkCmdWaitEvents-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdWaitEvents(commandBuffer, eventCount, pEvents, sourceStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers,
                         bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
@@ -1905,9 +2329,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdPipelineBarrier(VkCommandBuffer co
                                                               const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                                               uint32_t imageMemoryBarrierCount,
                                                               const VkImageMemoryBarrier *pImageMemoryBarriers) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdPipelineBarrier: Invalid commandBuffer [VUID-vkCmdPipelineBarrier-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers,
                              bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
@@ -1915,35 +2342,47 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdPipelineBarrier(VkCommandBuffer co
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
                                                          VkFlags flags) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdBeginQuery: Invalid commandBuffer [VUID-vkCmdBeginQuery-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdBeginQuery(commandBuffer, queryPool, slot, flags);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdEndQuery: Invalid commandBuffer [VUID-vkCmdEndQuery-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdEndQuery(commandBuffer, queryPool, slot);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
                                                              uint32_t firstQuery, uint32_t queryCount) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdResetQueryPool: Invalid commandBuffer [VUID-vkCmdResetQueryPool-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                              VkQueryPool queryPool, uint32_t slot) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdWriteTimestamp: Invalid commandBuffer [VUID-vkCmdWriteTimestamp-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, slot);
 }
@@ -1951,9 +2390,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdWriteTimestamp(VkCommandBuffer com
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
                                                                    uint32_t firstQuery, uint32_t queryCount, VkBuffer dstBuffer,
                                                                    VkDeviceSize dstOffset, VkDeviceSize stride, VkFlags flags) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdCopyQueryPoolResults: Invalid commandBuffer [VUID-vkCmdCopyQueryPoolResults-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags);
 }
@@ -1961,9 +2403,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyQueryPoolResults(VkCommandBuff
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                                             VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size,
                                                             const void *pValues) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdPushConstants: Invalid commandBuffer [VUID-vkCmdPushConstants-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
 }
@@ -1971,53 +2416,58 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdPushConstants(VkCommandBuffer comm
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBeginRenderPass(VkCommandBuffer commandBuffer,
                                                               const VkRenderPassBeginInfo *pRenderPassBegin,
                                                               VkSubpassContents contents) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdBeginRenderPass: Invalid commandBuffer [VUID-vkCmdBeginRenderPass-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdNextSubpass: Invalid commandBuffer [VUID-vkCmdNextSubpass-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdNextSubpass(commandBuffer, contents);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdEndRenderPass(VkCommandBuffer commandBuffer) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdEndRenderPass: Invalid commandBuffer [VUID-vkCmdEndRenderPass-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdEndRenderPass(commandBuffer);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBuffersCount,
                                                               const VkCommandBuffer *pCommandBuffers) {
-    const VkLayerDispatchTable *disp;
-
-    disp = loader_get_dispatch(commandBuffer);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdExecuteCommands: Invalid commandBuffer [VUID-vkCmdExecuteCommands-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
 
     disp->CmdExecuteCommands(commandBuffer, commandBuffersCount, pCommandBuffers);
 }
 
 // ---- Vulkan core 1.1 trampolines
 
-VkResult setupLoaderTrampPhysDevGroups(VkInstance instance) {
+VkResult setupLoaderTrampPhysDevGroups(VkInstance instance, struct loader_instance *inst) {
     VkResult res = VK_SUCCESS;
-    struct loader_instance *inst;
     uint32_t total_count = 0;
     VkPhysicalDeviceGroupPropertiesKHR **new_phys_dev_groups = NULL;
     VkPhysicalDeviceGroupPropertiesKHR *local_phys_dev_groups = NULL;
     PFN_vkEnumeratePhysicalDeviceGroups fpEnumeratePhysicalDeviceGroups = NULL;
-
-    inst = loader_get_instance(instance);
-    if (NULL == inst) {
-        res = VK_ERROR_INITIALIZATION_FAILED;
-        goto out;
-    }
 
     // Get the function pointer to use to call into the ICD. This could be the core or KHR version
     if (inst->enabled_known_extensions.khr_device_group_creation) {
@@ -2029,7 +2479,7 @@ VkResult setupLoaderTrampPhysDevGroups(VkInstance instance) {
     // Setup the trampoline loader physical devices.  This will actually
     // call down and setup the terminator loader physical devices during the
     // process.
-    VkResult setup_res = setup_loader_tramp_phys_devs(instance);
+    VkResult setup_res = setup_loader_tramp_phys_devs(inst);
     if (setup_res != VK_SUCCESS && setup_res != VK_INCOMPLETE) {
         res = setup_res;
         goto out;
@@ -2159,7 +2609,6 @@ VkResult setupLoaderTrampPhysDevGroups(VkInstance instance) {
     }
 
 out:
-
     if (VK_SUCCESS != res) {
         if (NULL != new_phys_dev_groups) {
             for (uint32_t i = 0; i < total_count; i++) {
@@ -2206,8 +2655,10 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDeviceGroups(
 
     inst = loader_get_instance(instance);
     if (NULL == inst) {
-        res = VK_ERROR_INITIALIZATION_FAILED;
-        goto out;
+        loader_log(
+            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            "vkEnumeratePhysicalDeviceGroupsKHR: Invalid instance [VUID-vkEnumeratePhysicalDeviceGroups-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
     }
 
     if (NULL == pPhysicalDeviceGroupCount) {
@@ -2218,7 +2669,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDeviceGroups(
         goto out;
     }
 
-    VkResult setup_res = setupLoaderTrampPhysDevGroups(instance);
+    VkResult setup_res = setupLoaderTrampPhysDevGroups(instance, inst);
     if (VK_SUCCESS != setup_res) {
         res = setup_res;
         goto out;
@@ -2252,6 +2703,12 @@ out:
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice,
                                                                       VkPhysicalDeviceFeatures2 *pFeatures) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceFeatures2: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceFeatures2-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(physicalDevice);
     const struct loader_instance *inst = ((struct loader_physical_device_tramp *)physicalDevice)->this_instance;
 
@@ -2265,6 +2722,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFeatures2(VkPhysical
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice,
                                                                         VkPhysicalDeviceProperties2 *pProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceProperties2: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceProperties2-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(physicalDevice);
     const struct loader_instance *inst = ((struct loader_physical_device_tramp *)physicalDevice)->this_instance;
 
@@ -2278,6 +2741,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceProperties2(VkPhysic
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                               VkFormatProperties2 *pFormatProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceFormatProperties2: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceFormatProperties2-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(physicalDevice);
     const struct loader_instance *inst = ((struct loader_physical_device_tramp *)physicalDevice)->this_instance;
 
@@ -2292,6 +2761,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkGetPhysicalDeviceImageFormatProperties2(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2 *pImageFormatInfo,
                                           VkImageFormatProperties2 *pImageFormatProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceImageFormatProperties2: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceImageFormatProperties2-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(physicalDevice);
     const struct loader_instance *inst = ((struct loader_physical_device_tramp *)physicalDevice)->this_instance;
 
@@ -2305,6 +2780,12 @@ vkGetPhysicalDeviceImageFormatProperties2(VkPhysicalDevice physicalDevice, const
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceQueueFamilyProperties2(
     VkPhysicalDevice physicalDevice, uint32_t *pQueueFamilyPropertyCount, VkQueueFamilyProperties2 *pQueueFamilyProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceQueueFamilyProperties2: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceQueueFamilyProperties2-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(physicalDevice);
     const struct loader_instance *inst = ((struct loader_physical_device_tramp *)physicalDevice)->this_instance;
 
@@ -2318,6 +2799,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceQueueFamilyPropertie
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL
 vkGetPhysicalDeviceMemoryProperties2(VkPhysicalDevice physicalDevice, VkPhysicalDeviceMemoryProperties2 *pMemoryProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceMemoryProperties2: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceMemoryProperties2-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(physicalDevice);
     const struct loader_instance *inst = ((struct loader_physical_device_tramp *)physicalDevice)->this_instance;
 
@@ -2332,6 +2819,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceSparseImageFormatPro
     VkPhysicalDevice physicalDevice, const VkPhysicalDeviceSparseImageFormatInfo2 *pFormatInfo, uint32_t *pPropertyCount,
     VkSparseImageFormatProperties2 *pProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceSparseImageFormatProperties2: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceSparseImageFormatProperties2-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(physicalDevice);
     const struct loader_instance *inst = ((struct loader_physical_device_tramp *)physicalDevice)->this_instance;
 
@@ -2346,6 +2839,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalBufferProper
     VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalBufferInfo *pExternalBufferInfo,
     VkExternalBufferProperties *pExternalBufferProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceExternalBufferProperties: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceExternalBufferProperties-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(physicalDevice);
     const struct loader_instance *inst = ((struct loader_physical_device_tramp *)physicalDevice)->this_instance;
 
@@ -2360,6 +2859,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalSemaphorePro
     VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalSemaphoreInfoKHR *pExternalSemaphoreInfo,
     VkExternalSemaphoreProperties *pExternalSemaphoreProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceExternalSemaphoreProperties: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceExternalSemaphoreProperties-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(physicalDevice);
     const struct loader_instance *inst = ((struct loader_physical_device_tramp *)physicalDevice)->this_instance;
 
@@ -2376,6 +2881,12 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalFencePropert
     VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalFenceInfo *pExternalFenceInfo,
     VkExternalFenceProperties *pExternalFenceProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetPhysicalDeviceExternalFenceProperties: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceExternalFenceProperties-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(physicalDevice);
     const struct loader_instance *inst = ((struct loader_physical_device_tramp *)physicalDevice)->this_instance;
 
@@ -2389,12 +2900,22 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalFencePropert
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkBindBufferMemory2(VkDevice device, uint32_t bindInfoCount,
                                                                  const VkBindBufferMemoryInfo *pBindInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkBindBufferMemory2: Invalid device [VUID-vkBindBufferMemory2-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->BindBufferMemory2(device, bindInfoCount, pBindInfos);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkBindImageMemory2(VkDevice device, uint32_t bindInfoCount,
                                                                 const VkBindImageMemoryInfo *pBindInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkBindImageMemory2: Invalid device [VUID-vkBindImageMemory2-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->BindImageMemory2(device, bindInfoCount, pBindInfos);
 }
 
@@ -2402,11 +2923,21 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceGroupPeerMemoryFeatures(VkDe
                                                                             uint32_t localDeviceIndex, uint32_t remoteDeviceIndex,
                                                                             VkPeerMemoryFeatureFlags *pPeerMemoryFeatures) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetDeviceGroupPeerMemoryFeatures: Invalid device [VUID-vkGetDeviceGroupPeerMemoryFeatures-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, pPeerMemoryFeatures);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdSetDeviceMask: Invalid commandBuffer [VUID-vkCmdSetDeviceMask-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdSetDeviceMask(commandBuffer, deviceMask);
 }
 
@@ -2414,12 +2945,22 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDispatchBase(VkCommandBuffer comma
                                                            uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
                                                            uint32_t groupCountZ) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdDispatchBase: Invalid commandBuffer [VUID-vkCmdDispatchBase-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetImageMemoryRequirements2(VkDevice device, const VkImageMemoryRequirementsInfo2 *pInfo,
                                                                        VkMemoryRequirements2 *pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetImageMemoryRequirements2: Invalid device [VUID-vkGetImageMemoryRequirements2-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetImageMemoryRequirements2(device, pInfo, pMemoryRequirements);
 }
 
@@ -2427,6 +2968,11 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetBufferMemoryRequirements2(VkDevice
                                                                         const VkBufferMemoryRequirementsInfo2 *pInfo,
                                                                         VkMemoryRequirements2 *pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetBufferMemoryRequirements2: Invalid device [VUID-vkGetBufferMemoryRequirements2-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetBufferMemoryRequirements2(device, pInfo, pMemoryRequirements);
 }
 
@@ -2434,17 +2980,31 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetImageSparseMemoryRequirements2(
     VkDevice device, const VkImageSparseMemoryRequirementsInfo2 *pInfo, uint32_t *pSparseMemoryRequirementCount,
     VkSparseImageMemoryRequirements2 *pSparseMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(
+            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            "vkGetImageSparseMemoryRequirements2: Invalid device [VUID-vkGetImageSparseMemoryRequirements2-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkTrimCommandPool(VkDevice device, VkCommandPool commandPool,
                                                            VkCommandPoolTrimFlags flags) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkTrimCommandPool: Invalid device [VUID-vkTrimCommandPool-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->TrimCommandPool(device, commandPool, flags);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2 *pQueueInfo, VkQueue *pQueue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkGetDeviceQueue2: Invalid device [VUID-vkGetDeviceQueue2-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetDeviceQueue2(device, pQueueInfo, pQueue);
     if (pQueue != NULL && *pQueue != NULL) {
         loader_set_dispatch(*pQueue, disp);
@@ -2456,12 +3016,22 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSamplerYcbcrConversion(VkDe
                                                                             const VkAllocationCallbacks *pAllocator,
                                                                             VkSamplerYcbcrConversion *pYcbcrConversion) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateSamplerYcbcrConversion: Invalid device [VUID-vkCreateSamplerYcbcrConversion-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
                                                                          const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroySamplerYcbcrConversion: Invalid device [VUID-vkDestroySamplerYcbcrConversion-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator);
 }
 
@@ -2469,6 +3039,11 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupport(VkDevic
                                                                          const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
                                                                          VkDescriptorSetLayoutSupport *pSupport) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetDescriptorSetLayoutSupport: Invalid device [VUID-vkGetDescriptorSetLayoutSupport-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->GetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport);
 }
 
@@ -2476,6 +3051,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
                                  const VkAllocationCallbacks *pAllocator, VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateDescriptorUpdateTemplate: Invalid device [VUID-vkCreateDescriptorUpdateTemplate-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
 }
 
@@ -2483,6 +3063,11 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDescriptorUpdateTemplate(VkDev
                                                                            VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                            const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkDestroyDescriptorUpdateTemplate: Invalid device [VUID-vkDestroyDescriptorUpdateTemplate-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
 }
 
@@ -2490,6 +3075,11 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkUpdateDescriptorSetWithTemplate(VkDev
                                                                            VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                            const void *pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkUpdateDescriptorSetWithTemplate: Invalid device [VUID-vkUpdateDescriptorSetWithTemplate-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->UpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData);
 }
 
@@ -2499,6 +3089,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateRenderPass2(VkDevice device
                                                                  const VkAllocationCallbacks *pAllocator,
                                                                  VkRenderPass *pRenderPass) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCreateRenderPass2: Invalid device [VUID-vkCreateRenderPass2-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass);
 }
 
@@ -2506,6 +3101,11 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBeginRenderPass2(VkCommandBuffer c
                                                                const VkRenderPassBeginInfo *pRenderPassBegin,
                                                                const VkSubpassBeginInfo *pSubpassBeginInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdBeginRenderPass2: Invalid commandBuffer [VUID-vkCmdBeginRenderPass2-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
 }
 
@@ -2513,12 +3113,22 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdNextSubpass2(VkCommandBuffer comma
                                                            const VkSubpassBeginInfo *pSubpassBeginInfo,
                                                            const VkSubpassEndInfo *pSubpassEndInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdNextSubpass2: Invalid commandBuffer [VUID-vkCmdNextSubpass2-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdEndRenderPass2(VkCommandBuffer commandBuffer,
                                                              const VkSubpassEndInfo *pSubpassEndInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdEndRenderPass2: Invalid commandBuffer [VUID-vkCmdEndRenderPass2-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdEndRenderPass2(commandBuffer, pSubpassEndInfo);
 }
 
@@ -2526,6 +3136,11 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndirectCount(VkCommandBuffer 
                                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                 uint32_t maxDrawCount, uint32_t stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkCmdDrawIndirectCount: Invalid commandBuffer [VUID-vkCmdDrawIndirectCount-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
 
@@ -2534,45 +3149,84 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexedIndirectCount(VkCommand
                                                                        VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                                        uint32_t stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    if (NULL == disp) {
+        loader_log(
+            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            "vkCmdDrawIndexedIndirectCount: Invalid commandBuffer [VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->CmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t *pValue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetSemaphoreCounterValue: Invalid device [VUID-vkGetSemaphoreCounterValue-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetSemaphoreCounterValue(device, semaphore, pValue);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo,
                                                               uint64_t timeout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkWaitSemaphores: Invalid device [VUID-vkWaitSemaphores-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->WaitSemaphores(device, pWaitInfo, timeout);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkSignalSemaphore: Invalid device [VUID-vkSignalSemaphore-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->SignalSemaphore(device, pSignalInfo);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkDeviceAddress VKAPI_CALL vkGetBufferDeviceAddress(VkDevice device,
                                                                              const VkBufferDeviceAddressInfo *pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetBufferDeviceAddress: Invalid device [VUID-vkGetBufferDeviceAddress-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetBufferDeviceAddress(device, pInfo);
 }
 
 LOADER_EXPORT VKAPI_ATTR uint64_t VKAPI_CALL vkGetBufferOpaqueCaptureAddress(VkDevice device,
                                                                              const VkBufferDeviceAddressInfo *pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+                   "vkGetBufferOpaqueCaptureAddress: Invalid device [VUID-vkGetBufferOpaqueCaptureAddress-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetBufferOpaqueCaptureAddress(device, pInfo);
 }
 
 LOADER_EXPORT VKAPI_ATTR uint64_t VKAPI_CALL
 vkGetDeviceMemoryOpaqueCaptureAddress(VkDevice device, const VkDeviceMemoryOpaqueCaptureAddressInfo *pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(
+            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            "vkGetDeviceMemoryOpaqueCaptureAddress: Invalid device [VUID-vkGetDeviceMemoryOpaqueCaptureAddress-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetDeviceMemoryOpaqueCaptureAddress(device, pInfo);
 }
 
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkResetQueryPool(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery,
                                                           uint32_t queryCount) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkResetQueryPool: Invalid device [VUID-vkResetQueryPool-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->ResetQueryPool(device, queryPool, firstQuery, queryCount);
 }

--- a/loader/vulkan-1.def
+++ b/loader/vulkan-1.def
@@ -182,6 +182,7 @@ EXPORTS
    vkCreateDisplayPlaneSurfaceKHR
    vkCreateSharedSwapchainsKHR
    vkCreateWin32SurfaceKHR
+   vkCreateHeadlessSurfaceEXT
    vkGetPhysicalDeviceWin32PresentationSupportKHR
 
    vkEnumerateInstanceVersion

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -166,6 +166,11 @@ bool wsi_unsupported_instance_extension(const VkExtensionProperties *ext_prop) {
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface,
                                                              const VkAllocationCallbacks *pAllocator) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroySurfaceKHR: Invalid instance [VUID-vkDestroySurfaceKHR-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     disp->DestroySurfaceKHR(instance, surface, pAllocator);
 }
@@ -207,6 +212,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceSupportKH
                                                                                   VkBool32 *pSupported) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceSurfaceSupportKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceSurfaceSupportKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkResult res = disp->GetPhysicalDeviceSurfaceSupportKHR(unwrapped_phys_dev, queueFamilyIndex, surface, pSupported);
     return res;
@@ -254,6 +265,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceCapabilit
     VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceSurfaceCapabilitiesKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceSurfaceCapabilitiesKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkResult res = disp->GetPhysicalDeviceSurfaceCapabilitiesKHR(unwrapped_phys_dev, surface, pSurfaceCapabilities);
     return res;
@@ -300,8 +317,14 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceFormatsKH
                                                                                   VkSurfaceKHR surface,
                                                                                   uint32_t *pSurfaceFormatCount,
                                                                                   VkSurfaceFormatKHR *pSurfaceFormats) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceSurfaceFormatsKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceSurfaceFormatsKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkResult res = disp->GetPhysicalDeviceSurfaceFormatsKHR(unwrapped_phys_dev, surface, pSurfaceFormatCount, pSurfaceFormats);
     return res;
@@ -350,8 +373,14 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfacePresentMo
                                                                                        VkSurfaceKHR surface,
                                                                                        uint32_t *pPresentModeCount,
                                                                                        VkPresentModeKHR *pPresentModes) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceSurfacePresentModesKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceSurfacePresentModesKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkResult res = disp->GetPhysicalDeviceSurfacePresentModesKHR(unwrapped_phys_dev, surface, pPresentModeCount, pPresentModes);
     return res;
@@ -400,8 +429,12 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfacePresentModesKH
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
                                                                   const VkAllocationCallbacks *pAllocator,
                                                                   VkSwapchainKHR *pSwapchain) {
-    const VkLayerDispatchTable *disp;
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateSwapchainKHR: Invalid device [VUID-vkCreateSwapchainKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain);
 }
 
@@ -434,31 +467,47 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateSwapchainKHR(VkDevice device, co
 // This is the trampoline entrypoint for DestroySwapchainKHR
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain,
                                                                const VkAllocationCallbacks *pAllocator) {
-    const VkLayerDispatchTable *disp;
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkDestroySwapchainKHR: Invalid device [VUID-vkDestroySwapchainKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp->DestroySwapchainKHR(device, swapchain, pAllocator);
 }
 
 // This is the trampoline entrypoint for GetSwapchainImagesKHR
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain,
                                                                      uint32_t *pSwapchainImageCount, VkImage *pSwapchainImages) {
-    const VkLayerDispatchTable *disp;
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetSwapchainImagesKHR: Invalid device [VUID-vkGetSwapchainImagesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages);
 }
 
 // This is the trampoline entrypoint for AcquireNextImageKHR
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
                                                                    VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex) {
-    const VkLayerDispatchTable *disp;
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkAcquireNextImageKHR: Invalid device [VUID-vkAcquireNextImageKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->AcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex);
 }
 
 // This is the trampoline entrypoint for QueuePresentKHR
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
-    const VkLayerDispatchTable *disp;
-    disp = loader_get_dispatch(queue);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkQueuePresentKHR: Invalid queue [VUID-vkQueuePresentKHR-queue-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->QueuePresentKHR(queue, pPresentInfo);
 }
 
@@ -495,6 +544,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateWin32SurfaceKHR(VkInstance 
                                                                      const VkAllocationCallbacks *pAllocator,
                                                                      VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateWin32SurfaceKHR: Invalid instance [VUID-vkCreateWin32SurfaceKHR-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -568,8 +622,14 @@ out:
 // GetPhysicalDeviceWin32PresentationSupportKHR
 LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice physicalDevice,
                                                                                             uint32_t queueFamilyIndex) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceWin32PresentationSupportKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceWin32PresentationSupportKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkBool32 res = disp->GetPhysicalDeviceWin32PresentationSupportKHR(unwrapped_phys_dev, queueFamilyIndex);
     return res;
@@ -607,6 +667,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateWaylandSurfaceKHR(VkInstanc
                                                                        const VkAllocationCallbacks *pAllocator,
                                                                        VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateWaylandSurfaceKHR: Invalid instance [VUID-vkCreateWaylandSurfaceKHR-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -680,8 +745,14 @@ out:
 LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWaylandPresentationSupportKHR(VkPhysicalDevice physicalDevice,
                                                                                               uint32_t queueFamilyIndex,
                                                                                               struct wl_display *display) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceWaylandPresentationSupportKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceWaylandPresentationSupportKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkBool32 res = disp->GetPhysicalDeviceWaylandPresentationSupportKHR(unwrapped_phys_dev, queueFamilyIndex, display);
     return res;
@@ -723,6 +794,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateXcbSurfaceKHR(VkInstance in
                                                                    const VkAllocationCallbacks *pAllocator,
                                                                    VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateXcbSurfaceKHR: Invalid instance [VUID-vkCreateXcbSurfaceKHR-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -796,8 +872,14 @@ LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXcbPresentationS
                                                                                           uint32_t queueFamilyIndex,
                                                                                           xcb_connection_t *connection,
                                                                                           xcb_visualid_t visual_id) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceXcbPresentationSupportKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceXcbPresentationSupportKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkBool32 res = disp->GetPhysicalDeviceXcbPresentationSupportKHR(unwrapped_phys_dev, queueFamilyIndex, connection, visual_id);
     return res;
@@ -840,6 +922,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateXlibSurfaceKHR(VkInstance i
                                                                     const VkAllocationCallbacks *pAllocator,
                                                                     VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateXlibSurfaceKHR: Invalid instance [VUID-vkCreateXlibSurfaceKHR-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -912,8 +999,14 @@ out:
 LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXlibPresentationSupportKHR(VkPhysicalDevice physicalDevice,
                                                                                            uint32_t queueFamilyIndex, Display *dpy,
                                                                                            VisualID visualID) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceXlibPresentationSupportKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceXlibPresentationSupportKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkBool32 res = disp->GetPhysicalDeviceXlibPresentationSupportKHR(unwrapped_phys_dev, queueFamilyIndex, dpy, visualID);
     return res;
@@ -954,6 +1047,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDirectFBSurfaceEXT(VkInstan
                                                                         const VkAllocationCallbacks *pAllocator,
                                                                         VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateDirectFBSurfaceEXT: Invalid instance [VUID-vkCreateDirectFBSurfaceEXT-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -1029,8 +1127,14 @@ out:
 LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceDirectFBPresentationSupportEXT(VkPhysicalDevice physicalDevice,
                                                                                                uint32_t queueFamilyIndex,
                                                                                                IDirectFB *dfb) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceDirectFBPresentationSupportEXT: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceDirectFBPresentationSupportEXT-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkBool32 res = disp->GetPhysicalDeviceDirectFBPresentationSupportEXT(unwrapped_phys_dev, queueFamilyIndex, dfb);
     return res;
@@ -1072,6 +1176,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateAndroidSurfaceKHR(VkInstanc
                                                                        const VkAllocationCallbacks *pAllocator,
                                                                        VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateAndroidSurfaceKHR: Invalid instance [VUID-vkCreateAndroidSurfaceKHR-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -1110,9 +1219,16 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateAndroidSurfaceKHR(VkInstance ins
 
 // Functions for the VK_EXT_headless_surface extension:
 
-VKAPI_ATTR VkResult VKAPI_CALL vkCreateHeadlessSurfaceEXT(VkInstance instance, const VkHeadlessSurfaceCreateInfoEXT *pCreateInfo,
-                                                          const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
+LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateHeadlessSurfaceEXT(VkInstance instance,
+                                                                        const VkHeadlessSurfaceCreateInfoEXT *pCreateInfo,
+                                                                        const VkAllocationCallbacks *pAllocator,
+                                                                        VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateHeadlessSurfaceEXT: Invalid instance [VUID-vkCreateHeadlessSurfaceEXT-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -1187,6 +1303,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateMacOSSurfaceMVK(VkInstance 
                                                                      const VkAllocationCallbacks *pAllocator,
                                                                      VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateMacOSSurfaceMVK: Invalid instance [VUID-vkCreateMacOSSurfaceMVK-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -1265,6 +1386,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateIOSSurfaceMVK(VkInstance in
                                                                    const VkAllocationCallbacks *pAllocator,
                                                                    VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateIOSSurfaceMVK: Invalid instance [VUID-vkCreateIOSSurfaceMVK-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -1309,6 +1435,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkCreateStreamDescriptorSurfaceGGP(VkInstance instance, const VkStreamDescriptorSurfaceCreateInfoGGP *pCreateInfo,
                                    const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(
+            NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+            "vkCreateStreamDescriptorSurfaceGGP: Invalid instance [VUID-vkCreateStreamDescriptorSurfaceGGP-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -1383,7 +1515,13 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateMetalSurfaceEXT(VkInstance 
                                                                      const VkMetalSurfaceCreateInfoEXT *pCreateInfo,
                                                                      const VkAllocationCallbacks *pAllocator,
                                                                      VkSurfaceKHR *pSurface) {
-    const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(instance);
+    const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateMetalSurfaceEXT: Invalid instance [VUID-vkCreateMetalSurfaceEXT-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
+    disp = loader_get_instance_layer_dispatch(instance);
     return disp->CreateMetalSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface);
 }
 
@@ -1450,8 +1588,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateScreenSurfaceQNX(VkInstance
                                                                       const VkScreenSurfaceCreateInfoQNX *pCreateInfo,
                                                                       const VkAllocationCallbacks *pAllocator,
                                                                       VkSurfaceKHR *pSurface) {
-    const VkLayerInstanceDispatchTable *disp;
-    disp = loader_get_instance_layer_dispatch(instance);
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateScreenSurfaceQNX: Invalid instance [VUID-vkCreateScreenSurfaceQNX-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
+    const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
     res = disp->CreateScreenSurfaceQNX(instance, pCreateInfo, pAllocator, pSurface);
@@ -1525,8 +1667,13 @@ LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceScreenPresentati
                                                                                              uint32_t queueFamilyIndex,
                                                                                              struct _screen_window *window) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
-    const VkLayerInstanceDispatchTable *disp;
-    disp = loader_get_instance_layer_dispatch(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceScreenPresentationSupportQNX: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceScreenPresentationSupportQNX-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
+    const VkLayerInstanceDispatchTable *disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkBool32 res = disp->GetPhysicalDeviceScreenPresentationSupportQNX(unwrapped_phys_dev, queueFamilyIndex, window);
     return res;
 }
@@ -1560,8 +1707,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceScreenPresentationSup
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDevice physicalDevice,
                                                                                      uint32_t *pPropertyCount,
                                                                                      VkDisplayPropertiesKHR *pProperties) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceDisplayPropertiesKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceDisplayPropertiesKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkResult res = disp->GetPhysicalDeviceDisplayPropertiesKHR(unwrapped_phys_dev, pPropertyCount, pProperties);
     return res;
@@ -1590,8 +1743,14 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceDisplayPropertiesKHR(
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount, VkDisplayPlanePropertiesKHR *pProperties) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceDisplayPlanePropertiesKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceDisplayPlanePropertiesKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkResult res = disp->GetPhysicalDeviceDisplayPlanePropertiesKHR(unwrapped_phys_dev, pPropertyCount, pProperties);
     return res;
@@ -1621,8 +1780,14 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceDisplayPlanePropertie
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice,
                                                                                    uint32_t planeIndex, uint32_t *pDisplayCount,
                                                                                    VkDisplayKHR *pDisplays) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDisplayPlaneSupportedDisplaysKHR: Invalid physicalDevice "
+                   "[VUID-vkGetDisplayPlaneSupportedDisplaysKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkResult res = disp->GetDisplayPlaneSupportedDisplaysKHR(unwrapped_phys_dev, planeIndex, pDisplayCount, pDisplays);
     return res;
@@ -1652,8 +1817,14 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayPlaneSupportedDisplaysKHR(Vk
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                                            uint32_t *pPropertyCount,
                                                                            VkDisplayModePropertiesKHR *pProperties) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDisplayModePropertiesKHR: Invalid physicalDevice "
+                   "[VUID-vkGetDisplayModePropertiesKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkResult res = disp->GetDisplayModePropertiesKHR(unwrapped_phys_dev, display, pPropertyCount, pProperties);
     return res;
@@ -1685,8 +1856,14 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDisplayModeKHR(VkPhysicalDe
                                                                     const VkDisplayModeCreateInfoKHR *pCreateInfo,
                                                                     const VkAllocationCallbacks *pAllocator,
                                                                     VkDisplayModeKHR *pMode) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateDisplayModeKHR: Invalid physicalDevice "
+                   "[VUID-vkCreateDisplayModeKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkResult res = disp->CreateDisplayModeKHR(unwrapped_phys_dev, display, pCreateInfo, pAllocator, pMode);
     return res;
@@ -1717,8 +1894,14 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDisplayModeKHR(VkPhysicalDevice 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevice,
                                                                               VkDisplayModeKHR mode, uint32_t planeIndex,
                                                                               VkDisplayPlaneCapabilitiesKHR *pCapabilities) {
-    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     const VkLayerInstanceDispatchTable *disp;
+    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDisplayPlaneCapabilitiesKHR: Invalid physicalDevice "
+                   "[VUID-vkGetDisplayPlaneCapabilitiesKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     VkResult res = disp->GetDisplayPlaneCapabilitiesKHR(unwrapped_phys_dev, mode, planeIndex, pCapabilities);
     return res;
@@ -1751,6 +1934,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDisplayPlaneSurfaceKHR(VkIn
                                                                             const VkAllocationCallbacks *pAllocator,
                                                                             VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateDisplayPlaneSurfaceKHR: Invalid instance [VUID-vkCreateDisplayPlaneSurfaceKHR-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -1829,8 +2017,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSharedSwapchainsKHR(VkDevic
                                                                          const VkSwapchainCreateInfoKHR *pCreateInfos,
                                                                          const VkAllocationCallbacks *pAllocator,
                                                                          VkSwapchainKHR *pSwapchains) {
-    const VkLayerDispatchTable *disp;
-    disp = loader_get_dispatch(device);
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateSharedSwapchainsKHR: Invalid device [VUID-vkCreateSharedSwapchainsKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->CreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
 }
 
@@ -1867,12 +2059,24 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateSharedSwapchainsKHR(VkDevice dev
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkGetDeviceGroupPresentCapabilitiesKHR(VkDevice device, VkDeviceGroupPresentCapabilitiesKHR *pDeviceGroupPresentCapabilities) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeviceGroupPresentCapabilitiesKHR: Invalid device "
+                   "[VUID-vkGetDeviceGroupPresentCapabilitiesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities);
 }
 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDeviceGroupSurfacePresentModesKHR(VkDevice device, VkSurfaceKHR surface,
                                                                                     VkDeviceGroupPresentModeFlagsKHR *pModes) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDeviceGroupSurfacePresentModesKHR: Invalid device "
+                   "[VUID-vkGetDeviceGroupSurfacePresentModesKHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->GetDeviceGroupSurfacePresentModesKHR(device, surface, pModes);
 }
 
@@ -1897,6 +2101,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDevicePresentRectangle
                                                                                      VkRect2D *pRects) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDevicePresentRectanglesKHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDevicePresentRectanglesKHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDevicePresentRectanglesKHR(unwrapped_phys_dev, surface, pRectCount, pRects);
 }
@@ -1923,6 +2133,11 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDevicePresentRectanglesKHR(
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo,
                                                                     uint32_t *pImageIndex) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    if (NULL == disp) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkAcquireNextImage2KHR: Invalid device [VUID-vkAcquireNextImage2KHR-device-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     return disp->AcquireNextImage2KHR(device, pAcquireInfo, pImageIndex);
 }
 
@@ -1933,6 +2148,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceDisplayPropertie
                                                                                       VkDisplayProperties2KHR *pProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceDisplayProperties2KHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceDisplayProperties2KHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceDisplayProperties2KHR(unwrapped_phys_dev, pPropertyCount, pProperties);
 }
@@ -1982,6 +2203,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceDisplayPlaneProp
     VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount, VkDisplayPlaneProperties2KHR *pProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceDisplayPlaneProperties2KHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceDisplayPlaneProperties2KHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceDisplayPlaneProperties2KHR(unwrapped_phys_dev, pPropertyCount, pProperties);
 }
@@ -2033,6 +2260,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDisplayModeProperties2KHR(VkPh
                                                                             VkDisplayModeProperties2KHR *pProperties) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDisplayModeProperties2KHR: Invalid physicalDevice "
+                   "[VUID-vkGetDisplayModeProperties2KHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetDisplayModeProperties2KHR(unwrapped_phys_dev, display, pPropertyCount, pProperties);
 }
@@ -2083,6 +2316,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDisplayPlaneCapabilities2KHR(V
                                                                                VkDisplayPlaneCapabilities2KHR *pCapabilities) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetDisplayPlaneCapabilities2KHR: Invalid physicalDevice "
+                   "[VUID-vkGetDisplayPlaneCapabilities2KHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetDisplayPlaneCapabilities2KHR(unwrapped_phys_dev, pDisplayPlaneInfo, pCapabilities);
 }
@@ -2116,6 +2355,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateImagePipeSurfaceFUCHSIA(VkI
                                                                              const VkAllocationCallbacks *pAllocator,
                                                                              VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
+    if (NULL == loader_get_instance(instance)) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkCreateImagePipeSurfaceFUCHSIA: Invalid instance [VUID-vkCreateImagePipeSurfaceFUCHSIA-instance-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(instance);
     VkResult res;
 
@@ -2193,6 +2437,12 @@ vkGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice, cons
                                            VkSurfaceCapabilities2KHR *pSurfaceCapabilities) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceSurfaceCapabilities2KHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceSurfaceCapabilities2KHR(unwrapped_phys_dev, pSurfaceInfo, pSurfaceCapabilities);
 }
@@ -2270,6 +2520,12 @@ vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, const VkP
                                       uint32_t *pSurfaceFormatCount, VkSurfaceFormat2KHR *pSurfaceFormats) {
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
+    if (VK_NULL_HANDLE == unwrapped_phys_dev) {
+        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+                   "vkGetPhysicalDeviceSurfaceFormats2KHR: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-physicalDevice-parameter]");
+        abort(); /* Intentionally fail so user can correct issue. */
+    }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
     return disp->GetPhysicalDeviceSurfaceFormats2KHR(unwrapped_phys_dev, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats);
 }

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2017 The Khronos Group Inc.
-# Copyright (c) 2015-2017 Valve Corporation
-# Copyright (c) 2015-2017 LunarG, Inc.
-# Copyright (c) 2015-2017 Google Inc.
+# Copyright (c) 2015-2021 The Khronos Group Inc.
+# Copyright (c) 2015-2021 Valve Corporation
+# Copyright (c) 2015-2021 LunarG, Inc.
+# Copyright (c) 2015-2021 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -107,9 +107,9 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
         write(file_comment, file=self.outFile)
         # Copyright Notice
         copyright =  '/*\n'
-        copyright += ' * Copyright (c) 2015-2017 The Khronos Group Inc.\n'
-        copyright += ' * Copyright (c) 2015-2017 Valve Corporation\n'
-        copyright += ' * Copyright (c) 2015-2017 LunarG, Inc.\n'
+        copyright += ' * Copyright (c) 2015-2021 The Khronos Group Inc.\n'
+        copyright += ' * Copyright (c) 2015-2021 Valve Corporation\n'
+        copyright += ' * Copyright (c) 2015-2021 LunarG, Inc.\n'
         copyright += ' *\n'
         copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
         copyright += ' * you may not use this file except in compliance with the License.\n'
@@ -227,11 +227,12 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
             entries = self.device_dispatch_list
             table += 'static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDispatchTable *table, PFN_vkGetDeviceProcAddr gpa) {\n'
             table += '    memset(table, 0, sizeof(*table));\n'
+            table += '    table->magic = DEVICE_DISP_TABLE_MAGIC_NUMBER;\n\n'
             table += '    // Device function pointers\n'
         else:
             entries = self.instance_dispatch_list
             table += 'static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa) {\n'
-            table += '    memset(table, 0, sizeof(*table));\n'
+            table += '    memset(table, 0, sizeof(*table));\n\n'
             table += '    // Instance function pointers\n'
 
         for item in entries:

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -250,7 +250,7 @@ class HelperFileOutputGenerator(OutputGenerator):
     def paramIsPointer(self, param):
         ispointer = False
         for elem in param:
-            if ((elem.tag is not 'type') and (elem.tail is not None)) and '*' in elem.tail:
+            if ((elem.tag != 'type') and (elem.tail is not None)) and '*' in elem.tail:
                 ispointer = True
         return ispointer
     #

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,16 +24,22 @@ option(TEST_USE_THREAD_SANITIZER "Linux only: Advanced thread checking" OFF)
 include(GoogleTest)
 add_subdirectory(framework)
 
-add_executable(test_regression loader_testing_main.cpp
-    loader_alloc_callback_tests.cpp
-    loader_get_proc_addr_tests.cpp
-    loader_layer_tests.cpp
-    loader_regression_tests.cpp
-    loader_version_tests.cpp
-    loader_unknown_ext_tests.cpp)
+add_executable(
+    test_regression
+        loader_testing_main.cpp
+        loader_alloc_callback_tests.cpp
+        loader_get_proc_addr_tests.cpp
+        loader_handle_validation_tests.cpp
+        loader_layer_tests.cpp
+        loader_regression_tests.cpp
+        loader_version_tests.cpp
+        loader_unknown_ext_tests.cpp)
 target_link_libraries(test_regression PRIVATE testing_dependencies)
 
-add_executable(test_wsi loader_testing_main.cpp loader_wsi_tests.cpp)
+add_executable(
+    test_wsi
+        loader_testing_main.cpp
+        loader_wsi_tests.cpp)
 target_link_libraries(test_wsi PRIVATE testing_dependencies)
 
 if(UNIX AND NOT APPLE) # i.e. Linux
@@ -53,7 +59,10 @@ if(UNIX AND NOT APPLE) # i.e. Linux
     endif()
 endif()
 
-add_executable(test_threading loader_testing_main.cpp loader_threading_tests.cpp)
+add_executable(
+    test_threading
+        loader_testing_main.cpp
+        loader_threading_tests.cpp)
 target_link_libraries(test_threading PRIVATE testing_dependencies)
 
 if(WIN32)

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -505,13 +505,16 @@ VulkanFunctions::VulkanFunctions() : loader(FRAMEWORK_VULKAN_LIBRARY_PATH) {
     vkGetPhysicalDeviceFeatures = loader.get_symbol<PFN_vkGetPhysicalDeviceFeatures>("vkGetPhysicalDeviceFeatures");
     vkGetPhysicalDeviceFeatures2 = loader.get_symbol<PFN_vkGetPhysicalDeviceFeatures2>("vkGetPhysicalDeviceFeatures2");
     vkGetPhysicalDeviceFormatProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceFormatProperties>("vkGetPhysicalDeviceFormatProperties");
+    vkGetPhysicalDeviceFormatProperties2 = loader.get_symbol<PFN_vkGetPhysicalDeviceFormatProperties2>("vkGetPhysicalDeviceFormatProperties2");
     vkGetPhysicalDeviceImageFormatProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceImageFormatProperties>("vkGetPhysicalDeviceImageFormatProperties");
+    vkGetPhysicalDeviceImageFormatProperties2 = loader.get_symbol<PFN_vkGetPhysicalDeviceImageFormatProperties2>("vkGetPhysicalDeviceImageFormatProperties2");
+    vkGetPhysicalDeviceSparseImageFormatProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceSparseImageFormatProperties>("vkGetPhysicalDeviceSparseImageFormatProperties");
+    vkGetPhysicalDeviceSparseImageFormatProperties2 = loader.get_symbol<PFN_vkGetPhysicalDeviceSparseImageFormatProperties2>("vkGetPhysicalDeviceSparseImageFormatProperties2");
     vkGetPhysicalDeviceProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceProperties>("vkGetPhysicalDeviceProperties");
     vkGetPhysicalDeviceProperties2 = loader.get_symbol<PFN_vkGetPhysicalDeviceProperties2>("vkGetPhysicalDeviceProperties2");
     vkGetPhysicalDeviceQueueFamilyProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceQueueFamilyProperties>("vkGetPhysicalDeviceQueueFamilyProperties");
     vkGetPhysicalDeviceQueueFamilyProperties2 = loader.get_symbol<PFN_vkGetPhysicalDeviceQueueFamilyProperties2>("vkGetPhysicalDeviceQueueFamilyProperties2");
     vkGetPhysicalDeviceMemoryProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceMemoryProperties>("vkGetPhysicalDeviceMemoryProperties");
-    vkGetPhysicalDeviceFormatProperties2 = loader.get_symbol<PFN_vkGetPhysicalDeviceFormatProperties2>("vkGetPhysicalDeviceFormatProperties2");
     vkGetPhysicalDeviceMemoryProperties2 = loader.get_symbol<PFN_vkGetPhysicalDeviceMemoryProperties2>("vkGetPhysicalDeviceMemoryProperties2");
     vkGetPhysicalDeviceSurfaceSupportKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceSurfaceSupportKHR>("vkGetPhysicalDeviceSurfaceSupportKHR");
     vkGetPhysicalDeviceSurfaceFormatsKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceSurfaceFormatsKHR>("vkGetPhysicalDeviceSurfaceFormatsKHR");
@@ -519,31 +522,76 @@ VulkanFunctions::VulkanFunctions() : loader(FRAMEWORK_VULKAN_LIBRARY_PATH) {
     vkGetPhysicalDeviceSurfaceCapabilitiesKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR>("vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
     vkEnumerateDeviceExtensionProperties = loader.get_symbol<PFN_vkEnumerateDeviceExtensionProperties>("vkEnumerateDeviceExtensionProperties");
     vkEnumerateDeviceLayerProperties = loader.get_symbol<PFN_vkEnumerateDeviceLayerProperties>("vkEnumerateDeviceLayerProperties");
+    vkGetPhysicalDeviceExternalBufferProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceExternalBufferProperties>("vkGetPhysicalDeviceExternalBufferProperties");
+    vkGetPhysicalDeviceExternalFenceProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceExternalFenceProperties>("vkGetPhysicalDeviceExternalFenceProperties");
+    vkGetPhysicalDeviceExternalSemaphoreProperties = loader.get_symbol<PFN_vkGetPhysicalDeviceExternalSemaphoreProperties>("vkGetPhysicalDeviceExternalSemaphoreProperties");
 
     vkDestroySurfaceKHR = loader.get_symbol<PFN_vkDestroySurfaceKHR>("vkDestroySurfaceKHR");
     vkGetDeviceProcAddr = loader.get_symbol<PFN_vkGetDeviceProcAddr>("vkGetDeviceProcAddr");
     vkCreateDevice = loader.get_symbol<PFN_vkCreateDevice>("vkCreateDevice");
 
+    vkCreateHeadlessSurfaceEXT = loader.get_symbol<PFN_vkCreateHeadlessSurfaceEXT>("vkCreateHeadlessSurfaceEXT");
+    vkCreateDisplayPlaneSurfaceKHR = loader.get_symbol<PFN_vkCreateDisplayPlaneSurfaceKHR>("vkCreateDisplayPlaneSurfaceKHR");
+    vkGetPhysicalDeviceDisplayPropertiesKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceDisplayPropertiesKHR>("vkGetPhysicalDeviceDisplayPropertiesKHR");
+    vkGetPhysicalDeviceDisplayPlanePropertiesKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>("vkGetPhysicalDeviceDisplayPlanePropertiesKHR");
+    vkGetDisplayPlaneSupportedDisplaysKHR = loader.get_symbol<PFN_vkGetDisplayPlaneSupportedDisplaysKHR>("vkGetDisplayPlaneSupportedDisplaysKHR");
+    vkGetDisplayModePropertiesKHR = loader.get_symbol<PFN_vkGetDisplayModePropertiesKHR>("vkGetDisplayModePropertiesKHR");
+    vkCreateDisplayModeKHR = loader.get_symbol<PFN_vkCreateDisplayModeKHR>("vkCreateDisplayModeKHR");
+    vkGetDisplayPlaneCapabilitiesKHR = loader.get_symbol<PFN_vkGetDisplayPlaneCapabilitiesKHR>("vkGetDisplayPlaneCapabilitiesKHR");
+    vkGetPhysicalDevicePresentRectanglesKHR = loader.get_symbol<PFN_vkGetPhysicalDevicePresentRectanglesKHR>("vkGetPhysicalDevicePresentRectanglesKHR");
+    vkGetPhysicalDeviceDisplayProperties2KHR = loader.get_symbol<PFN_vkGetPhysicalDeviceDisplayProperties2KHR>("vkGetPhysicalDeviceDisplayProperties2KHR");
+    vkGetPhysicalDeviceDisplayPlaneProperties2KHR = loader.get_symbol<PFN_vkGetPhysicalDeviceDisplayPlaneProperties2KHR>("vkGetPhysicalDeviceDisplayPlaneProperties2KHR");
+    vkGetDisplayModeProperties2KHR = loader.get_symbol<PFN_vkGetDisplayModeProperties2KHR>("vkGetDisplayModeProperties2KHR");
+    vkGetDisplayPlaneCapabilities2KHR = loader.get_symbol<PFN_vkGetDisplayPlaneCapabilities2KHR>("vkGetDisplayPlaneCapabilities2KHR");
+    vkGetPhysicalDeviceSurfaceCapabilities2KHR = loader.get_symbol<PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR>("vkGetPhysicalDeviceSurfaceCapabilities2KHR");
+    vkGetPhysicalDeviceSurfaceFormats2KHR = loader.get_symbol<PFN_vkGetPhysicalDeviceSurfaceFormats2KHR>("vkGetPhysicalDeviceSurfaceFormats2KHR");
+
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     vkCreateAndroidSurfaceKHR = loader.get_symbol<PFN_vkCreateAndroidSurfaceKHR>("vkCreateAndroidSurfaceKHR");
-#endif
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+#ifdef VK_USE_PLATFORM_DIRECTFB_EXT
+    vkCreateDirectFBSurfaceEXT = loader.get_symbol<PFN_vkCreateDirectFBSurfaceEXT>("vkCreateDirectFBSurfaceEXT");
+    vkGetPhysicalDeviceDirectFBPresentationSupportEXT = loader.get_symbol<PFN_vkGetPhysicalDeviceDirectFBPresentationSupportEXT>("vkGetPhysicalDeviceDirectFBPresentationSupportEXT");
+#endif  // VK_USE_PLATFORM_DIRECTFB_EXT
+#ifdef VK_USE_PLATFORM_FUCHSIA
+    vkCreateImagePipeSurfaceFUCHSIA = loader.get_symbol<PFN_vkCreateImagePipeSurfaceFUCHSIA>("vkCreateImagePipeSurfaceFUCHSIA");
+#endif  // VK_USE_PLATFORM_FUCHSIA
+#ifdef VK_USE_PLATFORM_GGP
+    vkCreateStreamDescriptorSurfaceGGP = loader.get_symbol<PFN_vkCreateStreamDescriptorSurfaceGGP>("vkCreateStreamDescriptorSurfaceGGP");
+#endif  // VK_USE_PLATFORM_GGP
+#ifdef VK_USE_PLATFORM_IOS_MVK
+    vkCreateIOSSurfaceMVK = loader.get_symbol<PFN_vkCreateIOSSurfaceMVK>("vkCreateIOSSurfaceMVK");
+#endif  // VK_USE_PLATFORM_IOS_MVK
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+    vkCreateMacOSSurfaceMVK = loader.get_symbol<PFN_vkCreateMacOSSurfaceMVK>("vkCreateMacOSSurfaceMVK");
+#endif  // VK_USE_PLATFORM_MACOS_MVK
 #ifdef VK_USE_PLATFORM_METAL_EXT
     vkCreateMetalSurfaceEXT = loader.get_symbol<PFN_vkCreateMetalSurfaceEXT>("vkCreateMetalSurfaceEXT")
-#endif
+#endif  // VK_USE_PLATFORM_METAL_EXT
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+    vkCreateScreenSurfaceQNX = loader.get_symbol<PFN_vkCreateScreenSurfaceQNX>("vkCreateScreenSurfaceQNX");
+    vkGetPhysicalDeviceScreenPresentationSupportQNX = loader.get_symbol<PFN_vkGetPhysicalDeviceScreenPresentationSupportQNX>("vkGetPhysicalDeviceScreenPresentationSupportQNX");
+#endif  // VK_USE_PLATFORM_SCREEN_QNX
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
     vkCreateWaylandSurfaceKHR = loader.get_symbol<PFN_vkCreateWaylandSurfaceKHR>("vkCreateWaylandSurfaceKHR");
-#endif
+    vkGetPhysicalDeviceWaylandPresentationSupportKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR>("vkGetPhysicalDeviceWaylandPresentationSupportKHR");
+#endif  // VK_USE_PLATFORM_WAYLAND_KHR
 #ifdef VK_USE_PLATFORM_XCB_KHR
     vkCreateXcbSurfaceKHR = loader.get_symbol<PFN_vkCreateXcbSurfaceKHR>("vkCreateXcbSurfaceKHR");
-#endif
+    vkGetPhysicalDeviceXcbPresentationSupportKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR>("vkGetPhysicalDeviceXcbPresentationSupportKHR");
+#endif  // VK_USE_PLATFORM_XCB_KHR
 #ifdef VK_USE_PLATFORM_XLIB_KHR
     vkCreateXlibSurfaceKHR = loader.get_symbol<PFN_vkCreateXlibSurfaceKHR>("vkCreateXlibSurfaceKHR");
-#endif
+    vkGetPhysicalDeviceXlibPresentationSupportKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR>("vkGetPhysicalDeviceXlibPresentationSupportKHR");
+#endif  // VK_USE_PLATFORM_XLIB_KHR
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     vkCreateWin32SurfaceKHR = loader.get_symbol<PFN_vkCreateWin32SurfaceKHR>("vkCreateWin32SurfaceKHR");
-#endif
+    vkGetPhysicalDeviceWin32PresentationSupportKHR = loader.get_symbol<PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR>("vkGetPhysicalDeviceWin32PresentationSupportKHR");
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+
     vkDestroyDevice = loader.get_symbol<PFN_vkDestroyDevice>("vkDestroyDevice");
     vkGetDeviceQueue = loader.get_symbol<PFN_vkGetDeviceQueue>("vkGetDeviceQueue");
+
     // clang-format on
 }
 

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -561,13 +561,16 @@ struct VulkanFunctions {
     PFN_vkGetPhysicalDeviceFeatures vkGetPhysicalDeviceFeatures = nullptr;
     PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 = nullptr;
     PFN_vkGetPhysicalDeviceFormatProperties vkGetPhysicalDeviceFormatProperties = nullptr;
+    PFN_vkGetPhysicalDeviceFormatProperties2 vkGetPhysicalDeviceFormatProperties2 = nullptr;
     PFN_vkGetPhysicalDeviceImageFormatProperties vkGetPhysicalDeviceImageFormatProperties = nullptr;
+    PFN_vkGetPhysicalDeviceImageFormatProperties2 vkGetPhysicalDeviceImageFormatProperties2 = nullptr;
+    PFN_vkGetPhysicalDeviceSparseImageFormatProperties vkGetPhysicalDeviceSparseImageFormatProperties = nullptr;
+    PFN_vkGetPhysicalDeviceSparseImageFormatProperties2 vkGetPhysicalDeviceSparseImageFormatProperties2 = nullptr;
     PFN_vkGetPhysicalDeviceProperties vkGetPhysicalDeviceProperties = nullptr;
     PFN_vkGetPhysicalDeviceProperties2 vkGetPhysicalDeviceProperties2 = nullptr;
     PFN_vkGetPhysicalDeviceQueueFamilyProperties vkGetPhysicalDeviceQueueFamilyProperties = nullptr;
     PFN_vkGetPhysicalDeviceQueueFamilyProperties2 vkGetPhysicalDeviceQueueFamilyProperties2 = nullptr;
     PFN_vkGetPhysicalDeviceMemoryProperties vkGetPhysicalDeviceMemoryProperties = nullptr;
-    PFN_vkGetPhysicalDeviceFormatProperties2 vkGetPhysicalDeviceFormatProperties2 = nullptr;
     PFN_vkGetPhysicalDeviceMemoryProperties2 vkGetPhysicalDeviceMemoryProperties2 = nullptr;
     PFN_vkGetPhysicalDeviceSurfaceSupportKHR vkGetPhysicalDeviceSurfaceSupportKHR = nullptr;
     PFN_vkGetPhysicalDeviceSurfaceFormatsKHR vkGetPhysicalDeviceSurfaceFormatsKHR = nullptr;
@@ -575,29 +578,72 @@ struct VulkanFunctions {
     PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR vkGetPhysicalDeviceSurfaceCapabilitiesKHR = nullptr;
     PFN_vkEnumerateDeviceExtensionProperties vkEnumerateDeviceExtensionProperties = nullptr;
     PFN_vkEnumerateDeviceLayerProperties vkEnumerateDeviceLayerProperties = nullptr;
+    PFN_vkGetPhysicalDeviceExternalBufferProperties vkGetPhysicalDeviceExternalBufferProperties = nullptr;
+    PFN_vkGetPhysicalDeviceExternalFenceProperties vkGetPhysicalDeviceExternalFenceProperties = nullptr;
+    PFN_vkGetPhysicalDeviceExternalSemaphoreProperties vkGetPhysicalDeviceExternalSemaphoreProperties = nullptr;
 
     PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr = nullptr;
     PFN_vkCreateDevice vkCreateDevice = nullptr;
 
 // WSI
+    PFN_vkCreateHeadlessSurfaceEXT vkCreateHeadlessSurfaceEXT = nullptr;
+    PFN_vkCreateDisplayPlaneSurfaceKHR vkCreateDisplayPlaneSurfaceKHR = nullptr;
+    PFN_vkGetPhysicalDeviceDisplayPropertiesKHR vkGetPhysicalDeviceDisplayPropertiesKHR = nullptr;
+    PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR vkGetPhysicalDeviceDisplayPlanePropertiesKHR = nullptr;
+    PFN_vkGetDisplayPlaneSupportedDisplaysKHR vkGetDisplayPlaneSupportedDisplaysKHR = nullptr;
+    PFN_vkGetDisplayModePropertiesKHR vkGetDisplayModePropertiesKHR = nullptr;
+    PFN_vkCreateDisplayModeKHR vkCreateDisplayModeKHR = nullptr;
+    PFN_vkGetDisplayPlaneCapabilitiesKHR vkGetDisplayPlaneCapabilitiesKHR = nullptr;
+    PFN_vkGetPhysicalDevicePresentRectanglesKHR vkGetPhysicalDevicePresentRectanglesKHR = nullptr;
+    PFN_vkGetPhysicalDeviceDisplayProperties2KHR vkGetPhysicalDeviceDisplayProperties2KHR = nullptr;
+    PFN_vkGetPhysicalDeviceDisplayPlaneProperties2KHR vkGetPhysicalDeviceDisplayPlaneProperties2KHR = nullptr;
+    PFN_vkGetDisplayModeProperties2KHR vkGetDisplayModeProperties2KHR = nullptr;
+    PFN_vkGetDisplayPlaneCapabilities2KHR vkGetDisplayPlaneCapabilities2KHR = nullptr;
+    PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR vkGetPhysicalDeviceSurfaceCapabilities2KHR = nullptr;
+    PFN_vkGetPhysicalDeviceSurfaceFormats2KHR vkGetPhysicalDeviceSurfaceFormats2KHR = nullptr;
+
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-    PFN_vkCreateAndroidSurfaceKHR vkCreateAndroidSurfaceKHR;
-#endif
+    PFN_vkCreateAndroidSurfaceKHR vkCreateAndroidSurfaceKHR = nullptr;
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+#ifdef VK_USE_PLATFORM_DIRECTFB_EXT
+    PFN_vkCreateDirectFBSurfaceEXT vkCreateDirectFBSurfaceEXT = nullptr;
+    PFN_vkGetPhysicalDeviceDirectFBPresentationSupportEXT vkGetPhysicalDeviceDirectFBPresentationSupportEXT = nullptr;
+#endif  // VK_USE_PLATFORM_DIRECTFB_EXT
+#ifdef VK_USE_PLATFORM_FUCHSIA
+    PFN_vkCreateImagePipeSurfaceFUCHSIA vkCreateImagePipeSurfaceFUCHSIA = nullptr;
+#endif  // VK_USE_PLATFORM_FUCHSIA
+#ifdef VK_USE_PLATFORM_GGP
+    PFN_vkCreateStreamDescriptorSurfaceGGP vkCreateStreamDescriptorSurfaceGGP = nullptr;
+#endif  // VK_USE_PLATFORM_GGP
+#ifdef VK_USE_PLATFORM_IOS_MVK
+    PFN_vkCreateIOSSurfaceMVK vkCreateIOSSurfaceMVK = nullptr;
+#endif  // VK_USE_PLATFORM_IOS_MVK
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+    PFN_vkCreateMacOSSurfaceMVK vkCreateMacOSSurfaceMVK = nullptr;
+#endif  // VK_USE_PLATFORM_MACOS_MVK
 #ifdef VK_USE_PLATFORM_METAL_EXT
-    PFN_vkCreateMetalSurfaceEXT vkCreateMetalSurfaceEXT;
-#endif
+    PFN_vkCreateMetalSurfaceEXT vkCreateMetalSurfaceEXT = nullptr;
+#endif  // VK_USE_PLATFORM_METAL_EXT
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+    PFN_vkCreateScreenSurfaceQNX vkCreateScreenSurfaceQNX = nullptr;
+    PFN_vkGetPhysicalDeviceScreenPresentationSupportQNX vkGetPhysicalDeviceScreenPresentationSupportQNX = nullptr;
+#endif  // VK_USE_PLATFORM_SCREEN_QNX
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-    PFN_vkCreateWaylandSurfaceKHR vkCreateWaylandSurfaceKHR;
-#endif
+    PFN_vkCreateWaylandSurfaceKHR vkCreateWaylandSurfaceKHR = nullptr;
+    PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR vkGetPhysicalDeviceWaylandPresentationSupportKHR = nullptr;
+#endif  // VK_USE_PLATFORM_WAYLAND_KHR
 #ifdef VK_USE_PLATFORM_XCB_KHR
-    PFN_vkCreateXcbSurfaceKHR vkCreateXcbSurfaceKHR;
-#endif
+    PFN_vkCreateXcbSurfaceKHR vkCreateXcbSurfaceKHR = nullptr;
+    PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR vkGetPhysicalDeviceXcbPresentationSupportKHR = nullptr;
+#endif  // VK_USE_PLATFORM_XCB_KHR
 #ifdef VK_USE_PLATFORM_XLIB_KHR
-    PFN_vkCreateXlibSurfaceKHR vkCreateXlibSurfaceKHR;
-#endif
+    PFN_vkCreateXlibSurfaceKHR vkCreateXlibSurfaceKHR = nullptr;
+    PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR vkGetPhysicalDeviceXlibPresentationSupportKHR = nullptr;
+#endif  // VK_USE_PLATFORM_XLIB_KHR
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-    PFN_vkCreateWin32SurfaceKHR vkCreateWin32SurfaceKHR;
-#endif
+    PFN_vkCreateWin32SurfaceKHR vkCreateWin32SurfaceKHR = nullptr;
+    PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR vkGetPhysicalDeviceWin32PresentationSupportKHR = nullptr;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
     PFN_vkDestroySurfaceKHR vkDestroySurfaceKHR = nullptr;
 
     // device functions

--- a/tests/loader_handle_validation_tests.cpp
+++ b/tests/loader_handle_validation_tests.cpp
@@ -1,0 +1,1722 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author(s): Charles Giessen <charles@lunarg.com>
+ *            Mark Young <marky@lunarg.com>
+ */
+
+#include "test_environment.h"
+
+class LoaderHandleValidTests : public ::testing::Test {
+   protected:
+    virtual void SetUp() { env = std::unique_ptr<SingleICDShim>(new SingleICDShim(TEST_ICD_PATH_VERSION_2)); }
+
+    virtual void TearDown() { env.reset(); }
+    std::unique_ptr<SingleICDShim> env;
+};
+
+// ---- Invalid Instance tests
+
+TEST_F(LoaderHandleValidTests, BadInstEnumPhysDevices) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+    uint32_t returned_physical_count = 0;
+
+    ASSERT_DEATH(env->vulkan_functions.vkEnumeratePhysicalDevices(bad_instance, &returned_physical_count, nullptr), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadInstGetInstProcAddr) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    ASSERT_DEATH(env->vulkan_functions.vkGetInstanceProcAddr(bad_instance, "vkGetBufferDeviceAddress"), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadInstDestroyInstance) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    ASSERT_DEATH(env->vulkan_functions.vkDestroyInstance(bad_instance, nullptr), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadInstDestroySurface) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_headless_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    ASSERT_DEATH(env->vulkan_functions.vkDestroySurfaceKHR(bad_instance, VK_NULL_HANDLE, nullptr), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadInstCreateHeadlessSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_headless_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_EXT_headless_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkHeadlessSurfaceCreateInfoEXT surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateHeadlessSurfaceEXT(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadInstCreateDisplayPlaneSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkDisplaySurfaceCreateInfoKHR surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateDisplayPlaneSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
+                 "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+TEST_F(LoaderHandleValidTests, BadInstCreateAndroidSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_android_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_android_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkAndroidSurfaceCreateInfoKHR surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateAndroidSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+
+#ifdef VK_USE_PLATFORM_DIRECTFB_EXT
+TEST_F(LoaderHandleValidTests, BadInstCreateDirectFBSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_directfb_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_EXT_directfb_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkDirectFBSurfaceCreateInfoEXT surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_DIRECTFB_SURFACE_CREATE_INFO_EXT;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateDirectFBSurfaceEXT(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_DIRECTFB_EXT
+
+#ifdef VK_USE_PLATFORM_FUCHSIA
+TEST_F(LoaderHandleValidTests, BadInstCreateFuchsiaSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_FUCHSIA_imagepipe_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_FUCHSIA_imagepipe_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkImagePipeSurfaceCreateInfoFUCHSIA surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateImagePipeSurfaceFUCHSIA(bad_instance, &surf_create_info, nullptr, &created_surface),
+                 "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_FUCHSIA
+
+#ifdef VK_USE_PLATFORM_GGP
+TEST_F(LoaderHandleValidTests, BadInstCreateGGPSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_GGP_stream_descriptor_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_GGP_stream_descriptor_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkStreamDescriptorSurfaceCreateInfoGGP surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(
+        env->vulkan_functions.vkCreateStreamDescriptorSurfaceGGP(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_GGP
+
+#ifdef VK_USE_PLATFORM_IOS_MVK
+TEST_F(LoaderHandleValidTests, BadInstCreateIOSSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_MVK_ios_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_MVK_ios_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkIOSSurfaceCreateInfoMVK surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateIOSSurfaceMVK(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_IOS_MVK
+
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+TEST_F(LoaderHandleValidTests, BadInstCreateMacOSSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_MVK_macos_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_MVK_macos_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkMacOSSurfaceCreateInfoMVK surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateMacOSSurfaceMVK(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_MACOS_MVK
+
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+TEST_F(LoaderHandleValidTests, BadInstCreateMetalSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_metal_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_EXT_metal_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkMetalSurfaceCreateInfoEXT surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateMetalSurfaceEXT(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_METAL_EXT
+
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+TEST_F(LoaderHandleValidTests, BadInstCreateQNXSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_QNX_screen_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_QNX_screen_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkScreenSurfaceCreateInfoQNX surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_SCREEN_SURFACE_CREATE_INFO_QNX;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateScreenSurfaceQNX(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_SCREEN_QNX
+
+#ifdef VK_USE_PLATFORM_VI_NN
+TEST_F(LoaderHandleValidTests, BadInstCreateViNNSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_NN_vi_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_NN_vi_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkViSurfaceCreateInfoNN surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.CreateViSurfaceNN(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_VI_NN
+
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+TEST_F(LoaderHandleValidTests, BadInstCreateWaylandSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_wayland_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_wayland_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkWaylandSurfaceCreateInfoKHR surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateWaylandSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_WAYLAND_KHR
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+TEST_F(LoaderHandleValidTests, BadInstCreateWin32Surf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_win32_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_win32_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkWin32SurfaceCreateInfoKHR surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateWin32SurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+
+#ifdef VK_USE_PLATFORM_XCB_KHR
+TEST_F(LoaderHandleValidTests, BadInstCreateXCBSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_xcb_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_xcb_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkXcbSurfaceCreateInfoKHR surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateXcbSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_XCB_KHR
+
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+TEST_F(LoaderHandleValidTests, BadInstCreateXlibSurf) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_xlib_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_xlib_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkInstance bad_instance = (VkInstance)(&my_bad_data);
+
+    VkXlibSurfaceCreateInfoKHR surf_create_info = {};
+    surf_create_info.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+    surf_create_info.pNext = nullptr;
+    VkSurfaceKHR created_surface = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateXlibSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface), "");
+    // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_XLIB_KHR
+
+// ---- Invalid Physical Device tests
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFeature) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkPhysicalDeviceFeatures features = {};
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceFeatures(bad_physical_dev, &features), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFormatProps) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkFormatProperties format_info = {};
+    ASSERT_DEATH(
+        env->vulkan_functions.vkGetPhysicalDeviceFormatProperties(bad_physical_dev, VK_FORMAT_R8G8B8A8_UNORM, &format_info), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevImgFormatProps) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkImageFormatProperties format_info = {};
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceImageFormatProperties(bad_physical_dev, VK_FORMAT_R8G8B8A8_UNORM,
+                                                                                VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_LINEAR,
+                                                                                VK_IMAGE_USAGE_STORAGE_BIT, 0, &format_info),
+                 "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevProps) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkPhysicalDeviceProperties properties = {};
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceProperties(bad_physical_dev, &properties), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamProps) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceQueueFamilyProperties(bad_physical_dev, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDevMemProps) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkPhysicalDeviceMemoryProperties properties = {};
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceMemoryProperties(bad_physical_dev, &properties), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevCreateDevice) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    float queue_priorities[3] = {0.0f, 0.5f, 1.0f};
+    VkDeviceQueueCreateInfo dev_queue_create_info = {};
+    dev_queue_create_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    dev_queue_create_info.pNext = nullptr;
+    dev_queue_create_info.flags = 0;
+    dev_queue_create_info.queueFamilyIndex = 0;
+    dev_queue_create_info.queueCount = 1;
+    dev_queue_create_info.pQueuePriorities = queue_priorities;
+    VkDeviceCreateInfo dev_create_info = {};
+    dev_create_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    dev_create_info.pNext = nullptr;
+    dev_create_info.flags = 0;
+    dev_create_info.queueCreateInfoCount = 1;
+    dev_create_info.pQueueCreateInfos = &dev_queue_create_info;
+    dev_create_info.enabledLayerCount = 0;
+    dev_create_info.ppEnabledLayerNames = nullptr;
+    dev_create_info.enabledExtensionCount = 0;
+    dev_create_info.ppEnabledExtensionNames = nullptr;
+    dev_create_info.pEnabledFeatures = nullptr;
+    VkDevice created_dev = VK_NULL_HANDLE;
+    ASSERT_DEATH(env->vulkan_functions.vkCreateDevice(bad_physical_dev, &dev_create_info, nullptr, &created_dev), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevEnumDevExtProps) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkEnumerateDeviceExtensionProperties(bad_physical_dev, nullptr, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevEnumDevLayerProps) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkEnumerateDeviceLayerProperties(bad_physical_dev, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSparseImgFormatProps) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSparseImageFormatProperties(
+                     bad_physical_dev, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D, VK_SAMPLE_COUNT_1_BIT,
+                     VK_IMAGE_USAGE_STORAGE_BIT, VK_IMAGE_TILING_LINEAR, &count, nullptr),
+                 "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFeature2) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkPhysicalDeviceFeatures2 features = {};
+    features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    features.pNext = nullptr;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceFeatures2(bad_physical_dev, &features), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFormatProps2) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkFormatProperties2 properties = {};
+    properties.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+    properties.pNext = nullptr;
+    ASSERT_DEATH(
+        env->vulkan_functions.vkGetPhysicalDeviceFormatProperties2(bad_physical_dev, VK_FORMAT_R8G8B8A8_UNORM, &properties), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevImgFormatProps2) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkPhysicalDeviceImageFormatInfo2 format_info = {};
+    format_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
+    format_info.pNext = nullptr;
+    VkImageFormatProperties2 properties = {};
+    properties.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
+    properties.pNext = nullptr;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceImageFormatProperties2(bad_physical_dev, &format_info, &properties), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevProps2) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkPhysicalDeviceProperties2 properties = {};
+    properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+    properties.pNext = nullptr;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceProperties2(bad_physical_dev, &properties), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamProps2) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceQueueFamilyProperties2(bad_physical_dev, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDevMemProps2) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkPhysicalDeviceMemoryProperties2 properties = {};
+    properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
+    properties.pNext = nullptr;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceMemoryProperties2(bad_physical_dev, &properties), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSparseImgFormatProps2) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkPhysicalDeviceSparseImageFormatInfo2 info = {};
+    info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2;
+    info.pNext = nullptr;
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSparseImageFormatProperties2(bad_physical_dev, &info, &count, nullptr),
+                 "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevExternFenceProps) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkPhysicalDeviceExternalFenceInfo info = {};
+    info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO;
+    info.pNext = nullptr;
+    VkExternalFenceProperties props = {};
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceExternalFenceProperties(bad_physical_dev, &info, &props), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevExternBufferProps) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkPhysicalDeviceExternalBufferInfo info = {};
+    info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO;
+    info.pNext = nullptr;
+    VkExternalBufferProperties props = {};
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceExternalBufferProperties(bad_physical_dev, &info, &props), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevExternSemaphoreProps) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VkPhysicalDeviceExternalSemaphoreInfoKHR info = {};
+    info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO;
+    info.pNext = nullptr;
+    VkExternalSemaphoreProperties props = {};
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceExternalSemaphoreProperties(bad_physical_dev, &info, &props), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceSupportKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_headless_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    VkBool32 supported = VK_FALSE;
+
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSurfaceSupportKHR(bad_physical_dev, 0, VK_NULL_HANDLE, &supported), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceCapsKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_headless_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    VkSurfaceCapabilitiesKHR caps = {};
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(bad_physical_dev, VK_NULL_HANDLE, &caps), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceFormatsKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_headless_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSurfaceFormatsKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfacePresentModesKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_headless_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSurfacePresentModesKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
+                 "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+#ifdef VK_USE_PLATFORM_DIRECTFB_EXT
+TEST_F(LoaderHandleValidTests, BadPhysDevGetDirectFBPresentSupportKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_directfb_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_EXT_directfb_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    IDirectFB directfb;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceDirectFBPresentationSupportEXT(bad_physical_dev, 0, &directfb), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_DIRECTFB_EXT
+
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+TEST_F(LoaderHandleValidTests, BadPhysDevGetQNXPresentSupportKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_QNX_screen_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_QNX_screen_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    ASSERT_DEATH(env->vulkan_functions.PFN_vkGetPhysicalDeviceScreenPresentationSupportQNX(bad_physical_dev, 0, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_SCREEN_QNX
+
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevWaylandPresentSupportKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_wayland_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_wayland_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceWaylandPresentationSupportKHR(bad_physical_dev, 0, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_WAYLAND_KHR
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevWin32PresentSupportKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_win32_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_win32_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceWin32PresentationSupportKHR(bad_physical_dev, 0), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+
+#ifdef VK_USE_PLATFORM_XCB_KHR
+TEST_F(LoaderHandleValidTests, BadPhysDevGetXCBPresentSupportKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_xcb_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_xcb_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    xcb_visualid_t visual = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceXcbPresentationSupportKHR(bad_physical_dev, 0, nullptr, visual), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_XCB_KHR
+
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+TEST_F(LoaderHandleValidTests, BadPhysDevGetXlibPresentSupportKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_xlib_surface"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_xlib_surface");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+
+    VisualID visual = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceXlibPresentationSupportKHR(bad_physical_dev, 0, nullptr, visual), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_XLIB_KHR
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPropsKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceDisplayPropertiesKHR(bad_physical_dev, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPlanePropsKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceDisplayPlanePropertiesKHR(bad_physical_dev, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneSupportedDisplaysKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetDisplayPlaneSupportedDisplaysKHR(bad_physical_dev, 0, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayModePropsKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetDisplayModePropertiesKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevCreateDisplayModeKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    VkDisplayModeCreateInfoKHR create_info = {};
+    create_info.sType = VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR;
+    create_info.pNext = nullptr;
+    VkDisplayModeKHR display_mode;
+    ASSERT_DEATH(
+        env->vulkan_functions.vkCreateDisplayModeKHR(bad_physical_dev, VK_NULL_HANDLE, &create_info, nullptr, &display_mode), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneCapsKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    VkDisplayPlaneCapabilitiesKHR caps = {};
+    ASSERT_DEATH(env->vulkan_functions.vkGetDisplayPlaneCapabilitiesKHR(bad_physical_dev, VK_NULL_HANDLE, 0, &caps), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevPresentRectsKHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDevicePresentRectanglesKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
+                 "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayProps2KHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_get_display_properties2"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_get_display_properties2");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceDisplayProperties2KHR(bad_physical_dev, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPlaneProps2KHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_get_display_properties2"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_get_display_properties2");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceDisplayPlaneProperties2KHR(bad_physical_dev, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayModeProps2KHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_get_display_properties2"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_get_display_properties2");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    ASSERT_DEATH(env->vulkan_functions.vkGetDisplayModeProperties2KHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneCaps2KHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_get_display_properties2"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_get_display_properties2");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    VkDisplayPlaneInfo2KHR disp_plane_info = {};
+    disp_plane_info.sType = VK_STRUCTURE_TYPE_DISPLAY_PLANE_INFO_2_KHR;
+    disp_plane_info.pNext = nullptr;
+    VkDisplayPlaneCapabilities2KHR caps = {};
+    ASSERT_DEATH(env->vulkan_functions.vkGetDisplayPlaneCapabilities2KHR(bad_physical_dev, &disp_plane_info, &caps), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceCaps2KHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_get_surface_capabilities2"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_surface");
+    inst_create_info.add_extension("VK_KHR_get_surface_capabilities2");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    VkPhysicalDeviceSurfaceInfo2KHR phys_dev_surf_info = {};
+    phys_dev_surf_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
+    phys_dev_surf_info.pNext = nullptr;
+    VkSurfaceCapabilities2KHR caps = {};
+    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSurfaceCapabilities2KHR(bad_physical_dev, &phys_dev_surf_info, &caps),
+                 "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceFormats2KHR) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_KHR_get_surface_capabilities2"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_KHR_get_surface_capabilities2");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    VkPhysicalDeviceSurfaceInfo2KHR phys_dev_surf_info = {};
+    phys_dev_surf_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
+    phys_dev_surf_info.pNext = nullptr;
+    uint32_t count = 0;
+    ASSERT_DEATH(
+        env->vulkan_functions.vkGetPhysicalDeviceSurfaceFormats2KHR(bad_physical_dev, &phys_dev_surf_info, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevEnumPhysDevQueueFamilyPerfQueryCountersKHR) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR pfn =
+        reinterpret_cast<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            env->vulkan_functions.vkGetInstanceProcAddr(instance,
+                                                        "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR"));
+    ASSERT_NE(pfn, nullptr);
+    ASSERT_DEATH(pfn(bad_physical_dev, 0, &count, nullptr, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamilyPerfQueryPassesKHR) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    VkQueryPoolPerformanceCreateInfoKHR create_info = {};
+    create_info.sType = VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR;
+    create_info.pNext = nullptr;
+    uint32_t count = 0;
+    PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR pfn =
+        reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR>(
+            env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR"));
+    ASSERT_NE(pfn, nullptr);
+    ASSERT_DEATH(pfn(bad_physical_dev, &create_info, &count), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFragmentShadingRatesKHR) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    uint32_t count = 0;
+    PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR pfn = reinterpret_cast<PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR>(
+        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFragmentShadingRatesKHR"));
+    ASSERT_NE(pfn, nullptr);
+    ASSERT_DEATH(pfn(bad_physical_dev, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevMSPropsEXT) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    VkMultisamplePropertiesEXT props = {};
+    PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT pfn = reinterpret_cast<PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT>(
+        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceMultisamplePropertiesEXT"));
+    ASSERT_NE(pfn, nullptr);
+    ASSERT_DEATH(pfn(bad_physical_dev, VK_SAMPLE_COUNT_1_BIT, &props), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevAcquireDrmDisplayEXT) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_acquire_drm_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_EXT_acquire_drm_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    PFN_vkAcquireDrmDisplayEXT pfn = reinterpret_cast<PFN_vkAcquireDrmDisplayEXT>(
+        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkAcquireDrmDisplayEXT"));
+    ASSERT_NE(pfn, nullptr);
+    ASSERT_DEATH(pfn(bad_physical_dev, 0, VK_NULL_HANDLE), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetDrmDisplayEXT) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_acquire_drm_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_EXT_acquire_drm_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    PFN_vkGetDrmDisplayEXT pfn =
+        reinterpret_cast<PFN_vkGetDrmDisplayEXT>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetDrmDisplayEXT"));
+    ASSERT_NE(pfn, nullptr);
+    ASSERT_DEATH(pfn(bad_physical_dev, 0, 0, VK_NULL_HANDLE), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevReleaseDisplayEXT) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_direct_mode_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_EXT_direct_mode_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    PFN_vkReleaseDisplayEXT pfn =
+        reinterpret_cast<PFN_vkReleaseDisplayEXT>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkReleaseDisplayEXT"));
+    ASSERT_NE(pfn, nullptr);
+    ASSERT_DEATH(pfn(bad_physical_dev, VK_NULL_HANDLE), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+#ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
+TEST_F(LoaderHandleValidTests, BadPhysDevAcquireXlibDisplayEXT) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_acquire_xlib_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_EXT_acquire_xlib_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    PFN_vkAcquireXlibDisplayEXT pfn = reinterpret_cast<PFN_vkAcquireXlibDisplayEXT>(
+        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkAcquireXlibDisplayEXT"));
+    ASSERT_NE(pfn, nullptr);
+    ASSERT_DEATH(pfn(bad_physical_dev, nullptr, VK_NULL_HANDLE), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetRandROutputDisplayEXT) {
+    Extension first_ext{"VK_KHR_surface"};
+    Extension second_ext{"VK_EXT_acquire_xlib_display"};
+    auto& driver = env->get_test_icd();
+    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_extension("VK_EXT_acquire_xlib_display");
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    RROutput rrout;
+    VkDisplayKHR disp;
+    PFN_vkGetRandROutputDisplayEXT pfn = reinterpret_cast<PFN_vkGetRandROutputDisplayEXT>(
+        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetRandROutputDisplayEXT"));
+    ASSERT_NE(pfn, nullptr);
+    ASSERT_DEATH(pfn(bad_physical_dev, nullptr, rrout, &disp), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_XLIB_XRANDR_EXT
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfacePresentModes2EXT) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    VkPhysicalDeviceSurfaceInfo2KHR phys_dev_surf_info = {};
+    phys_dev_surf_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
+    phys_dev_surf_info.pNext = nullptr;
+    uint32_t count = 0;
+    PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT pfn = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT>(
+        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfacePresentModes2EXT"));
+    ASSERT_NE(pfn, nullptr);
+    ASSERT_DEATH(pfn(bad_physical_dev, &phys_dev_surf_info, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+
+TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevToolPropertiesEXT) {
+    auto& driver = env->get_test_icd();
+    driver.physical_devices.emplace_back("physical_device_0");
+
+    VkInstance instance;
+    InstanceCreateInfo inst_create_info;
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(inst_create_info.get(), nullptr, &instance), VK_SUCCESS);
+
+    struct BadData {
+        uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
+    } my_bad_data;
+    VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
+    PFN_vkGetPhysicalDeviceToolPropertiesEXT pfn = reinterpret_cast<PFN_vkGetPhysicalDeviceToolPropertiesEXT>(
+        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceToolPropertiesEXT"));
+    ASSERT_NE(pfn, nullptr);
+    uint32_t count = 0;
+    ASSERT_DEATH(pfn(bad_physical_dev, &count, nullptr), "");
+    // TODO: Look for "invalid physicalDevice" in stderr log to make sure correct error is thrown
+}


### PR DESCRIPTION
Validate the Vulkan dispatchable handles (VkInstance, VkPhysicalDevice, etc) for
any trampoline functions the loader uses to query the dispatch table from.
This is so we can at least report errors before something bad happens.

Fixes GH Issue #64.