### PR TITLE
Consistent loader device ordering

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -181,6 +181,12 @@ if (!is_android) {
       }
       libs = [ "Cfgmgr32.lib" ]
     }
+    if (is_linux) {
+      sources += [
+        "loader/loader_linux.c",
+        "loader/loader_linux.h",
+      ]
+    }
     if (is_mac) {
       frameworks = [ "CoreFoundation.framework" ]
     }

--- a/BUILD.md
+++ b/BUILD.md
@@ -418,7 +418,8 @@ repository to other Linux distributions.
 #### Required Package List
 
     sudo apt-get install git build-essential libx11-xcb-dev \
-        libxkbcommon-dev libwayland-dev libxrandr-dev
+        libxkbcommon-dev libwayland-dev libxrandr-dev \
+        libxcb1-dev libdrm-dev
 
 ### Linux Build
 

--- a/cmake/FindLibDRM.cmake
+++ b/cmake/FindLibDRM.cmake
@@ -1,0 +1,50 @@
+# - Try to find libdrm
+#
+# LibDRM_FOUND - system has libdrm
+# LibDRM_LIBRARIES - Link these to use libdrm
+# LibDRM_INCLUDE_DIRS - the libdrm include dir
+
+# Copyright (c) 2021 The Khronos Group Inc.
+# Copyright (c) 2021 Valve Corporation
+# Copyright (c) 2021 LunarG, Inc.
+
+if (NOT WIN32)
+
+  # use pkg-config to get the directories and then use these values
+  # in the FIND_PATH() and FIND_LIBRARY() calls
+  find_package(PkgConfig)
+  pkg_check_modules(PKG_LIBDRM QUIET LibDRM)
+
+  find_path(
+    LibDRM_INCLUDE_DIRS
+      NAMES
+        drm.h
+        drm_fourcc.h
+        drm_mode.h
+      HINTS
+        ${PKG_LIBDRM_INCLUDE_DIRS}
+        /usr/include/libdrm
+  )
+  find_library(
+    LibDRM_LIBRARIES
+      NAMES
+        drm
+      HINTS
+        ${PKG_LIBDRM_LIBRARY_DIRS}
+        /usr/lib64
+        /usr/lib
+  )
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(LibDRM
+      FOUND_VAR
+          LibDRM_FOUND
+      REQUIRED_VARS
+          LibDRM_LIBRARIES
+          LibDRM_INCLUDE_DIRS
+  )
+
+else()
+  set(LibDRM_FOUND FALSE)
+endif()
+

--- a/docs/LoaderApplicationInterface.md
+++ b/docs/LoaderApplicationInterface.md
@@ -43,6 +43,7 @@
   * [Instance and Device Extensions](#instance-and-device-extensions)
   * [WSI Extensions](#wsi-extensions)
   * [Unknown Extensions](#unknown-extensions)
+* [Physical Device Ordering](#physical-device-ordering)
 
 ## Overview
 
@@ -888,5 +889,34 @@ variable to a non-zero number.
 This will effectively disable the loader's filtering of instance extension
 names.
 
+## Physical Device Ordering
+
+Prior to the 1.2.203 loader, physical devices on Linux could be returned in an
+inconsistent order.
+To remedy this, the functionality previously used in the Mesa device
+selection layer was ported into the Vulkan loader.
+This functionality prioritizes the device attached to the primary monitor
+of the running system, and then sorts all other devices by:
+ * Device Type (Discrete, Integrated, Virtual, all others)
+ * Internal to the types, it then sorts based on PCI Domain, Bus, Device, and
+   Function.
+
+This allows for a consistent physical device order from run to run on the same
+system, unless the actual underlying hardware changes.
+
+A new environment variable is defined to give users the ability to force a
+specific device, `VK_LOADER_DEVICE_SELECT`.
+This environment variable should be set to the desired devices hex value for
+Vendor Id and Device Id (as returned from `vkGetPhysicalDeviceProperties` in
+the `VkPhysicalDeviceProperties` structure).
+It should look like the following:
+
+```
+set VK_LOADER_DEVICE_SELECT=0x10de:0x1f91
+```
+
+This will force on the device with a vendor ID of "0x10de" and a device ID
+of "0x1f91".
+If that device is not found, this is simply ignored.
 
 [Return to the top-level LoaderInterfaceArchitecture.md file.](LoaderInterfaceArchitecture.md)

--- a/docs/LoaderInterfaceArchitecture.md
+++ b/docs/LoaderInterfaceArchitecture.md
@@ -538,6 +538,18 @@ discovery.
     </td>
   </tr>
   <tr>
+    <td><small><i>VK_LOADER_DEVICE_SELECT</i></small></td>
+    <td><b>Linux Only</b><br/>
+        Allows the user to force a particular device to be prioritized above all
+        other devices in the return order of <i>vkGetPhysicalDevices<i> and
+        <i>vkGetPhysicalDeviceGroups<i> functions.<br/>
+        The value should be "<hex vendor id>:<hex device id>".<br/>
+        <b>NOTE:</b> This not remove devices.
+    </td>
+    <td><small>set VK_LOADER_DEVICE_SELECT=0x10de:0x1f91</small>
+    </td>
+  </tr>
+  <tr>
     <td><small><i>VK_LOADER_DISABLE_INST_EXT_FILTER</i></small></td>
     <td>Disable the filtering out of instance extensions that the loader doesn't
         know about.

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -160,6 +160,11 @@ set(NORMAL_LOADER_SRCS
 
 if(WIN32)
     set(NORMAL_LOADER_SRCS ${NORMAL_LOADER_SRCS} loader_windows.c)
+else(UNIX AND NOT APPLE) # i.e.: Linux
+    set(NORMAL_LOADER_SRCS ${NORMAL_LOADER_SRCS} loader_linux.c)
+    if(BUILD_WSI_XCB_SUPPORT)
+        set(NORMAL_LOADER_SRCS ${NORMAL_LOADER_SRCS} xcb_select.c)
+    endif()
 endif()
 
 set(OPT_LOADER_SRCS dev_ext_trampoline.c phys_dev_ext.c)
@@ -315,6 +320,35 @@ else()
         add_library(vulkan STATIC ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS})
     else()
         add_library(vulkan SHARED ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS})
+    endif()
+    if(UNIX AND NOT APPLE) # i.e.: Linux
+        if(BUILD_WSI_XCB_SUPPORT)
+            find_package(XCB REQUIRED)
+            find_package(LibDRM)
+            find_library(XCB_DRI_LIBRARY
+                            NAMES xcb-dri3
+                            PATHS /usr/lib
+                                  /usr/lib64
+                                  /usr/local/lib
+                                  /usr/local/lib64)
+
+            set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS LOADER_ENABLE_LINUX_SORT)
+
+            target_include_directories(vulkan PRIVATE ${XCB_INCLUDE_DIRS})
+            target_link_libraries(vulkan ${XCB_LIBRARIES})
+            if (LibDRM_FOUND)
+                set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS LOADER_ENABLE_DRM)
+                target_include_directories(vulkan PRIVATE ${LibDRM_INCLUDE_DIRS})
+                target_link_libraries(vulkan ${LibDRM_LIBRARIES})
+                if (XCB_DRI_LIBRARY)
+                    target_link_libraries(vulkan ${XCB_DRI_LIBRARY})
+                else()
+                    MESSAGE(WARNING "libxcb-dri3 not found!")
+                endif()
+            else()
+                MESSAGE(WARNING "libDRM not found!")
+            endif()
+        endif()
     endif()
     add_dependencies(vulkan loader_asm_gen_files)
     # set version based on LOADER_GENERATED_HEADER_VERSION used to generate the code

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -210,6 +210,7 @@ struct loader_icd_term {
     struct loader_icd_term *next;
 
     PFN_PhysDevExt phys_dev_ext[MAX_NUM_UNKNOWN_EXTS];
+    bool supports_get_dev_prop_2;
 };
 
 // Per ICD library structure
@@ -333,6 +334,7 @@ struct loader_instance {
     bool wsi_display_enabled;
     bool wsi_display_props2_enabled;
     bool create_terminator_invalid_extension;
+    bool supports_get_dev_prop_2;
 };
 
 // VkPhysicalDevice requires special treatment by loader.  Firstly, terminator
@@ -365,6 +367,44 @@ struct loader_physical_device_term {
     struct loader_icd_term *this_icd_term;
     uint8_t icd_index;
     VkPhysicalDevice phys_dev;  // object from ICD
+};
+
+#ifdef LOADER_ENABLE_LINUX_SORT
+// Structure for storing the relevent device information for selecting a device.
+// NOTE: Needs to be defined here so we can store this content in the term structrue
+//       for quicker sorting.
+struct LinuxSortedDeviceInfo {
+    // Associated Vulkan Physical Device
+    VkPhysicalDevice physical_device;
+    bool default_device;
+
+    // Loader specific items about the driver providing support for this physical device
+    uint32_t icd_index;
+    struct loader_icd_term *icd_term;
+
+    // Some generic device properties
+    VkPhysicalDeviceType device_type;
+    char device_name[VK_MAX_PHYSICAL_DEVICE_NAME_SIZE];
+    uint32_t vendor_id;
+    uint32_t device_id;
+
+    // PCI information on this device
+    bool has_pci_bus_info;
+    uint32_t pci_domain;
+    uint32_t pci_bus;
+    uint32_t pci_device;
+    uint32_t pci_function;
+};
+#endif  // LOADER_ENABLE_LINUX_SORT
+
+// Per enumerated PhysicalDeviceGroup structure, used to wrap in terminator code
+struct loader_physical_device_group_term {
+    struct loader_icd_term *this_icd_term;
+    uint8_t icd_index;
+    VkPhysicalDeviceGroupProperties group_props;
+#ifdef LOADER_ENABLE_LINUX_SORT
+    struct LinuxSortedDeviceInfo internal_device_info[VK_MAX_DEVICE_GROUP_SIZE];
+#endif  // LOADER_ENABLE_LINUX_SORT
 };
 
 struct loader_struct {

--- a/loader/loader_linux.c
+++ b/loader/loader_linux.c
@@ -1,0 +1,612 @@
+/*
+ *
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Mark Young <marky@lunarg.com>
+ *
+ */
+
+// Non-windows and non-apple only header file, guard it so that accidental
+// inclusion doesn't cause unknown header include errors
+#ifdef LOADER_ENABLE_LINUX_SORT
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "loader_linux.h"
+
+#include "allocation.h"
+#include "get_environment.h"
+#include "loader.h"
+#include "log.h"
+
+// Determine a priority based on device type with the higher value being higher priority.
+static uint32_t determine_priority_type_value(VkPhysicalDeviceType type) {
+    switch (type) {
+        case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+            return 10;
+        case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+            return 5;
+        case VK_PHYSICAL_DEVICE_TYPE_OTHER:
+            return 3;
+        case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+        case VK_PHYSICAL_DEVICE_TYPE_CPU:
+            return 1;
+        case VK_PHYSICAL_DEVICE_TYPE_MAX_ENUM:  // Not really an enum, but throws warning if it's not here
+            break;
+    }
+    return 0;
+}
+
+// Compare the two device types.
+// This behaves similar to a qsort compare.
+static int32_t device_type_compare(VkPhysicalDeviceType a, VkPhysicalDeviceType b) {
+    uint32_t a_value = determine_priority_type_value(a);
+    uint32_t b_value = determine_priority_type_value(b);
+    if (a_value > b_value) {
+        return -1;
+    } else if (b_value > a_value) {
+        return 1;
+    }
+    return 0;
+}
+
+// Used to compare two devices and determine which one should have priority.  The criteria is
+// simple:
+//   1) Default device ALWAYS wins
+//   2) Sort by type
+//   3) Sort by PCI bus ID
+//   4) Ties broken by device_ID XOR vendor_ID comparison
+int32_t compare_devices(const void *a, const void *b) {
+    struct LinuxSortedDeviceInfo *left = (struct LinuxSortedDeviceInfo *)a;
+    struct LinuxSortedDeviceInfo *right = (struct LinuxSortedDeviceInfo *)b;
+
+    // Default device always gets priority
+    if (left->default_device) {
+        return -1;
+    } else if (right->default_device) {
+        return 1;
+    }
+
+    // Order by device type next
+    int32_t dev_type_comp = device_type_compare(left->device_type, right->device_type);
+    if (0 != dev_type_comp) {
+        return dev_type_comp;
+    }
+
+    // Sort by PCI info (prioritize devices that have info over those that don't)
+    if (left->has_pci_bus_info && !right->has_pci_bus_info) {
+        return -1;
+    } else if (!left->has_pci_bus_info && right->has_pci_bus_info) {
+        return 1;
+    } else if (left->has_pci_bus_info && right->has_pci_bus_info) {
+        // Sort low to high PCI domain
+        if (left->pci_domain < right->pci_domain) {
+            return -1;
+        } else if (left->pci_domain > right->pci_domain) {
+            return 1;
+        }
+        // Sort low to high PCI bus
+        if (left->pci_bus < right->pci_bus) {
+            return -1;
+        } else if (left->pci_bus > right->pci_bus) {
+            return 1;
+        }
+        // Sort low to high PCI device
+        if (left->pci_device < right->pci_device) {
+            return -1;
+        } else if (left->pci_device > right->pci_device) {
+            return 1;
+        }
+        // Sort low to high PCI function
+        if (left->pci_function < right->pci_function) {
+            return -1;
+        } else if (left->pci_function > right->pci_function) {
+            return 1;
+        }
+    }
+
+    // Somehow we have a tie above, so XOR vendorID and deviceID and compare
+    uint32_t left_xord_dev_vend = left->device_id ^ left->vendor_id;
+    uint32_t right_xord_dev_vend = right->device_id ^ right->vendor_id;
+    if (left_xord_dev_vend < right_xord_dev_vend) {
+        return -1;
+    } else if (right_xord_dev_vend < left_xord_dev_vend) {
+        return 1;
+    }
+    return 0;
+}
+
+// Used to compare two device groups and determine which one should have priority.
+// NOTE: This assumes that devices in each group have already been sorted.
+// The group sort criteria is simple:
+//   1) Group with the default device ALWAYS wins
+//   2) Group with the best device type for device 0 wins
+//   3) Group with best PCI bus ID for device 0 wins
+//   4) Ties broken by group device 0 device_ID XOR vendor_ID comparison
+int32_t compare_device_groups(const void *a, const void *b) {
+    struct loader_physical_device_group_term *grp_a = (struct loader_physical_device_group_term *)a;
+    struct loader_physical_device_group_term *grp_b = (struct loader_physical_device_group_term *)b;
+
+    // Use the first GPU's info from each group to sort the groups by
+    struct LinuxSortedDeviceInfo *left = &grp_a->internal_device_info[0];
+    struct LinuxSortedDeviceInfo *right = &grp_b->internal_device_info[0];
+
+    // Default device always gets priority
+    if (left->default_device) {
+        return -1;
+    } else if (right->default_device) {
+        return 1;
+    }
+
+    // Order by device type next
+    int32_t dev_type_comp = device_type_compare(left->device_type, right->device_type);
+    if (0 != dev_type_comp) {
+        return dev_type_comp;
+    }
+
+    // Sort by PCI info (prioritize devices that have info over those that don't)
+    if (left->has_pci_bus_info && !right->has_pci_bus_info) {
+        return -1;
+    } else if (!left->has_pci_bus_info && right->has_pci_bus_info) {
+        return 1;
+    } else if (left->has_pci_bus_info && right->has_pci_bus_info) {
+        // Sort low to high PCI domain
+        if (left->pci_domain < right->pci_domain) {
+            return -1;
+        } else if (left->pci_domain > right->pci_domain) {
+            return 1;
+        }
+        // Sort low to high PCI bus
+        if (left->pci_bus < right->pci_bus) {
+            return -1;
+        } else if (left->pci_bus > right->pci_bus) {
+            return 1;
+        }
+        // Sort low to high PCI device
+        if (left->pci_device < right->pci_device) {
+            return -1;
+        } else if (left->pci_device > right->pci_device) {
+            return 1;
+        }
+        // Sort low to high PCI function
+        if (left->pci_function < right->pci_function) {
+            return -1;
+        } else if (left->pci_function > right->pci_function) {
+            return 1;
+        }
+    }
+
+    // Somehow we have a tie above, so XOR vendorID and deviceID and compare
+    uint32_t left_xord_dev_vend = left->device_id ^ left->vendor_id;
+    uint32_t right_xord_dev_vend = right->device_id ^ right->vendor_id;
+    if (left_xord_dev_vend < right_xord_dev_vend) {
+        return -1;
+    } else if (right_xord_dev_vend < left_xord_dev_vend) {
+        return 1;
+    }
+    return 0;
+}
+
+// Search for the default device using the loader environment variable and then the Mesa
+// environment variable.  Both are formated the same.  This way, we can start working in
+// the same fashion and the layer can "migrate" away over time.
+const char loader_device_select_env_var[2][32] = {"VK_LOADER_DEVICE_SELECT", "MESA_VK_DEVICE_SELECT"};
+static bool linux_env_var_default_device(struct loader_instance *inst, uint32_t device_count,
+                                         struct LinuxSortedDeviceInfo *sorted_device_info) {
+    for (uint32_t env_var = 0; env_var < 2; ++env_var) {
+        char *selection = loader_getenv(loader_device_select_env_var[env_var], inst);
+        if (NULL != selection) {
+            loader_log(inst, VULKAN_LOADER_DEBUG_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                       "linux_env_var_default_device:  Found mesa environment variable %s set to %s",
+                       loader_device_select_env_var[env_var], selection);
+
+            // The environment variable exists, so grab the vendor ID and device ID of the
+            // selected default device
+            unsigned vendor_id, device_id;
+            int32_t matched = sscanf(selection, "%x:%x", &vendor_id, &device_id);
+            if (matched != 2) {
+                return false;
+            }
+
+            bool found = false;
+            for (int32_t i = 0; i < (int32_t)device_count; ++i) {
+                if (sorted_device_info[i].vendor_id == vendor_id && sorted_device_info[i].device_id == device_id) {
+                    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                               "linux_env_var_default_device:  Found default at index %u \'%s\'", i,
+                               sorted_device_info[i].device_name);
+                    sorted_device_info[i].default_device = true;
+                    found = true;
+                    break;
+                }
+            }
+
+            loader_free_getenv(selection, inst);
+            return found;
+        }
+    }
+    return false;
+}
+
+// Search for the default device using DRI_PRIME environment variable for device selection.
+// NOTE: If DRI_PRIME="1", the algorithm should choose any non-default device.
+const char dri_prime_device_select_env_var[] = "DRI_PRIME";
+static bool linux_dri_prime_default_device(struct loader_instance *inst, uint32_t device_count,
+                                           struct LinuxSortedDeviceInfo *sorted_device_info) {
+    char *selection = loader_getenv(dri_prime_device_select_env_var, inst);
+    if (NULL != selection) {
+        loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "linux_dri_prime_default_device:  Found DRI environment variable %s set to %s",
+                   dri_prime_device_select_env_var, selection);
+
+        bool found = false;
+        if (!strcmp("1", selection)) {
+            int32_t selected_index = -1;
+            for (int32_t i = 0; i < (int32_t)device_count; ++i) {
+                if (sorted_device_info[i].has_pci_bus_info) {
+                    char *tag = NULL;
+                    loader_log(inst, VULKAN_LOADER_DEBUG_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                               "linux_dri_prime_default_device:  Checking \'pci-%04x_%02x_%02x_%1u\'",
+                               sorted_device_info[i].pci_domain, sorted_device_info[i].pci_bus, sorted_device_info[i].pci_device,
+                               sorted_device_info[i].pci_function);
+                    if (asprintf(&tag, "pci-%04x_%02x_%02x_%1u", sorted_device_info[i].pci_domain, sorted_device_info[i].pci_bus,
+                                 sorted_device_info[i].pci_device, sorted_device_info[i].pci_function) >= 0) {
+                        // If not the device select it, if one is already selected, compare the two
+                        if (strcmp(selection, tag)) {
+                            if (selected_index < 0) {
+                                loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                                           "linux_dri_prime_default_device:  Found default at index %u \'%s\'", i,
+                                           sorted_device_info[i].device_name);
+                                sorted_device_info[i].default_device = true;
+                                selected_index = (int32_t)i;
+                            } else {
+                                // Since we already selected the previous device, unselect it for now for a good comparison.
+                                // It will be reset if it "wins".
+                                sorted_device_info[selected_index].default_device = false;
+                                int32_t compare = compare_devices(&sorted_device_info[selected_index], &sorted_device_info[i]);
+                                if (compare <= 0) {
+                                    sorted_device_info[selected_index].default_device = false;
+                                } else {
+                                    sorted_device_info[i].default_device = false;
+                                }
+                            }
+                        }
+                    }
+                    free(tag);
+                }
+            }
+            // We might not find a device if the only device is the default device.
+            if (selected_index >= 0) {
+                found = true;
+            }
+        } else {
+            // The environment variable exists, and isn't 1, so generat e a DRI ID using the PCI bus info and
+            // compare
+            for (int32_t i = 0; i < (int32_t)device_count; ++i) {
+                if (sorted_device_info[i].has_pci_bus_info) {
+                    char *tag = NULL;
+                    loader_log(inst, VULKAN_LOADER_DEBUG_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                               "linux_dri_prime_default_device:  Checking \'pci-%04x_%02x_%02x_%1u\'",
+                               sorted_device_info[i].pci_domain, sorted_device_info[i].pci_bus, sorted_device_info[i].pci_device,
+                               sorted_device_info[i].pci_function);
+                    if (asprintf(&tag, "pci-%04x_%02x_%02x_%1u", sorted_device_info[i].pci_domain, sorted_device_info[i].pci_bus,
+                                 sorted_device_info[i].pci_device, sorted_device_info[i].pci_function) >= 0) {
+                        if (!strcmp(selection, tag)) {
+                            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                                       "linux_dri_prime_default_device:  Found default at index %u \'%s\'", i,
+                                       sorted_device_info[i].device_name);
+                            sorted_device_info[i].default_device = true;
+                            found = true;
+                            break;
+                        }
+                    }
+                    free(tag);
+                }
+            }
+        }
+
+        loader_free_getenv(selection, inst);
+        return found;
+    }
+    return false;
+}
+
+// Search for the default device using the vga boot device information.
+static bool linux_vga_boot_default_device(struct loader_instance *inst, uint32_t device_count,
+                                          struct LinuxSortedDeviceInfo *sorted_device_info) {
+    bool found = false;
+    char boot_vga_path[4096];
+
+    for (int32_t i = 0; i < (int32_t)device_count; ++i) {
+        if (sorted_device_info[i].has_pci_bus_info) {
+            // Probe the boot_vga device information for each device using the PCI info.
+            snprintf(boot_vga_path, 4095, "/sys/bus/pci/devices/%04x:%02x:%02x.%x/boot_vga", sorted_device_info[i].pci_domain,
+                     sorted_device_info[i].pci_bus, sorted_device_info[i].pci_device, sorted_device_info[i].pci_function);
+            loader_log(inst, VULKAN_LOADER_DEBUG_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                       "linux_vga_boot_default_device:  Checking \'%s\'", boot_vga_path);
+
+            FILE *vga_boot_file = fopen(boot_vga_path, "rt");
+            // If file starts with a 1, this should be the default device
+            if (NULL != vga_boot_file) {
+                uint8_t val;
+                if (fread(&val, 1, 1, vga_boot_file) == 1 && val == '1') {
+                    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                               "linux_vga_boot_default_device:  Found default device at index %u \'%s\'", i,
+                               sorted_device_info[i].device_name);
+                    sorted_device_info[i].default_device = true;
+                    found = true;
+                }
+                fclose(vga_boot_file);
+            }
+            if (found) {
+                break;
+            }
+        }
+    }
+    return found;
+}
+
+// This function allocates an array in sorted_devices which must be freed by the caller if not null
+VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32_t icd_count,
+                                            struct loader_phys_dev_per_icd *icd_devices,
+                                            struct loader_physical_device_term **sorted_device_term) {
+    VkResult res = VK_SUCCESS;
+    bool is_vulkan_1_1 = false;
+    if (inst->app_api_major_version >= 1 && inst->app_api_minor_version >= 1) {
+        is_vulkan_1_1 = true;
+    }
+
+    struct LinuxSortedDeviceInfo *sorted_device_info = loader_instance_heap_alloc(
+        inst, inst->total_gpu_count * sizeof(struct LinuxSortedDeviceInfo), VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
+    if (NULL == sorted_device_info) {
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+    memset(sorted_device_info, 0, inst->total_gpu_count * sizeof(struct LinuxSortedDeviceInfo));
+
+    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "linux_read_sorted_physical_devices:  Original order:");
+
+    // Grab all the necessary info we can about each device
+    uint32_t index = 0;
+    for (uint32_t icd_idx = 0; icd_idx < icd_count; ++icd_idx) {
+        for (uint32_t phys_dev = 0; phys_dev < icd_devices[icd_idx].count; ++phys_dev) {
+            struct loader_icd_term *icd_term = icd_devices[icd_idx].this_icd_term;
+            VkPhysicalDeviceProperties dev_props = {};
+
+            sorted_device_info[index].physical_device = icd_devices[icd_idx].phys_devs[phys_dev];
+            sorted_device_info[index].icd_index = icd_idx;
+            sorted_device_info[index].icd_term = icd_term;
+            sorted_device_info[index].has_pci_bus_info = false;
+
+            icd_term->dispatch.GetPhysicalDeviceProperties(sorted_device_info[index].physical_device, &dev_props);
+            sorted_device_info[index].device_type = dev_props.deviceType;
+            strncpy(sorted_device_info[index].device_name, dev_props.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
+            sorted_device_info[index].vendor_id = dev_props.vendorID;
+            sorted_device_info[index].device_id = dev_props.deviceID;
+
+            bool device_is_1_1_capable =
+                VK_API_VERSION_MAJOR(dev_props.apiVersion) == 1 && VK_API_VERSION_MINOR(dev_props.apiVersion) >= 1;
+            sorted_device_info[index].has_pci_bus_info = device_is_1_1_capable;
+            if (!sorted_device_info[index].has_pci_bus_info) {
+                uint32_t ext_count;
+                icd_term->dispatch.EnumerateDeviceExtensionProperties(sorted_device_info[index].physical_device, NULL, &ext_count,
+                                                                      NULL);
+                if (ext_count > 0) {
+                    VkExtensionProperties *ext_props =
+                        (VkExtensionProperties *)loader_stack_alloc(sizeof(VkExtensionProperties) * ext_count);
+                    if (NULL == ext_props) {
+                        return VK_ERROR_OUT_OF_HOST_MEMORY;
+                    }
+                    icd_term->dispatch.EnumerateDeviceExtensionProperties(sorted_device_info[index].physical_device, NULL,
+                                                                          &ext_count, ext_props);
+                    for (uint32_t ext = 0; ext < ext_count; ++ext) {
+                        if (!strcmp(ext_props[ext].extensionName, VK_EXT_PCI_BUS_INFO_EXTENSION_NAME)) {
+                            sorted_device_info[index].has_pci_bus_info = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (sorted_device_info[index].has_pci_bus_info) {
+                VkPhysicalDevicePCIBusInfoPropertiesEXT pci_props = (VkPhysicalDevicePCIBusInfoPropertiesEXT){
+                    .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT};
+                VkPhysicalDeviceProperties2 dev_props2 = (VkPhysicalDeviceProperties2){
+                    .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, .pNext = (VkBaseInStructure *)&pci_props};
+                if (is_vulkan_1_1 && device_is_1_1_capable) {
+                    icd_term->dispatch.GetPhysicalDeviceProperties2(sorted_device_info[index].physical_device, &dev_props2);
+                } else {
+                    icd_term->dispatch.GetPhysicalDeviceProperties2KHR(sorted_device_info[index].physical_device, &dev_props2);
+                }
+                sorted_device_info[index].pci_domain = pci_props.pciDomain;
+                sorted_device_info[index].pci_bus = pci_props.pciBus;
+                sorted_device_info[index].pci_device = pci_props.pciDevice;
+                sorted_device_info[index].pci_function = pci_props.pciFunction;
+            }
+            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "           [%u] %s", index,
+                       sorted_device_info[index].device_name);
+            index++;
+        }
+    }
+
+    // Select default device in the following order:
+    //   1. If device select environment variable defined, use that
+    //   2. If DRI Prime device select environment variable defined, use that
+    //   3. If XCB is enabled, try selecting default XCB device.
+    //   4. If VGA boot device defined, select that
+    if (linux_env_var_default_device(inst, inst->total_gpu_count, sorted_device_info)) {
+        // Print out selected
+    } else if (linux_dri_prime_default_device(inst, inst->total_gpu_count, sorted_device_info)) {
+        // Print out selected
+    }
+#if defined(VK_USE_PLATFORM_XCB_KHR) && defined(LOADER_ENABLE_DRM)
+    else if (inst->wsi_xcb_surface_enabled && linux_find_xcb_default_device(inst, inst->total_gpu_count, sorted_device_info)) {
+        // Print out selected
+    }
+#endif  // defined(VK_USE_PLATFORM_XCB_KHR) && defined(LOADER_ENABLE_DRM)
+    else if (linux_vga_boot_default_device(inst, inst->total_gpu_count, sorted_device_info)) {
+        // Print out selected
+    }
+
+    // Sort devices by PCI info
+    qsort(sorted_device_info, inst->total_gpu_count, sizeof(struct LinuxSortedDeviceInfo), compare_devices);
+
+    // If we have a selected index, add that first.
+    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "linux_read_sorted_physical_devices:  Order set to:");
+
+    // Add all others after (they've already been sorted)
+    for (uint32_t dev = 0; dev < inst->total_gpu_count; ++dev) {
+        sorted_device_term[dev]->this_icd_term = sorted_device_info[dev].icd_term;
+        sorted_device_term[dev]->icd_index = sorted_device_info[dev].icd_index;
+        sorted_device_term[dev]->phys_dev = sorted_device_info[dev].physical_device;
+        loader_set_dispatch((void *)sorted_device_term[dev], inst->disp);
+        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "           [%u] %s  %s", dev,
+                   sorted_device_info[dev].device_name, (sorted_device_info[dev].default_device ? "[default]" : ""));
+    }
+
+    if (NULL != sorted_device_info) {
+        loader_instance_heap_free(inst, sorted_device_info);
+    }
+
+    return res;
+}
+
+// This function allocates an array in sorted_devices which must be freed by the caller if not null
+VkResult linux_read_sorted_physical_device_groups(struct loader_instance *inst, uint32_t group_count,
+                                                  struct loader_physical_device_group_term *sorted_group_term) {
+    VkResult res = VK_SUCCESS;
+    bool is_vulkan_1_1 = false;
+    if (inst->app_api_major_version >= 1 && inst->app_api_minor_version >= 1) {
+        is_vulkan_1_1 = true;
+    }
+
+    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+               "linux_read_sorted_physical_device_groups:  Original order:");
+
+    for (uint32_t group = 0; group < group_count; ++group) {
+        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "           Group %u", group);
+
+        struct loader_icd_term *icd_term = sorted_group_term[group].this_icd_term;
+        for (uint32_t gpu = 0; gpu < sorted_group_term[group].group_props.physicalDeviceCount; ++gpu) {
+            VkPhysicalDeviceProperties dev_props = {};
+
+            sorted_group_term[group].internal_device_info[gpu].physical_device =
+                sorted_group_term[group].group_props.physicalDevices[gpu];
+            sorted_group_term[group].internal_device_info[gpu].has_pci_bus_info = false;
+
+            icd_term->dispatch.GetPhysicalDeviceProperties(sorted_group_term[group].internal_device_info[gpu].physical_device,
+                                                           &dev_props);
+            sorted_group_term[group].internal_device_info[gpu].device_type = dev_props.deviceType;
+            strncpy(sorted_group_term[group].internal_device_info[gpu].device_name, dev_props.deviceName,
+                    VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
+            sorted_group_term[group].internal_device_info[gpu].vendor_id = dev_props.vendorID;
+            sorted_group_term[group].internal_device_info[gpu].device_id = dev_props.deviceID;
+
+            bool device_is_1_1_capable =
+                VK_API_VERSION_MAJOR(dev_props.apiVersion) == 1 && VK_API_VERSION_MINOR(dev_props.apiVersion) >= 1;
+            sorted_group_term[group].internal_device_info[gpu].has_pci_bus_info = device_is_1_1_capable;
+            if (!sorted_group_term[group].internal_device_info[gpu].has_pci_bus_info) {
+                uint32_t ext_count;
+                icd_term->dispatch.EnumerateDeviceExtensionProperties(
+                    sorted_group_term[group].internal_device_info[gpu].physical_device, NULL, &ext_count, NULL);
+                if (ext_count > 0) {
+                    VkExtensionProperties *ext_props =
+                        (VkExtensionProperties *)loader_stack_alloc(sizeof(VkExtensionProperties) * ext_count);
+                    if (NULL == ext_props) {
+                        return VK_ERROR_OUT_OF_HOST_MEMORY;
+                    }
+                    icd_term->dispatch.EnumerateDeviceExtensionProperties(
+                        sorted_group_term[group].internal_device_info[gpu].physical_device, NULL, &ext_count, ext_props);
+                    for (uint32_t ext = 0; ext < ext_count; ++ext) {
+                        if (!strcmp(ext_props[ext].extensionName, VK_EXT_PCI_BUS_INFO_EXTENSION_NAME)) {
+                            sorted_group_term[group].internal_device_info[gpu].has_pci_bus_info = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (sorted_group_term[group].internal_device_info[gpu].has_pci_bus_info) {
+                VkPhysicalDevicePCIBusInfoPropertiesEXT pci_props = (VkPhysicalDevicePCIBusInfoPropertiesEXT){
+                    .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT};
+                VkPhysicalDeviceProperties2 dev_props2 = (VkPhysicalDeviceProperties2){
+                    .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, .pNext = (VkBaseInStructure *)&pci_props};
+
+                if (is_vulkan_1_1 && device_is_1_1_capable) {
+                    icd_term->dispatch.GetPhysicalDeviceProperties2(
+                        sorted_group_term[group].internal_device_info[gpu].physical_device, &dev_props2);
+                } else {
+                    icd_term->dispatch.GetPhysicalDeviceProperties2KHR(
+                        sorted_group_term[group].internal_device_info[gpu].physical_device, &dev_props2);
+                }
+
+                sorted_group_term[group].internal_device_info[gpu].pci_domain = pci_props.pciDomain;
+                sorted_group_term[group].internal_device_info[gpu].pci_bus = pci_props.pciBus;
+                sorted_group_term[group].internal_device_info[gpu].pci_device = pci_props.pciDevice;
+                sorted_group_term[group].internal_device_info[gpu].pci_function = pci_props.pciFunction;
+            }
+            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "               [%u] %s", gpu,
+                       sorted_group_term[group].internal_device_info[gpu].device_name);
+        }
+
+        // Select default device in the following order:
+        //   1. If device select environment variable defined, use that
+        //   2. If DRI Prime device select environment variable defined, use that
+        //   3. If XCB is enabled, try selecting default XCB device.
+        //   4. If VGA boot device defined, select that
+        if (linux_env_var_default_device(inst, sorted_group_term[group].group_props.physicalDeviceCount,
+                                         sorted_group_term[group].internal_device_info)) {
+            // Print out selected
+        } else if (linux_dri_prime_default_device(inst, sorted_group_term[group].group_props.physicalDeviceCount,
+                                                  sorted_group_term[group].internal_device_info)) {
+            // Print out selected
+        }
+#if defined(VK_USE_PLATFORM_XCB_KHR) && defined(LOADER_ENABLE_DRM)
+        else if (inst->wsi_xcb_surface_enabled &&
+                 linux_find_xcb_default_device(inst, sorted_group_term[group].group_props.physicalDeviceCount,
+                                               sorted_group_term[group].internal_device_info)) {
+            // Print out selected
+        }
+#endif  // defined(VK_USE_PLATFORM_XCB_KHR) && defined(LOADER_ENABLE_DRM)
+        else if (linux_vga_boot_default_device(inst, sorted_group_term[group].group_props.physicalDeviceCount,
+                                               sorted_group_term[group].internal_device_info)) {
+            // Print out selected
+        }
+
+        // Sort GPUs in each group
+        qsort(sorted_group_term[group].internal_device_info, sorted_group_term[group].group_props.physicalDeviceCount,
+              sizeof(struct LinuxSortedDeviceInfo), compare_devices);
+    }
+
+    // Sort device groups by PCI info
+    qsort(sorted_group_term, group_count, sizeof(struct loader_physical_device_group_term), compare_device_groups);
+
+    if (loader_get_debug_level() & (VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT)) {
+        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                   "linux_read_sorted_physical_device_groups:  Sorted order:");
+        for (uint32_t group = 0; group < group_count; ++group) {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "           Group %u", group);
+            for (uint32_t gpu = 0; gpu < sorted_group_term[group].group_props.physicalDeviceCount; ++gpu) {
+                loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "               [%u] %s %s", gpu,
+                           sorted_group_term[group].internal_device_info[gpu].device_name,
+                           (sorted_group_term[group].internal_device_info[gpu].default_device ? "[default]" : ""));
+            }
+        }
+    }
+
+    return res;
+}
+
+#endif  // LOADER_ENABLE_LINUX_SORT

--- a/loader/loader_linux.h
+++ b/loader/loader_linux.h
@@ -1,0 +1,43 @@
+/*
+ *
+ * Copyright (c) 2021 The Khronos Group Inc.
+ * Copyright (c) 2021 Valve Corporation
+ * Copyright (c) 2021 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Mark Young <marky@lunarg.com>
+ *
+ */
+
+#pragma once
+
+#ifdef LOADER_ENABLE_LINUX_SORT
+
+#include "loader_common.h"
+
+// This function allocates an array in sorted_devices which must be freed by the caller if not null
+VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32_t icd_count,
+                                            struct loader_phys_dev_per_icd *icd_devices,
+                                            struct loader_physical_device_term **sorted_device_term);
+
+// This function allocates an array in sorted_devices which must be freed by the caller if not null
+VkResult linux_read_sorted_physical_device_groups(struct loader_instance *inst, uint32_t group_count,
+                                                  struct loader_physical_device_group_term *sorted_group_term);
+
+#if defined(VK_USE_PLATFORM_XCB_KHR) && defined(LOADER_ENABLE_DRM)
+bool linux_find_xcb_default_device(struct loader_instance *inst, uint32_t device_count,
+                                   struct LinuxSortedDeviceInfo *sorted_device_info);
+#endif  // defined(VK_USE_PLATFORM_XCB_KHR) && defined(LOADER_ENABLE_DRM)
+
+#endif  // LOADER_ENABLE_LINUX_SORT

--- a/loader/xcb_select.c
+++ b/loader/xcb_select.c
@@ -1,0 +1,135 @@
+#if defined(VK_USE_PLATFORM_XCB_KHR) && defined(LOADER_ENABLE_DRM)
+/*
+ * Copyright © 2019 Red Hat
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/* connect to an X server and work out the default device. */
+
+#include <xcb/xcb.h>
+#include <xcb/dri3.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <xf86drm.h>
+
+#include "loader_linux.h"
+#include "log.h"
+
+static int ds_dri3_open(xcb_connection_t *conn, xcb_window_t root, uint32_t provider) {
+    xcb_dri3_open_cookie_t cookie;
+    xcb_dri3_open_reply_t *reply;
+    int fd;
+
+    cookie = xcb_dri3_open(conn, root, provider);
+
+    reply = xcb_dri3_open_reply(conn, cookie, NULL);
+    if (!reply) return -1;
+
+    if (reply->nfd != 1) {
+        free(reply);
+        return -1;
+    }
+
+    fd = xcb_dri3_open_reply_fds(conn, reply)[0];
+    free(reply);
+    fcntl(fd, F_SETFD, fcntl(fd, F_GETFD) | FD_CLOEXEC);
+
+    return fd;
+}
+
+bool linux_find_xcb_default_device(struct loader_instance *inst, uint32_t device_count,
+                                   struct LinuxSortedDeviceInfo *sorted_device_info) {
+    const xcb_setup_t *setup;
+    xcb_screen_iterator_t iter;
+    int scrn;
+    xcb_connection_t *conn;
+    conn = xcb_connect(NULL, &scrn);
+    bool found = false;
+
+    if (!conn) {
+        goto out;
+    }
+
+    loader_log(inst, VULKAN_LOADER_DEBUG_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "linux_find_xcb_default_device: Checking XCB DRI info");
+
+    xcb_query_extension_cookie_t dri3_cookie;
+    xcb_query_extension_reply_t *dri3_reply;
+
+    dri3_cookie = xcb_query_extension(conn, 4, "DRI3");
+    dri3_reply = xcb_query_extension_reply(conn, dri3_cookie, NULL);
+
+    if (!dri3_reply) {
+        goto out;
+    }
+
+    if (dri3_reply->present == 0) {
+        goto out;
+    }
+    setup = xcb_get_setup(conn);
+    iter = xcb_setup_roots_iterator(setup);
+
+    xcb_screen_t *screen = iter.data;
+
+    int dri3_fd = ds_dri3_open(conn, screen->root, 0);
+    if (dri3_fd == -1) {
+        goto out;
+    }
+
+    drmDevicePtr xdev;
+    int ret = drmGetDevice2(dri3_fd, 0, &xdev);
+    close(dri3_fd);
+    if (ret < 0) {
+        goto out;
+    }
+
+    for (int32_t i = 0; i < (int32_t)device_count; i++) {
+        if (sorted_device_info[i].has_pci_bus_info) {
+            if (xdev->businfo.pci->domain == sorted_device_info[i].pci_domain &&
+                xdev->businfo.pci->bus == sorted_device_info[i].pci_bus &&
+                xdev->businfo.pci->dev == sorted_device_info[i].pci_device &&
+                xdev->businfo.pci->func == sorted_device_info[i].pci_function) {
+                loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                           "linux_find_xcb_default_device:  Found default at index %u \'%s\' using PCI info", i,
+                           sorted_device_info[i].device_name);
+                sorted_device_info[i].default_device = true;
+                found = true;
+                break;
+            }
+        } else {
+            if (xdev->deviceinfo.pci->vendor_id == sorted_device_info[i].vendor_id &&
+                xdev->deviceinfo.pci->device_id == sorted_device_info[i].device_id) {
+                loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                           "linux_find_xcb_default_device:  Found default at index %u \'%s\' using Vendor/Device info", i,
+                           sorted_device_info[i].device_name);
+                sorted_device_info[i].default_device = true;
+                found = true;
+                break;
+            }
+        }
+    }
+out:
+    if (conn) {
+        xcb_disconnect(conn);
+    }
+    return found;
+}
+#endif  // defined(VK_USE_PLATFORM_XCB_KHR) && defined(LOADER_ENABLE_DRM)

--- a/tests/framework/icd/physical_device.h
+++ b/tests/framework/icd/physical_device.h
@@ -34,7 +34,8 @@ struct PhysicalDevice {
     PhysicalDevice() {}
     PhysicalDevice(std::string name) : deviceName(name) {}
     PhysicalDevice(const char* name) : deviceName(name) {}
-
+    PhysicalDevice(std::string name, uint32_t bus) : deviceName(name), pci_bus(bus) {}
+    PhysicalDevice(const char* name, uint32_t bus) : deviceName(name), pci_bus(bus) {}
     DispatchableHandle<VkPhysicalDevice> vk_physical_device;
     BUILDER_VALUE(PhysicalDevice, std::string, deviceName, "")
     BUILDER_VALUE(PhysicalDevice, VkPhysicalDeviceProperties, properties, {})
@@ -57,6 +58,7 @@ struct PhysicalDevice {
     // The purpose of this list is so that vkGetDeviceProcAddr returns 'a real function pointer' in tests
     // without actually implementing any of the logic inside of it.
     BUILDER_VECTOR(PhysicalDevice, VulkanFunction, known_device_functions, device_function)
+    uint32_t pci_bus{};
 };
 
 struct PhysicalDeviceGroup {

--- a/tests/loader_handle_validation_tests.cpp
+++ b/tests/loader_handle_validation_tests.cpp
@@ -2144,6 +2144,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingXlibSurf) {
 }
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
+#if 0 // Disable for now to get this commit in
 static VkBool32 JunkDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
                                        VkDebugUtilsMessageTypeFlagsEXT messageTypes,
                                        const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData) {
@@ -2155,7 +2156,6 @@ static VkBool32 JunkDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT me
     return VK_FALSE;
 }
 
-#if 0  // Disable for now to get this commit in
 TEST_F(LoaderHandleValidTests, VerifyHandleWrappingDebugUtilsMessenger) {
     Extension ext{"VK_EXT_debug_utils"};
     auto& driver = env->get_test_icd();


### PR DESCRIPTION
The loader ICD ordering could be random on Linux based on using readdir
to find ICD manifest files.  This can result in random behaviors as
applications that select only the first device can switch which device is
used.  To resolve this, port over the behavior of the Mesa device select
layer so that the default device in XCB or the OS device details is
always first, followed by all other devices sorted by Type then by PCI
bus ordering.

This also introduces a VK_LOADER_DEFAULT_DEVICE environment variable
that can be used to force a specific PCI device.  This environment variable
is actually a duplicate of the MESA_VK_DEVICE_SELECT variable, which is
also looked for if the loader environment variable is not found.