### PR TITLE
Fix Vulkan CTS testcase bug: "create_instance_device_intentional_alloc_fail"

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2310,6 +2310,7 @@ static VkResult loader_scanned_icd_add(const struct loader_instance *inst, struc
 #endif
     if (NULL == handle) {
         loader_log_load_library_error(inst, filename);
+        res = VK_ERROR_INCOMPATIBLE_DRIVER;
         goto out;
     }
 


### PR DESCRIPTION
To duplicate the bug, run the Vulkan CTS testcase:
```
./deqp-vk -n dEQP-VK.api.device_init.create_instance_device_intentional_alloc_fail
```

Root cause: when running the 64bit test, `loader_scanned_icd_add()` returns `VK_SUCCESS` for 32bit icd, but `icd_tramp_list.count` still equals to 0, then `num_good_icds` will be added to 1 in `loader_icd_scan()`, next is the 64bit icd, because the memory allocation is limited in the special case, exception happens after `loader_get_json()` but before `loader_scanned_icd_add()`, for example: memory allocation fails while printing "file_format_version" item, loader exists with `res = VK_SUCCESS` but `icd_tramp_list.count = 0`, which would cause unexpected error: `VK_ERROR_INCOMPATIBLE_DRIVER`

Fix: `loader_scanned_icd_add()` should return an error code for 32bit icd in this 64bit test, the `VK_ERROR_INCOMPATIBLE_DRIVER` error should be reasonable here.
