### PR TITLE
Fix test framework leaking registry entries

### DIFF
--- a/tests/framework/shim/shim.h
+++ b/tests/framework/shim/shim.h
@@ -110,6 +110,8 @@ struct D3DKMT_Adapter {
     fs::path path;
 };
 
+uint32_t setup_override(DebugMode debug_mode);
+void clear_override(DebugMode debug_mode, uint32_t random_base_path);
 #endif
 // Necessary to have inline definitions as shim is a dll and thus functions
 // defined in the .cpp wont be found by the rest of the application

--- a/tests/framework/shim/shim_common.cpp
+++ b/tests/framework/shim/shim_common.cpp
@@ -177,7 +177,8 @@ void clear_key_values(HKEY const& key) {
     }
 }
 
-void PlatformShim::setup_override(DebugMode debug_mode) {
+uint32_t setup_override(DebugMode debug_mode) {
+    uint32_t random_base_path = 0;
     std::random_device rd;
     std::ranlux48 gen(rd());
     std::uniform_int_distribution<uint32_t> dist(0, 2000000);
@@ -207,8 +208,9 @@ void PlatformShim::setup_override(DebugMode debug_mode) {
 
     setup_override_key(HKEY_LOCAL_MACHINE, random_base_path);
     setup_override_key(HKEY_CURRENT_USER, random_base_path);
+    return random_base_path;
 }
-void PlatformShim::clear_override(DebugMode debug_mode) {
+void clear_override(DebugMode debug_mode, uint32_t random_base_path) {
     if (debug_mode != DebugMode::no_delete) {
         revert_override(HKEY_CURRENT_USER, random_base_path);
         revert_override(HKEY_LOCAL_MACHINE, random_base_path);

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -127,16 +127,12 @@ PlatformShimWrapper::PlatformShimWrapper(DebugMode debug_mode) noexcept : debug_
 #elif defined(__linux__) || defined(__FreeBSD__)
     platform_shim = get_platform_shim();
 #endif
-    platform_shim->setup_override(debug_mode);
     platform_shim->reset(debug_mode);
 
     // leave it permanently on at full blast
     set_env_var("VK_LOADER_DEBUG", "all");
 }
-PlatformShimWrapper::~PlatformShimWrapper() noexcept {
-    platform_shim->reset(debug_mode);
-    platform_shim->clear_override(debug_mode);
-}
+PlatformShimWrapper::~PlatformShimWrapper() noexcept { platform_shim->reset(debug_mode); }
 
 TestICDHandle::TestICDHandle() noexcept {}
 TestICDHandle::TestICDHandle(fs::path const& icd_path) noexcept : icd_library(icd_path) {

--- a/tests/loader_testing_main.cpp
+++ b/tests/loader_testing_main.cpp
@@ -65,8 +65,22 @@ int main(int argc, char** argv) {
     set_env_var("HOME", "/home/fake_home");
 #endif
 
-    ::testing::InitGoogleTest(&argc, argv);
+#if defined(_WIN32)
+    // Death tests call main twice, this causes the override to be set up multiple times.
+    // Use an env-var to signal whether the override has been set up.
+    uint32_t random_base_path = 0;
+    std::string env_var{"size_large_enough"};
+    DWORD ret = GetEnvironmentVariable("VK_LOADER_TEST_REGISTRY_IS_SETUP", (LPSTR)env_var.c_str(), 256);
+    if (ret == 0) {
+        random_base_path = setup_override(DebugMode::none);
+        set_env_var("VK_LOADER_TEST_REGISTRY_IS_SETUP", "SETUP");
+    }
+#endif
 
+    ::testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
+#if defined(_WIN32)
+    clear_override(DebugMode::none, random_base_path);
+#endif
     return result;
 }


### PR DESCRIPTION
Previously, Death tests would unknowningly create multiple registry overrides
and subsequently leak them when the death test dies. This is fixed by only
calling override once in main and setting an environment variable to prevent
subprocesses (death tests) from calling override again.

This change also moves the override setup from the shim setup to main, since
it had no depencies on the shim library itself.