### PR TITLE
Test framework improvements

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -158,5 +158,5 @@ if(WIN32)
     endif()
 endif()
 
-#must happen after the dll's get copied over
+# must happen after the dll's get copied over
 gtest_discover_tests(test_regression)

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,25 @@
 This directory contains a test suite for the Vulkan loader.
 These tests are not exhaustive &mdash; they are expected to be supplemented with other tests, such as CTS.
 
-## Running Tests
+
+## (NEW) Running Tests
+
+For most purposes `ctest` is the desired method of running tests.
+This is because when a test fails, `ctest` will automatically printout the failing test case.
+
+Tests are organized into various executables:
+ * `test_regression` - Contains the vast majority of tests.
+ * `test_wsi` - These test require presentation engine support.
+   * Because the test suite is meant to be run in CI, these test require extra work to make happen and thus live in their own executable.
+ * `test_threading` - Tests which need multiple threads to execute.
+   * This allows targeted testing which uses tools like ThreadSanitizer
+
+The loader test framework is designed to be easy to use, as simple as just running a single executable. To achieve that requires extensive build script
+automation is required. More details are in the tests/framework/README.md.
+The consequence of this automation: Do not relocate the build folder of the project without cleaning the CMakeCache. Most components are found by absolute
+path and thus require the contents of the folder to not be relocated.
+
+## (OLD) Running Tests
 
 To run the tests, your environment needs to be configured so that the test layers will be found.
 This can be done by setting the `VK_LAYER_PATH` environment variable to point at the built layers.
@@ -12,3 +30,13 @@ Depending on the platform build tool you use, this location will either be `${CM
 When using Visual Studio, a the generated project will already be set up to set the environment as needed.
 Running the tests through the `run_loader_tests.sh` script on Linux will also set up the environment properly.
 With any other toolchain, the user will have to set up the environment manually.
+
+## Writing Tests
+
+The `test_environment.h/cpp` are the primary tool used when creating new tests. Either use the existing child classes of FrameworkEnvironment or create a new one
+to suite the tests need. Refer to the `tests/framework/README.md` for more details.
+
+IMPORTANT NOTES:
+ * NEVER FORGET TO DESTROY A VKINSTANCE THAT WAS SUCCESSFULLY CREATED.
+   * The loader loads dynamic libraries in `vkCreateInstance` and unloads them in `vkDestroyInstance`. If these dynamic libraries aren't unloaded, they leak state
+   into the next test that runs, causing spurious failures or even crashes.

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -33,7 +33,8 @@ target_compile_options(testing_framework_util INTERFACE
 if(UNIX)
     target_compile_options(testing_framework_util PUBLIC -fPIC)
 endif()
-target_include_directories(testing_framework_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+# Gives access to all headers in the framework folder, in the framework binary, and in the whole project (mainly for loader/generated)
+target_include_directories(testing_framework_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR})
 
 if (UNIX)
     if (TEST_USE_ADDRESS_SANITIZER)

--- a/tests/framework/framework_config.h.in
+++ b/tests/framework/framework_config.h.in
@@ -34,6 +34,7 @@
 
 #define TEST_ICD_BUILD_LOCATION "$<TARGET_FILE_DIR:test_icd_export_none>"
 
+// TestICD Binaries
 #define TEST_ICD_PATH_EXPORT_NONE "$<TARGET_FILE:test_icd_export_none>"
 #define TEST_ICD_PATH_EXPORT_ICD_GIPA "$<TARGET_FILE:test_icd_export_icd_gipa>"
 #define TEST_ICD_PATH_EXPORT_NEGOTIATE_INTERFACE_VERSION "$<TARGET_FILE:test_icd_export_negotiate_interface_version>"
@@ -45,3 +46,9 @@
 
 // Assumes version 2 exports
 #define TEST_ICD_PATH_VERSION_2_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES "$<TARGET_FILE:test_icd_version_2_export_icd_enumerate_adapter_physical_devices>"
+
+// TestLayer binaries
+#define TEST_LAYER_PATH_EXPORT_BASE "$<TARGET_FILE:test_layer_export_base>"
+#define TEST_LAYER_PATH_EXPORT_VERSION_0 "$<TARGET_FILE:test_layer_export_version_0>"
+#define TEST_LAYER_PATH_EXPORT_VERSION_1 "$<TARGET_FILE:test_layer_export_version_1>"
+#define TEST_LAYER_PATH_EXPORT_VERSION_2 "$<TARGET_FILE:test_layer_export_version_2>"

--- a/tests/framework/layer/CMakeLists.txt
+++ b/tests/framework/layer/CMakeLists.txt
@@ -36,20 +36,20 @@ set(TEST_LAYER_VERSION_2_EXPORTS TEST_LAYER_EXPORT_GET_PHYSICAL_DEVICE_PROC_ADDR
     LAYER_EXPORT_NEGOTIATE_LOADER_LAYER_INTERFACE_VERSION=1 ${TEST_LAYER_BASE_EXPORTS})
 
 add_library(test_layer_export_base SHARED ${TEST_LAYER_SOURCES})
-target_link_libraries(test_layer_export_base PRIVATE test_icd_deps)
+target_link_libraries(test_layer_export_base PRIVATE test_layer_deps)
 target_compile_definitions(test_layer_export_base PRIVATE ${TEST_LAYER_BASE_EXPORTS})
 
 add_library(test_layer_export_version_0 SHARED ${TEST_LAYER_SOURCES})
-target_link_libraries(test_layer_export_version_0 PRIVATE test_icd_deps)
+target_link_libraries(test_layer_export_version_0 PRIVATE test_layer_deps)
 target_compile_definitions(test_layer_export_version_0 PRIVATE ${TEST_LAYER_VERSION_0_EXPORTS})
 
 add_library(test_layer_export_version_1 SHARED ${TEST_LAYER_SOURCES})
-target_link_libraries(test_layer_export_version_1 PRIVATE test_icd_deps)
+target_link_libraries(test_layer_export_version_1 PRIVATE test_layer_deps)
 target_compile_definitions(test_layer_export_version_1 PRIVATE
     ${TEST_LAYER_VERSION_0_EXPORTS} ${TEST_LAYER_VERSION_1_EXPORTS})
 
 add_library(test_layer_export_version_2 SHARED ${TEST_LAYER_SOURCES})
-target_link_libraries(test_layer_export_version_2 PRIVATE test_icd_deps)
+target_link_libraries(test_layer_export_version_2 PRIVATE test_layer_deps)
 target_compile_definitions(test_layer_export_version_2 PRIVATE
     ${TEST_LAYER_VERSION_0_EXPORTS} ${TEST_LAYER_VERSION_1_EXPORTS} ${TEST_LAYER_VERSION_2_EXPORTS} )
 

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -31,6 +31,8 @@
 
 #include "layer/layer_util.h"
 
+#include "loader/generated/vk_layer_dispatch_table.h"
+
 /*
 Interface Version 0
 */
@@ -103,6 +105,15 @@ struct TestLayer {
 
     bool intercept_vkEnumerateInstanceExtensionProperties = false;
     bool intercept_vkEnumerateInstanceLayerProperties = false;
+
+    VkInstance instance_handle;
+    VkLayerInstanceDispatchTable instance_dispatch_table;
+
+    struct Device {
+        VkDevice device_handle;
+        VkLayerDispatchTable dispatch_table;
+    };
+    std::vector<Device> created_devices;
 };
 
 using GetTestLayerFunc = TestLayer* (*)();

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -111,6 +111,7 @@ void EnvVarICDOverrideShim::SetEnvOverrideICD(const char* icd_path, const char* 
 
 SingleICDShim::SingleICDShim(TestICDDetails icd_details, DebugMode debug_mode) noexcept : FrameworkEnvironment(debug_mode) {
     icd_handle = detail::TestICDHandle(icd_details.icd_path);
+    icd_handle.get_new_test_icd();
 
     AddICD(icd_details, "test_icd.json");
 }
@@ -128,6 +129,7 @@ MultipleICDShim::MultipleICDShim(std::vector<TestICDDetails> icd_details_vector,
         auto new_driver_location = icd_folder.copy_file(test_icd_detail.icd_path, new_driver_name.str());
 
         icds.push_back(detail::TestICDHandle(new_driver_location));
+        icds.back().get_new_test_icd();
         test_icd_detail.icd_path = new_driver_location.c_str();
         AddICD(test_icd_detail, std::string("test_icd_") + std::to_string(i) + ".json");
         i++;

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -74,8 +74,8 @@
 
 namespace detail {
 struct PlatformShimWrapper {
-    PlatformShimWrapper(DebugMode debug_mode = DebugMode::none);
-    ~PlatformShimWrapper();
+    PlatformShimWrapper(DebugMode debug_mode = DebugMode::none) noexcept;
+    ~PlatformShimWrapper() noexcept;
     PlatformShimWrapper(PlatformShimWrapper const&) = delete;
     PlatformShimWrapper& operator=(PlatformShimWrapper const&) = delete;
 
@@ -88,11 +88,11 @@ struct PlatformShimWrapper {
 };
 
 struct TestICDHandle {
-    TestICDHandle();
-    TestICDHandle(fs::path const& icd_path);
-    TestICD& get_new_test_icd();
-    TestICD& get_test_icd();
-    fs::path get_icd_full_path();
+    TestICDHandle() noexcept;
+    TestICDHandle(fs::path const& icd_path) noexcept;
+    TestICD& get_new_test_icd() noexcept;
+    TestICD& get_test_icd() noexcept;
+    fs::path get_icd_full_path() noexcept;
 
     // Must use statically
     LibraryWrapper icd_library;
@@ -100,11 +100,11 @@ struct TestICDHandle {
     GetNewTestICDFunc proc_addr_get_new_test_icd;
 };
 struct TestLayerHandle {
-    TestLayerHandle();
-    TestLayerHandle(fs::path const& icd_path);
-    TestLayer& get_new_test_layer();
-    TestLayer& get_test_layer();
-    fs::path get_layer_full_path();
+    TestLayerHandle() noexcept;
+    TestLayerHandle(fs::path const& icd_path) noexcept;
+    TestLayer& get_new_test_layer() noexcept;
+    TestLayer& get_test_layer() noexcept;
+    fs::path get_layer_full_path() noexcept;
 
     // Must use statically
     LibraryWrapper layer_library;
@@ -114,24 +114,24 @@ struct TestLayerHandle {
 }  // namespace detail
 
 struct TestICDDetails {
-    TestICDDetails(const char* icd_path, uint32_t api_version = VK_MAKE_VERSION(1, 0, 0))
+    TestICDDetails(const char* icd_path, uint32_t api_version = VK_MAKE_VERSION(1, 0, 0)) noexcept
         : icd_path(icd_path), api_version(api_version) {}
     const char* icd_path = nullptr;
     uint32_t api_version = VK_MAKE_VERSION(1, 0, 0);
 };
 struct TestLayerDetails {
-    TestLayerDetails(const char* layer_path, uint32_t api_version = VK_MAKE_VERSION(1, 0, 0))
+    TestLayerDetails(const char* layer_path, uint32_t api_version = VK_MAKE_VERSION(1, 0, 0)) noexcept
         : layer_path(layer_path), api_version(api_version) {}
     const char* layer_path = nullptr;
     uint32_t api_version = VK_MAKE_VERSION(1, 0, 0);
 };
 
 struct FrameworkEnvironment {
-    FrameworkEnvironment(DebugMode debug_mode = DebugMode::none);
+    FrameworkEnvironment(DebugMode debug_mode = DebugMode::none) noexcept;
 
-    void AddICD(TestICDDetails icd_details, const std::string& json_name);
-    void AddImplicitLayer(ManifestLayer layer_manifest, const std::string& json_name);
-    void AddExplicitLayer(ManifestLayer layer_manifest, const std::string& json_name);
+    void AddICD(TestICDDetails icd_details, const std::string& json_name) noexcept;
+    void AddImplicitLayer(ManifestLayer layer_manifest, const std::string& json_name) noexcept;
+    void AddExplicitLayer(ManifestLayer layer_manifest, const std::string& json_name) noexcept;
 
     detail::PlatformShimWrapper platform_shim;
     fs::FolderManager null_folder;
@@ -141,32 +141,32 @@ struct FrameworkEnvironment {
     VulkanFunctions vulkan_functions;
 };
 
-struct EnvVarICDOverrideShim : FrameworkEnvironment {
-    EnvVarICDOverrideShim(DebugMode debug_mode = DebugMode::none);
+struct EnvVarICDOverrideShim : public FrameworkEnvironment {
+    EnvVarICDOverrideShim(DebugMode debug_mode = DebugMode::none) noexcept;
 
-    void SetEnvOverrideICD(const char* icd_path, const char* manifest_name);
+    void SetEnvOverrideICD(const char* icd_path, const char* manifest_name) noexcept;
 
     LibraryWrapper driver_wrapper;
     GetNewTestICDFunc get_new_test_icd;
 };
 
-struct SingleICDShim : FrameworkEnvironment {
-    SingleICDShim(TestICDDetails icd_details, DebugMode debug_mode = DebugMode::none);
+struct SingleICDShim : public FrameworkEnvironment {
+    SingleICDShim(TestICDDetails icd_details, DebugMode debug_mode = DebugMode::none) noexcept;
 
-    TestICD& get_test_icd();
-    TestICD& get_new_test_icd();
+    TestICD& get_test_icd() noexcept;
+    TestICD& get_new_test_icd() noexcept;
 
-    fs::path get_test_icd_path();
+    fs::path get_test_icd_path() noexcept;
 
     detail::TestICDHandle icd_handle;
 };
 
-struct MultipleICDShim : FrameworkEnvironment {
-    MultipleICDShim(std::vector<TestICDDetails> icd_details_vector, DebugMode debug_mode = DebugMode::none);
+struct MultipleICDShim : public FrameworkEnvironment {
+    MultipleICDShim(std::vector<TestICDDetails> icd_details_vector, DebugMode debug_mode = DebugMode::none) noexcept;
 
-    TestICD& get_test_icd(int index);
-    TestICD& get_new_test_icd(int index);
-    fs::path get_test_icd_path(int index);
+    TestICD& get_test_icd(int index) noexcept;
+    TestICD& get_new_test_icd(int index) noexcept;
+    fs::path get_test_icd_path(int index) noexcept;
 
     std::vector<detail::TestICDHandle> icds;
 };

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -68,12 +68,11 @@ TEST_F(CreateInstance, BasicRun) {
 
 // LX435
 TEST_F(CreateInstance, ConstInstanceInfo) {
+    VkInstance inst = VK_NULL_HANDLE;
     VkInstanceCreateInfo const info = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO, nullptr, 0, nullptr, 0, nullptr, 0, nullptr};
-
-    VkInstance instance = VK_NULL_HANDLE;
-    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(&info, VK_NULL_HANDLE, &instance), VK_SUCCESS);
-
-    env->vulkan_functions.vkDestroyInstance(instance, nullptr);
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(&info, VK_NULL_HANDLE, &inst), VK_SUCCESS);
+    // Must clean up
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 }
 
 // VUID-vkDestroyInstance-instance-parameter, VUID-vkDestroyInstance-pAllocator-parameter
@@ -85,24 +84,24 @@ TEST_F(CreateInstance, DestroyDeviceNullHandle) { env->vulkan_functions.vkDestro
 // VUID-vkCreateInstance-ppEnabledExtensionNames-01388
 TEST_F(CreateInstance, ExtensionNotPresent) {
     {
-        VkInstance inst = VK_NULL_HANDLE;
-        InstanceCreateInfo inst_info;
-        inst_info.add_extension("VK_EXT_validation_features");  // test icd won't report this as supported
-        ASSERT_EQ(VK_ERROR_EXTENSION_NOT_PRESENT, env->vulkan_functions.vkCreateInstance(inst_info.get(), VK_NULL_HANDLE, &inst));
+        InstWrapper inst{env->vulkan_functions};
+        InstanceCreateInfo inst_create_info;
+        inst_create_info.add_extension("VK_EXT_validation_features");  // test icd won't report this as supported
+        ASSERT_EQ(VK_ERROR_EXTENSION_NOT_PRESENT, CreateInst(inst, inst_create_info));
     }
     {
-        VkInstance inst = VK_NULL_HANDLE;
-        InstanceCreateInfo inst_info;
-        inst_info.add_extension("Non_existant_extension");  // unknown instance extension
-        ASSERT_EQ(VK_ERROR_EXTENSION_NOT_PRESENT, env->vulkan_functions.vkCreateInstance(inst_info.get(), VK_NULL_HANDLE, &inst));
+        InstWrapper inst{env->vulkan_functions};
+        InstanceCreateInfo inst_create_info;
+        inst_create_info.add_extension("Non_existant_extension");  // unknown instance extension
+        ASSERT_EQ(VK_ERROR_EXTENSION_NOT_PRESENT, CreateInst(inst, inst_create_info));
     }
 }
 
 TEST_F(CreateInstance, LayerNotPresent) {
-    VkInstance inst = VK_NULL_HANDLE;
-    InstanceCreateInfo inst_info;
-    inst_info.add_layer("VK_NON_EXISTANT_LAYER");
-    ASSERT_EQ(VK_ERROR_LAYER_NOT_PRESENT, env->vulkan_functions.vkCreateInstance(inst_info.get(), VK_NULL_HANDLE, &inst));
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_layer("VK_NON_EXISTANT_LAYER");
+    ASSERT_EQ(VK_ERROR_LAYER_NOT_PRESENT, CreateInst(inst, inst_create_info));
 }
 
 TEST_F(CreateInstance, LayerPresent) {
@@ -115,10 +114,10 @@ TEST_F(CreateInstance, LayerPresent) {
     layer.layers.push_back(description);
     env->AddExplicitLayer(layer, "test_layer.json");
 
-    VkInstance inst = VK_NULL_HANDLE;
-    InstanceCreateInfo inst_info;
-    inst_info.add_layer(layer_name);
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkCreateInstance(inst_info.get(), VK_NULL_HANDLE, &inst));
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_layer(layer_name);
+    ASSERT_EQ(VK_SUCCESS, CreateInst(inst, inst_create_info));
 }
 
 TEST_F(EnumeratePhysicalDevices, OneCall) {

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -105,6 +105,22 @@ TEST_F(CreateInstance, LayerNotPresent) {
     ASSERT_EQ(VK_ERROR_LAYER_NOT_PRESENT, env->vulkan_functions.vkCreateInstance(inst_info.get(), VK_NULL_HANDLE, &inst));
 }
 
+TEST_F(CreateInstance, LayerPresent) {
+    const char* layer_name = "TestLayer";
+    ManifestLayer::LayerDescription description{};
+    description.name = layer_name;
+    description.lib_path = TEST_LAYER_PATH_EXPORT_VERSION_1;
+
+    ManifestLayer layer;
+    layer.layers.push_back(description);
+    env->AddExplicitLayer(layer, "test_layer.json");
+
+    VkInstance inst = VK_NULL_HANDLE;
+    InstanceCreateInfo inst_info;
+    inst_info.add_layer(layer_name);
+    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkCreateInstance(inst_info.get(), VK_NULL_HANDLE, &inst));
+}
+
 TEST_F(EnumeratePhysicalDevices, OneCall) {
     auto& driver = env->get_test_icd().SetMinICDInterfaceVersion(5);
 

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -98,6 +98,13 @@ TEST_F(CreateInstance, ExtensionNotPresent) {
     }
 }
 
+TEST_F(CreateInstance, LayerNotPresent) {
+    VkInstance inst = VK_NULL_HANDLE;
+    InstanceCreateInfo inst_info;
+    inst_info.add_layer("VK_NON_EXISTANT_LAYER");
+    ASSERT_EQ(VK_ERROR_LAYER_NOT_PRESENT, env->vulkan_functions.vkCreateInstance(inst_info.get(), VK_NULL_HANDLE, &inst));
+}
+
 TEST_F(EnumeratePhysicalDevices, OneCall) {
     auto& driver = env->get_test_icd().SetMinICDInterfaceVersion(5);
 

--- a/tests/loader_validation_tests.cpp
+++ b/tests/loader_validation_tests.cpp
@@ -292,17 +292,6 @@ void test_create_device(VkPhysicalDevice physical) {
 // LVLGH = loader and validation github
 // LVLGL = loader and validation gitlab
 
-TEST(CreateInstance, LayerNotPresent) {
-    char const *const names[] = {"NotPresent"};  // Temporary required due to MSVC bug.
-    auto const info = VK::InstanceCreateInfo().enabledLayerCount(1).ppEnabledLayerNames(names);
-
-    VkInstance instance = VK_NULL_HANDLE;
-    VkResult result = vkCreateInstance(info, VK_NULL_HANDLE, &instance);
-    ASSERT_EQ(result, VK_ERROR_LAYER_NOT_PRESENT);
-
-    // It's not necessary to destroy the instance because it will not be created successfully.
-}
-
 // Used by run_loader_tests.sh to test for layer insertion.
 TEST(CreateInstance, LayerPresent) {
     char const *const names1[] = {"VK_LAYER_LUNARG_test"};  // Temporary required due to MSVC bug.


### PR DESCRIPTION
Tests should no longer fail when running the executable on its own.

Alternatively, its possible the loader should 'unload' all dll's when it gets unloaded itself. Would need to research the legality of that, as init/shutdown of dll's is messy and sometimes better to just let the OS handle it.