### PR TITLE
test: Fix compiler warnings in MSVC

### DIFF
--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -83,11 +83,11 @@ VkResult FillCountPtr(std::vector<T> const& data_vec, uint32_t* pCount, U* pData
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
     if (pData == nullptr) {
-        *pCount = data_vec.size();
+        *pCount = static_cast<uint32_t>(data_vec.size());
         return VK_SUCCESS;
     }
     uint32_t amount_written = 0;
-    uint32_t amount_to_write = data_vec.size();
+    uint32_t amount_to_write = static_cast<uint32_t>(data_vec.size());
     if (*pCount < data_vec.size()) {
         amount_to_write = *pCount;
     }
@@ -109,11 +109,11 @@ VkResult FillCountPtr(std::vector<T> const& data_vec, uint32_t* pCount, T* pData
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
     if (pData == nullptr) {
-        *pCount = data_vec.size();
+        *pCount = static_cast<uint32_t>(data_vec.size());
         return VK_SUCCESS;
     }
     uint32_t amount_written = 0;
-    uint32_t amount_to_write = data_vec.size();
+    uint32_t amount_to_write = static_cast<uint32_t>(data_vec.size());
     if (*pCount < data_vec.size()) {
         amount_to_write = *pCount;
     }
@@ -178,7 +178,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroyInstance(VkInstance instance, const VkA
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
                                                                VkPhysicalDevice* pPhysicalDevices) {
     if (pPhysicalDevices == nullptr) {
-        *pPhysicalDeviceCount = icd.physical_devices.size();
+        *pPhysicalDeviceCount = static_cast<uint32_t>(icd.physical_devices.size());
     } else {
         uint32_t handles_written = 0;
         for (size_t i = 0; i < icd.physical_devices.size(); i++) {
@@ -199,7 +199,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDevices(VkInstance instan
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDeviceGroups(
     VkInstance instance, uint32_t* pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties) {
     if (pPhysicalDeviceGroupProperties == nullptr) {
-        *pPhysicalDeviceGroupCount = icd.physical_device_groups.size();
+        *pPhysicalDeviceGroupCount = static_cast<uint32_t>(icd.physical_device_groups.size());
     } else {
         for (size_t device_group = 0; device_group < icd.physical_device_groups.size(); device_group++) {
             if (device_group >= *pPhysicalDeviceGroupCount) {

--- a/tests/framework/layer/layer_util.h
+++ b/tests/framework/layer/layer_util.h
@@ -47,10 +47,10 @@ struct LayerDefinition {
 
     VkLayerProperties get() const noexcept {
         VkLayerProperties props{};
-        std::strncpy(props.layerName, layerName.data(), VK_MAX_EXTENSION_NAME_SIZE);
+        copy_string_to_char_array(layerName, &props.layerName[0], VK_MAX_EXTENSION_NAME_SIZE);
         props.specVersion = specVersion;
         props.implementationVersion = implementationVersion;
-        std::strncpy(props.description, layerName.data(), VK_MAX_DESCRIPTION_SIZE);
+        copy_string_to_char_array(description, &props.description[0], VK_MAX_DESCRIPTION_SIZE);
         return props;
     }
 };

--- a/tests/framework/shim/windows_shim.cpp
+++ b/tests/framework/shim/windows_shim.cpp
@@ -41,7 +41,7 @@ extern "C" {
 
 static LibraryWrapper gdi32_dll;
 
-using PFN_GetSidSubAuthority = PDWORD (__stdcall *)(PSID pSid, DWORD nSubAuthority);
+using PFN_GetSidSubAuthority = PDWORD(__stdcall *)(PSID pSid, DWORD nSubAuthority);
 static PFN_GetSidSubAuthority fpGetSidSubAuthority = GetSidSubAuthority;
 
 PDWORD __stdcall ShimGetSidSubAuthority(PSID pSid, DWORD nSubAuthority) { return &platform_shim.elevation_level; }
@@ -65,9 +65,9 @@ NTSTATUS APIENTRY ShimEnumAdapters2(LoaderEnumAdapters2 *adapters) {
             adapters->adapters[i].present_move_regions_preferred =
                 platform_shim.d3dkmt_adapters[i].info.bPresentMoveRegionsPreferred;
         }
-        adapters->adapter_count = platform_shim.d3dkmt_adapters.size();
+        adapters->adapter_count = static_cast<ULONG>(platform_shim.d3dkmt_adapters.size());
     } else {
-        adapters->adapter_count = platform_shim.d3dkmt_adapters.size();
+        adapters->adapter_count = static_cast<ULONG>(platform_shim.d3dkmt_adapters.size());
     }
     return STATUS_SUCCESS;
 }
@@ -86,7 +86,7 @@ NTSTATUS APIENTRY ShimQueryAdapterInfo(const LoaderQueryAdapterInfo *query_info)
     auto *reg_info = reinterpret_cast<LoaderQueryRegistryInfo *>(query_info->private_data);
     reg_info->status = LOADER_QUERY_REGISTRY_STATUS_SUCCESS;
     if (reg_info->output_value_size == 0) {
-        reg_info->output_value_size = it->path.size();
+        reg_info->output_value_size = static_cast<ULONG>(it->path.size());
     } else if (reg_info->output_value_size == it->path.size()) {
         std::wstring path_wstr(1, L'\0');
         path_wstr.assign(it->path.str().begin(), it->path.str().end());
@@ -113,7 +113,7 @@ CONFIGRET WINAPI SHIM_CM_Get_Device_ID_List_SizeW(PULONG pulLen, PCWSTR pszFilte
     if (pulLen == nullptr) {
         return CR_INVALID_POINTER;
     }
-    *pulLen = platform_shim.CM_device_ID_list.size();
+    *pulLen = static_cast<ULONG>(platform_shim.CM_device_ID_list.size());
     return CR_SUCCESS;
 }
 CONFIGRET WINAPI SHIM_CM_Get_Device_ID_ListW(PCWSTR pszFilter, PZZWSTR Buffer, ULONG BufferLen, ULONG ulFlags) {
@@ -147,8 +147,6 @@ static LibraryWrapper dxgi_module;
 typedef HRESULT(APIENTRY *PFN_CreateDXGIFactory1)(REFIID riid, void **ppFactory);
 
 PFN_CreateDXGIFactory1 RealCreateDXGIFactory1;
-
-
 
 HRESULT __stdcall ShimGetDesc1(IDXGIAdapter1 *pAdapter,
                                /* [annotation][out] */

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -188,8 +188,8 @@ std::string ManifestLayer::LayerDescription::get_manifest_str() const {
 
 VkLayerProperties ManifestLayer::LayerDescription::get_layer_properties() const {
     VkLayerProperties properties{};
-    strncpy(properties.layerName, name.c_str(), 256);
-    strncpy(properties.description, description.c_str(), 256);
+    copy_string_to_char_array(name, properties.layerName, VK_MAX_EXTENSION_NAME_SIZE);
+    copy_string_to_char_array(description, properties.description, VK_MAX_EXTENSION_NAME_SIZE);
     properties.implementationVersion = implementation_version;
     properties.specVersion = api_version;
     return properties;

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -362,8 +362,8 @@ TEST_F(EnumeratePhysicalDevices, OneCall) {
     InstWrapper inst{env->vulkan_functions};
     inst.CheckCreate();
 
-    uint32_t physical_count = driver.physical_devices.size();
-    uint32_t returned_physical_count = driver.physical_devices.size();
+    uint32_t physical_count = static_cast<uint32_t>(driver.physical_devices.size());
+    uint32_t returned_physical_count = static_cast<uint32_t>(driver.physical_devices.size());
     std::vector<VkPhysicalDevice> physical_device_handles = std::vector<VkPhysicalDevice>(physical_count);
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &returned_physical_count, physical_device_handles.data()));
     ASSERT_EQ(physical_count, returned_physical_count);
@@ -380,7 +380,7 @@ TEST_F(EnumeratePhysicalDevices, TwoCall) {
     InstWrapper inst{env->vulkan_functions};
     inst.CheckCreate();
 
-    uint32_t physical_count = driver.physical_devices.size();
+    uint32_t physical_count = static_cast<uint32_t>(driver.physical_devices.size());
     uint32_t returned_physical_count = 0;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst.inst, &returned_physical_count, nullptr));
     ASSERT_EQ(physical_count, returned_physical_count);
@@ -403,7 +403,7 @@ TEST_F(EnumeratePhysicalDevices, MatchOneAndTwoCallNumbers) {
     InstWrapper inst1{env->vulkan_functions};
     inst1.CheckCreate();
 
-    uint32_t physical_count_one_call = driver.physical_devices.size();
+    uint32_t physical_count_one_call = static_cast<uint32_t>(driver.physical_devices.size());
     std::array<VkPhysicalDevice, real_device_count> physical_device_handles_one_call;
     ASSERT_EQ(VK_SUCCESS,
               inst1->vkEnumeratePhysicalDevices(inst1, &physical_count_one_call, physical_device_handles_one_call.data()));
@@ -412,7 +412,7 @@ TEST_F(EnumeratePhysicalDevices, MatchOneAndTwoCallNumbers) {
     InstWrapper inst2{env->vulkan_functions};
     inst2.CheckCreate();
 
-    uint32_t physical_count = driver.physical_devices.size();
+    uint32_t physical_count = static_cast<uint32_t>(driver.physical_devices.size());
     uint32_t returned_physical_count = 0;
     ASSERT_EQ(VK_SUCCESS, inst2->vkEnumeratePhysicalDevices(inst2, &returned_physical_count, nullptr));
     ASSERT_EQ(physical_count, returned_physical_count);
@@ -605,7 +605,7 @@ TEST_F(EnumeratePhysicalDeviceGroups, OneCall) {
         ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &returned_phys_dev_count, physical_devices.data()));
         handle_assert_has_values(physical_devices);
 
-        uint32_t group_count = driver.physical_device_groups.size();
+        uint32_t group_count = static_cast<uint32_t>(driver.physical_device_groups.size());
         uint32_t returned_group_count = group_count;
         VkPhysicalDeviceGroupProperties group_props{};
         group_props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES;
@@ -629,7 +629,7 @@ TEST_F(EnumeratePhysicalDeviceGroups, OneCall) {
         ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &returned_phys_dev_count, physical_devices.data()));
         handle_assert_has_values(physical_devices);
 
-        uint32_t group_count = driver.physical_device_groups.size();
+        uint32_t group_count = static_cast<uint32_t>(driver.physical_device_groups.size());
         uint32_t returned_group_count = group_count;
         VkPhysicalDeviceGroupPropertiesKHR group_props{};
         group_props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES_KHR;
@@ -663,7 +663,7 @@ TEST_F(EnumeratePhysicalDeviceGroups, TwoCall) {
         ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &returned_phys_dev_count, physical_devices.data()));
         handle_assert_has_values(physical_devices);
 
-        uint32_t group_count = driver.physical_device_groups.size();
+        uint32_t group_count = static_cast<uint32_t>(driver.physical_device_groups.size());
         uint32_t returned_group_count = 0;
         ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &returned_group_count, nullptr));
         ASSERT_EQ(group_count, returned_group_count);
@@ -690,7 +690,7 @@ TEST_F(EnumeratePhysicalDeviceGroups, TwoCall) {
         auto vkEnumeratePhysicalDeviceGroupsKHR = reinterpret_cast<PFN_vkEnumeratePhysicalDeviceGroupsKHR>(
             env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkEnumeratePhysicalDeviceGroupsKHR"));
 
-        uint32_t group_count = driver.physical_device_groups.size();
+        uint32_t group_count = static_cast<uint32_t>(driver.physical_device_groups.size());
         uint32_t returned_group_count = 0;
         ASSERT_EQ(VK_SUCCESS, vkEnumeratePhysicalDeviceGroupsKHR(inst, &returned_group_count, nullptr));
         ASSERT_EQ(group_count, returned_group_count);
@@ -721,7 +721,7 @@ TEST_F(EnumeratePhysicalDeviceGroups, TwoCallIncomplete) {
         inst.create_info.set_api_version(1, 1, 0);
         inst.CheckCreate();
 
-        uint32_t group_count = driver.physical_device_groups.size();
+        uint32_t group_count = static_cast<uint32_t>(driver.physical_device_groups.size());
         uint32_t returned_group_count = 0;
         ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &returned_group_count, nullptr));
         ASSERT_EQ(group_count, returned_group_count);
@@ -743,7 +743,7 @@ TEST_F(EnumeratePhysicalDeviceGroups, TwoCallIncomplete) {
         auto vkEnumeratePhysicalDeviceGroupsKHR = reinterpret_cast<PFN_vkEnumeratePhysicalDeviceGroupsKHR>(
             env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkEnumeratePhysicalDeviceGroupsKHR"));
 
-        uint32_t group_count = driver.physical_device_groups.size();
+        uint32_t group_count = static_cast<uint32_t>(driver.physical_device_groups.size());
         uint32_t returned_group_count = 0;
         ASSERT_EQ(VK_SUCCESS, vkEnumeratePhysicalDeviceGroupsKHR(inst, &returned_group_count, nullptr));
         ASSERT_EQ(group_count, returned_group_count);

--- a/tests/loader_threading_tests.cpp
+++ b/tests/loader_threading_tests.cpp
@@ -47,7 +47,7 @@ void create_destroy_device_loop(uint32_t num_loops_create_destroy_device, uint32
         dev.create_info.add_device_queue(DeviceQueueCreateInfo{}.add_priority(1.0));
         dev.CheckCreate(phys_dev);
 
-        for (uint32_t i = 0; i < num_loops_try_get_proc_addr; i++) {
+        for (uint32_t j = 0; j < num_loops_try_get_proc_addr; j++) {
             PFN_vkCmdBindPipeline p =
                 reinterpret_cast<PFN_vkCmdBindPipeline>(dev->vkGetDeviceProcAddr(dev.dev, "vkCmdBindPipeline"));
             ASSERT_NE(p, nullptr);

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -189,8 +189,8 @@ TEST_F(ICDInterfaceVersion2Plus, version_5) {
     auto& driver = env->get_test_icd();
     driver.physical_devices.emplace_back("physical_device_1");
     driver.physical_devices.emplace_back("physical_device_0");
-    uint32_t physical_count = driver.physical_devices.size();
-    uint32_t returned_physical_count = driver.physical_devices.size();
+    uint32_t physical_count = static_cast<uint32_t>(driver.physical_devices.size());
+    uint32_t returned_physical_count = static_cast<uint32_t>(driver.physical_devices.size());
     std::vector<VkPhysicalDevice> physical_device_handles = std::vector<VkPhysicalDevice>(physical_count);
 
     driver.min_icd_interface_version = 5;
@@ -210,8 +210,8 @@ TEST_F(ICDInterfaceVersion2PlusEnumerateAdapterPhysicalDevices, version_6) {
     auto& driver = env->get_test_icd();
     driver.physical_devices.emplace_back("physical_device_1");
     driver.physical_devices.emplace_back("physical_device_0");
-    uint32_t physical_count = driver.physical_devices.size();
-    uint32_t returned_physical_count = driver.physical_devices.size();
+    uint32_t physical_count = static_cast<uint32_t>(driver.physical_devices.size());
+    uint32_t returned_physical_count = static_cast<uint32_t>(driver.physical_devices.size());
     std::vector<VkPhysicalDevice> physical_device_handles = std::vector<VkPhysicalDevice>(physical_count);
 
     driver.min_icd_interface_version = 6;
@@ -219,7 +219,7 @@ TEST_F(ICDInterfaceVersion2PlusEnumerateAdapterPhysicalDevices, version_6) {
     uint32_t driver_index = 2;  // which drive this test pretends to be
     auto& known_driver = known_driver_list.at(2);
     DXGI_ADAPTER_DESC1 desc1{};
-    wcsncpy(&desc1.Description[0], L"TestDriver1", 128);
+    wcsncpy_s(&desc1.Description[0], 128, L"TestDriver1", 128);
     desc1.VendorId = known_driver.vendor_id;
     desc1.AdapterLuid;
     desc1.Flags = DXGI_ADAPTER_FLAG_NONE;
@@ -242,8 +242,8 @@ TEST_F(ICDInterfaceVersion2PlusEnumerateAdapterPhysicalDevices, EnumAdapters2) {
     auto& driver = env->get_test_icd();
     driver.physical_devices.emplace_back("physical_device_1");
     driver.physical_devices.emplace_back("physical_device_0");
-    uint32_t physical_count = driver.physical_devices.size();
-    uint32_t returned_physical_count = driver.physical_devices.size();
+    uint32_t physical_count = static_cast<uint32_t>(driver.physical_devices.size());
+    uint32_t returned_physical_count = static_cast<uint32_t>(driver.physical_devices.size());
     std::vector<VkPhysicalDevice> physical_device_handles = std::vector<VkPhysicalDevice>(physical_count);
 
     SHIM_D3DKMT_ADAPTERINFO d3dkmt_adapter_info{};
@@ -277,9 +277,9 @@ TEST(MultipleICDConfig, Basic) {
     env.get_test_icd(1).physical_devices.at(0).properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
     env.get_test_icd(2).physical_devices.at(0).properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_CPU;
 
-    strcpy(env.get_test_icd(0).physical_devices.at(0).properties.deviceName, "dev0");
-    strcpy(env.get_test_icd(1).physical_devices.at(0).properties.deviceName, "dev1");
-    strcpy(env.get_test_icd(2).physical_devices.at(0).properties.deviceName, "dev2");
+    copy_string_to_char_array("dev0", env.get_test_icd(0).physical_devices.at(0).properties.deviceName, VK_MAX_EXTENSION_NAME_SIZE);
+    copy_string_to_char_array("dev1", env.get_test_icd(1).physical_devices.at(0).properties.deviceName, VK_MAX_EXTENSION_NAME_SIZE);
+    copy_string_to_char_array("dev2", env.get_test_icd(2).physical_devices.at(0).properties.deviceName, VK_MAX_EXTENSION_NAME_SIZE);
 
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();


### PR DESCRIPTION
Various C string handling functions are considered unsafe. Best to use
proper alternatives.

Warnings/fixes include:
* strcpy/strncpy/wstrcpy
* Dropping static on inline functions
* Use localtime_s
* Name shadowing
* Use wcstombs_s