### PR TITLE
Add VK_LOADER_TEST_LOADER_PATH env-var for tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,15 +5,13 @@ This directory contains a test suite for the Vulkan loader.
 These tests are not exhaustive &mdash; they are expected to be supplemented with other tests, such as CTS.
 
 
-## (NEW) Running Tests
+## Running Tests
 
 For most purposes `ctest` is the desired method of running tests.
 This is because when a test fails, `ctest` will automatically printout the failing test case.
 
 Tests are organized into various executables:
- * `test_regression` - Contains the vast majority of tests.
- * `test_wsi` - These test require presentation engine support.
-   * Because the test suite is meant to be run in CI, these test require extra work to make happen and thus live in their own executable.
+ * `test_regression` - Contains most tests.
  * `test_threading` - Tests which need multiple threads to execute.
    * This allows targeted testing which uses tools like ThreadSanitizer
 
@@ -21,15 +19,6 @@ The loader test framework is designed to be easy to use, as simple as just runni
 automation is required. More details are in the tests/framework/README.md.
 The consequence of this automation: Do not relocate the build folder of the project without cleaning the CMakeCache. Most components are found by absolute
 path and thus require the contents of the folder to not be relocated.
-
-## (OLD) Running Tests
-
-To run the tests, your environment needs to be configured so that the test layers will be found.
-This can be done by setting the `VK_LAYER_PATH` environment variable to point at the built layers.
-Depending on the platform build tool you use, this location will either be `${CMAKE_BINARY_DIR}/tests/layers` or `${CMAKE_BINARY_DIR}/tests/layers/${CONFIGURATION}`.
-When using Visual Studio, a the generated project will already be set up to set the environment as needed.
-Running the tests through the `run_loader_tests.sh` script on Linux will also set up the environment properly.
-With any other toolchain, the user will have to set up the environment manually.
 
 ## Writing Tests
 
@@ -40,3 +29,15 @@ IMPORTANT NOTES:
  * NEVER FORGET TO DESTROY A VKINSTANCE THAT WAS SUCCESSFULLY CREATED.
    * The loader loads dynamic libraries in `vkCreateInstance` and unloads them in `vkDestroyInstance`. If these dynamic libraries aren't unloaded, they leak state
    into the next test that runs, causing spurious failures or even crashes.
+   * Use InstWrapper helper as well as DeviceWrapper to automate this concern away.
+
+## Using a specific loader with the tests
+
+The environment variable `VK_LOADER_TEST_LOADER_PATH` can be used to specify which vulkan-loader binary should be used. This is useful when writing tests to exercise
+a bug fix. Simply build the loader without the fix, stash it in a known location. Write the fix and the test that should exercise the bug and it passes. Then run the
+test again but with this env-var set to the older loader without the fix and show that the test now fails.
+
+Basic usage example:
+```c
+VK_LOADER_TEST_LOADER_PATH="/path/to/older/loader/build" ctest --output-on-failure
+```


### PR DESCRIPTION
The environment variable VK_LOADER_TEST_LOADER_PATH allows running of tests
using a different binary than the one built by the repo. This is extremely
useful for checking that a test exercises a bugfix, by quickly allowing the
running of the same test on the current 'fixed' loader and an older 'broken'
loader.