### PR TITLE
Fix readlink error in asm_offset on linux

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -245,6 +245,7 @@ else(UNIX AND NOT APPLE) # i.e.: Linux
     if(ASSEMBLER_WORKS)
         add_executable(asm_offset asm_offset.c)
         target_link_libraries(asm_offset Vulkan::Headers)
+        target_compile_definitions(asm_offset PRIVATE _GNU_SOURCE)
         add_custom_command(OUTPUT gen_defines.asm DEPENDS asm_offset COMMAND asm_offset GAS)
         add_custom_target(loader_asm_gen_files DEPENDS gen_defines.asm)
     else()


### PR DESCRIPTION
The readlink function required _GNU_SOURCE to be a compiler definition but
wasn't added since it was in a different executable than the main vulkan
loader. Adding it to the asm_offset target fixes the error.