### PR TITLE
loader: Only include loader_windows.h on windows

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -64,7 +64,9 @@
 #include "vk_loader_platform.h"
 #include "wsi.h"
 
+#if defined(WIN32)
 #include "loader_windows.h"
+#endif
 
 // Generated file containing all the extension data
 #include "vk_loader_extensions.c"


### PR DESCRIPTION
This header should only be included on windows platforms, since non-windows platforms
may not know that the header should be present (which is the case for GN builds).

Fixes #704 