### PR TITLE
Add test for unknown physical device functions

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,8 @@ add_executable(test_regression loader_testing_main.cpp
     loader_get_proc_addr_tests.cpp
     loader_layer_tests.cpp
     loader_regression_tests.cpp
-    loader_version_tests.cpp)
+    loader_version_tests.cpp
+    loader_unknown_ext_tests.cpp)
 target_link_libraries(test_regression PRIVATE testing_dependencies)
 
 add_executable(test_wsi loader_testing_main.cpp loader_wsi_tests.cpp)

--- a/tests/framework/icd/physical_device.h
+++ b/tests/framework/icd/physical_device.h
@@ -29,11 +29,6 @@
 
 #include "test_util.h"
 
-struct VulkanFunction {
-    const char* name;
-    void* function;
-};
-
 // Move only type because it holds a DispatchableHandle<VkPhysicalDevice>
 struct PhysicalDevice {
     PhysicalDevice() {}

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -502,6 +502,11 @@ PFN_vkVoidFunction get_physical_device_func(VkInstance instance, const char* pNa
             return TO_VOID_PFN(test_vkGetPhysicalDeviceImageFormatProperties2);
         }
     }
+    for (auto& func : icd.custom_physical_device_functions) {
+        if (func.name == pName) {
+            return TO_VOID_PFN(func.function);
+        }
+    }
     return nullptr;
 }
 
@@ -525,6 +530,12 @@ PFN_vkVoidFunction get_instance_func(VkInstance instance, const char* pName) {
 
     PFN_vkVoidFunction ret_wsi = get_instance_func_wsi(instance, pName);
     if (ret_wsi != nullptr) return ret_wsi;
+
+    for (auto& func : icd.custom_instance_functions) {
+        if (func.name == pName) {
+            return TO_VOID_PFN(func.function);
+        }
+    }
 
     return nullptr;
 }

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -79,6 +79,12 @@ struct TestICD {
     uint64_t created_surface_count = 0;
     uint64_t created_swapchain_count = 0;
 
+    // Unknown instance and physical device functions. Add a `VulkanFunction` to this list which will be searched in
+    // vkGetInstanceProcAddr for custom_instance_functions and vk_icdGetPhysicalDeviceProcAddr for custom_physical_device_functions.
+    // To add unknown device functions, add it to the PhysicalDevice directly (in the known_device_functions member)
+    std::vector<VulkanFunction> custom_instance_functions;
+    std::vector<VulkanFunction> custom_physical_device_functions;
+
     TestICD() {}
     ~TestICD() {}
 

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -673,3 +673,8 @@ inline bool operator==(const VkExtensionProperties& a, const VkExtensionProperti
     return string_eq(a.extensionName, b.extensionName, 256) && a.specVersion == b.specVersion;
 }
 inline bool operator!=(const VkExtensionProperties& a, const VkExtensionProperties& b) { return !(a == b); }
+
+struct VulkanFunction {
+    const char* name;
+    void* function;
+};

--- a/tests/loader_unknown_ext_tests.cpp
+++ b/tests/loader_unknown_ext_tests.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#include "test_environment.h"
+
+class UnknownExtension : public ::testing::Test {
+   protected:
+    virtual void SetUp() {
+        env = std::unique_ptr<SingleICDShim>(
+            new SingleICDShim(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_MAKE_VERSION(1, 0, 0))));
+    }
+
+    virtual void TearDown() { env.reset(); }
+    std::unique_ptr<SingleICDShim> env;
+};
+
+/*
+ Creates a TestICD with a function unknown to the loader called vkNotRealFuncTEST. The TestICD, when vk_icdGetPhysicalDeviceProcAddr
+ is called, will return the custom_physical_device_function if the function name matches vkNotRealFuncTEST. The test then calls the
+ function to verify that the unknown physical device function dispatching is working correctly.
+*/
+
+VkResult custom_physical_device_function(VkPhysicalDevice device, int foo, int bar) { return VK_SUCCESS; }
+using PFN_custom_physical_device_function = decltype(&custom_physical_device_function);
+
+TEST_F(UnknownExtension, ICDKnownExtension) {
+    auto& driver = env->get_test_icd();
+    const char* fake_function_name = "vkNotRealFuncTEST";
+
+    driver.physical_devices.emplace_back("physical_device_0");
+    driver.custom_physical_device_functions.push_back(
+        VulkanFunction{fake_function_name, reinterpret_cast<void*>(custom_physical_device_function)});
+
+    InstWrapper inst{env->vulkan_functions};
+    inst.CheckCreate();
+
+    VkPhysicalDevice phys_dev = inst.GetPhysDev();
+
+    PFN_custom_physical_device_function returned_func = reinterpret_cast<PFN_custom_physical_device_function>(
+        env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, fake_function_name));
+    ASSERT_NE(returned_func, nullptr);
+    ASSERT_EQ(returned_func(phys_dev, 42, 58008), VK_SUCCESS);
+}


### PR DESCRIPTION
Requires adding support in the ICD for unknown instance and physical device
functions separately.