### PR TITLE
Add VK_NN_vi_surface to WSI extension names array

### DIFF
--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -4028,42 +4028,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleNV(
 
 #endif // VK_USE_PLATFORM_WIN32_KHR
 
-// ---- VK_NN_vi_surface extension trampoline/terminators
-
-#ifdef VK_USE_PLATFORM_VI_NN
-VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
-    VkInstance                                  instance,
-    const VkViSurfaceCreateInfoNN*              pCreateInfo,
-    const VkAllocationCallbacks*                pAllocator,
-    VkSurfaceKHR*                               pSurface) {
-    struct loader_instance *inst = loader_get_instance(instance);
-    if (NULL == inst) {
-        loader_log(
-            NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
-            "vkCreateViSurfaceNN: Invalid instance [VUID-vkCreateViSurfaceNN-instance-parameter]");
-        abort(); /* Intentionally fail so user can correct issue. */
-    }
-#error("Not implemented. Likely needs to be manually generated!");
-    return inst->disp->CreateViSurfaceNN(instance, pCreateInfo, pAllocator, pSurface);
-}
-
-VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateViSurfaceNN(
-    VkInstance                                  instance,
-    const VkViSurfaceCreateInfoNN*              pCreateInfo,
-    const VkAllocationCallbacks*                pAllocator,
-    VkSurfaceKHR*                               pSurface) {
-    struct loader_instance *inst = loader_get_instance(instance);
-    if (NULL == inst) {
-        loader_log(
-            NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
-            "vkCreateViSurfaceNN: Invalid instance [VUID-vkCreateViSurfaceNN-instance-parameter]");
-        abort(); /* Intentionally fail so user can correct issue. */
-    }
-#error("Not implemented. Likely needs to be manually generated!");
-}
-
-#endif // VK_USE_PLATFORM_VI_NN
-
 // ---- VK_EXT_conditional_rendering extension trampoline/terminators
 
 VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
@@ -7232,16 +7196,6 @@ bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *na
     }
 #endif // VK_USE_PLATFORM_WIN32_KHR
 
-    // ---- VK_NN_vi_surface extension commands
-#ifdef VK_USE_PLATFORM_VI_NN
-    if (!strcmp("vkCreateViSurfaceNN", name)) {
-        *addr = (ptr_instance->enabled_known_extensions.nn_vi_surface == 1)
-                     ? (void *)CreateViSurfaceNN
-                     : NULL;
-        return true;
-    }
-#endif // VK_USE_PLATFORM_VI_NN
-
     // ---- VK_EXT_conditional_rendering extension commands
     if (!strcmp("vkCmdBeginConditionalRenderingEXT", name)) {
         *addr = (void *)CmdBeginConditionalRenderingEXT;
@@ -8037,12 +7991,6 @@ void extensions_create_instance(struct loader_instance *ptr_instance, const VkIn
     // ---- VK_NV_external_memory_capabilities extension commands
         } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NV_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME)) {
             ptr_instance->enabled_known_extensions.nv_external_memory_capabilities = 1;
-
-    // ---- VK_NN_vi_surface extension commands
-#ifdef VK_USE_PLATFORM_VI_NN
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NN_VI_SURFACE_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.nn_vi_surface = 1;
-#endif // VK_USE_PLATFORM_VI_NN
 
     // ---- VK_EXT_direct_mode_display extension commands
         } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME)) {

--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -475,7 +475,6 @@ union loader_instance_extension_enables {
         uint8_t khr_external_fence_capabilities : 1;
         uint8_t ext_debug_report : 1;
         uint8_t nv_external_memory_capabilities : 1;
-        uint8_t nn_vi_surface : 1;
         uint8_t ext_direct_mode_display : 1;
         uint8_t ext_acquire_xlib_display : 1;
         uint8_t ext_display_surface_counter : 1;

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -45,7 +45,8 @@ WSI_EXT_NAMES = ['VK_KHR_surface',
                  'VK_KHR_display_swapchain',
                  'VK_KHR_get_display_properties2',
                  'VK_KHR_get_surface_capabilities2',
-                 'VK_QNX_screen_surface']
+                 'VK_QNX_screen_surface',
+                 'VK_NN_vi_surface']
 
 ADD_INST_CMDS = ['vkCreateInstance',
                  'vkEnumerateInstanceExtensionProperties',


### PR DESCRIPTION
This PR adds the WSI extension VK_NN_vi_surface to the WSI_EXT_NAMES array in loader_extension_generator.py so that vk_loader_extensions.c/.h are no longer generated with incorrect code for this extension.