### PR TITLE
scripts: Remove loader_icd_init_entries duplicate

### DIFF
--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -83,9 +83,6 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
 VKAPI_ATTR void* VKAPI_CALL loader_lookup_instance_dispatch_table(const VkLayerInstanceDispatchTable *table, const char *name,
                                                                   bool *found_name);
 
-VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_icd_term *icd_term, VkInstance inst,
-                                                   const PFN_vkGetInstanceProcAddr fp_gipa);
-
 // Loader core instance terminators
 VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -282,7 +282,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
         self.type = interface.get('type')
         self.num_commands = 0
         name = interface.get('name')
-        self.currentExtension = name 
+        self.currentExtension = name
 
     #
     # Process commands, adding to appropriate dispatch tables
@@ -483,9 +483,6 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
         protos += '// Instance command lookup function\n'
         protos += 'VKAPI_ATTR void* VKAPI_CALL loader_lookup_instance_dispatch_table(const VkLayerInstanceDispatchTable *table, const char *name,\n'
         protos += '                                                                  bool *found_name);\n'
-        protos += '\n'
-        protos += 'VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_icd_term *icd_term, VkInstance inst,\n'
-        protos += '                                                   const PFN_vkGetInstanceProcAddr fp_gipa);\n'
         protos += '\n'
         return protos
 
@@ -1517,7 +1514,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 commands = self.ext_commands
 
             for cur_cmd in commands:
-                
+
                 if cur_cmd.handle_type == 'VkInstance' or cur_cmd.handle_type == 'VkPhysicalDevice':
                     if cur_cmd.ext_name != cur_extension_name:
                         if 'VK_VERSION_' in cur_cmd.ext_name:


### PR DESCRIPTION
Seems to be a copy-paste error that makes the function declaration appear twice.