### PR TITLE
build: Checkin loader.rc

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -180,7 +180,6 @@ The following is a table of all string options currently supported by this repos
 | FALLBACK_CONFIG_DIRS | Linux/MacOS | `/etc/xdg` | Configuration path(s) to use instead of `XDG_CONFIG_DIRS` if that environment variable is unavailable. The default setting is freedesktop compliant. |
 | FALLBACK_DATA_DIRS | Linux/MacOS | `/usr/local/share:/usr/share` | Configuration path(s) to use instead of `XDG_DATA_DIRS` if that environment variable is unavailable. The default setting is freedesktop compliant. |
 | BUILD_DLL_VERSIONINFO | Windows | `""` (empty string) | Allows setting the Windows specific version information for the Loader DLL. Format is "major.minor.patch.build". |
-| RELEASE_BUILD | Windows | `OFF` | Configures the loader.rc file for a \"Release\" build. Used for SDK builds primarily. Does not change CMAKE_BUILD_TYPE. Default is off. |
 
 These variables should be set using the `-D` option when invoking CMake to generate the native platform files.
 

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -121,28 +121,25 @@ if(WIN32)
     # ~~~
     # Setup the loader.rc flie to contain the correct info
     # Optionally uses the BUILD_DLL_VERSIONINFO build option to allow setting the exact build version
-    # Adds "Dev Build" to any build without the RELEASE_BUILD configure option set
+    # Adds "Dev Build" to any build without the BUILD_DLL_VERSIONINFO option set
     # ~~~
     if ("$CACHE{BUILD_DLL_VERSIONINFO}" STREQUAL "")
         # default case - use 0 as the BUILDNO
-        set(LOADER_RC_VERSION "${LOADER_GENERATED_HEADER_VERSION}.0")
+        set(LOADER_RC_VERSION "1.0.1111.2222")
+        set(LOADER_VER_FILE_VERSION_STR "\"${LOADER_RC_VERSION}.Dev Build\"")
+        set(LOADER_VER_FILE_DESCRIPTION_STR "\"Vulkan Loader - Dev Build\"")
     else()
         set(LOADER_RC_VERSION "$CACHE{BUILD_DLL_VERSIONINFO}")
+        set(LOADER_VER_FILE_VERSION_STR "\"${LOADER_RC_VERSION}\"")
+        set(LOADER_VER_FILE_DESCRIPTION_STR "\"Vulkan Loader\"")
     endif()
 
     # RC file wants the value of FILEVERSION to separated by commas
     string(REPLACE "." ", " LOADER_VER_FILE_VERSION "${LOADER_RC_VERSION}")
 
-    if (RELEASE_BUILD)
-        set(LOADER_VER_FILE_VERSION_STR "\"${LOADER_RC_VERSION}\"")
-        set(LOADER_VER_FILE_DESCRIPTION_STR "\"Vulkan Loader\"")
-    else()
-        set(LOADER_VER_FILE_VERSION_STR "\"${LOADER_RC_VERSION}.Dev Build\"")
-        set(LOADER_VER_FILE_DESCRIPTION_STR "\"Vulkan Loader - Dev Build\"")
-    endif()
-
     # Configure the file to include the versioning info
-    configure_file(loader.rc.in ${CMAKE_CURRENT_BINARY_DIR}/loader.rc)
+    # Place it in the current directory for check-in - so the GN build has up to date info
+    configure_file(loader.rc.in ${CMAKE_CURRENT_LIST_DIR}/loader.rc)
 endif()
 
 set(NORMAL_LOADER_SRCS
@@ -258,7 +255,7 @@ if(WIN32)
                 $<TARGET_OBJECTS:loader-norm>
                 $<TARGET_OBJECTS:loader-unknown-chain>
                 ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-1.def
-                ${CMAKE_CURRENT_BINARY_DIR}/loader.rc)
+                ${CMAKE_CURRENT_LIST_DIR}/loader.rc)
 
     if (UPDATE_DEPS)
         add_dependencies(vulkan vl_update_deps)

--- a/loader/loader.rc
+++ b/loader/loader.rc
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2014-2021 The Khronos Group Inc.
+// Copyright (c) 2014-2021 Valve Corporation
+// Copyright (c) 2014-2021 LunarG, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: David Pinedo <david@lunarg.com>
+// Author: Charles Giessen <charles@lunarg.com>
+//
+
+#include "winres.h"
+
+// All set through CMake
+#define VER_FILE_VERSION 1, 0, 1111, 2222
+#define VER_FILE_DESCRIPTION_STR "Vulkan Loader - Dev Build"
+#define VER_FILE_VERSION_STR "1.0.1111.2222.Dev Build"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION VER_FILE_VERSION
+ PRODUCTVERSION VER_FILE_VERSION
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS VS_FF_DEBUG
+#else
+ FILEFLAGS 0x0L
+#endif
+
+ FILEOS 0x00000L
+ FILETYPE VFT_DLL
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "04090000"
+        BEGIN
+            VALUE "FileDescription", VER_FILE_DESCRIPTION_STR
+            VALUE "FileVersion", VER_FILE_VERSION_STR
+            VALUE "LegalCopyright", "Copyright (C) 2015-2021"
+            VALUE "ProductName", "Vulkan Runtime"
+            VALUE "ProductVersion", VER_FILE_VERSION_STR
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 0000
+    END
+END


### PR DESCRIPTION
This allows gn build to use the most recently generated loader.rc file
without generating it themselves.

fixes #704