### PR TITLE
loader: Make all loader functions use snake_case

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -472,8 +472,8 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
 
 bool compare_vk_extension_properties(const VkExtensionProperties *op1, const VkExtensionProperties *op2);
 
-VkResult loaderValidateLayers(const struct loader_instance *inst, const uint32_t layer_count,
-                              const char *const *ppEnabledLayerNames, const struct loader_layer_list *list);
+VkResult loader_validate_layers(const struct loader_instance *inst, const uint32_t layer_count,
+                                const char *const *ppEnabledLayerNames, const struct loader_layer_list *list);
 
 VkResult loader_validate_instance_extensions(struct loader_instance *inst, const struct loader_extension_list *icd_exts,
                                              const struct loader_layer_list *instance_layer,
@@ -496,16 +496,17 @@ VkResult loader_add_device_extensions(const struct loader_instance *inst,
                                       struct loader_extension_list *ext_list);
 VkResult loader_init_generic_list(const struct loader_instance *inst, struct loader_generic_list *list_info, size_t element_size);
 void loader_destroy_generic_list(const struct loader_instance *inst, struct loader_generic_list *list);
-void loaderDestroyLayerList(const struct loader_instance *inst, struct loader_device *device, struct loader_layer_list *layer_list);
-void loaderDeleteLayerListAndProperties(const struct loader_instance *inst, struct loader_layer_list *layer_list);
-VkResult loaderAddLayerNameToList(const struct loader_instance *inst, const char *name, const enum layer_type_flags type_flags,
-                                  const struct loader_layer_list *source_list, struct loader_layer_list *target_list,
-                                  struct loader_layer_list *expanded_target_list);
+void loader_destroy_layer_list(const struct loader_instance *inst, struct loader_device *device,
+                               struct loader_layer_list *layer_list);
+void loader_delete_layer_list_and_properties(const struct loader_instance *inst, struct loader_layer_list *layer_list);
+VkResult loader_add_layer_name_to_list(const struct loader_instance *inst, const char *name, const enum layer_type_flags type_flags,
+                                       const struct loader_layer_list *source_list, struct loader_layer_list *target_list,
+                                       struct loader_layer_list *expanded_target_list);
 void loader_scanned_icd_clear(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
 VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
-void loaderScanForLayers(struct loader_instance *inst, struct loader_layer_list *instance_layers);
-void loaderScanForImplicitLayers(struct loader_instance *inst, struct loader_layer_list *instance_layers);
-bool loaderImplicitLayerIsEnabled(const struct loader_instance *inst, const struct loader_layer_properties *prop);
+void loader_scan_for_layers(struct loader_instance *inst, struct loader_layer_list *instance_layers);
+void loader_scan_for_implicit_layers(struct loader_instance *inst, struct loader_layer_list *instance_layers);
+bool loader_implicit_layer_is_enabled(const struct loader_instance *inst, const struct loader_layer_properties *prop);
 VkResult loader_get_icd_loader_instance_extensions(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list,
                                                    struct loader_extension_list *inst_exts);
 struct loader_icd_term *loader_get_icd_and_device(const void *device, struct loader_device **found_dev, uint32_t *icd_index);
@@ -517,7 +518,7 @@ bool loader_phys_dev_ext_gpa(struct loader_instance *inst, const char *funcName,
 void *loader_get_phys_dev_ext_tramp(uint32_t index);
 void *loader_get_phys_dev_ext_termin(uint32_t index);
 struct loader_instance *loader_get_instance(const VkInstance instance);
-void loaderDeactivateLayers(const struct loader_instance *instance, struct loader_device *device, struct loader_layer_list *list);
+void loader_deactivate_layers(const struct loader_instance *instance, struct loader_device *device, struct loader_layer_list *list);
 struct loader_device *loader_create_logical_device(const struct loader_instance *inst, const VkAllocationCallbacks *pAllocator);
 void loader_add_logical_device(const struct loader_instance *inst, struct loader_icd_term *icd_term,
                                struct loader_device *found_dev);
@@ -528,13 +529,13 @@ void loader_remove_logical_device(const struct loader_instance *inst, struct loa
 void loader_destroy_logical_device(const struct loader_instance *inst, struct loader_device *dev,
                                    const VkAllocationCallbacks *pAllocator);
 
-VkResult loaderEnableInstanceLayers(struct loader_instance *inst, const VkInstanceCreateInfo *pCreateInfo,
-                                    const struct loader_layer_list *instance_layers);
+VkResult loader_enable_instance_layers(struct loader_instance *inst, const VkInstanceCreateInfo *pCreateInfo,
+                                       const struct loader_layer_list *instance_layers);
 
 VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
                                       struct loader_instance *inst, VkInstance *created_instance);
 
-void loaderActivateInstanceLayerExtensions(struct loader_instance *inst, VkInstance created_inst);
+void loader_activate_instance_layer_extensions(struct loader_instance *inst, VkInstance created_inst);
 
 VKAPI_ATTR VkResult VKAPI_CALL loader_layer_create_device(VkInstance instance, VkPhysicalDevice physicalDevice,
                                                           const VkDeviceCreateInfo *pCreateInfo,
@@ -552,8 +553,8 @@ VkResult loader_validate_device_extensions(struct loader_instance *this_instance
                                            const struct loader_layer_list *activated_device_layers,
                                            const struct loader_extension_list *icd_exts, const VkDeviceCreateInfo *pCreateInfo);
 
-VkResult setupLoaderTrampPhysDevs(VkInstance instance);
-VkResult setupLoaderTermPhysDevs(struct loader_instance *inst);
+VkResult setup_loader_tramp_phys_devs(VkInstance instance);
+VkResult setup_loader_term_phys_devs(struct loader_instance *inst);
 
 VkStringErrorFlags vk_string_validate(const int max_length, const char *char_array);
 

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -117,7 +117,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
     // Get the implicit layers
     struct loader_layer_list layers;
     memset(&layers, 0, sizeof(layers));
-    loaderScanForImplicitLayers(NULL, &layers);
+    loader_scan_for_implicit_layers(NULL, &layers);
 
     // We'll need to save the dl handles so we can close them later
     loader_platform_dl_handle *libs = malloc(sizeof(loader_platform_dl_handle) * layers.count);
@@ -128,7 +128,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
 
     // Prepend layers onto the chain if they implement this entry point
     for (uint32_t i = 0; i < layers.count; ++i) {
-        if (!loaderImplicitLayerIsEnabled(NULL, layers.list + i) ||
+        if (!loader_implicit_layer_is_enabled(NULL, layers.list + i) ||
             layers.list[i].pre_instance_functions.enumerate_instance_extension_properties[0] == '\0') {
             continue;
         }
@@ -171,7 +171,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
     }
 
     // Free up the layers
-    loaderDeleteLayerListAndProperties(NULL, &layers);
+    loader_delete_layer_list_and_properties(NULL, &layers);
 
     // Tear down the chain
     while (chain_head != &chain_tail) {
@@ -211,7 +211,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
     // Get the implicit layers
     struct loader_layer_list layers;
     memset(&layers, 0, sizeof(layers));
-    loaderScanForImplicitLayers(NULL, &layers);
+    loader_scan_for_implicit_layers(NULL, &layers);
 
     // We'll need to save the dl handles so we can close them later
     loader_platform_dl_handle *libs = malloc(sizeof(loader_platform_dl_handle) * layers.count);
@@ -222,7 +222,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
 
     // Prepend layers onto the chain if they implement this entry point
     for (uint32_t i = 0; i < layers.count; ++i) {
-        if (!loaderImplicitLayerIsEnabled(NULL, layers.list + i) ||
+        if (!loader_implicit_layer_is_enabled(NULL, layers.list + i) ||
             layers.list[i].pre_instance_functions.enumerate_instance_layer_properties[0] == '\0') {
             continue;
         }
@@ -265,7 +265,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
     }
 
     // Free up the layers
-    loaderDeleteLayerListAndProperties(NULL, &layers);
+    loader_delete_layer_list_and_properties(NULL, &layers);
 
     // Tear down the chain
     while (chain_head != &chain_tail) {
@@ -304,7 +304,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
     // Get the implicit layers
     struct loader_layer_list layers;
     memset(&layers, 0, sizeof(layers));
-    loaderScanForImplicitLayers(NULL, &layers);
+    loader_scan_for_implicit_layers(NULL, &layers);
 
     // We'll need to save the dl handles so we can close them later
     loader_platform_dl_handle *libs = malloc(sizeof(loader_platform_dl_handle) * layers.count);
@@ -315,7 +315,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
 
     // Prepend layers onto the chain if they implement this entry point
     for (uint32_t i = 0; i < layers.count; ++i) {
-        if (!loaderImplicitLayerIsEnabled(NULL, layers.list + i) ||
+        if (!loader_implicit_layer_is_enabled(NULL, layers.list + i) ||
             layers.list[i].pre_instance_functions.enumerate_instance_version[0] == '\0') {
             continue;
         }
@@ -356,7 +356,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
     }
 
     // Free up the layers
-    loaderDeleteLayerListAndProperties(NULL, &layers);
+    loader_delete_layer_list_and_properties(NULL, &layers);
 
     // Tear down the chain
     while (chain_head != &chain_tail) {
@@ -461,14 +461,14 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
 
     // Due to implicit layers need to get layer list even if
     // enabledLayerCount == 0 and VK_INSTANCE_LAYERS is unset. For now always
-    // get layer list via loaderScanForLayers().
+    // get layer list via loader_scan_for_layers().
     memset(&ptr_instance->instance_layer_list, 0, sizeof(ptr_instance->instance_layer_list));
-    loaderScanForLayers(ptr_instance, &ptr_instance->instance_layer_list);
+    loader_scan_for_layers(ptr_instance, &ptr_instance->instance_layer_list);
 
     // Validate the app requested layers to be enabled
     if (pCreateInfo->enabledLayerCount > 0) {
-        res = loaderValidateLayers(ptr_instance, pCreateInfo->enabledLayerCount, pCreateInfo->ppEnabledLayerNames,
-                                   &ptr_instance->instance_layer_list);
+        res = loader_validate_layers(ptr_instance, pCreateInfo->enabledLayerCount, pCreateInfo->ppEnabledLayerNames,
+                                     &ptr_instance->instance_layer_list);
         if (res != VK_SUCCESS) {
             goto out;
         }
@@ -513,7 +513,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
     loader.instances = ptr_instance;
 
     // Activate any layers on instance chain
-    res = loaderEnableInstanceLayers(ptr_instance, &ici, &ptr_instance->instance_layer_list);
+    res = loader_enable_instance_layers(ptr_instance, &ici, &ptr_instance->instance_layer_list);
     if (res != VK_SUCCESS) {
         goto out;
     }
@@ -538,7 +538,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         // the CreateInstance command go by. This allows the layer's
         // GetInstanceProcAddr functions to return valid extension functions
         // if enabled.
-        loaderActivateInstanceLayerExtensions(ptr_instance, *pInstance);
+        loader_activate_instance_layer_extensions(ptr_instance, *pInstance);
     }
 
 out:
@@ -567,13 +567,13 @@ out:
             }
 
             if (NULL != ptr_instance->expanded_activated_layer_list.list) {
-                loaderDeactivateLayers(ptr_instance, NULL, &ptr_instance->expanded_activated_layer_list);
+                loader_deactivate_layers(ptr_instance, NULL, &ptr_instance->expanded_activated_layer_list);
             }
             if (NULL != ptr_instance->app_activated_layer_list.list) {
-                loaderDestroyLayerList(ptr_instance, NULL, &ptr_instance->app_activated_layer_list);
+                loader_destroy_layer_list(ptr_instance, NULL, &ptr_instance->app_activated_layer_list);
             }
 
-            loaderDeleteLayerListAndProperties(ptr_instance, &ptr_instance->instance_layer_list);
+            loader_delete_layer_list_and_properties(ptr_instance, &ptr_instance->instance_layer_list);
             loader_scanned_icd_clear(ptr_instance, &ptr_instance->icd_tramp_list);
             loader_destroy_generic_list(ptr_instance, (struct loader_generic_list *)&ptr_instance->ext_list);
 
@@ -633,10 +633,10 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
     disp->DestroyInstance(instance, pAllocator);
 
     if (NULL != ptr_instance->expanded_activated_layer_list.list) {
-        loaderDeactivateLayers(ptr_instance, NULL, &ptr_instance->expanded_activated_layer_list);
+        loader_deactivate_layers(ptr_instance, NULL, &ptr_instance->expanded_activated_layer_list);
     }
     if (NULL != ptr_instance->app_activated_layer_list.list) {
-        loaderDestroyLayerList(ptr_instance, NULL, &ptr_instance->app_activated_layer_list);
+        loader_destroy_layer_list(ptr_instance, NULL, &ptr_instance->app_activated_layer_list);
     }
 
     if (ptr_instance->phys_devs_tramp) {
@@ -698,7 +698,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDevices(VkInstan
     // Setup the trampoline loader physical devices.  This will actually
     // call down and setup the terminator loader physical devices during the
     // process.
-    VkResult setup_res = setupLoaderTrampPhysDevs(instance);
+    VkResult setup_res = setup_loader_tramp_phys_devs(instance);
     if (setup_res != VK_SUCCESS && setup_res != VK_INCOMPLETE) {
         res = setup_res;
         goto out;
@@ -2029,7 +2029,7 @@ VkResult setupLoaderTrampPhysDevGroups(VkInstance instance) {
     // Setup the trampoline loader physical devices.  This will actually
     // call down and setup the terminator loader physical devices during the
     // process.
-    VkResult setup_res = setupLoaderTrampPhysDevs(instance);
+    VkResult setup_res = setup_loader_tramp_phys_devs(instance);
     if (setup_res != VK_SUCCESS && setup_res != VK_INCOMPLETE) {
         res = setup_res;
         goto out;


### PR DESCRIPTION
Before it was a mix of camelCase, PascalCase, and snake_case.

"Vulkan" functions, like terminator_GetPhysicalDeviceProperties, remain in camelCase.
This way it looks visually similar with the actual vulkan functions they correspond to.