### PR TITLE
Fix crash from Null instance layer or extension ptr

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5174,11 +5174,17 @@ VkResult loader_validate_layers(const struct loader_instance *inst, const uint32
                                 const char *const *ppEnabledLayerNames, const struct loader_layer_list *list) {
     struct loader_layer_properties *prop;
 
+    if (layer_count > 0 && ppEnabledLayerNames == NULL) {
+        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+                   "loader_validate_instance_layers: ppEnabledLayerNames is NULL but enabledLayerCount is greater than zero");
+        return VK_ERROR_LAYER_NOT_PRESENT;
+    }
+
     for (uint32_t i = 0; i < layer_count; i++) {
         VkStringErrorFlags result = vk_string_validate(MaxLoaderStringLength, ppEnabledLayerNames[i]);
         if (result != VK_STRING_ERROR_NONE) {
             loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                       "loader_validate_layers: Device ppEnabledLayerNames contains string that is too long or is badly formed");
+                       "loader_validate_layers: ppEnabledLayerNames contains string that is too long or is badly formed");
             return VK_ERROR_LAYER_NOT_PRESENT;
         }
 
@@ -5204,6 +5210,13 @@ VkResult loader_validate_instance_extensions(struct loader_instance *inst, const
     struct loader_layer_list expanded_layers;
     memset(&active_layers, 0, sizeof(active_layers));
     memset(&expanded_layers, 0, sizeof(expanded_layers));
+
+    if (pCreateInfo->enabledExtensionCount > 0 && pCreateInfo->ppEnabledExtensionNames == NULL) {
+        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+                   "loader_validate_instance_extensions: Instance ppEnabledExtensionNames is NULL but enabledExtensionCount is "
+                   "greater than zero");
+        return VK_ERROR_EXTENSION_NOT_PRESENT;
+    }
     if (!loader_init_layer_list(inst, &active_layers)) {
         res = VK_ERROR_OUT_OF_HOST_MEMORY;
         goto out;

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -890,3 +890,20 @@ TEST(ExtensionManual, ToolingProperties) {
         string_eq(props.name, icd_tool_props.name);
     }
 }
+
+TEST_F(CreateInstance, InstanceNullLayerPtr) {
+    VkInstance inst = VK_NULL_HANDLE;
+    VkInstanceCreateInfo info{};
+    info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    info.enabledLayerCount = 1;
+
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(&info, VK_NULL_HANDLE, &inst), VK_ERROR_LAYER_NOT_PRESENT);
+}
+TEST_F(CreateInstance, InstanceNullExtensionPtr) {
+    VkInstance inst = VK_NULL_HANDLE;
+    VkInstanceCreateInfo info{};
+    info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    info.enabledExtensionCount = 1;
+
+    ASSERT_EQ(env->vulkan_functions.vkCreateInstance(&info, VK_NULL_HANDLE, &inst), VK_ERROR_EXTENSION_NOT_PRESENT);
+}


### PR DESCRIPTION
Passing in a VkInstanceCreateInfo where the layer count or extension count was non zero but
their respective pointers were NULL caused a nullptr dereference. The loader now checks for
this condition in the layer and instance extension validation functions and returns
VK_ERROR_LAYER|EXTENSION_NOT_PRESENT.