### PR TITLE
Add more layer tests and fix layer removal logic bugs

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2001,7 +2001,7 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
     if (!strcmp(name, VK_OVERRIDE_LAYER_NAME)) {
         cJSON *expiration;
 
-        if (version.major < 1 && version.minor < 1 && version.patch < 2) {
+        if (version.major == 0 || (version.minor == 1 && version.patch < 2) || version.minor == 0) {
             loader_log(
                 inst, VULKAN_LOADER_WARN_BIT, 0,
                 "Override layer expiration date not added until version 1.1.2.  Please update JSON file version appropriately.");
@@ -2109,7 +2109,7 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
             }
         }
     } else if (NULL != component_layers) {
-        if (version.major == 1 && ((version.minor == 1 && version.patch < 1) || (version.minor == 0))) {
+        if (version.major == 0 || (version.minor == 1 && version.patch < 1) || (version.minor == 0)) {
             loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
                        "Indicating meta-layer-specific component_layers, but using older JSON file version.");
         }
@@ -2195,7 +2195,7 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
 
     override_paths = cJSON_GetObjectItem(layer_node, "override_paths");
     if (NULL != override_paths) {
-        if (version.major == 1 && (version.minor < 1 || version.patch < 1)) {
+        if (version.major == 0 || (version.minor == 1 && version.patch) < 1 || version.minor == 0) {
             loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
                        "Indicating meta-layer-specific override paths, but using older JSON file version.");
         }

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,9 +33,11 @@ IMPORTANT NOTES:
 
 ## Using a specific loader with the tests
 
-The environment variable `VK_LOADER_TEST_LOADER_PATH` can be used to specify which vulkan-loader binary should be used. This is useful when writing tests to exercise
-a bug fix. Simply build the loader without the fix, stash it in a known location. Write the fix and the test that should exercise the bug and it passes. Then run the
-test again but with this env-var set to the older loader without the fix and show that the test now fails.
+The environment variable `VK_LOADER_TEST_LOADER_PATH` can be used to specify which vulkan-loader binary should be used.
+This is useful when writing tests to exercise a bug fix.
+Simply build the loader without the fix, stash it in a known location.
+Write the fix and the test that should exercise the bug and it passes.
+Then run the test again but with this env-var set to the older loader without the fix and show that the test now fails.
 
 Basic usage example:
 ```c

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -725,8 +725,8 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceProperties(VkPhysicalDevice p
     if (nullptr != pProperties) {
         auto& phys_dev = icd.GetPhysDevice(physicalDevice);
         memcpy(pProperties, &phys_dev.properties, sizeof(VkPhysicalDeviceProperties));
-        uint32_t max_len = (phys_dev.deviceName.length() > VK_MAX_PHYSICAL_DEVICE_NAME_SIZE) ? VK_MAX_PHYSICAL_DEVICE_NAME_SIZE
-                                                                                             : phys_dev.deviceName.length();
+        size_t max_len = (phys_dev.deviceName.length() > VK_MAX_PHYSICAL_DEVICE_NAME_SIZE) ? VK_MAX_PHYSICAL_DEVICE_NAME_SIZE
+                                                                                           : phys_dev.deviceName.length();
         std::copy(phys_dev.deviceName.c_str(), phys_dev.deviceName.c_str() + max_len, pProperties->deviceName);
         pProperties->deviceName[VK_MAX_PHYSICAL_DEVICE_NAME_SIZE - 1] = '\0';
     }

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -188,9 +188,11 @@ void FrameworkEnvironment::add_icd(TestICDDetails icd_details) noexcept {
     }
     std::string full_json_name = icd_details.json_name + "_" + std::to_string(cur_icd_index) + ".json";
 
-    auto driver_loc = icd_folder.write(full_json_name, ManifestICD{}
-                                                           .set_lib_path(fs::fixup_backslashes_in_path(icd_details.icd_path).str())
-                                                           .set_api_version(icd_details.api_version));
+    auto driver_loc =
+        icd_folder.write_manifest(full_json_name, ManifestICD{}
+                                                      .set_lib_path(fs::fixup_backslashes_in_path(icd_details.icd_path).str())
+                                                      .set_api_version(icd_details.api_version)
+                                                      .get_manifest_str());
 
     if (icd_details.use_env_var_icd_filenames) {
         if (!env_var_vk_icd_filenames.empty()) {
@@ -244,7 +246,7 @@ void FrameworkEnvironment::add_layer_impl(ManifestLayer& layer_manifest, const s
         }
     }
 
-    auto layer_loc = folder_manager.write(json_name, layer_manifest);
+    auto layer_loc = folder_manager.write_manifest(json_name, layer_manifest.get_manifest_str());
     platform_shim->add_manifest(category, layer_loc);
 }
 

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -299,12 +299,23 @@ struct TestICDDetails {
     BUILDER_VALUE(TestICDDetails, bool, is_fake, false);
 };
 
+struct TestLayerDetails {
+    TestLayerDetails(ManifestLayer layer_manifest, const std::string& json_name) noexcept
+        : layer_manifest(layer_manifest), json_name(json_name) {}
+    BUILDER_VALUE(TestLayerDetails, ManifestLayer, layer_manifest, {});
+    BUILDER_VALUE(TestLayerDetails, std::string, json_name, "test_layer");
+    BUILDER_VALUE(TestLayerDetails, bool, add_to_regular_search_paths, true);
+    BUILDER_VALUE(TestLayerDetails, bool, is_fake, false);
+};
+
 struct FrameworkEnvironment {
     FrameworkEnvironment(DebugMode debug_mode = DebugMode::none) noexcept;
 
     void add_icd(TestICDDetails icd_details) noexcept;
     void add_implicit_layer(ManifestLayer layer_manifest, const std::string& json_name) noexcept;
+    void add_implicit_layer(TestLayerDetails layer_details) noexcept;
     void add_explicit_layer(ManifestLayer layer_manifest, const std::string& json_name) noexcept;
+    void add_explicit_layer(TestLayerDetails layer_details) noexcept;
 
     TestICD& get_test_icd(int index = 0) noexcept;
     TestICD& reset_icd(int index = 0) noexcept;
@@ -328,6 +339,5 @@ struct FrameworkEnvironment {
     std::string env_var_vk_icd_filenames;
 
    private:
-    void add_layer_impl(ManifestLayer& layer_manifest, const std::string& json_name, fs::FolderManager& folder_manager,
-                        ManifestCategory category);
+    void add_layer_impl(TestLayerDetails layer_details, fs::FolderManager& folder_manager, ManifestCategory category);
 };

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -112,7 +112,7 @@ void print_vector_of_strings(std::string& out, const char* object_name, std::vec
         out += std::string(",\n\t\t\"") + object_name + "\": [";
         for (size_t i = 0; i < strings.size(); i++) {
             if (i > 0) out += ",\t\t\t";
-            out += "\"" + strings.at(i) + "\"";
+            out += "\"" + fs::fixup_backslashes_in_path(strings.at(i)) + "\"";
         }
         out += "]";
     }

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -96,6 +96,28 @@ std::string get_env_var(std::string const& name, bool report_failure) {
 }
 #endif
 
+template <typename T>
+void print_vector_of_t(std::string& out, const char* object_name, std::vector<T> const& vec) {
+    if (vec.size() > 0) {
+        out += std::string(",\n\t\t\"") + object_name + "\": [";
+        for (size_t i = 0; i < vec.size(); i++) {
+            if (i > 0) out += ",\t\t\t";
+            out += "\n\t\t\t" + vec.at(i).get_manifest_str();
+        }
+        out += "\n\t\t}";
+    }
+}
+void print_vector_of_strings(std::string& out, const char* object_name, std::vector<std::string> const& strings) {
+    if (strings.size() > 0) {
+        out += std::string(",\n\t\t\"") + object_name + "\": [";
+        for (size_t i = 0; i < strings.size(); i++) {
+            if (i > 0) out += ",\t\t\t";
+            out += "\"" + strings.at(i) + "\"";
+        }
+        out += "]";
+    }
+}
+
 std::string ManifestICD::get_manifest_str() const {
     std::string out;
     out += "{\n";
@@ -111,15 +133,8 @@ std::string ManifestICD::get_manifest_str() const {
 std::string ManifestLayer::LayerDescription::Extension::get_manifest_str() const {
     std::string out;
     out += "{ \"name\":\"" + name + "\",\n\t\t\t\"spec_version\":\"" + std::to_string(spec_version) + "\"";
-    if (entrypoints.size() > 0) {
-        out += ",\n\t\t\t\"entrypoints\": [";
-        for (size_t i = 0; i < entrypoints.size(); i++) {
-            if (i > 0) out += ", ";
-            out += "\"" + entrypoints.at(i) + "\"";
-        }
-        out += "]";
-    }
-    out += "\t\t\t}";
+    print_vector_of_strings(out, "entrypoints", entrypoints);
+    out += "\n\t\t\t}";
     return out;
 }
 
@@ -134,54 +149,20 @@ std::string ManifestLayer::LayerDescription::get_manifest_str() const {
     out += "\t\t\"api_version\": \"" + version_to_string(api_version) + "\",\n";
     out += "\t\t\"implementation_version\":\"" + std::to_string(implementation_version) + "\",\n";
     out += "\t\t\"description\": \"" + description + "\"";
-    if (functions.size() > 0) {
-        out += ",\n\t\t\"functions\": {";
-        for (size_t i = 0; i < functions.size(); i++) {
-            if (i > 0) out += ",";
-            out += "\n\t\t\t" + functions.at(i).get_manifest_str();
-        }
-        out += "\n\t\t}";
+    print_vector_of_t(out, "functions", functions);
+    print_vector_of_t(out, "instance_extensions", instance_extensions);
+    print_vector_of_t(out, "device_extensions", device_extensions);
+    if (!enable_environment.empty()) {
+        out += ",\n\t\t\"enable_environment\": { \"" + enable_environment + "\": \"1\" }";
     }
-    if (instance_extensions.size() > 0) {
-        out += ",\n\t\t\"instance_extensions\": [";
-        for (size_t i = 0; i < instance_extensions.size(); i++) {
-            if (i > 0) out += ",";
-            out += "\n\t\t\t" + instance_extensions.at(i).get_manifest_str();
-        }
-        out += "\n\t\t]";
+    if (!disable_environment.empty()) {
+        out += ",\n\t\t\"disable_environment\": { \"" + disable_environment + "\": \"1\" }";
     }
-    if (device_extensions.size() > 0) {
-        out += ",\n\t\t\"device_extensions\": [";
-        for (size_t i = 0; i < device_extensions.size(); i++) {
-            if (i > 0) out += ",";
-            out += "\n\t\t\t" + device_extensions.at(i).get_manifest_str();
-        }
-        out += "\n\t\t]";
-    }
-    if (enable_environment.size() > 0) {
-        out += ",\n\t\t\"enable_environment\": { \"" + enable_environment + "\": \"1\"";
-        out += "\n\t\t}";
-    }
-    if (disable_environment.size() > 0) {
-        out += ",\n\t\t\"disable_environment\": { \"" + disable_environment + "\": \"1\"";
-        out += "\n\t\t}";
-    }
-    if (component_layers.size() > 0) {
-        out += ",\n\t\t\"component_layers\": [";
-        for (size_t i = 0; i < component_layers.size(); i++) {
-            if (i > 0) out += ", ";
-            out += "\"" + component_layers.at(i) + "\"";
-        }
-        out += "]\n";
-    }
-    if (pre_instance_functions.size() > 0) {
-        out += ",\n\t\t\"pre_instance_functions\": [";
-        for (size_t i = 0; i < pre_instance_functions.size(); i++) {
-            if (i > 0) out += ", ";
-            out += "\"" + pre_instance_functions.at(i) + "\"";
-        }
-        out += "]\n\t\t}";
-    }
+    print_vector_of_strings(out, "component_layers", component_layers);
+    print_vector_of_strings(out, "blacklisted_layers", blacklisted_layers);
+    print_vector_of_strings(out, "override_paths", override_paths);
+    print_vector_of_strings(out, "pre_instance_functions", pre_instance_functions);
+
     out += "\n\t}";
     return out;
 }

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -435,38 +435,21 @@ FolderManager::~FolderManager() {
         std::cout << "Deleting folder " << folder.str() << "\n";
     }
 }
-path FolderManager::write(std::string const& name, ManifestICD const& icd_manifest) {
+path FolderManager::write_manifest(std::string const& name, std::string const& contents) {
     path out_path = folder / name;
     auto found = std::find(files.begin(), files.end(), name);
     if (found != files.end()) {
-        if (debug >= DebugMode::log) std::cout << "Writing icd manifest to " << name << "\n";
+        std::cout << "Overwriting manifest " << name << ". Was this intended?\n";
     } else {
-        if (debug >= DebugMode::log) std::cout << "Creating icd manifest " << name << " at " << out_path.str() << "\n";
+        if (debug >= DebugMode::log) std::cout << "Creating manifest " << name << " at " << out_path.str() << "\n";
         files.emplace_back(name);
     }
     auto file = std::ofstream(out_path.str(), std::ios_base::trunc | std::ios_base::out);
     if (!file) {
-        std::cerr << "Failed to create icd manifest " << name << " at " << out_path.str() << "\n";
+        std::cerr << "Failed to create manifest " << name << " at " << out_path.str() << "\n";
         return out_path;
     }
-    file << icd_manifest.get_manifest_str() << std::endl;
-    return out_path;
-}
-path FolderManager::write(std::string const& name, ManifestLayer const& layer_manifest) {
-    path out_path = folder / name;
-    auto found = std::find(files.begin(), files.end(), name);
-    if (found != files.end()) {
-        if (debug >= DebugMode::log) std::cout << "Writing layer manifest to " << name << "\n";
-    } else {
-        if (debug >= DebugMode::log) std::cout << "Creating layer manifest " << name << " at " << out_path.str() << "\n";
-        files.emplace_back(name);
-    }
-    auto file = std::ofstream(out_path.str(), std::ios_base::trunc | std::ios_base::out);
-    file << layer_manifest.get_manifest_str() << std::endl;
-    if (!file) {
-        std::cerr << "Failed to create icd manifest " << name << " at " << out_path.str() << "\n";
-        return out_path;
-    }
+    file << contents << std::endl;
     return out_path;
 }
 // close file handle, delete file, remove `name` from managed file list.

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -104,7 +104,7 @@ void print_vector_of_t(std::string& out, const char* object_name, std::vector<T>
             if (i > 0) out += ",\t\t\t";
             out += "\n\t\t\t" + vec.at(i).get_manifest_str();
         }
-        out += "\n\t\t}";
+        out += "\n\t\t]";
     }
 }
 void print_vector_of_strings(std::string& out, const char* object_name, std::vector<std::string> const& strings) {

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -198,6 +198,10 @@ struct path {
     std::string& str() { return contents; }
     size_t size() const { return contents.size(); };
 
+    // equality
+    bool operator==(path const& other) const noexcept { return contents == other.contents; }
+    bool operator!=(path const& other) const noexcept { return !(*this == other); }
+
    private:
     std::string contents;
 };

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -767,3 +767,33 @@ struct VulkanFunction {
     const char* name;
     void* function;
 };
+template <typename T, size_t U>
+bool check_permutation(std::initializer_list<const char*> expected, std::array<T, U> const& returned) {
+    if (expected.size() != returned.size()) return false;
+    for (uint32_t i = 0; i < expected.size(); i++) {
+        bool found = false;
+        for (auto& elem : returned) {
+            if (string_eq(*(expected.begin() + i), elem.layerName)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) return false;
+    }
+    return true;
+}
+template <typename T, size_t U>
+bool check_permutation(std::initializer_list<const char*> expected, std::vector<T> const& returned) {
+    if (expected.size() != returned.size()) return false;
+    for (uint32_t i = 0; i < expected.size(); i++) {
+        bool found = false;
+        for (auto& elem : returned) {
+            if (string_eq(*(expected.begin() + i), elem.layerName)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) return false;
+    }
+    return true;
+}

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -212,8 +212,10 @@ class FolderManager {
    public:
     explicit FolderManager(path root_path, std::string name, DebugMode debug = DebugMode::none);
     ~FolderManager();
-    path write(std::string const& name, ManifestICD const& icd_manifest);
-    path write(std::string const& name, ManifestLayer const& layer_manifest);
+    FolderManager(FolderManager const&) = delete;
+    FolderManager& operator=(FolderManager const&) = delete;
+
+    path write_manifest(std::string const& name, std::string const& contents);
 
     // close file handle, delete file, remove `name` from managed file list.
     void remove(std::string const& name);
@@ -223,9 +225,6 @@ class FolderManager {
 
     // location of the managed folder
     path location() const { return folder; }
-
-    FolderManager(FolderManager const&) = delete;
-    FolderManager& operator=(FolderManager const&) = delete;
 
    private:
     DebugMode debug;

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -558,6 +558,8 @@ struct ManifestLayer {
         BUILDER_VALUE(LayerDescription, std::string, enable_environment, {})
         BUILDER_VALUE(LayerDescription, std::string, disable_environment, {})
         BUILDER_VECTOR(LayerDescription, std::string, component_layers, component_layer)
+        BUILDER_VECTOR(LayerDescription, std::string, blacklisted_layers, blacklisted_layer)
+        BUILDER_VECTOR(LayerDescription, std::string, override_paths, override_path)
         BUILDER_VECTOR(LayerDescription, std::string, pre_instance_functions, pre_instance_function)
 
         std::string get_manifest_str() const;

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -215,8 +215,7 @@ TEST_F(MetaLayers, ExplicitMetaLayer) {
     std::array<VkLayerProperties, 2> layer_props;
     EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
     EXPECT_EQ(layer_count, 2);
-    EXPECT_TRUE(string_eq(layer_props[0].layerName, meta_layer_name));
-    EXPECT_TRUE(string_eq(layer_props[1].layerName, regular_layer_name));
+    EXPECT_TRUE(check_permutation({regular_layer_name, meta_layer_name}, layer_props));
 
     uint32_t extension_count = 0;
     std::array<VkExtensionProperties, 2> extensions;
@@ -245,8 +244,7 @@ TEST_F(MetaLayers, ExplicitMetaLayer) {
         std::array<VkLayerProperties, 2> layer_props;
         env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
         ASSERT_EQ(count, 2);
-        EXPECT_TRUE(string_eq(layer_props[0].layerName, regular_layer_name));
-        EXPECT_TRUE(string_eq(layer_props[1].layerName, meta_layer_name));
+        EXPECT_TRUE(check_permutation({regular_layer_name, meta_layer_name}, layer_props));
     }
 }
 
@@ -324,9 +322,7 @@ TEST_F(MetaLayers, MetaLayerWhichAddsMetaLayer) {
     std::array<VkLayerProperties, 3> layer_props;
     EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
     EXPECT_EQ(layer_count, 3);
-    EXPECT_TRUE(string_eq(layer_props[0].layerName, meta_layer_name));
-    EXPECT_TRUE(string_eq(layer_props[1].layerName, meta_meta_layer_name));
-    EXPECT_TRUE(string_eq(layer_props[2].layerName, regular_layer_name));
+    EXPECT_TRUE(check_permutation({regular_layer_name, meta_layer_name, meta_meta_layer_name}, layer_props));
 
     uint32_t extension_count = 0;
     std::array<VkExtensionProperties, 2> extensions;
@@ -491,8 +487,7 @@ TEST_F(OverrideMetaLayer, OlderVersionThanInstance) {
     std::array<VkLayerProperties, 2> layer_props;
     EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
     EXPECT_EQ(layer_count, 2);
-    EXPECT_TRUE(string_eq(layer_props[0].layerName, lunarg_meta_layer_name));
-    EXPECT_TRUE(string_eq(layer_props[1].layerName, regular_layer_name));
+    EXPECT_TRUE(check_permutation({regular_layer_name, lunarg_meta_layer_name}, layer_props));
     {  // 1.1 instance
         InstWrapper inst{env->vulkan_functions};
         inst.create_info.api_version = VK_API_VERSION_1_1;
@@ -550,8 +545,7 @@ TEST_F(OverrideMetaLayer, OlderMetaLayerWithNewerInstanceVersion) {
     std::array<VkLayerProperties, 2> layer_props;
     EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
     EXPECT_EQ(layer_count, 2);
-    EXPECT_TRUE(string_eq(layer_props[0].layerName, lunarg_meta_layer_name));
-    EXPECT_TRUE(string_eq(layer_props[1].layerName, regular_layer_name));
+    EXPECT_TRUE(check_permutation({regular_layer_name, lunarg_meta_layer_name}, layer_props));
 
     {
         // 1.1 instance

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -999,7 +999,7 @@ TEST_F(LayerExtensions, ImplicitDirDispModeInstanceExtension) {
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 1);
+    ASSERT_EQ(extension_count, 3);  // the instance extension, debug_utils, and debug_report
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS,
               env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
@@ -1058,7 +1058,7 @@ TEST_F(LayerExtensions, ImplicitDispSurfCountInstanceExtension) {
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 1);
+    ASSERT_EQ(extension_count, 3);  // the instance extension, debug_utils, and debug_report
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS,
               env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
@@ -1118,7 +1118,7 @@ TEST_F(LayerExtensions, ImplicitBothInstanceExtensions) {
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 2);
+    ASSERT_EQ(extension_count, 4);  // the two instance extension plus debug_utils and debug_report
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS,
               env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
@@ -1246,7 +1246,7 @@ TEST_F(LayerExtensions, ExplicitDirDispModeInstanceExtension) {
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
               env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 1);
+    ASSERT_EQ(extension_count, 1);
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count,
                                                                                        extension_props.data()));
@@ -1319,7 +1319,7 @@ TEST_F(LayerExtensions, ExplicitDispSurfCountInstanceExtension) {
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
               env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 1);
+    ASSERT_EQ(extension_count, 1);
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count,
                                                                                        extension_props.data()));
@@ -1393,7 +1393,7 @@ TEST_F(LayerExtensions, ExplicitBothInstanceExtensions) {
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
               env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 2);
+    ASSERT_EQ(extension_count, 2);
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count,
                                                                                        extension_props.data()));
@@ -1522,7 +1522,7 @@ TEST_F(LayerExtensions, ImplicitMaintenanceDeviceExtension) {
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 1);
+    ASSERT_EQ(extension_count, 1);
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
                                                                                      extension_props.data()));
@@ -1581,7 +1581,7 @@ TEST_F(LayerExtensions, ImplicitPresentImageDeviceExtension) {
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 1);
+    ASSERT_EQ(extension_count, 1);
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
                                                                                      extension_props.data()));
@@ -1641,7 +1641,7 @@ TEST_F(LayerExtensions, ImplicitBothDeviceExtensions) {
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 2);
+    ASSERT_EQ(extension_count, 2);
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
                                                                                      extension_props.data()));
@@ -1782,7 +1782,7 @@ TEST_F(LayerExtensions, ExplicitMaintenanceDeviceExtension) {
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
               env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 1);
+    ASSERT_EQ(extension_count, 1);
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name,
                                                                                      &extension_count, extension_props.data()));
@@ -1852,7 +1852,7 @@ TEST_F(LayerExtensions, ExplicitPresentImageDeviceExtension) {
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
               env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 1);
+    ASSERT_EQ(extension_count, 1);
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name,
                                                                                      &extension_count, extension_props.data()));
@@ -1924,7 +1924,7 @@ TEST_F(LayerExtensions, ExplicitBothDeviceExtensions) {
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
               env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count, nullptr));
-    ASSERT_GE(extension_count, 1);
+    ASSERT_EQ(extension_count, 2);  // debug_utils, and debug_report
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name,
                                                                                      &extension_count, extension_props.data()));

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -570,7 +570,7 @@ TEST(TryLoadWrongBinaries, WrongExplicitAndImplicit) {
     auto layer_0 = ManifestLayer{}.add_layer(
         ManifestLayer::LayerDescription{}.set_name(layer_name_0).set_lib_path(CURRENT_PLATFORM_DUMMY_BINARY));
 
-    auto layer_loc_0 = env.explicit_layer_folder.write("dummy_test_layer_0.json", layer_0);
+    auto layer_loc_0 = env.explicit_layer_folder.write_manifest("dummy_test_layer_0.json", layer_0.get_manifest_str());
     env.platform_shim->add_manifest(ManifestCategory::explicit_layer, layer_loc_0);
 
     const char* layer_name_1 = "DummyLayerImplicit";
@@ -579,7 +579,7 @@ TEST(TryLoadWrongBinaries, WrongExplicitAndImplicit) {
                                                  .set_lib_path(CURRENT_PLATFORM_DUMMY_BINARY)
                                                  .set_disable_environment("DISABLE_ENV"));
 
-    auto layer_loc_1 = env.implicit_layer_folder.write("dummy_test_layer_1.json", layer_1);
+    auto layer_loc_1 = env.implicit_layer_folder.write_manifest("dummy_test_layer_1.json", layer_1.get_manifest_str());
     env.platform_shim->add_manifest(ManifestCategory::implicit_layer, layer_loc_1);
 
     uint32_t layer_count = 0;

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -371,7 +371,7 @@ TEST_F(EnumeratePhysicalDevices, TwoCall) {
     env->reset_icd().add_instance_extension(first_ext);
 
     const uint32_t real_device_count = 2;
-    for (size_t i = 0; i < real_device_count; i++) {
+    for (uint32_t i = 0; i < real_device_count; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i), i + 1);
         driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
     }
@@ -397,7 +397,7 @@ TEST_F(EnumeratePhysicalDevices, MatchOneAndTwoCallNumbers) {
     env->reset_icd().add_instance_extension(first_ext);
 
     const uint32_t real_device_count = 3;
-    for (size_t i = 0; i < real_device_count; i++) {
+    for (uint32_t i = 0; i < real_device_count; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i), i + 1);
         driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
     }
@@ -432,7 +432,7 @@ TEST_F(EnumeratePhysicalDevices, TwoCallIncomplete) {
     env->reset_icd().add_instance_extension(first_ext);
 
     const uint32_t real_device_count = 2;
-    for (size_t i = 0; i < real_device_count; i++) {
+    for (uint32_t i = 0; i < real_device_count; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i), i + 1);
         driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
     }


### PR DESCRIPTION
Loader changes include:
* The Loader makes sure all component layers in a meta layer are found. It would then do this check
immediately afterwards. This is redundant and can be removed.

* The loader_read_layer_json function wasn't decrementing the count of layers in the
list if it failed to load, leading to inconsistent results. Several places were removing layers in a layer list
manually when the functions loader_remove_layer_in_list exists. They also weren't modifying their loop counters
when it was necessary.

Small cleanup of FolderManager code.

Add tests for:
ExplicitMetaLayer - meta layer found in explicit paths
MetaLayerNameInComponentLayers - meta layer contains itself
MetaLayerWhichAddsmetaLayer - when a meta layer enables another meta layer
InstanceExtensionInComponentLayer - instance extension propagation
DeviceExtensionInComponentLayer - device extension propagation
OverrideMetaLayer.OlderVersionThanInstance - Checks behavior of override layer
  if the applications version is greater.