### PR TITLE
vulkan.pc cross-compile fix

### DIFF
--- a/loader/vulkan.pc.in
+++ b/loader/vulkan.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_FULL_LIBDIR_PC@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @CMAKE_PROJECT_NAME@
 Description: Vulkan Loader


### PR DESCRIPTION
- pkg-config variable ${prefix} is required for adjusting sysroot

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>