### PR TITLE
test: Add test for PR #639

### DIFF
--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -145,9 +145,10 @@ FakeBinaryICDShim::FakeBinaryICDShim(TestICDDetails read_icd_details, TestICDDet
     real_icd = detail::TestICDHandle(read_icd_details.icd_path);
     real_icd.get_new_test_icd();
 
+    // Must use name that isn't a substring of eachother, otherwise loader removes the other ICD
+    // EX test_icd.json is fully contained in fake_test_icd.json, causing test_icd.json to not be loaded
+    AddICD(fake_icd_details, "test_fake_icd.json");
     AddICD(read_icd_details, "test_icd.json");
-
-    AddICD(fake_icd_details, "fake_test_icd.json");
 }
 TestICD& FakeBinaryICDShim::get_test_icd() noexcept { return real_icd.get_test_icd(); }
 TestICD& FakeBinaryICDShim::get_new_test_icd() noexcept { return real_icd.get_new_test_icd(); }


### PR DESCRIPTION
This test tries to recreate an out of memory condition which causes
a binary of the wrong type to be confused with a valid binary, which
causes VK_ERROR_INCOMPATIBLE_DRIVER to be returned instead of VK_SUCCESS
(Or OOM if the case may be)