### PR TITLE
Make GetPhysDevToolProps call into drivers

### DIFF
--- a/loader/extension_manual.c
+++ b/loader/extension_manual.c
@@ -28,6 +28,7 @@
 
 #include <vulkan/vk_icd.h>
 
+#include "allocation.h"
 #include "debug_utils.h"
 #include "loader.h"
 #include "log.h"
@@ -301,6 +302,14 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevi
 
 VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevice physicalDevice, uint32_t *pToolCount,
                                                                              VkPhysicalDeviceToolPropertiesEXT *pToolProperties) {
-   *pToolCount = 0;
+    struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
+    struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
+
+    if (icd_term->dispatch.GetPhysicalDeviceToolPropertiesEXT) {
+        return icd_term->dispatch.GetPhysicalDeviceToolPropertiesEXT(phys_dev_term->phys_dev, pToolCount, pToolProperties);
+    }
+
+    // In the case the driver didn't support the extension, make sure that the first layer doesn't find the count uninitialized
+    *pToolCount = 0;
     return VK_SUCCESS;
 }

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -85,6 +85,12 @@ struct TestICD {
     std::vector<VulkanFunction> custom_instance_functions;
     std::vector<VulkanFunction> custom_physical_device_functions;
 
+    // Must explicitely state support for the tooling info extension, that way we can control if vkGetInstanceProcAddr returns a
+    // function pointer for vkGetPhysicalDeviceToolPropertiesEXT
+    bool supports_tooling_info_ext = false;
+    // List of tooling properties that this driver 'supports'
+    std::vector<VkPhysicalDeviceToolPropertiesEXT> tooling_properties;
+
     TestICD() {}
     ~TestICD() {}
 


### PR DESCRIPTION
Add support for vkGetPhysicalDeviceToolProperties to call into the driver if the entrypoint is exposed.

Added a basic test to ensure the trampoline/terminator works.

Fixed #733 