### PR TITLE
Small revision of layer loading logic

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -852,6 +852,11 @@ static VkResult loader_add_layer_names_to_list(const struct loader_instance *ins
             continue;
         }
 
+        // Make sure the layer isn't already in the output_list, skip adding it if it is.
+        if (loader_find_layer_name_in_list(source_name, output_list)) {
+            continue;
+        }
+
         // If not a meta-layer, simply add it.
         if (0 == (layer_prop->type_flags & VK_LAYER_TYPE_FLAG_META_LAYER)) {
             loader_add_layer_properties_to_list(inst, output_list, 1, layer_prop);

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -446,25 +446,23 @@ void loader_remove_layers_not_in_implicit_meta_layers(const struct loader_instan
     }
 
     for (i = 0; i < layer_count; i++) {
-        struct loader_layer_properties cur_layer_prop = layer_list->list[i];
+        struct loader_layer_properties *cur_layer_prop = &layer_list->list[i];
 
-        if (0 == (cur_layer_prop.type_flags & VK_LAYER_TYPE_FLAG_EXPLICIT_LAYER)) {
-            cur_layer_prop.keep = true;
-        } else {
+        if (0 == (cur_layer_prop->type_flags & VK_LAYER_TYPE_FLAG_EXPLICIT_LAYER)) {
+            cur_layer_prop->keep = true;
             continue;
         }
+        for (j = 0; j < layer_count; j++) {
+            struct loader_layer_properties layer_to_check = layer_list->list[j];
 
-        if (cur_layer_prop.type_flags & VK_LAYER_TYPE_FLAG_META_LAYER) {
-            for (j = 0; j < layer_count; j++) {
-                struct loader_layer_properties layer_to_check = layer_list->list[j];
+            if (i == j) {
+                continue;
+            }
 
-                if (i == j) {
-                    continue;
-                }
-
+            if (layer_to_check.type_flags & VK_LAYER_TYPE_FLAG_META_LAYER) {
                 // For all layers found in this meta layer, we want to keep them as well.
-                if (loader_find_layer_name_in_meta_layer(inst, layer_to_check.info.layerName, layer_list, &cur_layer_prop)) {
-                    cur_layer_prop.keep = true;
+                if (loader_find_layer_name_in_meta_layer(inst, cur_layer_prop->info.layerName, layer_list, &layer_to_check)) {
+                    cur_layer_prop->keep = true;
                 }
             }
         }

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1721,24 +1721,22 @@ static bool verify_meta_layer_component_layers(const struct loader_instance *ins
 
     for (uint32_t comp_layer = 0; comp_layer < prop->num_component_layers; comp_layer++) {
         if (!loader_find_layer_name_in_list(prop->component_layer_names[comp_layer], instance_layers)) {
-            if (NULL != inst) {
-                loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
-                           "verify_meta_layer_component_layers: Meta-layer %s can't find component layer %s at index %d."
-                           "  Skipping this layer.",
-                           prop->info.layerName, prop->component_layer_names[comp_layer], comp_layer);
-            }
+            loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
+                       "verify_meta_layer_component_layers: Meta-layer %s can't find component layer %s at index %d."
+                       "  Skipping this layer.",
+                       prop->info.layerName, prop->component_layer_names[comp_layer], comp_layer);
+
             success = false;
             break;
         } else {
             struct loader_layer_properties *comp_prop =
                 loader_find_layer_property(prop->component_layer_names[comp_layer], instance_layers);
             if (comp_prop == NULL) {
-                if (NULL != inst) {
-                    loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
-                               "verify_meta_layer_component_layers: Meta-layer %s can't find property for component layer "
-                               "%s at index %d.  Skipping this layer.",
-                               prop->info.layerName, prop->component_layer_names[comp_layer], comp_layer);
-                }
+                loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
+                           "verify_meta_layer_component_layers: Meta-layer %s can't find property for component layer "
+                           "%s at index %d.  Skipping this layer.",
+                           prop->info.layerName, prop->component_layer_names[comp_layer], comp_layer);
+
                 success = false;
                 break;
             }
@@ -1747,42 +1745,36 @@ static bool verify_meta_layer_component_layers(const struct loader_instance *ins
             uint32_t cur_major = VK_VERSION_MAJOR(comp_prop->info.specVersion);
             uint32_t cur_minor = VK_VERSION_MINOR(comp_prop->info.specVersion);
             if (cur_major != expected_major || cur_minor != expected_minor) {
-                if (NULL != inst) {
-                    loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
-                               "verify_meta_layer_component_layers: Meta-layer uses API version %d.%d, but component "
-                               "layer %d uses API version %d.%d.  Skipping this layer.",
-                               expected_major, expected_minor, comp_layer, cur_major, cur_minor);
-                }
+                loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
+                           "verify_meta_layer_component_layers: Meta-layer uses API version %d.%d, but component "
+                           "layer %d uses API version %d.%d.  Skipping this layer.",
+                           expected_major, expected_minor, comp_layer, cur_major, cur_minor);
+
                 success = false;
                 break;
             }
 
             // Make sure the layer isn't using it's own name
             if (!strcmp(prop->info.layerName, prop->component_layer_names[comp_layer])) {
-                if (NULL != inst) {
-                    loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
-                               "verify_meta_layer_component_layers: Meta-layer %s lists itself in its component layer "
-                               "list at index %d.  Skipping this layer.",
-                               prop->info.layerName, comp_layer);
-                }
+                loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
+                           "verify_meta_layer_component_layers: Meta-layer %s lists itself in its component layer "
+                           "list at index %d.  Skipping this layer.",
+                           prop->info.layerName, comp_layer);
+
                 success = false;
                 break;
             }
             if (comp_prop->type_flags & VK_LAYER_TYPE_FLAG_META_LAYER) {
-                if (NULL != inst) {
-                    loader_log(inst, VULKAN_LOADER_INFO_BIT, 0,
-                               "verify_meta_layer_component_layers: Adding meta-layer %s which also contains meta-layer %s",
-                               prop->info.layerName, comp_prop->info.layerName);
-                }
+                loader_log(inst, VULKAN_LOADER_INFO_BIT, 0,
+                           "verify_meta_layer_component_layers: Adding meta-layer %s which also contains meta-layer %s",
+                           prop->info.layerName, comp_prop->info.layerName);
 
                 // Make sure if the layer is using a meta-layer in its component list that we also verify that.
                 if (!verify_meta_layer_component_layers(inst, comp_prop, instance_layers)) {
-                    if (NULL != inst) {
-                        loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
-                                   "Meta-layer %s component layer %s can not find all component layers."
-                                   "  Skipping this layer.",
-                                   prop->info.layerName, prop->component_layer_names[comp_layer]);
-                    }
+                    loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
+                               "Meta-layer %s component layer %s can not find all component layers."
+                               "  Skipping this layer.",
+                               prop->info.layerName, prop->component_layer_names[comp_layer]);
                     success = false;
                     break;
                 }
@@ -1791,22 +1783,20 @@ static bool verify_meta_layer_component_layers(const struct loader_instance *ins
             // Add any instance and device extensions from component layers to this layer
             // list, so that anyone querying extensions will only need to look at the meta-layer
             for (uint32_t ext = 0; ext < comp_prop->instance_extension_list.count; ext++) {
-                if (NULL != inst) {
-                    loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Meta-layer %s component layer %s adding instance extension %s",
-                               prop->info.layerName, prop->component_layer_names[comp_layer],
-                               comp_prop->instance_extension_list.list[ext].extensionName);
-                }
+                loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Meta-layer %s component layer %s adding instance extension %s",
+                           prop->info.layerName, prop->component_layer_names[comp_layer],
+                           comp_prop->instance_extension_list.list[ext].extensionName);
+
                 if (!has_vk_extension_property(&comp_prop->instance_extension_list.list[ext], &prop->instance_extension_list)) {
                     loader_add_to_ext_list(inst, &prop->instance_extension_list, 1, &comp_prop->instance_extension_list.list[ext]);
                 }
             }
 
             for (uint32_t ext = 0; ext < comp_prop->device_extension_list.count; ext++) {
-                if (NULL != inst) {
-                    loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Meta-layer %s component layer %s adding device extension %s",
-                               prop->info.layerName, prop->component_layer_names[comp_layer],
-                               comp_prop->device_extension_list.list[ext].props.extensionName);
-                }
+                loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Meta-layer %s component layer %s adding device extension %s",
+                           prop->info.layerName, prop->component_layer_names[comp_layer],
+                           comp_prop->device_extension_list.list[ext].props.extensionName);
+
                 if (!has_vk_dev_ext_property(&comp_prop->device_extension_list.list[ext].props, &prop->device_extension_list)) {
                     loader_add_to_dev_ext_list(inst, &prop->device_extension_list,
                                                &comp_prop->device_extension_list.list[ext].props, 0, NULL);
@@ -1838,10 +1828,9 @@ static void verify_all_meta_layers(struct loader_instance *inst, struct loader_l
         // If this is a meta-layer, make sure it is valid
         if ((prop->type_flags & VK_LAYER_TYPE_FLAG_META_LAYER) &&
             !verify_meta_layer_component_layers(inst, prop, instance_layers)) {
-            if (NULL != inst) {
-                loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0,
-                           "Removing meta-layer %s from instance layer list since it appears invalid.", prop->info.layerName);
-            }
+            loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0,
+                       "Removing meta-layer %s from instance layer list since it appears invalid.", prop->info.layerName);
+
             loader_remove_layer_in_list(inst, instance_layers, i);
 
         } else if (prop->is_override && loader_implicit_layer_is_enabled(inst, prop)) {

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2139,7 +2139,7 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
             }
         }
     } else if (NULL != component_layers) {
-        if (version.major == 1 && (version.minor < 1 || version.patch < 1)) {
+        if (version.major == 1 && ((version.minor == 1 && version.patch < 1) || (version.minor == 0))) {
             loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
                        "Indicating meta-layer-specific component_layers, but using older JSON file version.");
         }

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -1666,3 +1666,65 @@ TEST(TestLayers, ExplicitlyEnableImplicitLayer) {
         ASSERT_EQ(1, count);
     }
 }
+
+TEST(TestLayers, NewerInstanceVersionThanImplicitLayer) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_MAKE_API_VERSION(0, 1, 2, 0)));
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 2, 0);
+    VkPhysicalDeviceProperties properties{};
+    properties.apiVersion = VK_MAKE_API_VERSION(0, 1, 2, 0);
+    env.get_test_icd().add_physical_device({});
+    env.get_test_icd().physical_devices.back().set_properties(properties);
+
+    const char* regular_layer_name = "VK_LAYER_TestLayer1";
+    env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(regular_layer_name)
+                                                         .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                                         .set_disable_environment("DisableMeIfYouCan")),
+                           "regular_test_layer.json");
+
+    uint32_t layer_count = 0;
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+    EXPECT_EQ(layer_count, 1);
+
+    std::array<VkLayerProperties, 1> layer_props;
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
+    EXPECT_EQ(layer_count, 1);
+    EXPECT_TRUE(string_eq(layer_props[0].layerName, regular_layer_name));
+
+    {  // 1.1 instance -- instance layer should be found
+        InstWrapper inst{env.vulkan_functions};
+        inst.create_info.set_api_version(1, 1, 0);
+        inst.CheckCreate();
+        VkPhysicalDevice phys_dev = inst.GetPhysDev();
+
+        uint32_t count = 0;
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        EXPECT_EQ(1, count);
+        VkLayerProperties layer_props{};
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
+        EXPECT_EQ(1, count);
+        ASSERT_TRUE(string_eq(regular_layer_name, layer_props.layerName));
+    }
+    {  // 1.2 instance -- instance layer shouldn't be found
+        DebugUtilsLogger log;
+        InstWrapper inst{env.vulkan_functions};
+        inst.create_info.set_api_version(1, 2, 0);
+        FillDebugUtilsCreateDetails(inst.create_info, log);
+        inst.CheckCreate();
+        VkPhysicalDevice phys_dev = inst.GetPhysDev();
+
+        const char* err_message =
+            "loader_add_implicit_layer: Disabling implicit layer VK_LAYER_TestLayer1 for using an old API version 1.1 versus "
+            "application requested 1.2";
+        ASSERT_TRUE(log.find(err_message));
+
+        uint32_t count = 0;
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        ASSERT_EQ(0, count);
+        VkLayerProperties layer_props{};
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
+        ASSERT_EQ(0, count);
+    }
+}


### PR DESCRIPTION
Fixed several bugs and added 4 tests.

Bugs:
* Layers not in the active meta layer would be removed erroneously, due to very faulty logic in that function. Was cleaned up.
* Logging messages for incorrect meta layers were dropped during pre-instance functions
* If an implicit layer was added by the application manually, this created duplicates in the activated_layer_list
* Layer manifest version check was incorrect (wasn't updated for the newer 1.2 manifest version) - only affected whether a log message was emitted.

Tests:
* OlderMetaLayerWithNewerInstanceVersion - Checks for interaction between app's
instance version and the meta layer version
* NewerComponentLayerInMetaLayer - When a component layer has an API version
newer than the meta layer, the meta layer is disabled.
* OlderComponentLayerInMetaLayer - When a component layer has an API version
older than the meta layer, the meta layer is disabled.
* ExplicitlyEnableImplicitLayer - Implicit layers that are manually enabled by the 
application should be enabled even if their version is too old.
* NewerInstanceVersionThanImplicitLayer - When an implicit layer has an API version
less than that of the application's API version specified in VkInstanceCreateInfo.