### PR TITLE
loader: Add loader.rc to Windows GN build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -157,6 +157,7 @@ if (!is_android) {
         "loader/dirent_on_windows.h",
         "loader/loader_windows.c",
         "loader/loader_windows.h",
+        "loader/loader.rc",
         "loader/vulkan-1.def",
       ]
       if (!is_clang) {


### PR DESCRIPTION
This omission was causing the build dll to be missing version info.

PTAL