### PR TITLE
Fix GCC 11.2 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,6 @@ jobs:
                 python-version: '3.7'
             - run: sudo apt install libwayland-dev libxrandr-dev
 
-            - name: Get Google Test
-              run: git clone --branch release-1.10.0 https://github.com/google/googletest.git external/googletest
-
             - name: Generate build files
               run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -DBUILD_TESTS=On -DUPDATE_DEPS=ON
               env:
@@ -89,9 +86,6 @@ jobs:
               with:
                 winsdk-build-version: 17763
               if: matrix.os == 'windows-2016'
-
-            - name: Get Google Test
-              run: git clone --branch release-1.10.0 https://github.com/google/googletest.git external/googletest
 
             - name: Get Detours
               run: git clone --branch v4.0.1 https://github.com/microsoft/Detours.git external/detours

--- a/BUILD.md
+++ b/BUILD.md
@@ -78,7 +78,7 @@ it on the CMake command line for building this repository, as described below.
 The loader tests depend on the [Google Test](https://github.com/google/googletest) library and
 on Windows platforms depends on the [Microsoft Detours](https://github.com/microsoft/Detours) library.
 
-To build the tests, pass the `DUPDATE_DEPS=ON` and `-DBUILD_TESTS=ON` options when generating the project:
+To build the tests, pass the `-DUPDATE_DEPS=ON` and `-DBUILD_TESTS=ON` options when generating the project:
 ```bash
 cmake ... -DUPDATE_DEPS=ON -DBUILD_TESTS=ON ...
 ```
@@ -94,22 +94,34 @@ although you can place these directories in any location.
 ### Building Dependent Repositories with Known-Good Revisions
 
 There is a Python utility script, `scripts/update_deps.py`, that you can use
-to gather and build the dependent repositories mentioned above. This program
-also uses information stored in the `scripts/known-good.json` file to checkout
-dependent repository revisions that are known to be compatible with the
-revision of this repository that you currently have checked out.
+to gather and build the dependent repositories mentioned above.
+This program also uses information stored in the `scripts/known-good.json` file
+to checkout dependent repository revisions that are known to be compatible with
+the revision of this repository that you currently have checked out.
 
-Here is a usage example for this repository:
+You can choose to do this manually or automatically.
+The first step to either is cloning the Vulkan-Loader repo and stepping into
+that newly cloned folder:
 
-    git clone git@github.com:KhronosGroup/Vulkan-Loader.git
-    cd Vulkan-Loader
-    mkdir build
-    cd build
-    ../scripts/update_deps.py
-    cmake -C helper.cmake ..
-    cmake --build .
+```
+  git clone git@github.com:KhronosGroup/Vulkan-Loader.git
+  cd Vulkan-Loader
+```
 
-#### Notes
+#### Manually
+
+To manually update the dependencies you now must create the build folder, and
+run the update deps script followed by the necessary CMake build commands:
+
+```
+  mkdir build
+  cd build
+  ../scripts/update_deps.py
+  cmake -C helper.cmake ..
+  cmake --build .
+```
+
+##### Notes About the Manual Option
 
 - You may need to adjust some of the CMake options based on your platform. See
   the platform-specific sections later in this document.
@@ -136,6 +148,27 @@ Here is a usage example for this repository:
   execution.
 - Please use `update_deps.py --help` to list additional options and read the
   internal documentation in `update_deps.py` for further information.
+
+
+#### Automatically
+
+On the other hand, if you choose to let the CMake scripts do all the
+heavy-lifting, you may just trigger the following CMake commands:
+
+```
+  cmake -S. -Bbuild -DUPDATE_DEPS=On
+  cmake --build build
+```
+
+##### Notes About the Automatic Option
+
+- You may need to adjust some of the CMake options based on your platform. See
+  the platform-specific sections later in this document.
+- The `build` directory is also being used to build this
+  (Vulkan-ValidationLayers) repository. But there shouldn't be any conflicts
+  inside the `build` directory between the dependent repositories and the
+  build files for this repository.
+
 
 ### Generated source code
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,7 +346,7 @@ if(BUILD_TESTS)
         set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
         # The googletest directory exists, so enable it as a target.
         message(STATUS "Vulkan-Loader/external: " "googletest found - configuring it for tests")
-        add_subdirectory("${GOOGLETEST_INSTALL_DIR}/googletest")
+        add_subdirectory("${GOOGLETEST_INSTALL_DIR}")
     else()
         message(SEND_ERROR "Could not find googletest directory. Be sure to run update_deps.py with the --tests option to download the appropriate version of googletest")
         set(BUILD_TESTS OFF)

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -15,7 +15,7 @@
             "build_dir": "googletest",
             "install_dir": "googletest",
             "build_step": "skip",
-            "commit": "release-1.10.0",
+            "commit": "release-1.11.0",
             "optional": [
                 "tests"
             ]


### PR DESCRIPTION
Gcc 11.2 build was failing to build with the GoogleTest version
that was being built.  So bump to next version of GoogleTest with
fixes (GoogleTest release-1.11.0), but that also required changing
the build directory to build GoogleTest in so update our Makefiles
to build in the new folder as well.