### PR TITLE
Modify loader warning about physical device count

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -707,7 +707,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDevices(VkInstan
     count = inst->phys_dev_count_tramp;
 
     if (inst->phys_dev_count_tramp != inst->total_gpu_count) {
-        loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
+        loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0,
                    "vkEnumeratePhysicalDevices: One or more layers modified physical devices!"
                    "Count returned by ICDs = %d, count returned above layers = %d",
                    inst->total_gpu_count, inst->phys_dev_count_tramp);


### PR DESCRIPTION
Modify the loader warning about one or more layers modifying the
physical device count.  Originally, it was as a general warning,
but modified it to also output during layer debug.