### PR TITLE
Fallback to 2KHR terminators if available

### DIFF
--- a/loader/terminator.c
+++ b/loader/terminator.c
@@ -134,7 +134,8 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceFeatures2(VkPhysicalDevic
     PFN_vkGetPhysicalDeviceFeatures2 fpGetPhysicalDeviceFeatures2 = NULL;
     if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
         fpGetPhysicalDeviceFeatures2 = icd_term->dispatch.GetPhysicalDeviceFeatures2;
-    } else if (inst->enabled_known_extensions.khr_get_physical_device_properties2) {
+    }
+    if (fpGetPhysicalDeviceFeatures2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
         fpGetPhysicalDeviceFeatures2 = icd_term->dispatch.GetPhysicalDeviceFeatures2KHR;
     }
 
@@ -189,7 +190,8 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceProperties2(VkPhysicalDev
     PFN_vkGetPhysicalDeviceProperties2 fpGetPhysicalDeviceProperties2 = NULL;
     if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
         fpGetPhysicalDeviceProperties2 = icd_term->dispatch.GetPhysicalDeviceProperties2;
-    } else if (inst->enabled_known_extensions.khr_get_physical_device_properties2) {
+    }
+    if (fpGetPhysicalDeviceProperties2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
         fpGetPhysicalDeviceProperties2 = icd_term->dispatch.GetPhysicalDeviceProperties2KHR;
     }
 
@@ -251,7 +253,8 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceFormatProperties2(VkPhysi
     PFN_vkGetPhysicalDeviceFormatProperties2 fpGetPhysicalDeviceFormatProperties2 = NULL;
     if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
         fpGetPhysicalDeviceFormatProperties2 = icd_term->dispatch.GetPhysicalDeviceFormatProperties2;
-    } else if (inst->enabled_known_extensions.khr_get_physical_device_properties2) {
+    }
+    if (fpGetPhysicalDeviceFormatProperties2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
         fpGetPhysicalDeviceFormatProperties2 = icd_term->dispatch.GetPhysicalDeviceFormatProperties2KHR;
     }
 
@@ -288,7 +291,8 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceImageFormatProperties
     PFN_vkGetPhysicalDeviceImageFormatProperties2 fpGetPhysicalDeviceImageFormatProperties2 = NULL;
     if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
         fpGetPhysicalDeviceImageFormatProperties2 = icd_term->dispatch.GetPhysicalDeviceImageFormatProperties2;
-    } else if (inst->enabled_known_extensions.khr_get_physical_device_properties2) {
+    }
+    if (fpGetPhysicalDeviceImageFormatProperties2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
         fpGetPhysicalDeviceImageFormatProperties2 = icd_term->dispatch.GetPhysicalDeviceImageFormatProperties2KHR;
     }
 
@@ -327,7 +331,8 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceQueueFamilyProperties2(Vk
     PFN_vkGetPhysicalDeviceQueueFamilyProperties2 fpGetPhysicalDeviceQueueFamilyProperties2 = NULL;
     if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
         fpGetPhysicalDeviceQueueFamilyProperties2 = icd_term->dispatch.GetPhysicalDeviceQueueFamilyProperties2;
-    } else if (inst->enabled_known_extensions.khr_get_physical_device_properties2) {
+    }
+    if (fpGetPhysicalDeviceQueueFamilyProperties2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
         fpGetPhysicalDeviceQueueFamilyProperties2 = icd_term->dispatch.GetPhysicalDeviceQueueFamilyProperties2KHR;
     }
 
@@ -384,7 +389,8 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceMemoryProperties2(VkPhysi
     PFN_vkGetPhysicalDeviceMemoryProperties2 fpGetPhysicalDeviceMemoryProperties2 = NULL;
     if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
         fpGetPhysicalDeviceMemoryProperties2 = icd_term->dispatch.GetPhysicalDeviceMemoryProperties2;
-    } else if (inst->enabled_known_extensions.khr_get_physical_device_properties2) {
+    }
+    if (fpGetPhysicalDeviceMemoryProperties2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
         fpGetPhysicalDeviceMemoryProperties2 = icd_term->dispatch.GetPhysicalDeviceMemoryProperties2KHR;
     }
 
@@ -421,7 +427,9 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceSparseImageFormatProperti
     PFN_vkGetPhysicalDeviceSparseImageFormatProperties2 fpGetPhysicalDeviceSparseImageFormatProperties2 = NULL;
     if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
         fpGetPhysicalDeviceSparseImageFormatProperties2 = icd_term->dispatch.GetPhysicalDeviceSparseImageFormatProperties2;
-    } else if (inst->enabled_known_extensions.khr_get_physical_device_properties2) {
+    }
+    if (fpGetPhysicalDeviceSparseImageFormatProperties2 == NULL &&
+        inst->enabled_known_extensions.khr_get_physical_device_properties2) {
         fpGetPhysicalDeviceSparseImageFormatProperties2 = icd_term->dispatch.GetPhysicalDeviceSparseImageFormatProperties2KHR;
     }
 
@@ -489,7 +497,8 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceExternalBufferProperties(
     PFN_vkGetPhysicalDeviceExternalBufferProperties fpGetPhysicalDeviceExternalBufferProperties = NULL;
     if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
         fpGetPhysicalDeviceExternalBufferProperties = icd_term->dispatch.GetPhysicalDeviceExternalBufferProperties;
-    } else if (inst->enabled_known_extensions.khr_external_memory_capabilities) {
+    }
+    if (fpGetPhysicalDeviceExternalBufferProperties == NULL && inst->enabled_known_extensions.khr_external_memory_capabilities) {
         fpGetPhysicalDeviceExternalBufferProperties = icd_term->dispatch.GetPhysicalDeviceExternalBufferPropertiesKHR;
     }
 
@@ -531,7 +540,9 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceExternalSemaphoreProperti
     PFN_vkGetPhysicalDeviceExternalSemaphoreProperties fpGetPhysicalDeviceExternalSemaphoreProperties = NULL;
     if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
         fpGetPhysicalDeviceExternalSemaphoreProperties = icd_term->dispatch.GetPhysicalDeviceExternalSemaphoreProperties;
-    } else if (inst->enabled_known_extensions.khr_external_semaphore_capabilities) {
+    }
+    if (fpGetPhysicalDeviceExternalSemaphoreProperties == NULL &&
+        inst->enabled_known_extensions.khr_external_semaphore_capabilities) {
         fpGetPhysicalDeviceExternalSemaphoreProperties = icd_term->dispatch.GetPhysicalDeviceExternalSemaphorePropertiesKHR;
     }
 
@@ -576,7 +587,8 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceExternalFenceProperties(
     PFN_vkGetPhysicalDeviceExternalFenceProperties fpGetPhysicalDeviceExternalFenceProperties = NULL;
     if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
         fpGetPhysicalDeviceExternalFenceProperties = icd_term->dispatch.GetPhysicalDeviceExternalFenceProperties;
-    } else if (inst->enabled_known_extensions.khr_external_fence_capabilities) {
+    }
+    if (fpGetPhysicalDeviceExternalFenceProperties == NULL && inst->enabled_known_extensions.khr_external_fence_capabilities) {
         fpGetPhysicalDeviceExternalFenceProperties = icd_term->dispatch.GetPhysicalDeviceExternalFencePropertiesKHR;
     }
 

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -1023,48 +1023,61 @@ PFN_vkVoidFunction get_physical_device_func(VkInstance instance, const char* pNa
     if (string_eq(pName, "vkGetPhysicalDeviceImageFormatProperties"))
         return TO_VOID_PFN(test_vkGetPhysicalDeviceImageFormatProperties);
 
-    if (icd.icd_api_version >= VK_MAKE_API_VERSION(0, 1, 1, 0) ||
-        IsInstanceExtensionEnabled("VK_KHR_get_physical_device_properties2")) {
-        if (string_eq(pName, "vkGetPhysicalDeviceFeatures2") || string_eq(pName, "vkGetPhysicalDeviceFeatures2KHR"))
-            return TO_VOID_PFN(test_vkGetPhysicalDeviceFeatures2);
-        if (string_eq(pName, "vkGetPhysicalDeviceProperties2") || string_eq(pName, "vkGetPhysicalDeviceProperties2KHR"))
-            return TO_VOID_PFN(test_vkGetPhysicalDeviceProperties2);
-        if (string_eq(pName, "vkGetPhysicalDeviceFormatProperties2") || string_eq(pName, "vkGetPhysicalDeviceFormatProperties2KHR"))
+    if (IsInstanceExtensionEnabled("VK_KHR_get_physical_device_properties2")) {
+        if (string_eq(pName, "vkGetPhysicalDeviceFeatures2KHR")) return TO_VOID_PFN(test_vkGetPhysicalDeviceFeatures2);
+        if (string_eq(pName, "vkGetPhysicalDeviceProperties2KHR")) return TO_VOID_PFN(test_vkGetPhysicalDeviceProperties2);
+        if (string_eq(pName, "vkGetPhysicalDeviceFormatProperties2KHR"))
             return TO_VOID_PFN(test_vkGetPhysicalDeviceFormatProperties2);
-        if (string_eq(pName, "vkGetPhysicalDeviceMemoryProperties2") || string_eq(pName, "vkGetPhysicalDeviceMemoryProperties2KHR"))
+        if (string_eq(pName, "vkGetPhysicalDeviceMemoryProperties2KHR"))
             return TO_VOID_PFN(test_vkGetPhysicalDeviceMemoryProperties2);
 
-        if (string_eq(pName, "vkGetPhysicalDeviceQueueFamilyProperties2") ||
-            string_eq(pName, "vkGetPhysicalDeviceQueueFamilyProperties2KHR"))
+        if (string_eq(pName, "vkGetPhysicalDeviceQueueFamilyProperties2KHR"))
             return TO_VOID_PFN(test_vkGetPhysicalDeviceQueueFamilyProperties2);
 
-        if (string_eq(pName, "vkGetPhysicalDeviceSparseImageFormatProperties2") ||
-            string_eq(pName, "vkGetPhysicalDeviceSparseImageFormatProperties2KHR"))
+        if (string_eq(pName, "vkGetPhysicalDeviceSparseImageFormatProperties2KHR"))
             return TO_VOID_PFN(test_vkGetPhysicalDeviceSparseImageFormatProperties2);
 
-        if (string_eq(pName, "vkGetPhysicalDeviceImageFormatProperties2") ||
-            string_eq(pName, "vkGetPhysicalDeviceImageFormatProperties2KHR")) {
+        if (string_eq(pName, "vkGetPhysicalDeviceImageFormatProperties2KHR")) {
             return TO_VOID_PFN(test_vkGetPhysicalDeviceImageFormatProperties2);
         }
     }
-    if (icd.icd_api_version >= VK_MAKE_API_VERSION(0, 1, 1, 0) ||
-        IsInstanceExtensionEnabled("VK_KHR_external_memory_capabilities")) {
-        if (string_eq(pName, "vkGetPhysicalDeviceExternalBufferProperties") ||
-            string_eq(pName, "vkGetPhysicalDeviceExternalBufferPropertiesKHR"))
+    if (IsInstanceExtensionEnabled("VK_KHR_external_memory_capabilities")) {
+        if (string_eq(pName, "vkGetPhysicalDeviceExternalBufferPropertiesKHR"))
             return TO_VOID_PFN(test_vkGetPhysicalDeviceExternalBufferProperties);
     }
-    if (icd.icd_api_version >= VK_MAKE_API_VERSION(0, 1, 1, 0) ||
-        IsInstanceExtensionEnabled("VK_KHR_external_semaphore_capabilities")) {
-        if (string_eq(pName, "vkGetPhysicalDeviceExternalSemaphoreProperties") ||
-            string_eq(pName, "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR"))
+    if (IsInstanceExtensionEnabled("VK_KHR_external_semaphore_capabilities")) {
+        if (string_eq(pName, "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR"))
             return TO_VOID_PFN(test_vkGetPhysicalDeviceExternalSemaphoreProperties);
     }
-    if (icd.icd_api_version >= VK_MAKE_API_VERSION(0, 1, 1, 0) ||
-        IsInstanceExtensionEnabled("VK_KHR_external_fence_capabilities")) {
-        if (string_eq(pName, "vkGetPhysicalDeviceExternalFenceProperties") ||
-            string_eq(pName, "vkGetPhysicalDeviceExternalFencePropertiesKHR"))
+    if (IsInstanceExtensionEnabled("VK_KHR_external_fence_capabilities")) {
+        if (string_eq(pName, "vkGetPhysicalDeviceExternalFencePropertiesKHR"))
             return TO_VOID_PFN(test_vkGetPhysicalDeviceExternalFenceProperties);
     }
+
+    if (icd.icd_api_version >= VK_MAKE_API_VERSION(0, 1, 1, 0)) {
+        if (string_eq(pName, "vkGetPhysicalDeviceFeatures2")) return TO_VOID_PFN(test_vkGetPhysicalDeviceFeatures2);
+        if (string_eq(pName, "vkGetPhysicalDeviceProperties2")) return TO_VOID_PFN(test_vkGetPhysicalDeviceProperties2);
+        if (string_eq(pName, "vkGetPhysicalDeviceFormatProperties2")) return TO_VOID_PFN(test_vkGetPhysicalDeviceFormatProperties2);
+        if (string_eq(pName, "vkGetPhysicalDeviceMemoryProperties2")) return TO_VOID_PFN(test_vkGetPhysicalDeviceMemoryProperties2);
+
+        if (string_eq(pName, "vkGetPhysicalDeviceQueueFamilyProperties2"))
+            return TO_VOID_PFN(test_vkGetPhysicalDeviceQueueFamilyProperties2);
+
+        if (string_eq(pName, "vkGetPhysicalDeviceSparseImageFormatProperties2"))
+            return TO_VOID_PFN(test_vkGetPhysicalDeviceSparseImageFormatProperties2);
+
+        if (string_eq(pName, "vkGetPhysicalDeviceImageFormatProperties2")) {
+            return TO_VOID_PFN(test_vkGetPhysicalDeviceImageFormatProperties2);
+        }
+
+        if (string_eq(pName, "vkGetPhysicalDeviceExternalBufferProperties"))
+            return TO_VOID_PFN(test_vkGetPhysicalDeviceExternalBufferProperties);
+        if (string_eq(pName, "vkGetPhysicalDeviceExternalSemaphoreProperties"))
+            return TO_VOID_PFN(test_vkGetPhysicalDeviceExternalSemaphoreProperties);
+        if (string_eq(pName, "vkGetPhysicalDeviceExternalFenceProperties"))
+            return TO_VOID_PFN(test_vkGetPhysicalDeviceExternalFenceProperties);
+    }
+
     if (icd.supports_tooling_info_ext) {
         if (string_eq(pName, "vkGetPhysicalDeviceToolPropertiesEXT")) return TO_VOID_PFN(test_vkGetPhysicalDeviceToolPropertiesEXT);
     }


### PR DESCRIPTION
The functions added from VK_KHR_get_physical_device_properties2 were made core, but a
recent loader change meant that an application which was trying to use the extension may
use the fallback version (which ignores the pNext chain) by accident. This breaks existing
applications and thus needs to be rectified. This commit makes it so that if the core
GetPhysicalDeviceXXX functions aren't available and the extension is supported & enabled,
the extension version is used instead.

Fixes #785 