### PR TITLE
Improve test framework

### DIFF
--- a/tests/framework/icd/physical_device.h
+++ b/tests/framework/icd/physical_device.h
@@ -34,39 +34,21 @@ struct PhysicalDevice {
     PhysicalDevice() {}
     PhysicalDevice(std::string name) : deviceName(name) {}
     PhysicalDevice(const char* name) : deviceName(name) {}
-    PhysicalDevice& set_properties(VkPhysicalDeviceProperties properties) {
-        this->properties = properties;
-        return *this;
-    }
-    PhysicalDevice& set_features(VkPhysicalDeviceFeatures features) {
-        this->features = features;
-        return *this;
-    }
-    PhysicalDevice& set_memory_properties(VkPhysicalDeviceMemoryProperties memory_properties) {
-        this->memory_properties = memory_properties;
-        return *this;
-    }
-    PhysicalDevice& add_queue_family_properties(VkQueueFamilyProperties properties, bool support_present = true) {
-        queue_family_properties.push_back(MockQueueFamilyProperties(properties, support_present));
-        return *this;
-    }
-    PhysicalDevice& add_queue_family_properties(MockQueueFamilyProperties properties) {
-        queue_family_properties.push_back(properties);
-        return *this;
-    }
+
     DispatchableHandle<VkPhysicalDevice> vk_physical_device;
-    std::string deviceName;
-    VkPhysicalDeviceProperties properties{};
-    VkPhysicalDeviceFeatures features{};
-    VkPhysicalDeviceMemoryProperties memory_properties{};
-    std::vector<MockQueueFamilyProperties> queue_family_properties;
-    std::vector<VkFormatProperties> format_properties;
+    BUILDER_VALUE(PhysicalDevice, std::string, deviceName, "")
+    BUILDER_VALUE(PhysicalDevice, VkPhysicalDeviceProperties, properties, {})
+    BUILDER_VALUE(PhysicalDevice, VkPhysicalDeviceFeatures, features, {})
+    BUILDER_VALUE(PhysicalDevice, VkPhysicalDeviceMemoryProperties, memory_properties, {})
 
-    std::vector<Extension> extensions;
+    BUILDER_VECTOR(PhysicalDevice, MockQueueFamilyProperties, queue_family_properties, queue_family_properties)
+    BUILDER_VECTOR(PhysicalDevice, VkFormatProperties, format_properties, format_properties)
 
-    VkSurfaceCapabilitiesKHR surface_capabilities;
-    std::vector<VkSurfaceFormatKHR> surface_formats;
-    std::vector<VkPresentModeKHR> surface_present_modes;
+    BUILDER_VECTOR(PhysicalDevice, Extension, extensions, extension)
+
+    BUILDER_VALUE(PhysicalDevice, VkSurfaceCapabilitiesKHR, surface_capabilities, {})
+    BUILDER_VECTOR(PhysicalDevice, VkSurfaceFormatKHR, surface_formats, surface_format)
+    BUILDER_VECTOR(PhysicalDevice, VkPresentModeKHR, surface_present_modes, surface_present_mode)
 
     // VkDevice handles created from this physical device
     std::vector<VkDevice> device_handles;
@@ -74,7 +56,7 @@ struct PhysicalDevice {
     // List of function names which are 'known' to the physical device but have test defined implementations
     // The purpose of this list is so that vkGetDeviceProcAddr returns 'a real function pointer' in tests
     // without actually implementing any of the logic inside of it.
-    std::vector<VulkanFunction> known_device_functions;
+    BUILDER_VECTOR(PhysicalDevice, VulkanFunction, known_device_functions, device_function)
 };
 
 struct PhysicalDeviceGroup {

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -56,22 +56,23 @@ struct TestICD {
     CalledNegotiateInterface called_negotiate_interface = CalledNegotiateInterface::not_called;
 
     InterfaceVersionCheck interface_version_check = InterfaceVersionCheck::not_called;
-    uint32_t min_icd_interface_version = 0;
-    uint32_t max_icd_interface_version = 6;
+    BUILDER_VALUE(TestICD, uint32_t, min_icd_interface_version, 0)
+    BUILDER_VALUE(TestICD, uint32_t, max_icd_interface_version, 6)
     uint32_t icd_interface_version_received = 0;
 
     CalledEnumerateAdapterPhysicalDevices called_enumerate_adapter_physical_devices =
         CalledEnumerateAdapterPhysicalDevices::not_called;
 
-    bool enable_icd_wsi = false;
+    BUILDER_VALUE(TestICD, bool, enable_icd_wsi, false);
     UsingICDProvidedWSI is_using_icd_wsi = UsingICDProvidedWSI::not_using;
 
-    uint32_t icd_api_version = VK_MAKE_VERSION(1, 0, 0);
-    std::vector<LayerDefinition> instance_layers;
-    std::vector<Extension> instance_extensions;
-    std::vector<PhysicalDevice> physical_devices;
+    BUILDER_VALUE(TestICD, uint32_t, icd_api_version, VK_MAKE_VERSION(1, 0, 0))
+    BUILDER_VECTOR(TestICD, LayerDefinition, instance_layers, instance_layer)
+    BUILDER_VECTOR(TestICD, Extension, instance_extensions, instance_extension)
 
-    std::vector<PhysicalDeviceGroup> physical_device_groups;
+    BUILDER_VECTOR_MOVE_ONLY(TestICD, PhysicalDevice, physical_devices, physical_device);
+
+    BUILDER_VECTOR(TestICD, PhysicalDeviceGroup, physical_device_groups, physical_device_group);
 
     DispatchableHandle<VkInstance> instance_handle;
     std::vector<DispatchableHandle<VkDevice>> device_handles;
@@ -82,44 +83,15 @@ struct TestICD {
     // Unknown instance and physical device functions. Add a `VulkanFunction` to this list which will be searched in
     // vkGetInstanceProcAddr for custom_instance_functions and vk_icdGetPhysicalDeviceProcAddr for custom_physical_device_functions.
     // To add unknown device functions, add it to the PhysicalDevice directly (in the known_device_functions member)
-    std::vector<VulkanFunction> custom_instance_functions;
-    std::vector<VulkanFunction> custom_physical_device_functions;
+    BUILDER_VECTOR(TestICD, VulkanFunction, custom_instance_functions, custom_instance_function)
+    BUILDER_VECTOR(TestICD, VulkanFunction, custom_physical_device_functions, custom_physical_device_function)
 
     // Must explicitely state support for the tooling info extension, that way we can control if vkGetInstanceProcAddr returns a
     // function pointer for vkGetPhysicalDeviceToolPropertiesEXT
-    bool supports_tooling_info_ext = false;
+    BUILDER_VALUE(TestICD, bool, supports_tooling_info_ext, false)
     // List of tooling properties that this driver 'supports'
     std::vector<VkPhysicalDeviceToolPropertiesEXT> tooling_properties;
 
-    TestICD() {}
-    ~TestICD() {}
-
-    TestICD& SetMinICDInterfaceVersion(uint32_t icd_interface_version) {
-        this->min_icd_interface_version = icd_interface_version;
-        return *this;
-    }
-    TestICD& SetICDAPIVersion(uint32_t api_version) {
-        this->icd_api_version = api_version;
-        return *this;
-    }
-    TestICD& AddInstanceLayer(LayerDefinition layer) { return AddInstanceLayers({layer}); }
-
-    TestICD& AddInstanceLayers(std::vector<LayerDefinition> layers) {
-        this->instance_layers.reserve(layers.size() + this->instance_layers.size());
-        for (auto& layer : layers) {
-            this->instance_layers.push_back(layer);
-        }
-        return *this;
-    }
-    TestICD& AddInstanceExtension(Extension extension) { return AddInstanceExtensions({extension}); }
-
-    TestICD& AddInstanceExtensions(std::vector<Extension> extensions) {
-        this->instance_extensions.reserve(extensions.size() + this->instance_extensions.size());
-        for (auto& extension : extensions) {
-            this->instance_extensions.push_back(extension);
-        }
-        return *this;
-    }
     PhysicalDevice& GetPhysDevice(VkPhysicalDevice physicalDevice) {
         for (auto& phys_dev : physical_devices) {
             if (phys_dev.vk_physical_device.handle == physicalDevice) return phys_dev;

--- a/tests/framework/layer/layer_util.h
+++ b/tests/framework/layer/layer_util.h
@@ -30,11 +30,11 @@
 #include "test_util.h"
 
 struct LayerDefinition {
-    std::string layerName;
-    uint32_t specVersion = VK_MAKE_VERSION(1, 0, 0);
-    uint32_t implementationVersion = VK_MAKE_VERSION(1, 0, 0);
-    std::string description;
-    std::vector<Extension> extensions;
+    BUILDER_VALUE(LayerDefinition, std::string, layerName, {})
+    BUILDER_VALUE(LayerDefinition, uint32_t, specVersion, VK_MAKE_VERSION(1, 0, 0))
+    BUILDER_VALUE(LayerDefinition, uint32_t, implementationVersion, VK_MAKE_VERSION(1, 0, 0))
+    BUILDER_VALUE(LayerDefinition, std::string, description, {})
+    BUILDER_VECTOR(LayerDefinition, Extension, extensions, extension)
 
     LayerDefinition(std::string layerName, uint32_t specVersion = VK_MAKE_VERSION(1, 0, 0),
                     uint32_t implementationVersion = VK_MAKE_VERSION(1, 0, 0), std::string description = "",

--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -161,8 +161,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo*
     // next layer in the chain.
     layer_init_instance_dispatch_table(layer.instance_handle, &layer.instance_dispatch_table, fpGetInstanceProcAddr);
 
-    if (layer.create_instance_callback.callback)
-        result = layer.create_instance_callback.callback(layer, layer.create_instance_callback.data);
+    if (layer.create_instance_callback) result = layer.create_instance_callback(layer);
 
     return result;
 }
@@ -195,8 +194,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevi
     // initialize layer's dispatch table
     layer_init_device_dispatch_table(device.device_handle, &device.dispatch_table, fpGetDeviceProcAddr);
 
-    if (layer.create_device_callback.callback)
-        result = layer.create_device_callback.callback(layer, layer.create_device_callback.data);
+    if (layer.create_device_callback) result = layer.create_device_callback(layer);
 
     return result;
 }

--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -161,7 +161,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo*
     // next layer in the chain.
     layer_init_instance_dispatch_table(layer.instance_handle, &layer.instance_dispatch_table, fpGetInstanceProcAddr);
 
-    if (layer.create_instance_callback) result = layer.create_instance_callback(layer, layer.create_instance_callback_data);
+    if (layer.create_instance_callback.callback)
+        result = layer.create_instance_callback.callback(layer, layer.create_instance_callback.data);
 
     return result;
 }
@@ -194,7 +195,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevi
     // initialize layer's dispatch table
     layer_init_device_dispatch_table(device.device_handle, &device.dispatch_table, fpGetDeviceProcAddr);
 
-    if (layer.create_device_callback) result = layer.create_device_callback(layer, layer.create_device_callback_data);
+    if (layer.create_device_callback.callback)
+        result = layer.create_device_callback.callback(layer, layer.create_device_callback.data);
 
     return result;
 }

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -92,26 +92,34 @@ struct TestLayer {
     fs::path manifest_file_path;
     uint32_t manifest_version = VK_MAKE_VERSION(1, 1, 2);
 
-    bool is_meta_layer = false;
+    BUILDER_VALUE(TestLayer, bool, is_meta_layer, false)
 
-    std::string unique_name;
-    uint32_t api_version = VK_MAKE_VERSION(1, 0, 0);
-    uint32_t implementation_version = 2;
-    uint32_t min_implementation_version = 0;
-    std::string description;
+    BUILDER_VALUE(TestLayer, std::string, unique_name, {})
+    BUILDER_VALUE(TestLayer, uint32_t, api_version, VK_MAKE_VERSION(1, 0, 0))
+    BUILDER_VALUE(TestLayer, uint32_t, implementation_version, 2)
+    BUILDER_VALUE(TestLayer, uint32_t, min_implementation_version, 0)
+    BUILDER_VALUE(TestLayer, std::string, description, {})
 
-    std::vector<std::string> alternative_function_names;
+    BUILDER_VECTOR(TestLayer, std::string, alternative_function_names, alternative_function_name)
 
-    std::vector<Extension> instance_extensions;
-    std::vector<Extension> device_extensions;
+    BUILDER_VECTOR(TestLayer, Extension, instance_extensions, instance_extension)
+    BUILDER_VECTOR(TestLayer, Extension, device_extensions, device_extension)
 
-    std::string enable_environment;
-    std::string disable_environment;
+    BUILDER_VALUE(TestLayer, std::string, enable_environment, {});
+    BUILDER_VALUE(TestLayer, std::string, disable_environment, {});
 
-    std::vector<LayerDefinition> meta_component_layers;
+    BUILDER_VECTOR(TestLayer, LayerDefinition, meta_component_layers, meta_component_layer);
 
-    bool intercept_vkEnumerateInstanceExtensionProperties = false;
-    bool intercept_vkEnumerateInstanceLayerProperties = false;
+    BUILDER_VALUE(TestLayer, bool, intercept_vkEnumerateInstanceExtensionProperties, false)
+    BUILDER_VALUE(TestLayer, bool, intercept_vkEnumerateInstanceLayerProperties, false)
+    struct LayerCallback {
+        FP_layer_callback callback = nullptr;
+        void* data = nullptr;
+    };
+    // Called in vkCreateInstance after calling down the chain & returning
+    BUILDER_VALUE(TestLayer, LayerCallback, create_instance_callback, {})
+    // Called in vkCreateDevice after calling down the chain & returning
+    BUILDER_VALUE(TestLayer, LayerCallback, create_device_callback, {})
 
     PFN_vkGetInstanceProcAddr next_vkGetInstanceProcAddr = VK_NULL_HANDLE;
     PFN_vkGetDeviceProcAddr next_vkGetDeviceProcAddr = VK_NULL_HANDLE;
@@ -124,23 +132,6 @@ struct TestLayer {
         VkLayerDispatchTable dispatch_table;
     };
     std::vector<Device> created_devices;
-
-    // Called in vkCreateInstance after calling down the chain & returning
-    FP_layer_callback create_instance_callback = nullptr;
-    void* create_instance_callback_data = nullptr;
-
-    // Called in vkCreateDevice after calling down the chain & returning
-    FP_layer_callback create_device_callback = nullptr;
-    void* create_device_callback_data = nullptr;
-
-    void SetCreateInstanceCallback(FP_layer_callback callback, void* data) noexcept {
-        create_instance_callback = callback;
-        create_instance_callback_data = data;
-    }
-    void SetCreateDeviceCallback(FP_layer_callback callback, void* data) noexcept {
-        create_device_callback = callback;
-        create_device_callback_data = data;
-    }
 };
 
 using GetTestLayerFunc = TestLayer* (*)();

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -112,14 +112,10 @@ struct TestLayer {
 
     BUILDER_VALUE(TestLayer, bool, intercept_vkEnumerateInstanceExtensionProperties, false)
     BUILDER_VALUE(TestLayer, bool, intercept_vkEnumerateInstanceLayerProperties, false)
-    struct LayerCallback {
-        FP_layer_callback callback = nullptr;
-        void* data = nullptr;
-    };
     // Called in vkCreateInstance after calling down the chain & returning
-    BUILDER_VALUE(TestLayer, LayerCallback, create_instance_callback, {})
+    BUILDER_VALUE(TestLayer, std::function<VkResult(TestLayer& layer)>, create_instance_callback, {})
     // Called in vkCreateDevice after calling down the chain & returning
-    BUILDER_VALUE(TestLayer, LayerCallback, create_device_callback, {})
+    BUILDER_VALUE(TestLayer, std::function<VkResult(TestLayer& layer)>, create_device_callback, {})
 
     PFN_vkGetInstanceProcAddr next_vkGetInstanceProcAddr = VK_NULL_HANDLE;
     PFN_vkGetDeviceProcAddr next_vkGetDeviceProcAddr = VK_NULL_HANDLE;

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -107,11 +107,11 @@ VkResult CreateDebugUtilsMessenger(DebugUtilsWrapper& debug_utils) {
 
 void FillDebugUtilsCreateDetails(InstanceCreateInfo& create_info, DebugUtilsLogger& logger) {
     create_info.add_extension("VK_EXT_debug_utils");
-    create_info.inst_info.pNext = logger.get();
+    create_info.instance_info.pNext = logger.get();
 }
 void FillDebugUtilsCreateDetails(InstanceCreateInfo& create_info, DebugUtilsWrapper& wrapper) {
     create_info.add_extension("VK_EXT_debug_utils");
-    create_info.inst_info.pNext = wrapper.get();
+    create_info.instance_info.pNext = wrapper.get();
 }
 
 PlatformShimWrapper::PlatformShimWrapper(DebugMode debug_mode) noexcept : debug_mode(debug_mode) {

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -52,12 +52,8 @@ InstWrapper& InstWrapper::operator=(InstWrapper&& other) noexcept {
     return *this;
 }
 
-testing::AssertionResult InstWrapper::CheckCreate(VkResult result_to_check) {
-    VkResult res = functions->vkCreateInstance(create_info.get(), callbacks, &inst);
-    if (res == result_to_check)
-        return testing::AssertionSuccess();
-    else
-        return testing::AssertionFailure() << " Expected VkCreateInstance to return " << result_to_check << " but got " << res;
+void InstWrapper::CheckCreate(VkResult result_to_check) {
+    ASSERT_EQ(result_to_check, functions->vkCreateInstance(create_info.get(), callbacks, &inst));
 }
 
 std::vector<VkPhysicalDevice> InstWrapper::GetPhysDevs(uint32_t phys_dev_count, VkResult result_to_check) {

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -212,8 +212,9 @@ void FrameworkEnvironment::add_explicit_layer(ManifestLayer layer_manifest, cons
 void FrameworkEnvironment::add_layer_impl(ManifestLayer& layer_manifest, const std::string& json_name,
                                           fs::FolderManager& folder_manager, ManifestCategory category) {
     for (auto& layer : layer_manifest.layers) {
+        size_t cur_layer_index = layers.size();
         if (!layer.lib_path.str().empty()) {
-            std::string new_layer_name = layer.name + "_" + layer.lib_path.filename().str();
+            std::string new_layer_name = layer.name + "_" + std::to_string(cur_layer_index) + "_" + layer.lib_path.filename().str();
 
             auto new_layer_location = folder_manager.copy_file(layer.lib_path, new_layer_name);
 

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -298,12 +298,6 @@ struct TestICDDetails {
     BUILDER_VALUE(TestICDDetails, bool, use_env_var_icd_filenames, false);
     BUILDER_VALUE(TestICDDetails, bool, is_fake, false);
 };
-struct TestLayerDetails {
-    TestLayerDetails(fs::path layer_path, uint32_t api_version = VK_MAKE_VERSION(1, 0, 0)) noexcept
-        : layer_path(layer_path), api_version(api_version) {}
-    BUILDER_VALUE(TestLayerDetails, fs::path, layer_path, {});
-    BUILDER_VALUE(TestLayerDetails, uint32_t, api_version, VK_MAKE_VERSION(1, 0, 0));
-};
 
 struct FrameworkEnvironment {
     FrameworkEnvironment(DebugMode debug_mode = DebugMode::none) noexcept;
@@ -332,4 +326,8 @@ struct FrameworkEnvironment {
     std::vector<TestLayerHandle> layers;
 
     std::string env_var_vk_icd_filenames;
+
+   private:
+    void add_layer_impl(ManifestLayer& layer_manifest, const std::string& json_name, fs::FolderManager& folder_manager,
+                        ManifestCategory category);
 };

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -130,7 +130,7 @@ struct InstWrapper {
     InstWrapper& operator=(InstWrapper&&) noexcept;
 
     // Construct this VkInstance using googletest to assert if it succeeded
-    testing::AssertionResult CheckCreate(VkResult result_to_check = VK_SUCCESS);
+    void CheckCreate(VkResult result_to_check = VK_SUCCESS);
 
     // Convenience
     operator VkInstance() { return inst; }

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -290,24 +290,35 @@ struct TestLayerHandle {
 };
 
 struct TestICDDetails {
-    TestICDDetails(const char* icd_path, uint32_t api_version = VK_MAKE_VERSION(1, 0, 0)) noexcept
+    TestICDDetails(fs::path icd_path, uint32_t api_version = VK_MAKE_VERSION(1, 0, 0)) noexcept
         : icd_path(icd_path), api_version(api_version) {}
-    const char* icd_path = nullptr;
-    uint32_t api_version = VK_MAKE_VERSION(1, 0, 0);
+    BUILDER_VALUE(TestICDDetails, fs::path, icd_path, {});
+    BUILDER_VALUE(TestICDDetails, uint32_t, api_version, VK_MAKE_VERSION(1, 0, 0));
+    BUILDER_VALUE(TestICDDetails, std::string, json_name, "test_icd");
+    BUILDER_VALUE(TestICDDetails, bool, use_env_var_icd_filenames, false);
+    BUILDER_VALUE(TestICDDetails, bool, is_fake, false);
 };
 struct TestLayerDetails {
-    TestLayerDetails(const char* layer_path, uint32_t api_version = VK_MAKE_VERSION(1, 0, 0)) noexcept
+    TestLayerDetails(fs::path layer_path, uint32_t api_version = VK_MAKE_VERSION(1, 0, 0)) noexcept
         : layer_path(layer_path), api_version(api_version) {}
-    const char* layer_path = nullptr;
-    uint32_t api_version = VK_MAKE_VERSION(1, 0, 0);
+    BUILDER_VALUE(TestLayerDetails, fs::path, layer_path, {});
+    BUILDER_VALUE(TestLayerDetails, uint32_t, api_version, VK_MAKE_VERSION(1, 0, 0));
 };
 
 struct FrameworkEnvironment {
     FrameworkEnvironment(DebugMode debug_mode = DebugMode::none) noexcept;
 
-    void AddICD(TestICDDetails icd_details, const std::string& json_name) noexcept;
-    void AddImplicitLayer(ManifestLayer layer_manifest, const std::string& json_name) noexcept;
-    void AddExplicitLayer(ManifestLayer layer_manifest, const std::string& json_name) noexcept;
+    void add_icd(TestICDDetails icd_details) noexcept;
+    void add_implicit_layer(ManifestLayer layer_manifest, const std::string& json_name) noexcept;
+    void add_explicit_layer(ManifestLayer layer_manifest, const std::string& json_name) noexcept;
+
+    TestICD& get_test_icd(int index = 0) noexcept;
+    TestICD& reset_icd(int index = 0) noexcept;
+    fs::path get_test_icd_path(int index = 0) noexcept;
+
+    TestLayer& get_test_layer(int index = 0) noexcept;
+    TestLayer& reset_layer(int index = 0) noexcept;
+    fs::path get_test_layer_path(int index = 0) noexcept;
 
     PlatformShimWrapper platform_shim;
     fs::FolderManager null_folder;
@@ -316,45 +327,9 @@ struct FrameworkEnvironment {
     fs::FolderManager implicit_layer_folder;
     DebugUtilsLogger debug_log;
     VulkanFunctions vulkan_functions;
-};
-
-struct EnvVarICDOverrideShim : public FrameworkEnvironment {
-    EnvVarICDOverrideShim(DebugMode debug_mode = DebugMode::none) noexcept;
-
-    void SetEnvOverrideICD(const char* icd_path, const char* manifest_name) noexcept;
-
-    LibraryWrapper driver_wrapper;
-    GetNewTestICDFunc reset_icd;
-};
-
-struct SingleICDShim : public FrameworkEnvironment {
-    SingleICDShim(TestICDDetails icd_details, DebugMode debug_mode = DebugMode::none) noexcept;
-
-    TestICD& get_test_icd() noexcept;
-    TestICD& reset_icd() noexcept;
-
-    fs::path get_test_icd_path() noexcept;
-
-    TestICDHandle icd_handle;
-};
-
-struct MultipleICDShim : public FrameworkEnvironment {
-    MultipleICDShim(std::vector<TestICDDetails> icd_details_vector, DebugMode debug_mode = DebugMode::none) noexcept;
-
-    TestICD& get_test_icd(int index) noexcept;
-    TestICD& reset_icd(int index) noexcept;
-    fs::path get_test_icd_path(int index) noexcept;
 
     std::vector<TestICDHandle> icds;
-};
+    std::vector<TestLayerHandle> layers;
 
-struct FakeBinaryICDShim : public FrameworkEnvironment {
-    FakeBinaryICDShim(TestICDDetails read_icd_details, TestICDDetails fake_icd_details,
-                      DebugMode debug_mode = DebugMode::none) noexcept;
-
-    TestICD& get_test_icd() noexcept;
-    TestICD& reset_icd() noexcept;
-    fs::path get_test_icd_path() noexcept;
-
-    TestICDHandle real_icd;
+    std::string env_var_vk_icd_filenames;
 };

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -247,6 +247,7 @@ std::string fixup_backslashes_in_path(std::string const& in_path) {
     }
     return out;
 }
+fs::path fixup_backslashes_in_path(fs::path const& in_path) { return fixup_backslashes_in_path(in_path.str()); }
 
 path& path::operator+=(path const& in) {
     contents += in.contents;

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -596,65 +596,29 @@ VulkanFunctions::VulkanFunctions() : loader(FRAMEWORK_VULKAN_LIBRARY_PATH) {
 }
 
 InstanceCreateInfo::InstanceCreateInfo() {
-    inst_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-    app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    application_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
 }
 
 VkInstanceCreateInfo* InstanceCreateInfo::get() noexcept {
-    app_info.pApplicationName = app_name.c_str();
-    app_info.pEngineName = engine_name.c_str();
-    app_info.applicationVersion = app_version;
-    app_info.engineVersion = engine_version;
-    app_info.apiVersion = api_version;
-    inst_info.pApplicationInfo = &app_info;
-    inst_info.enabledLayerCount = static_cast<uint32_t>(enabled_layers.size());
-    inst_info.ppEnabledLayerNames = enabled_layers.data();
-    inst_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
-    inst_info.ppEnabledExtensionNames = enabled_extensions.data();
-    return &inst_info;
-}
-InstanceCreateInfo& InstanceCreateInfo::set_application_name(std::string app_name) {
-    this->app_name = app_name;
-    return *this;
-}
-InstanceCreateInfo& InstanceCreateInfo::set_engine_name(std::string engine_name) {
-    this->engine_name = engine_name;
-    return *this;
-}
-InstanceCreateInfo& InstanceCreateInfo::set_app_version(uint32_t app_version) {
-    this->app_version = app_version;
-    return *this;
-}
-InstanceCreateInfo& InstanceCreateInfo::set_engine_version(uint32_t engine_version) {
-    this->engine_version = engine_version;
-    return *this;
-}
-InstanceCreateInfo& InstanceCreateInfo::set_api_version(uint32_t api_version) {
-    this->api_version = api_version;
-    return *this;
+    application_info.pApplicationName = app_name.c_str();
+    application_info.pEngineName = engine_name.c_str();
+    application_info.applicationVersion = app_version;
+    application_info.engineVersion = engine_version;
+    application_info.apiVersion = api_version;
+    instance_info.pApplicationInfo = &application_info;
+    instance_info.enabledLayerCount = static_cast<uint32_t>(enabled_layers.size());
+    instance_info.ppEnabledLayerNames = enabled_layers.data();
+    instance_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
+    instance_info.ppEnabledExtensionNames = enabled_extensions.data();
+    return &instance_info;
 }
 InstanceCreateInfo& InstanceCreateInfo::set_api_version(uint32_t major, uint32_t minor, uint32_t patch) {
     this->api_version = VK_MAKE_API_VERSION(0, major, minor, patch);
     return *this;
 }
-InstanceCreateInfo& InstanceCreateInfo::add_layer(const char* layer_name) {
-    enabled_layers.push_back(layer_name);
-    return *this;
-}
-InstanceCreateInfo& InstanceCreateInfo::add_extension(const char* ext_name) {
-    enabled_extensions.push_back(ext_name);
-    return *this;
-}
 
-DeviceQueueCreateInfo::DeviceQueueCreateInfo() { queue.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO; }
-DeviceQueueCreateInfo& DeviceQueueCreateInfo::add_priority(float priority) {
-    priorities.push_back(priority);
-    return *this;
-}
-DeviceQueueCreateInfo& DeviceQueueCreateInfo::set_props(VkQueueFamilyProperties props) {
-    queue.queueCount = props.queueCount;
-    return *this;
-}
+DeviceQueueCreateInfo::DeviceQueueCreateInfo() { queue_create_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO; }
 
 VkDeviceCreateInfo* DeviceCreateInfo::get() noexcept {
     dev.enabledLayerCount = static_cast<uint32_t>(enabled_layers.size());
@@ -667,18 +631,4 @@ VkDeviceCreateInfo* DeviceCreateInfo::get() noexcept {
     dev.queueCreateInfoCount = static_cast<uint32_t>(queue_infos.size());
     dev.pQueueCreateInfos = queue_infos.data();
     return &dev;
-}
-DeviceCreateInfo& DeviceCreateInfo::add_layer(const char* layer_name) {
-    enabled_layers.push_back(layer_name);
-
-    return *this;
-}
-DeviceCreateInfo& DeviceCreateInfo::add_extension(const char* ext_name) {
-    enabled_extensions.push_back(ext_name);
-
-    return *this;
-}
-DeviceCreateInfo& DeviceCreateInfo::add_device_queue(DeviceQueueCreateInfo queue_info_detail) {
-    queue_info_details.push_back(queue_info_detail);
-    return *this;
 }

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -499,11 +499,11 @@ inline std::string version_to_string(uint32_t version) {
     }
 
 struct ManifestVersion {
-    uint32_t major = 1;
-    uint32_t minor = 0;
-    uint32_t patch = 0;
-    explicit ManifestVersion() noexcept {};
-    explicit ManifestVersion(uint32_t major, uint32_t minor, uint32_t patch) noexcept : major(major), minor(minor), patch(patch){};
+    BUILDER_VALUE(ManifestVersion, uint32_t, major, 1)
+    BUILDER_VALUE(ManifestVersion, uint32_t, minor, 0)
+    BUILDER_VALUE(ManifestVersion, uint32_t, patch, 0)
+    ManifestVersion() noexcept {};
+    ManifestVersion(uint32_t major, uint32_t minor, uint32_t patch) noexcept : major(major), minor(minor), patch(patch){};
 
     std::string get_version_str() const noexcept {
         return std::string("\"file_format_version\": \"") + std::to_string(major) + "." + std::to_string(minor) + "." +
@@ -563,8 +563,8 @@ struct ManifestLayer {
         std::string get_manifest_str() const;
         VkLayerProperties get_layer_properties() const;
     };
-    ManifestVersion file_format_version;
-    std::vector<LayerDescription> layers;
+    BUILDER_VALUE(ManifestLayer, ManifestVersion, file_format_version, {})
+    BUILDER_VECTOR(ManifestLayer, LayerDescription, layers, layer)
 
     std::string get_manifest_str() const;
 };

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -57,6 +57,7 @@
 #include <unordered_map>
 #include <utility>
 #include <memory>
+#include <functional>
 
 #include <cassert>
 #include <cstring>

--- a/tests/loader_alloc_callback_tests.cpp
+++ b/tests/loader_alloc_callback_tests.cpp
@@ -199,11 +199,12 @@ class MemoryTracker {
 class Allocation : public ::testing::Test {
    protected:
     virtual void SetUp() {
-        env = std::unique_ptr<SingleICDShim>(new SingleICDShim(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_MAKE_VERSION(1, 0, 0))));
+        env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
+        env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     }
 
     virtual void TearDown() { env.reset(); }
-    std::unique_ptr<SingleICDShim> env;
+    std::unique_ptr<FrameworkEnvironment> env;
 };
 
 // Test making sure the allocation functions are called to allocate and cleanup everything during
@@ -260,7 +261,7 @@ TEST_F(Allocation, InstanceAndDevice) {
     MemoryTracker tracker;
     auto& driver = env->get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
-    driver.physical_devices[0].add_queue_family_properties({VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}});
+    driver.physical_devices[0].add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false});
     {
         InstWrapper inst{env->vulkan_functions, tracker.get()};
         inst.CheckCreate();
@@ -305,7 +306,7 @@ TEST_F(Allocation, InstanceButNotDevice) {
     {
         auto& driver = env->get_test_icd();
         driver.physical_devices.emplace_back("physical_device_0");
-        driver.physical_devices[0].add_queue_family_properties({VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}});
+        driver.physical_devices[0].add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false});
 
         InstWrapper inst{env->vulkan_functions, tracker.get()};
         inst.CheckCreate();
@@ -351,7 +352,7 @@ TEST_F(Allocation, DeviceButNotInstance) {
     {
         auto& driver = env->get_test_icd();
         driver.physical_devices.emplace_back("physical_device_0");
-        driver.physical_devices[0].add_queue_family_properties({VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}});
+        driver.physical_devices[0].add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false});
 
         InstWrapper inst{env->vulkan_functions};
         inst.CheckCreate();
@@ -415,9 +416,9 @@ TEST_F(Allocation, CreateInstanceIntentionalAllocFail) {
 TEST_F(Allocation, CreateDeviceIntentionalAllocFail) {
     auto& driver = env->get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
-    driver.physical_devices[0].add_queue_family_properties({VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}});
+    driver.physical_devices[0].add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false});
     driver.physical_devices.emplace_back("physical_device_1");
-    driver.physical_devices[1].add_queue_family_properties({VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}});
+    driver.physical_devices[1].add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false});
 
     InstWrapper inst{env->vulkan_functions};
     inst.CheckCreate();
@@ -469,7 +470,7 @@ TEST_F(Allocation, CreateDeviceIntentionalAllocFail) {
 TEST_F(Allocation, CreateInstanceDeviceIntentionalAllocFail) {
     auto& driver = env->get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
-    driver.physical_devices[0].add_queue_family_properties({VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}});
+    driver.physical_devices[0].add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false});
 
     size_t fail_index = 0;
     VkResult result = VK_ERROR_OUT_OF_HOST_MEMORY;
@@ -536,7 +537,9 @@ TEST_F(Allocation, CreateInstanceDeviceIntentionalAllocFail) {
 // to make sure the loader uses the valid ICD and doesn't report incompatible driver just because
 // an incompatible driver exists
 TEST(TryLoadWrongBinaries, CreateInstanceIntentionalAllocFail) {
-    FakeBinaryICDShim env(TestICDDetails(TEST_ICD_PATH_VERSION_2), TestICDDetails(CURRENT_PLATFORM_DUMMY_BINARY));
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.add_icd(TestICDDetails(CURRENT_PLATFORM_DUMMY_BINARY).set_is_fake(true));
     size_t fail_index = 0;
     VkResult result = VK_ERROR_OUT_OF_HOST_MEMORY;
     while (result == VK_ERROR_OUT_OF_HOST_MEMORY && fail_index <= 10000) {
@@ -568,7 +571,7 @@ TEST_F(Allocation, EnumeratePhysicalDevicesIntentionalAllocFail) {
 
         for (uint32_t i = 0; i < physical_dev_count; i++) {
             driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-            driver.physical_devices[i].add_queue_family_properties({VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}});
+            driver.physical_devices[i].add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false});
         }
         MemoryTracker tracker{MemoryTrackerSettings{false, 0, true, fail_index}};
         InstanceCreateInfo inst_create_info;

--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -30,7 +30,8 @@
 // Load the global function pointers with and without a NULL vkInstance handle.
 // Call the function to make sure it is callable, don't care about what is returned.
 TEST(GetProcAddr, GlobalFunctions) {
-    SingleICDShim env(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.get_test_icd().physical_devices.emplace_back("physical_device_0");
 
     auto& gipa = env.vulkan_functions.vkGetInstanceProcAddr;

--- a/tests/loader_handle_validation_tests.cpp
+++ b/tests/loader_handle_validation_tests.cpp
@@ -1658,13 +1658,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingAndroidSurface) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -1699,13 +1696,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingDirectFBSurf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -1740,13 +1734,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingFuchsiaSurf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -1781,13 +1772,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingGGPSurf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -1822,13 +1810,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingIOSSurf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -1863,13 +1848,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingMacOSSurf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -1904,13 +1886,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingMetalSurf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -1945,13 +1924,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingQNXSurf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -1986,13 +1962,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingViNNSurf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -2027,13 +2000,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingWaylandSurf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -2068,13 +2038,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingWin32Surf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->add_explicit_layer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -2109,13 +2076,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingXCBSurf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -2150,13 +2114,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingXlibSurf) {
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    ManifestLayer::LayerDescription wrap_objects_description{};
-    wrap_objects_description.name = wrap_objects_name;
-    wrap_objects_description.lib_path = TEST_LAYER_WRAP_OBJECTS;
-
-    ManifestLayer wrap_objects_layer;
-    wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+        "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};

--- a/tests/loader_handle_validation_tests.cpp
+++ b/tests/loader_handle_validation_tests.cpp
@@ -30,10 +30,12 @@
 
 class LoaderHandleValidTests : public ::testing::Test {
    protected:
-    virtual void SetUp() { env = std::unique_ptr<SingleICDShim>(new SingleICDShim(TEST_ICD_PATH_VERSION_2)); }
-
+    virtual void SetUp() {
+        env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
+        env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    }
     virtual void TearDown() { env.reset(); }
-    std::unique_ptr<SingleICDShim> env;
+    std::unique_ptr<FrameworkEnvironment> env;
 };
 
 // ---- Invalid Instance tests
@@ -91,7 +93,7 @@ TEST_F(LoaderHandleValidTests, BadInstDestroySurface) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -111,7 +113,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateHeadlessSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -136,7 +138,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateDisplayPlaneSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -163,7 +165,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateAndroidSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_android_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -190,7 +192,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateDirectFBSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_directfb_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -217,7 +219,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateFuchsiaSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_FUCHSIA_imagepipe_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -245,7 +247,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateGGPSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_GGP_stream_descriptor_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -273,7 +275,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateIOSSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_MVK_ios_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -300,7 +302,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateMacOSSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_MVK_macos_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -327,7 +329,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateMetalSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_metal_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -354,7 +356,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateQNXSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_QNX_screen_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -381,7 +383,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateViNNSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_NN_vi_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -408,7 +410,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateWaylandSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_wayland_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -435,7 +437,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateWin32Surf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_win32_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -462,7 +464,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateXCBSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xcb_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -489,7 +491,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateXlibSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xlib_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -906,7 +908,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceSupportKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -927,7 +929,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceCapsKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -947,7 +949,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceFormatsKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -967,7 +969,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfacePresentModesKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -989,7 +991,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDirectFBPresentSupportKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_directfb_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1012,7 +1014,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetQNXPresentSupportKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_QNX_screen_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1034,7 +1036,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevWaylandPresentSupportKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_wayland_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1056,7 +1058,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevWin32PresentSupportKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_win32_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1078,7 +1080,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetXCBPresentSupportKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xcb_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1102,7 +1104,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetXlibPresentSupportKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xlib_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1125,7 +1127,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPropsKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1146,7 +1148,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPlanePropsKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1167,7 +1169,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneSupportedDisplaysKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1188,7 +1190,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayModePropsKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1209,7 +1211,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevCreateDisplayModeKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1234,7 +1236,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneCapsKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1255,7 +1257,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevPresentRectsKHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1277,7 +1279,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayProps2KHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_display_properties2"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1298,7 +1300,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPlaneProps2KHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_display_properties2"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1319,7 +1321,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayModeProps2KHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_display_properties2"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1340,7 +1342,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneCaps2KHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_display_properties2"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1364,7 +1366,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceCaps2KHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_surface_capabilities2"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1389,7 +1391,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceFormats2KHR) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_surface_capabilities2"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1495,7 +1497,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevAcquireDrmDisplayEXT) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_acquire_drm_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1517,7 +1519,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDrmDisplayEXT) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_acquire_drm_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1539,7 +1541,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevReleaseDisplayEXT) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_direct_mode_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1562,7 +1564,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevAcquireXlibDisplayEXT) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_acquire_xlib_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1584,7 +1586,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetRandROutputDisplayEXT) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_acquire_xlib_display"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
     InstWrapper instance(env->vulkan_functions);
@@ -1653,7 +1655,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingAndroidSurface) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_android_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -1694,7 +1696,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingDirectFBSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_directfb_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -1735,7 +1737,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingFuchsiaSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_FUCHSIA_imagepipe_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -1776,7 +1778,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingGGPSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_GGP_stream_descriptor_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -1817,7 +1819,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingIOSSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_MVK_ios_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -1858,7 +1860,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingMacOSSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_MVK_macos_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -1899,7 +1901,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingMetalSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_metal_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -1940,7 +1942,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingQNXSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_QNX_screen_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -1981,7 +1983,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingViNNSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_NN_vi_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -2022,7 +2024,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingWaylandSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_wayland_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -2063,7 +2065,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingWin32Surf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_win32_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -2072,7 +2074,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingWin32Surf) {
 
     ManifestLayer wrap_objects_layer;
     wrap_objects_layer.layers.push_back(wrap_objects_description);
-    env->AddExplicitLayer(wrap_objects_layer, "wrap_objects_layer.json");
+    env->add_explicit_layer(wrap_objects_layer, "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
@@ -2104,7 +2106,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingXCBSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xcb_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -2145,7 +2147,7 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingXlibSurf) {
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xlib_surface"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({first_ext, second_ext});
+    driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};
@@ -2192,11 +2194,11 @@ static VkBool32 JunkDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT me
     return VK_FALSE;
 }
 
-#if 0 // Disable for now to get this commit in
+#if 0  // Disable for now to get this commit in
 TEST_F(LoaderHandleValidTests, VerifyHandleWrappingDebugUtilsMessenger) {
     Extension ext{"VK_EXT_debug_utils"};
     auto& driver = env->get_test_icd();
-    driver.AddInstanceExtensions({ext});
+    driver.add_instance_extensions({ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
     ManifestLayer::LayerDescription wrap_objects_description{};

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -241,28 +241,26 @@ TEST_F(LayerCreateInstance, GetPhysicalDeviceProperties2) {
         "regular_test_layer.json");
 
     auto& layer = env->get_test_layer(0);
-    layer.set_create_instance_callback(TestLayer::LayerCallback{
-        [](TestLayer& layer, void* data) -> VkResult {
-            uint32_t phys_dev_count = 0;
-            VkResult res = layer.instance_dispatch_table.EnumeratePhysicalDevices(layer.instance_handle, &phys_dev_count, nullptr);
-            if (res != VK_SUCCESS || phys_dev_count > 1) {
-                return VK_ERROR_INITIALIZATION_FAILED;  // expecting only a single physical device.
-            }
-            VkPhysicalDevice phys_dev{};
-            res = layer.instance_dispatch_table.EnumeratePhysicalDevices(layer.instance_handle, &phys_dev_count, &phys_dev);
-            if (res != VK_SUCCESS) {
-                return VK_ERROR_INITIALIZATION_FAILED;
-            }
-            VkPhysicalDeviceProperties2 props2{};
-            props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-            layer.instance_dispatch_table.GetPhysicalDeviceProperties2(phys_dev, &props2);
+    layer.set_create_instance_callback([](TestLayer& layer) -> VkResult {
+        uint32_t phys_dev_count = 0;
+        VkResult res = layer.instance_dispatch_table.EnumeratePhysicalDevices(layer.instance_handle, &phys_dev_count, nullptr);
+        if (res != VK_SUCCESS || phys_dev_count > 1) {
+            return VK_ERROR_INITIALIZATION_FAILED;  // expecting only a single physical device.
+        }
+        VkPhysicalDevice phys_dev{};
+        res = layer.instance_dispatch_table.EnumeratePhysicalDevices(layer.instance_handle, &phys_dev_count, &phys_dev);
+        if (res != VK_SUCCESS) {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        VkPhysicalDeviceProperties2 props2{};
+        props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+        layer.instance_dispatch_table.GetPhysicalDeviceProperties2(phys_dev, &props2);
 
-            VkPhysicalDeviceFeatures2 features2{};
-            features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-            layer.instance_dispatch_table.GetPhysicalDeviceFeatures2(phys_dev, &features2);
-            return VK_SUCCESS;
-        },
-        nullptr});
+        VkPhysicalDeviceFeatures2 features2{};
+        features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+        layer.instance_dispatch_table.GetPhysicalDeviceFeatures2(phys_dev, &features2);
+        return VK_SUCCESS;
+    });
 
     InstWrapper inst{env->vulkan_functions};
     inst.create_info.add_layer(regular_layer_name).set_api_version(1, 1, 0);
@@ -280,22 +278,20 @@ TEST_F(LayerCreateInstance, GetPhysicalDeviceProperties2KHR) {
         "regular_test_layer.json");
 
     auto& layer = env->get_test_layer(0);
-    layer.set_create_instance_callback(TestLayer::LayerCallback{
-        [](TestLayer& layer, void* data) -> VkResult {
-            uint32_t phys_dev_count = 1;
-            VkPhysicalDevice phys_dev{};
-            layer.instance_dispatch_table.EnumeratePhysicalDevices(layer.instance_handle, &phys_dev_count, &phys_dev);
+    layer.set_create_instance_callback([](TestLayer& layer) -> VkResult {
+        uint32_t phys_dev_count = 1;
+        VkPhysicalDevice phys_dev{};
+        layer.instance_dispatch_table.EnumeratePhysicalDevices(layer.instance_handle, &phys_dev_count, &phys_dev);
 
-            VkPhysicalDeviceProperties2KHR props2{};
-            props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
-            layer.instance_dispatch_table.GetPhysicalDeviceProperties2KHR(phys_dev, &props2);
+        VkPhysicalDeviceProperties2KHR props2{};
+        props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
+        layer.instance_dispatch_table.GetPhysicalDeviceProperties2KHR(phys_dev, &props2);
 
-            VkPhysicalDeviceFeatures2KHR features2{};
-            features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
-            layer.instance_dispatch_table.GetPhysicalDeviceFeatures2KHR(phys_dev, &features2);
-            return VK_SUCCESS;
-        },
-        nullptr});
+        VkPhysicalDeviceFeatures2KHR features2{};
+        features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
+        layer.instance_dispatch_table.GetPhysicalDeviceFeatures2KHR(phys_dev, &features2);
+        return VK_SUCCESS;
+    });
 
     InstWrapper inst{env->vulkan_functions};
     inst.create_info.add_layer(regular_layer_name).add_extension("VK_KHR_get_physical_device_properties2");

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -772,7 +772,8 @@ TEST_F(EnumeratePhysicalDeviceGroups, TwoCallIncomplete) {
 #if defined(__linux__) || defined(__FreeBSD__)
 // Make sure the loader reports the correct message based on if USE_UNSAFE_FILE_SEARCH is set or not
 TEST(EnvironmentVariables, NonSecureEnvVarLookup) {
-    SingleICDShim env(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.get_test_icd().physical_devices.emplace_back("physical_device_0");
 
     DebugUtilsLogger log{VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT};
@@ -799,7 +800,8 @@ TEST(EnvironmentVariables, XDG) {
     set_env_var("XDG_DATA_DIRS", "::::/tmp/goober3:/tmp/goober4/with spaces:::");
     set_env_var("XDG_DATA_HOME", "::::/tmp/goober3:/tmp/goober4/with spaces:::");
 
-    SingleICDShim env{TestICDDetails{TEST_ICD_PATH_VERSION_6}};
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.get_test_icd().physical_devices.push_back({});
 
     InstWrapper inst{env.vulkan_functions};
@@ -828,12 +830,13 @@ TEST(EnvironmentVariables, VK_LAYER_PATH) {
     vk_layer_path += (HOME / "/ with spaces/:::::/tandy:").str();
     set_env_var("VK_LAYER_PATH", vk_layer_path);
 
-    SingleICDShim env{TestICDDetails{TEST_ICD_PATH_VERSION_6}};
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.get_test_icd().physical_devices.push_back({});
     env.platform_shim->redirect_path("/tmp/carol", env.explicit_layer_folder.location());
 
     const char* layer_name = "TestLayer";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
         "test_layer.json");

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -102,13 +102,10 @@ TEST_F(CreateInstance, LayerNotPresent) {
 
 TEST_F(CreateInstance, LayerPresent) {
     const char* layer_name = "TestLayer";
-    ManifestLayer::LayerDescription description{};
-    description.name = layer_name;
-    description.lib_path = TEST_LAYER_PATH_EXPORT_VERSION_1;
-
-    ManifestLayer layer;
-    layer.layers.push_back(description);
-    env->add_explicit_layer(layer, "test_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+        "test_layer.json");
 
     InstWrapper inst{env->vulkan_functions};
     inst.create_info.add_layer(layer_name);
@@ -125,21 +122,15 @@ TEST_F(EnumerateInstanceLayerProperties, UsageChecks) {
     const char* layer_name_1 = "TestLayer1";
     const char* layer_name_2 = "TestLayer1";
 
-    ManifestLayer::LayerDescription description1{};
-    description1.name = layer_name_1;
-    description1.lib_path = TEST_LAYER_PATH_EXPORT_VERSION_2;
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(layer_name_1).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+        "test_layer_1.json");
 
-    ManifestLayer layer1;
-    layer1.layers.push_back(description1);
-    env->add_explicit_layer(layer1, "test_layer_1.json");
-
-    ManifestLayer::LayerDescription description2{};
-    description2.name = layer_name_1;
-    description2.lib_path = TEST_LAYER_PATH_EXPORT_VERSION_2;
-
-    ManifestLayer layer2;
-    layer2.layers.push_back(description2);
-    env->add_explicit_layer(layer2, "test_layer_2.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(layer_name_2).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+        "test_layer_2.json");
 
     {  // OnePass
         VkLayerProperties layer_props[2] = {};
@@ -272,13 +263,10 @@ TEST_F(EnumerateDeviceLayerProperties, LayersMatch) {
     driver.physical_devices.emplace_back("physical_device_0");
 
     const char* layer_name = "TestLayer";
-    ManifestLayer::LayerDescription description{};
-    description.name = layer_name;
-    description.lib_path = TEST_LAYER_PATH_EXPORT_VERSION_2;
-
-    ManifestLayer layer;
-    layer.layers.push_back(description);
-    env->add_explicit_layer(layer, "test_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+        "test_layer.json");
 
     InstWrapper inst{env->vulkan_functions};
     inst.create_info.add_layer(layer_name);
@@ -569,24 +557,17 @@ TEST(TryLoadWrongBinaries, WrongExplicitAndImplicit) {
     env.get_test_icd().physical_devices.emplace_back("physical_device_0");
 
     const char* layer_name_0 = "DummyLayerExplicit";
-    auto description_0 = ManifestLayer::LayerDescription{};
-    description_0.name = layer_name_0;
-    description_0.lib_path = CURRENT_PLATFORM_DUMMY_BINARY;
-
-    ManifestLayer layer_0;
-    layer_0.layers.push_back(description_0);
+    auto layer_0 = ManifestLayer{}.add_layer(
+        ManifestLayer::LayerDescription{}.set_name(layer_name_0).set_lib_path(CURRENT_PLATFORM_DUMMY_BINARY));
 
     auto layer_loc_0 = env.explicit_layer_folder.write("dummy_test_layer_0.json", layer_0);
     env.platform_shim->add_manifest(ManifestCategory::explicit_layer, layer_loc_0);
 
     const char* layer_name_1 = "DummyLayerImplicit";
-    auto description_1 = ManifestLayer::LayerDescription{};
-    description_1.name = layer_name_1;
-    description_1.lib_path = CURRENT_PLATFORM_DUMMY_BINARY;
-    description_1.disable_environment = "DISABLE_ENV";
-
-    ManifestLayer layer_1;
-    layer_1.layers.push_back(description_1);
+    auto layer_1 = ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                 .set_name(layer_name_1)
+                                                 .set_lib_path(CURRENT_PLATFORM_DUMMY_BINARY)
+                                                 .set_disable_environment("DISABLE_ENV"));
 
     auto layer_loc_1 = env.implicit_layer_folder.write("dummy_test_layer_1.json", layer_1);
     env.platform_shim->add_manifest(ManifestCategory::implicit_layer, layer_loc_1);
@@ -850,15 +831,12 @@ TEST(EnvironmentVariables, VK_LAYER_PATH) {
     SingleICDShim env{TestICDDetails{TEST_ICD_PATH_VERSION_6}};
     env.get_test_icd().physical_devices.push_back({});
     env.platform_shim->redirect_path("/tmp/carol", env.explicit_layer_folder.location());
+
     const char* layer_name = "TestLayer";
-
-    ManifestLayer::LayerDescription description{};
-    description.name = layer_name;
-    description.lib_path = TEST_LAYER_PATH_EXPORT_VERSION_2;
-
-    ManifestLayer layer;
-    layer.layers.push_back(description);
-    env.AddExplicitLayer(layer, "test_layer.json");
+    env->add_explicit_layer(
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+        "test_layer.json");
 
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_layer(layer_name);

--- a/tests/loader_testing_main.cpp
+++ b/tests/loader_testing_main.cpp
@@ -70,8 +70,8 @@ int main(int argc, char** argv) {
     // Use an env-var to signal whether the override has been set up.
     uint32_t random_base_path = 0;
     std::string env_var{"size_large_enough"};
-    DWORD ret = GetEnvironmentVariable("VK_LOADER_TEST_REGISTRY_IS_SETUP", (LPSTR)env_var.c_str(), 256);
-    if (ret == 0) {
+    DWORD has_not_setup_tests = GetEnvironmentVariable("VK_LOADER_TEST_REGISTRY_IS_SETUP", (LPSTR)env_var.c_str(), 256);
+    if (has_not_setup_tests == 0) {
         random_base_path = setup_override(DebugMode::none);
         set_env_var("VK_LOADER_TEST_REGISTRY_IS_SETUP", "SETUP");
     }
@@ -80,7 +80,9 @@ int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
 #if defined(_WIN32)
-    clear_override(DebugMode::none, random_base_path);
+    if (has_not_setup_tests == 0) {
+        clear_override(DebugMode::none, random_base_path);
+    }
 #endif
     return result;
 }

--- a/tests/loader_threading_tests.cpp
+++ b/tests/loader_threading_tests.cpp
@@ -33,11 +33,12 @@
 class ThreadingTests : public ::testing::Test {
    protected:
     virtual void SetUp() {
-        env = std::unique_ptr<SingleICDShim>(new SingleICDShim(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_MAKE_VERSION(1, 0, 0))));
+        env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
+        env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     }
 
     virtual void TearDown() { env.reset(); }
-    std::unique_ptr<SingleICDShim> env;
+    std::unique_ptr<FrameworkEnvironment> env;
 };
 
 void create_destroy_device_loop(uint32_t num_loops_create_destroy_device, uint32_t num_loops_try_get_proc_addr, InstWrapper* inst,

--- a/tests/loader_unknown_ext_tests.cpp
+++ b/tests/loader_unknown_ext_tests.cpp
@@ -30,12 +30,12 @@
 class UnknownExtension : public ::testing::Test {
    protected:
     virtual void SetUp() {
-        env = std::unique_ptr<SingleICDShim>(
-            new SingleICDShim(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_MAKE_VERSION(1, 0, 0))));
+        env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
+        env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     }
 
     virtual void TearDown() { env.reset(); }
-    std::unique_ptr<SingleICDShim> env;
+    std::unique_ptr<FrameworkEnvironment> env;
 };
 
 /*

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -33,10 +33,12 @@
 
 class RegressionTests : public ::testing::Test {
    protected:
-    virtual void SetUp() { env = std::unique_ptr<SingleICDShim>(new SingleICDShim(TestICDDetails(TEST_ICD_PATH_VERSION_2))); }
-
+    virtual void SetUp() {
+        env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
+        env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    }
     virtual void TearDown() { env.reset(); }
-    std::unique_ptr<SingleICDShim> env;
+    std::unique_ptr<FrameworkEnvironment> env;
 
     int width = 100;
     int height = 100;
@@ -49,10 +51,10 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) { r
 
 TEST_F(RegressionTests, CreateSurfaceWin32) {
     auto& driver = env->get_test_icd();
-    driver.SetICDAPIVersion(VK_MAKE_VERSION(1, 0, 0));
-    driver.SetMinICDInterfaceVersion(5);
-    driver.AddInstanceExtension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
-    driver.AddInstanceExtension(Extension(VK_KHR_WIN32_SURFACE_EXTENSION_NAME));
+    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_min_icd_interface_version(5);
+    driver.add_instance_extension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
+    driver.add_instance_extension(Extension(VK_KHR_WIN32_SURFACE_EXTENSION_NAME));
     driver.enable_icd_wsi = true;
 
     InstWrapper inst{env->vulkan_functions};
@@ -116,10 +118,10 @@ TEST_F(RegressionTests, CreateSurfaceWin32) {
 #if defined(VK_USE_PLATFORM_XCB_KHR)
 TEST_F(RegressionTests, CreateSurfaceXCB) {
     auto& driver = env->get_test_icd();
-    driver.SetICDAPIVersion(VK_MAKE_VERSION(1, 0, 0));
-    driver.SetMinICDInterfaceVersion(5);
-    driver.AddInstanceExtension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
-    driver.AddInstanceExtension(Extension(VK_KHR_XCB_SURFACE_EXTENSION_NAME));
+    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_min_icd_interface_version(5);
+    driver.add_instance_extension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
+    driver.add_instance_extension(Extension(VK_KHR_XCB_SURFACE_EXTENSION_NAME));
     driver.enable_icd_wsi = true;
 
     InstWrapper inst{env->vulkan_functions};
@@ -177,10 +179,10 @@ TEST_F(RegressionTests, CreateSurfaceXCB) {
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
 TEST_F(RegressionTests, CreateSurfaceXLIB) {
     auto& driver = env->get_test_icd();
-    driver.SetICDAPIVersion(VK_MAKE_VERSION(1, 0, 0));
-    driver.SetMinICDInterfaceVersion(5);
-    driver.AddInstanceExtension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
-    driver.AddInstanceExtension(Extension(VK_KHR_XLIB_SURFACE_EXTENSION_NAME));
+    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_min_icd_interface_version(5);
+    driver.add_instance_extension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
+    driver.add_instance_extension(Extension(VK_KHR_XLIB_SURFACE_EXTENSION_NAME));
     driver.enable_icd_wsi = true;
 
     InstWrapper inst{env->vulkan_functions};
@@ -245,10 +247,10 @@ static const struct wl_registry_listener wayland_registry_listener = {wayland_re
 
 TEST_F(RegressionTests, CreateSurfaceWayland) {
     auto& driver = env->get_test_icd();
-    driver.SetICDAPIVersion(VK_MAKE_VERSION(1, 0, 0));
-    driver.SetMinICDInterfaceVersion(5);
-    driver.AddInstanceExtension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
-    driver.AddInstanceExtension(Extension(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME));
+    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_min_icd_interface_version(5);
+    driver.add_instance_extension(Extension(VK_KHR_SURFACE_EXTENSION_NAME));
+    driver.add_instance_extension(Extension(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME));
     driver.enable_icd_wsi = true;
 
     InstWrapper inst{env->vulkan_functions};


### PR DESCRIPTION
Added builders to a majority of the test framework, fixes bugs causing inconsistent results due to old tests not being cleaned up properly, and fixed InstWrapper not asserting if the result didn't match.