### PR TITLE
Loader layer free logic cleanup

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -486,6 +486,7 @@ bool has_vk_extension_property_array(const VkExtensionProperties *vk_ext_prop, c
                                      const VkExtensionProperties *ext_array);
 bool has_vk_extension_property(const VkExtensionProperties *vk_ext_prop, const struct loader_extension_list *ext_list);
 
+void loader_free_layer_properties(const struct loader_instance *inst, struct loader_layer_properties *layer_properties);
 VkResult loader_add_to_ext_list(const struct loader_instance *inst, struct loader_extension_list *ext_list,
                                 uint32_t prop_list_count, const VkExtensionProperties *props);
 VkResult loader_add_to_dev_ext_list(const struct loader_instance *inst, struct loader_device_extension_list *ext_list,

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -172,7 +172,7 @@ std::string ManifestLayer::LayerDescription::get_manifest_str() const {
             if (i > 0) out += ", ";
             out += "\"" + component_layers.at(i) + "\"";
         }
-        out += "]\n\t\t}";
+        out += "]\n";
     }
     if (pre_instance_functions.size() > 0) {
         out += ",\n\t\t\"pre_instance_functions\": [";


### PR DESCRIPTION
Existing logic for freeing layers was scattered across loader.c. This PR moves it to a single function and adds a test for Override Meta Layers.

Fixes #671 
