### PR TITLE
Fix loader not knowing about extensions enabled in layers

### DIFF
--- a/loader/debug_utils.c
+++ b/loader/debug_utils.c
@@ -869,9 +869,6 @@ void debug_utils_AddInstanceExtensions(const struct loader_instance *inst, struc
 }
 
 void debug_utils_CreateInstance(struct loader_instance *ptr_instance, const VkInstanceCreateInfo *pCreateInfo) {
-    ptr_instance->enabled_known_extensions.ext_debug_report = 0;
-    ptr_instance->enabled_known_extensions.ext_debug_utils = 0;
-
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_DEBUG_REPORT_EXTENSION_NAME) == 0) {
             ptr_instance->enabled_known_extensions.ext_debug_report = 1;

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -6664,6 +6664,17 @@ out:
             }
             loader_icd_destroy(ptr_instance, icd_term, pAllocator);
         }
+    } else {
+        // Check for enabled extensions here to setup the loader structures so the loader knows what extensions
+        // it needs to worry about.
+        // We do it here and again above the layers in the trampoline function since the trampoline function
+        // may think different extensions are enabled than what's down here.
+        // This is why we don't clear inside of these function calls.
+        // The clearing should actually be handled by the overall memset of the pInstance structure in the
+        // trampoline.
+        wsi_create_instance(ptr_instance, pCreateInfo);
+        debug_utils_CreateInstance(ptr_instance, pCreateInfo);
+        extensions_create_instance(ptr_instance, pCreateInfo);
     }
 
     return res;

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -522,8 +522,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
     res = loader_create_instance_chain(&ici, pAllocator, ptr_instance, &created_instance);
 
     if (res == VK_SUCCESS) {
-        memset(ptr_instance->enabled_known_extensions.padding, 0, sizeof(uint64_t) * 4);
-
+        // Check for enabled extensions here to setup the loader structures so the loader knows what extensions
+        // it needs to worry about.
+        // We do it in the terminator and again above the layers here since we may think different extensions
+        // are enabled than what's down in the terminator.
+        // This is why we don't clear inside of these function calls.
+        // The clearing should actually be handled by the overall memset of the pInstance structure above.
         wsi_create_instance(ptr_instance, &ici);
         debug_utils_CreateInstance(ptr_instance, &ici);
         extensions_create_instance(ptr_instance, &ici);

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -38,47 +38,6 @@
 #define ICD_VER_SUPPORTS_ICD_SURFACE_KHR 3
 
 void wsi_create_instance(struct loader_instance *ptr_instance, const VkInstanceCreateInfo *pCreateInfo) {
-    ptr_instance->wsi_surface_enabled = false;
-
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    ptr_instance->wsi_win32_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_WIN32_KHR
-#ifdef VK_USE_PLATFORM_WAYLAND_KHR
-    ptr_instance->wsi_wayland_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_WAYLAND_KHR
-#ifdef VK_USE_PLATFORM_XCB_KHR
-    ptr_instance->wsi_xcb_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_XCB_KHR
-#ifdef VK_USE_PLATFORM_XLIB_KHR
-    ptr_instance->wsi_xlib_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_XLIB_KHR
-#ifdef VK_USE_PLATFORM_DIRECTFB_EXT
-    ptr_instance->wsi_directfb_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_DIRECTFB_EXT
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
-    ptr_instance->wsi_android_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_ANDROID_KHR
-#ifdef VK_USE_PLATFORM_MACOS_MVK
-    ptr_instance->wsi_macos_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_MACOS_MVK
-#ifdef VK_USE_PLATFORM_IOS_MVK
-    ptr_instance->wsi_ios_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_IOS_MVK
-#ifdef VK_USE_PLATFORM_GGP
-    ptr_instance->wsi_ggp_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_GGP
-#ifdef VK_USE_PLATFORM_FUCHSIA
-    ptr_instance->wsi_imagepipe_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_FUCHSIA
-    ptr_instance->wsi_display_enabled = false;
-    ptr_instance->wsi_display_props2_enabled = false;
-#ifdef VK_USE_PLATFORM_METAL_EXT
-    ptr_instance->wsi_metal_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_METAL_EXT
-#ifdef VK_USE_PLATFORM_SCREEN_QNX
-    ptr_instance->wsi_screen_surface_enabled = false;
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SURFACE_EXTENSION_NAME) == 0) {
             ptr_instance->wsi_surface_enabled = true;


### PR DESCRIPTION
This change allows the loader to know extensions enabled in the layers
as well as extensions enabled but handled by layers.
This should fix several issues where the enabled extensions is not
known soon enough for layers to use.