### PR TITLE
test: Isolate Env-Vars from test framework

### DIFF
--- a/tests/loader_testing_main.cpp
+++ b/tests/loader_testing_main.cpp
@@ -48,6 +48,13 @@ int main(int argc, char** argv) {
     fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "explicit_layer_manifests");
     fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "implicit_layer_manifests");
 
+    // make sure the tests don't find these env-vars if they were set on the system
+    remove_env_var("VK_ICD_FILENAMES");
+    remove_env_var("VK_LAYER_PATH");
+    remove_env_var("VK_INSTANCE_LAYERS");
+    remove_env_var("VK_LOADER_DEBUG");
+    remove_env_var("VK_LOADER_DISABLE_INST_EXT_FILTER");
+
     ::testing::InitGoogleTest(&argc, argv);
 
     int result = RUN_ALL_TESTS();


### PR DESCRIPTION
Previously if any of the env-vars the loader looks for were set on the
system, the loader would find and use them, leading to highly confusing
logs. Removing them preemptively at tests start make this a non-issue.

Fixes #695 