### PR TITLE
Add `loader_layer_tests.cpp`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,7 +120,7 @@ option(TEST_USE_THREAD_SANITIZER "Linux only: Advanced thread checking" OFF)
 include(GoogleTest)
 add_subdirectory(framework)
 
-add_executable(test_regression loader_testing_main.cpp loader_regression_tests.cpp
+add_executable(test_regression loader_testing_main.cpp loader_regression_tests.cpp loader_layer_tests.cpp
     loader_version_tests.cpp loader_alloc_callback_tests.cpp)
 target_link_libraries(test_regression PRIVATE testing_dependencies)
 

--- a/tests/framework/shim/shim.h
+++ b/tests/framework/shim/shim.h
@@ -432,7 +432,6 @@ inline void PlatformShim::redirect_category(fs::path const& new_path, ManifestCa
 
 #elif defined(__linux__) || defined(__APPLE__)
 
-#include <sys/types.h>
 #include <dirent.h>
 #include <unistd.h>
 

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -128,7 +128,9 @@ std::string ManifestLayer::LayerDescription::get_manifest_str() const {
     out += "\t{\n";
     out += "\t\t\"name\":\"" + name + "\",\n";
     out += "\t\t\"type\":\"" + get_type_str(type) + "\",\n";
-    out += "\t\t\"library_path\": \"" + lib_path + "\",\n";
+    if (lib_path != "") {
+        out += "\t\t\"library_path\": \"" + lib_path + "\",\n";
+    }
     out += "\t\t\"api_version\": \"" + version_to_string(api_version) + "\",\n";
     out += "\t\t\"implementation_version\":\"" + std::to_string(implementation_version) + "\",\n";
     out += "\t\t\"description\": \"" + description + "\"";

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -99,7 +99,7 @@ std::string get_env_var(std::string const& name) {
 std::string ManifestICD::get_manifest_str() const {
     std::string out;
     out += "{\n";
-    out += "    \"file_format_version\": \"1.0.0\",\n";
+    out += "    " + file_format_version.get_version_str() + "\n";
     out += "    \"ICD\": {\n";
     out += "        \"library_path\": \"" + lib_path + "\",\n";
     out += "        \"api_version\": \"" + version_to_string(api_version) + "\"\n";
@@ -128,7 +128,7 @@ std::string ManifestLayer::LayerDescription::get_manifest_str() const {
     out += "\t{\n";
     out += "\t\t\"name\":\"" + name + "\",\n";
     out += "\t\t\"type\":\"" + get_type_str(type) + "\",\n";
-    if (lib_path != "") {
+    if (lib_path.size() > 0) {
         out += "\t\t\"library_path\": \"" + lib_path + "\",\n";
     }
     out += "\t\t\"api_version\": \"" + version_to_string(api_version) + "\",\n";
@@ -159,11 +159,11 @@ std::string ManifestLayer::LayerDescription::get_manifest_str() const {
         out += "\n\t\t}";
     }
     if (enable_environment.size() > 0) {
-        out += ",\n\t\t{ \"" + enable_environment + "\": \"1\"";
+        out += ",\n\t\t\"enable_environment\": { \"" + enable_environment + "\": \"1\"";
         out += "\n\t\t}";
     }
     if (disable_environment.size() > 0) {
-        out += ",\n\t\t{ \"" + disable_environment + "\": \"1\"";
+        out += ",\n\t\t\"disable_environment\": { \"" + disable_environment + "\": \"1\"";
         out += "\n\t\t}";
     }
     if (component_layers.size() > 0) {
@@ -198,7 +198,7 @@ VkLayerProperties ManifestLayer::LayerDescription::get_layer_properties() const 
 std::string ManifestLayer::get_manifest_str() const {
     std::string out;
     out += "{\n";
-    out += "\t\"file_format_version\": \"1.0.0\",\n";
+    out += "\t" + file_format_version.get_version_str() + "\n";
     if (layers.size() == 1) {
         out += "\t\"layer\": ";
         out += layers.at(0).get_manifest_str() + "\n";

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -135,7 +135,7 @@ std::string ManifestLayer::LayerDescription::get_manifest_str() const {
     out += "\t\t\"implementation_version\":\"" + std::to_string(implementation_version) + "\",\n";
     out += "\t\t\"description\": \"" + description + "\"";
     if (functions.size() > 0) {
-        out += ",\n\t\t{";
+        out += ",\n\t\t\"functions\": {";
         for (size_t i = 0; i < functions.size(); i++) {
             if (i > 0) out += ",";
             out += "\n\t\t\t" + functions.at(i).get_manifest_str();
@@ -143,20 +143,20 @@ std::string ManifestLayer::LayerDescription::get_manifest_str() const {
         out += "\n\t\t}";
     }
     if (instance_extensions.size() > 0) {
-        out += ",\n\t\t{";
+        out += ",\n\t\t\"instance_extensions\": [";
         for (size_t i = 0; i < instance_extensions.size(); i++) {
             if (i > 0) out += ",";
             out += "\n\t\t\t" + instance_extensions.at(i).get_manifest_str();
         }
-        out += "\n\t\t}";
+        out += "\n\t\t]";
     }
     if (device_extensions.size() > 0) {
-        out += ",\n\t\t{";
+        out += ",\n\t\t\"device_extensions\": [";
         for (size_t i = 0; i < device_extensions.size(); i++) {
             if (i > 0) out += ",";
             out += "\n\t\t\t" + device_extensions.at(i).get_manifest_str();
         }
-        out += "\n\t\t}";
+        out += "\n\t\t]";
     }
     if (enable_environment.size() > 0) {
         out += ",\n\t\t\"enable_environment\": { \"" + enable_environment + "\": \"1\"";

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -164,6 +164,9 @@ struct ManifestLayer {
             std::string get_manifest_str() const { return std::string("{ \"") + vk_func + "\":\"" + override_name + "\" }"; }
         };
         struct Extension {
+            Extension() noexcept {}
+            Extension(std::string name, uint32_t spec_version = 0, std::vector<std::string> entrypoints = {}) noexcept
+                : name(name), spec_version(spec_version), entrypoints(entrypoints) {}
             std::string name;
             uint32_t spec_version = 0;
             std::vector<std::string> entrypoints;

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -76,6 +76,11 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <dlfcn.h>
+
+// Prevent macro collisions from <sys/types.h>
+#undef major
+#undef minor
+
 #endif
 
 #include <vulkan/vulkan.h>

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -126,7 +126,21 @@ inline std::string version_to_string(uint32_t version) {
            std::to_string(VK_VERSION_PATCH(version));
 }
 
+struct ManifestVersion {
+    uint32_t major = 1;
+    uint32_t minor = 0;
+    uint32_t patch = 0;
+    explicit ManifestVersion() noexcept {};
+    explicit ManifestVersion(uint32_t major, uint32_t minor, uint32_t patch) noexcept : major(major), minor(minor), patch(patch){};
+
+    std::string get_version_str() const noexcept {
+        return std::string("\"file_format_version\": \"") + std::to_string(major) + "." + std::to_string(minor) + "." +
+               std::to_string(patch) + "\",";
+    }
+};
+
 struct ManifestICD {
+    ManifestVersion file_format_version = ManifestVersion();
     uint32_t api_version = VK_MAKE_VERSION(1, 0, 0);
     std::string lib_path;
 
@@ -172,9 +186,7 @@ struct ManifestLayer {
         std::string get_manifest_str() const;
         VkLayerProperties get_layer_properties() const;
     };
-    uint32_t file_format_major = 1;
-    uint32_t file_format_minor = 1;
-    uint32_t file_format_patch = 2;
+    ManifestVersion file_format_version;
     std::vector<LayerDescription> layers;
 
     std::string get_manifest_str() const;

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#include "test_environment.h"
+
+class LayerTests : public ::testing::Test {
+   protected:
+    virtual void SetUp() {
+        env = std::unique_ptr<SingleICDShim>(new SingleICDShim(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_MAKE_VERSION(1, 0, 0))));
+    }
+
+    virtual void TearDown() { env.reset(); }
+    std::unique_ptr<SingleICDShim> env;
+};
+
+// Subtyping for organization
+class ExplicitLayers : public LayerTests {};
+class ImplicitLayers : public LayerTests {};
+class MetaLayers : public LayerTests {};
+class OverrideMetaLayer : public LayerTests {};
+
+TEST_F(MetaLayers, InvalidComponentLayer) {
+    const char* layer_name = "TestLayer";
+    ManifestLayer::LayerDescription description{};
+    description.name = layer_name;
+    description.component_layers = {"InvalidLayer1", "InvalidLayer2"};
+
+    ManifestLayer meta_layer;
+    meta_layer.layers.push_back(description);
+    env->AddExplicitLayer(meta_layer, "meta_test_layer.json");
+
+    InstWrapper inst{env->vulkan_functions};
+    InstanceCreateInfo inst_create_info;
+    inst_create_info.add_layer(layer_name);
+    ASSERT_EQ(VK_ERROR_LAYER_NOT_PRESENT, CreateInst(inst, inst_create_info));
+}

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -49,6 +49,8 @@ TEST_F(MetaLayers, InvalidComponentLayer) {
     description.name = meta_layer_name;
     description.component_layers = {"InvalidLayer1", "InvalidLayer2"};
     description.disable_environment = "NotGonnaWork";
+    description.instance_extensions.push_back({"NeverGonnaGiveYouUp"});
+    description.device_extensions.push_back({"NeverGonnaLetYouDown"});
 
     ManifestLayer meta_layer;
     meta_layer.file_format_version = ManifestVersion(1, 1, 2);


### PR DESCRIPTION
Create a new file which should host all the layer specific tests.

The first test in it only tests for a single case of invalid meta layers. But several fixes in various parts of the framework were needed to allow this test, thus proving its worth.

Also was able to reproduce issue #635 with this test, and showed that #636 successfully fixes it.