### PR TITLE
Fix vkGetInstanceProcAddr not handling null instance

### DIFF
--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -79,4 +79,11 @@ TEST(GetProcAddr, GlobalFunctions) {
 
     GetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(gipa(inst, "vkGetInstanceProcAddr"));
     handle_assert_null(GetInstanceProcAddr);
+
+    // get a non pre-instance function pointer
+    auto EnumeratePhysicalDevices = reinterpret_cast<PFN_vkGetInstanceProcAddr>(gipa(inst, "vkEnumeratePhysicalDevices"));
+    handle_assert_has_value(EnumeratePhysicalDevices);
+
+    EnumeratePhysicalDevices = reinterpret_cast<PFN_vkGetInstanceProcAddr>(gipa(NULL, "vkEnumeratePhysicalDevices"));
+    handle_assert_null(EnumeratePhysicalDevices);
 }


### PR DESCRIPTION
The issue was that trying to get a non-pre-instance function with a NULL
instance handle would cause a crash. This change also adds a test that
would of caught the oversight.

Code style criticisms welcome.