### PR TITLE
Only parse git information if .git/HEAD exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ if(APPLE)
 endif()
 
 find_package (Git)
-if (GIT_FOUND)
+if (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git/HEAD")
     execute_process(
         COMMAND ${GIT_EXECUTABLE} describe --tags --always
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
If the source comes from somewhere else (eg. the release tarballs) then
.git/HEAD does not exist, so the cmake step was failing. Only try to
colelct the git information if the file exists.

Fixes #714.