### PR TITLE
Handle Vulkan variant's correctly

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -252,7 +252,7 @@ static uint32_t loader_make_version(char *vers_str) {
         }
     }
 
-    return VK_MAKE_VERSION(major, minor, patch);
+    return VK_MAKE_API_VERSION(0, major, minor, patch);
 }
 
 bool compare_vk_extension_properties(const VkExtensionProperties *op1, const VkExtensionProperties *op2) {
@@ -521,8 +521,8 @@ static VkResult loader_add_instance_extensions(const struct loader_instance *ins
 
         bool ext_unsupported = wsi_unsupported_instance_extension(&ext_props[i]);
         if (!ext_unsupported) {
-            (void)snprintf(spec_version, sizeof(spec_version), "%d.%d.%d", VK_VERSION_MAJOR(ext_props[i].specVersion),
-                           VK_VERSION_MINOR(ext_props[i].specVersion), VK_VERSION_PATCH(ext_props[i].specVersion));
+            (void)snprintf(spec_version, sizeof(spec_version), "%d.%d.%d", VK_API_VERSION_MAJOR(ext_props[i].specVersion),
+                           VK_API_VERSION_MINOR(ext_props[i].specVersion), VK_API_VERSION_PATCH(ext_props[i].specVersion));
             loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Instance Extension: %s (%s) version %s", ext_props[i].extensionName,
                        lib_name, spec_version);
 
@@ -554,8 +554,8 @@ static VkResult loader_init_device_extensions(const struct loader_instance *inst
 
     for (i = 0; i < count; i++) {
         char spec_version[64];
-        (void)snprintf(spec_version, sizeof(spec_version), "%d.%d.%d", VK_VERSION_MAJOR(ext_props[i].specVersion),
-                       VK_VERSION_MINOR(ext_props[i].specVersion), VK_VERSION_PATCH(ext_props[i].specVersion));
+        (void)snprintf(spec_version, sizeof(spec_version), "%d.%d.%d", VK_API_VERSION_MAJOR(ext_props[i].specVersion),
+                       VK_API_VERSION_MINOR(ext_props[i].specVersion), VK_API_VERSION_PATCH(ext_props[i].specVersion));
         loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Device Extension: %s (%s) version %s", ext_props[i].extensionName,
                    phys_dev_term->this_icd_term->scanned_icd->lib_name, spec_version);
         res = loader_add_to_ext_list(inst, ext_list, 1, &ext_props[i]);
@@ -587,8 +587,8 @@ VkResult loader_add_device_extensions(const struct loader_instance *inst,
         }
         for (i = 0; i < count; i++) {
             char spec_version[64];
-            (void)snprintf(spec_version, sizeof(spec_version), "%d.%d.%d", VK_VERSION_MAJOR(ext_props[i].specVersion),
-                           VK_VERSION_MINOR(ext_props[i].specVersion), VK_VERSION_PATCH(ext_props[i].specVersion));
+            (void)snprintf(spec_version, sizeof(spec_version), "%d.%d.%d", VK_API_VERSION_MAJOR(ext_props[i].specVersion),
+                           VK_API_VERSION_MINOR(ext_props[i].specVersion), VK_API_VERSION_PATCH(ext_props[i].specVersion));
             loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Device Extension: %s (%s) version %s", ext_props[i].extensionName,
                        lib_name, spec_version);
             res = loader_add_to_ext_list(inst, ext_list, 1, &ext_props[i]);
@@ -934,8 +934,8 @@ static void loader_add_implicit_layer(const struct loader_instance *inst, const 
     // If the implicit layer is supposed to be enable, make sure the layer supports at least the same API version
     // that the application is asking (i.e. layer's API >= app's API).  If it's not, disable this layer.
     if (enable) {
-        uint16_t layer_api_major_version = VK_VERSION_MAJOR(prop->info.specVersion);
-        uint16_t layer_api_minor_version = VK_VERSION_MINOR(prop->info.specVersion);
+        uint16_t layer_api_major_version = VK_API_VERSION_MAJOR(prop->info.specVersion);
+        uint16_t layer_api_minor_version = VK_API_VERSION_MINOR(prop->info.specVersion);
         if (inst->app_api_major_version > layer_api_major_version ||
             (inst->app_api_major_version == layer_api_major_version && inst->app_api_minor_version > layer_api_minor_version)) {
             loader_log(inst, VULKAN_LOADER_INFO_BIT, 0,
@@ -966,8 +966,8 @@ bool loader_add_meta_layer(const struct loader_instance *inst, const struct load
     bool found = true;
 
     // We need to add all the individual component layers
-    uint16_t meta_layer_api_major_version = VK_VERSION_MAJOR(prop->info.specVersion);
-    uint16_t meta_layer_api_minor_version = VK_VERSION_MINOR(prop->info.specVersion);
+    uint16_t meta_layer_api_major_version = VK_API_VERSION_MAJOR(prop->info.specVersion);
+    uint16_t meta_layer_api_minor_version = VK_API_VERSION_MINOR(prop->info.specVersion);
     for (uint32_t comp_layer = 0; comp_layer < prop->num_component_layers; comp_layer++) {
         bool found_comp = false;
         const struct loader_layer_properties *search_prop =
@@ -975,8 +975,8 @@ bool loader_add_meta_layer(const struct loader_instance *inst, const struct load
         if (search_prop != NULL) {
             found_comp = true;
 
-            uint16_t search_layer_api_major_version = VK_VERSION_MAJOR(search_prop->info.specVersion);
-            uint16_t search_layer_api_minor_version = VK_VERSION_MINOR(search_prop->info.specVersion);
+            uint16_t search_layer_api_major_version = VK_API_VERSION_MAJOR(search_prop->info.specVersion);
+            uint16_t search_layer_api_minor_version = VK_API_VERSION_MINOR(search_prop->info.specVersion);
             if (meta_layer_api_major_version != search_layer_api_major_version ||
                 meta_layer_api_minor_version > search_layer_api_minor_version) {
                 loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0,
@@ -1704,8 +1704,8 @@ out:
 static bool verify_meta_layer_component_layers(const struct loader_instance *inst, struct loader_layer_properties *prop,
                                                struct loader_layer_list *instance_layers) {
     bool success = true;
-    const uint32_t expected_major = VK_VERSION_MAJOR(prop->info.specVersion);
-    const uint32_t expected_minor = VK_VERSION_MINOR(prop->info.specVersion);
+    const uint32_t expected_major = VK_API_VERSION_MAJOR(prop->info.specVersion);
+    const uint32_t expected_minor = VK_API_VERSION_MINOR(prop->info.specVersion);
 
     for (uint32_t comp_layer = 0; comp_layer < prop->num_component_layers; comp_layer++) {
         struct loader_layer_properties *comp_prop =
@@ -1721,8 +1721,8 @@ static bool verify_meta_layer_component_layers(const struct loader_instance *ins
         }
 
         // Check the version of each layer, they need to at least match MAJOR and MINOR
-        uint32_t cur_major = VK_VERSION_MAJOR(comp_prop->info.specVersion);
-        uint32_t cur_minor = VK_VERSION_MINOR(comp_prop->info.specVersion);
+        uint32_t cur_major = VK_API_VERSION_MAJOR(comp_prop->info.specVersion);
+        uint32_t cur_minor = VK_API_VERSION_MINOR(comp_prop->info.specVersion);
         if (cur_major != expected_major || cur_minor != expected_minor) {
             loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
                        "verify_meta_layer_component_layers: Meta-layer uses API version %d.%d, but component "
@@ -4535,8 +4535,8 @@ VkResult loader_enable_instance_layers(struct loader_instance *inst, const VkIns
         // Verify that the layer api version is at least that of the application's request, if not, throw a warning since
         // undefined behavior could occur.
         prop = inst->expanded_activated_layer_list.list + i;
-        layer_api_major_version = VK_VERSION_MAJOR(prop->info.specVersion);
-        layer_api_minor_version = VK_VERSION_MINOR(prop->info.specVersion);
+        layer_api_major_version = VK_API_VERSION_MAJOR(prop->info.specVersion);
+        layer_api_minor_version = VK_API_VERSION_MINOR(prop->info.specVersion);
         if (inst->app_api_major_version > layer_api_major_version ||
             (inst->app_api_major_version == layer_api_major_version && inst->app_api_minor_version > layer_api_minor_version)) {
             loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0,
@@ -5533,7 +5533,8 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateInstance(const VkInstanceCreateI
 
         // Create an instance, substituting the version to 1.0 if necessary
         VkApplicationInfo icd_app_info;
-        uint32_t icd_version_nopatch = VK_MAKE_VERSION(VK_VERSION_MAJOR(icd_version), VK_VERSION_MINOR(icd_version), 0);
+        uint32_t icd_version_nopatch =
+            VK_MAKE_API_VERSION(0, VK_API_VERSION_MAJOR(icd_version), VK_API_VERSION_MINOR(icd_version), 0);
         uint32_t requested_version = pCreateInfo == NULL || pCreateInfo->pApplicationInfo == NULL
                                          ? VK_API_VERSION_1_0
                                          : pCreateInfo->pApplicationInfo->apiVersion;

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2265,6 +2265,15 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
         props->disable_env_var.value[sizeof(props->disable_env_var.value) - 1] = '\0';
     }
 
+    // Make sure the layer's manifest doesn't contain a non zero variant value
+    if (VK_API_VERSION_VARIANT(props->info.specVersion) != 0) {
+        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                   "Layer %s has an \'api_version\' field which contains a non-zero variant value of %d. "
+                   " Skipping Layer.",
+                   props->info.layerName, VK_API_VERSION_VARIANT(props->info.specVersion));
+        goto out;
+    }
+
 // Now get all optional items and objects and put in list:
 // functions
 // instance_extensions

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3513,6 +3513,16 @@ VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_t
                     loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                                "loader_icd_scan: ICD JSON %s does not have an \'api_version\' field.", file_str);
                 }
+                if (VK_API_VERSION_VARIANT(vers) != 0) {
+                    loader_log(
+                        inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                        "loader_icd_scan: Driver's ICD JSON %s \'api_version\' field contains a non-zero variant value of %d. "
+                        " Skipping ICD JSON.",
+                        file_str, VK_API_VERSION_VARIANT(vers));
+                    cJSON_Delete(inst, json);
+                    json = NULL;
+                    continue;
+                }
                 VkResult icd_add_res = VK_SUCCESS;
                 icd_add_res = loader_scanned_icd_add(inst, icd_tramp_list, fullpath, vers);
                 if (VK_ERROR_OUT_OF_HOST_MEMORY == icd_add_res) {

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -231,8 +231,9 @@ static size_t loader_platform_combine_path(char *dest, size_t len, ...) {
 }
 
 // Given string of three part form "maj.min.pat" convert to a vulkan version number.
+// Also can understand four part form "variant.major.minor.patch" if provided.
 static uint32_t loader_make_version(char *vers_str) {
-    uint32_t major = 0, minor = 0, patch = 0;
+    uint32_t variant = 0, major = 0, minor = 0, patch = 0;
     char *vers_tok;
 
     if (!vers_str) {
@@ -248,11 +249,20 @@ static uint32_t loader_make_version(char *vers_str) {
             vers_tok = strtok(NULL, ".\"\n\r");
             if (NULL != vers_tok) {
                 patch = (uint16_t)atoi(vers_tok);
+                vers_tok = strtok(NULL, ".\"\n\r");
+                // check that we are using a 4 part version string
+                if (NULL != vers_tok) {
+                    // if we are, find the correct major, minor, and patch values (basically skip variant)
+                    variant = major;
+                    major = minor;
+                    minor = patch;
+                    patch = (uint16_t)atoi(vers_tok);
+                }
             }
         }
     }
 
-    return VK_MAKE_API_VERSION(0, major, minor, patch);
+    return VK_MAKE_API_VERSION(variant, major, minor, patch);
 }
 
 bool compare_vk_extension_properties(const VkExtensionProperties *op1, const VkExtensionProperties *op2) {

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -104,6 +104,13 @@ struct loader_override_expiration {
     uint8_t minute;
 };
 
+// This structure is used to store the json file version in a more manageable way.
+typedef struct {
+    uint16_t major;
+    uint16_t minor;
+    uint16_t patch;
+} loader_api_version;
+
 struct loader_layer_properties {
     VkLayerProperties info;
     enum layer_type_flags type_flags;

--- a/loader/terminator.c
+++ b/loader/terminator.c
@@ -630,7 +630,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceToolProperties(VkPhys
     if (icd_term->dispatch.GetPhysicalDeviceProperties) {
         icd_term->dispatch.GetPhysicalDeviceProperties(phys_dev_term->phys_dev, &properties);
 
-        if (VK_VERSION_MINOR(properties.apiVersion) >= 3 && icd_term->dispatch.GetPhysicalDeviceToolProperties) {
+        if (VK_API_VERSION_MINOR(properties.apiVersion) >= 3 && icd_term->dispatch.GetPhysicalDeviceToolProperties) {
             return icd_term->dispatch.GetPhysicalDeviceToolProperties(phys_dev_term->phys_dev, pToolCount, pToolProperties);
         }
     }

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -516,6 +516,17 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         }
     }
 
+    // Make sure the application provided API version has 0 for its variant
+    if (NULL != pCreateInfo->pApplicationInfo) {
+        uint32_t variant_version = VK_API_VERSION_VARIANT(pCreateInfo->pApplicationInfo->apiVersion);
+        if (0 != variant_version) {
+            loader_log(ptr_instance, VULKAN_LOADER_WARN_BIT, 0,
+                       "vkCreateInstance: The API Variant specified in pCreateInfo->pApplicationInfo.apiVersion is %d instead of "
+                       "the expected value of 0.",
+                       variant_version);
+        }
+    }
+
     // Due to implicit layers need to get layer list even if
     // enabledLayerCount == 0 and VK_INSTANCE_LAYERS is unset. For now always
     // get layer list via loader_scan_for_layers().

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -471,8 +471,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         ptr_instance->app_api_major_version = 1;
         ptr_instance->app_api_minor_version = 0;
     } else {
-        ptr_instance->app_api_major_version = VK_VERSION_MAJOR(pCreateInfo->pApplicationInfo->apiVersion);
-        ptr_instance->app_api_minor_version = VK_VERSION_MINOR(pCreateInfo->pApplicationInfo->apiVersion);
+        ptr_instance->app_api_major_version = VK_API_VERSION_MAJOR(pCreateInfo->pApplicationInfo->apiVersion);
+        ptr_instance->app_api_minor_version = VK_API_VERSION_MINOR(pCreateInfo->pApplicationInfo->apiVersion);
     }
 
     // Look for one or more VK_EXT_debug_report or VK_EXT_debug_utils create info structures

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -150,7 +150,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceLayerProperties(uint32_t*
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceVersion(uint32_t* pApiVersion) {
     if (pApiVersion != nullptr) {
-        *pApiVersion = VK_MAKE_VERSION(1, 0, 0);
+        *pApiVersion = VK_API_VERSION_1_0;
     }
     return VK_SUCCESS;
 }
@@ -161,8 +161,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo*
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
 
-    if (icd.icd_api_version < VK_MAKE_VERSION(1, 1, 0)) {
-        if (pCreateInfo->pApplicationInfo->apiVersion > VK_MAKE_VERSION(1, 0, 0)) {
+    if (icd.icd_api_version < VK_API_VERSION_1_1) {
+        if (pCreateInfo->pApplicationInfo->apiVersion > VK_API_VERSION_1_0) {
             return VK_ERROR_INCOMPATIBLE_DRIVER;
         }
     }
@@ -910,7 +910,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceExternalFenceProperties(
 #define TO_VOID_PFN(func) reinterpret_cast<PFN_vkVoidFunction>(func)
 
 PFN_vkVoidFunction get_instance_func_ver_1_1(VkInstance instance, const char* pName) {
-    if (icd.icd_api_version >= VK_MAKE_VERSION(1, 1, 0)) {
+    if (icd.icd_api_version >= VK_API_VERSION_1_1) {
         if (string_eq(pName, "test_vkEnumerateInstanceVersion")) {
             return TO_VOID_PFN(test_vkEnumerateInstanceVersion);
         }
@@ -918,7 +918,7 @@ PFN_vkVoidFunction get_instance_func_ver_1_1(VkInstance instance, const char* pN
     return nullptr;
 }
 PFN_vkVoidFunction get_instance_func_ver_1_2(VkInstance instance, const char* pName) {
-    if (icd.icd_api_version >= VK_MAKE_VERSION(1, 2, 0)) {
+    if (icd.icd_api_version >= VK_API_VERSION_1_2) {
         return nullptr;
     }
     return nullptr;

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -66,7 +66,7 @@ struct TestICD {
     BUILDER_VALUE(TestICD, bool, enable_icd_wsi, false);
     UsingICDProvidedWSI is_using_icd_wsi = UsingICDProvidedWSI::not_using;
 
-    BUILDER_VALUE(TestICD, uint32_t, icd_api_version, VK_MAKE_VERSION(1, 0, 0))
+    BUILDER_VALUE(TestICD, uint32_t, icd_api_version, VK_API_VERSION_1_0)
     BUILDER_VECTOR(TestICD, LayerDefinition, instance_layers, instance_layer)
     BUILDER_VECTOR(TestICD, Extension, instance_extensions, instance_extension)
 

--- a/tests/framework/layer/layer_util.h
+++ b/tests/framework/layer/layer_util.h
@@ -31,13 +31,13 @@
 
 struct LayerDefinition {
     BUILDER_VALUE(LayerDefinition, std::string, layerName, {})
-    BUILDER_VALUE(LayerDefinition, uint32_t, specVersion, VK_MAKE_VERSION(1, 0, 0))
-    BUILDER_VALUE(LayerDefinition, uint32_t, implementationVersion, VK_MAKE_VERSION(1, 0, 0))
+    BUILDER_VALUE(LayerDefinition, uint32_t, specVersion, VK_API_VERSION_1_0)
+    BUILDER_VALUE(LayerDefinition, uint32_t, implementationVersion, VK_API_VERSION_1_0)
     BUILDER_VALUE(LayerDefinition, std::string, description, {})
     BUILDER_VECTOR(LayerDefinition, Extension, extensions, extension)
 
-    LayerDefinition(std::string layerName, uint32_t specVersion = VK_MAKE_VERSION(1, 0, 0),
-                    uint32_t implementationVersion = VK_MAKE_VERSION(1, 0, 0), std::string description = "",
+    LayerDefinition(std::string layerName, uint32_t specVersion = VK_API_VERSION_1_0,
+                    uint32_t implementationVersion = VK_API_VERSION_1_0, std::string description = "",
                     std::vector<Extension> extensions = {})
         : layerName(layerName),
           specVersion(specVersion),

--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -130,7 +130,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateDeviceExtensionProperties(VkPhysi
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceVersion(uint32_t* pApiVersion) {
     if (pApiVersion != nullptr) {
-        *pApiVersion = VK_MAKE_VERSION(1, 0, 0);
+        *pApiVersion = VK_API_VERSION_1_0;
     }
     return VK_SUCCESS;
 }

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -90,12 +90,12 @@ using FP_layer_callback = VkResult (*)(TestLayer& layer, void* data);
 
 struct TestLayer {
     fs::path manifest_file_path;
-    uint32_t manifest_version = VK_MAKE_VERSION(1, 1, 2);
+    uint32_t manifest_version = VK_MAKE_API_VERSION(0, 1, 1, 2);
 
     BUILDER_VALUE(TestLayer, bool, is_meta_layer, false)
 
     BUILDER_VALUE(TestLayer, std::string, unique_name, {})
-    BUILDER_VALUE(TestLayer, uint32_t, api_version, VK_MAKE_VERSION(1, 0, 0))
+    BUILDER_VALUE(TestLayer, uint32_t, api_version, VK_API_VERSION_1_0)
     BUILDER_VALUE(TestLayer, uint32_t, implementation_version, 2)
     BUILDER_VALUE(TestLayer, uint32_t, min_implementation_version, 0)
     BUILDER_VALUE(TestLayer, std::string, description, {})

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -228,7 +228,6 @@ void FrameworkEnvironment::add_layer_impl(TestLayerDetails layer_details, fs::Fo
 
             // Don't load the layer binary if using any of the wrap objects layers, since it doesn't export the same interface
             // functions
-            std::cout << "stem: " << layer.lib_path.stem().str() << "\n";
             if (layer.lib_path.stem().str().find(fs::path(TEST_LAYER_WRAP_OBJECTS).stem().str()) == std::string::npos) {
                 layers.push_back(TestLayerHandle(new_layer_location));
                 layers.back().reset_layer();

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -290,10 +290,10 @@ struct TestLayerHandle {
 };
 
 struct TestICDDetails {
-    TestICDDetails(fs::path icd_path, uint32_t api_version = VK_MAKE_VERSION(1, 0, 0)) noexcept
+    TestICDDetails(fs::path icd_path, uint32_t api_version = VK_API_VERSION_1_0) noexcept
         : icd_path(icd_path), api_version(api_version) {}
     BUILDER_VALUE(TestICDDetails, fs::path, icd_path, {});
-    BUILDER_VALUE(TestICDDetails, uint32_t, api_version, VK_MAKE_VERSION(1, 0, 0));
+    BUILDER_VALUE(TestICDDetails, uint32_t, api_version, VK_API_VERSION_1_0);
     BUILDER_VALUE(TestICDDetails, std::string, json_name, "test_icd");
     BUILDER_VALUE(TestICDDetails, bool, use_env_var_icd_filenames, false);
     BUILDER_VALUE(TestICDDetails, bool, is_fake, false);

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -600,12 +600,14 @@ InstanceCreateInfo::InstanceCreateInfo() {
 }
 
 VkInstanceCreateInfo* InstanceCreateInfo::get() noexcept {
-    application_info.pApplicationName = app_name.c_str();
-    application_info.pEngineName = engine_name.c_str();
-    application_info.applicationVersion = app_version;
-    application_info.engineVersion = engine_version;
-    application_info.apiVersion = api_version;
-    instance_info.pApplicationInfo = &application_info;
+    if (fill_in_application_info) {
+        application_info.pApplicationName = app_name.c_str();
+        application_info.pEngineName = engine_name.c_str();
+        application_info.applicationVersion = app_version;
+        application_info.engineVersion = engine_version;
+        application_info.apiVersion = api_version;
+        instance_info.pApplicationInfo = &application_info;
+    }
     instance_info.enabledLayerCount = static_cast<uint32_t>(enabled_layers.size());
     instance_info.ppEnabledLayerNames = enabled_layers.data();
     instance_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -463,8 +463,10 @@ bool string_eq(const char* a, const char* b) noexcept;
 bool string_eq(const char* a, const char* b, size_t len) noexcept;
 
 inline std::string version_to_string(uint32_t version) {
-    return std::to_string(VK_API_VERSION_MAJOR(version)) + "." + std::to_string(VK_API_VERSION_MINOR(version)) + "." +
-           std::to_string(VK_API_VERSION_PATCH(version));
+    std::string out = std::to_string(VK_API_VERSION_MAJOR(version)) + "." + std::to_string(VK_API_VERSION_MINOR(version)) + "." +
+                      std::to_string(VK_API_VERSION_PATCH(version));
+    if (VK_API_VERSION_VARIANT(version) != 0) out += std::to_string(VK_API_VERSION_VARIANT(version)) + "." + out;
+    return out;
 }
 
 // Macro to ease the definition of variables with builder member functions

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -723,10 +723,13 @@ struct InstanceCreateInfo {
     BUILDER_VALUE(InstanceCreateInfo, uint32_t, api_version, VK_MAKE_VERSION(1, 0, 0))
     BUILDER_VECTOR(InstanceCreateInfo, const char*, enabled_layers, layer)
     BUILDER_VECTOR(InstanceCreateInfo, const char*, enabled_extensions, extension)
+    // tell the get() function to not provide `application_info`
+    BUILDER_VALUE(InstanceCreateInfo, bool, fill_in_application_info, true)
 
     InstanceCreateInfo();
 
     VkInstanceCreateInfo* get() noexcept;
+
     InstanceCreateInfo& set_api_version(uint32_t major, uint32_t minor, uint32_t patch);
 };
 

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -463,8 +463,8 @@ bool string_eq(const char* a, const char* b) noexcept;
 bool string_eq(const char* a, const char* b, size_t len) noexcept;
 
 inline std::string version_to_string(uint32_t version) {
-    return std::to_string(VK_VERSION_MAJOR(version)) + "." + std::to_string(VK_VERSION_MINOR(version)) + "." +
-           std::to_string(VK_VERSION_PATCH(version));
+    return std::to_string(VK_API_VERSION_MAJOR(version)) + "." + std::to_string(VK_API_VERSION_MINOR(version)) + "." +
+           std::to_string(VK_API_VERSION_PATCH(version));
 }
 
 // Macro to ease the definition of variables with builder member functions

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -553,7 +553,7 @@ struct ManifestLayer {
         BUILDER_VALUE(LayerDescription, std::string, name, {})
         BUILDER_VALUE(LayerDescription, Type, type, Type::INSTANCE)
         BUILDER_VALUE(LayerDescription, fs::path, lib_path, {})
-        BUILDER_VALUE(LayerDescription, uint32_t, api_version, VK_MAKE_VERSION(1, 0, 0))
+        BUILDER_VALUE(LayerDescription, uint32_t, api_version, VK_API_VERSION_1_0)
         BUILDER_VALUE(LayerDescription, uint32_t, implementation_version, 0)
         BUILDER_VALUE(LayerDescription, std::string, description, {})
         BUILDER_VECTOR(LayerDescription, FunctionOverride, functions, function)
@@ -577,9 +577,9 @@ struct ManifestLayer {
 
 struct Extension {
     BUILDER_VALUE(Extension, std::string, extensionName, {})
-    BUILDER_VALUE(Extension, uint32_t, specVersion, VK_MAKE_VERSION(1, 0, 0))
+    BUILDER_VALUE(Extension, uint32_t, specVersion, VK_API_VERSION_1_0)
 
-    Extension(std::string extensionName, uint32_t specVersion = VK_MAKE_VERSION(1, 0, 0))
+    Extension(std::string extensionName, uint32_t specVersion = VK_API_VERSION_1_0)
         : extensionName(extensionName), specVersion(specVersion) {}
 
     VkExtensionProperties get() const noexcept {
@@ -720,7 +720,7 @@ struct InstanceCreateInfo {
     BUILDER_VALUE(InstanceCreateInfo, std::string, engine_name, {})
     BUILDER_VALUE(InstanceCreateInfo, uint32_t, app_version, 0)
     BUILDER_VALUE(InstanceCreateInfo, uint32_t, engine_version, 0)
-    BUILDER_VALUE(InstanceCreateInfo, uint32_t, api_version, VK_MAKE_VERSION(1, 0, 0))
+    BUILDER_VALUE(InstanceCreateInfo, uint32_t, api_version, VK_API_VERSION_1_0)
     BUILDER_VECTOR(InstanceCreateInfo, const char*, enabled_layers, layer)
     BUILDER_VECTOR(InstanceCreateInfo, const char*, enabled_extensions, extension)
     // tell the get() function to not provide `application_info`

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -596,3 +596,18 @@ TEST(MinorVersionUpdate, Version1_3) {
     auto SetPrivateData = reinterpret_cast<PFN_vkSetPrivateData>(inst.functions->vkGetDeviceProcAddr(device, "vkSetPrivateData"));
     SetPrivateData(device, VK_OBJECT_TYPE_UNKNOWN, 0, {}, 0);
 }
+
+TEST(ApplicationInfoVersion, NonVulkanVariant) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().physical_devices.push_back({});
+
+    DebugUtilsLogger log;
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.set_api_version(VK_MAKE_API_VERSION(1, 0, 0, 0));
+    FillDebugUtilsCreateDetails(inst.create_info, log);
+    inst.CheckCreate();
+    ASSERT_TRUE(log.find(
+        std::string("vkCreateInstance: The API Variant specified in pCreateInfo->pApplicationInfo.apiVersion is 1 instead of "
+                    "the expected value of 0.")));
+}

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -46,7 +46,7 @@ class WsiTests : public ::testing::Test {
 // When ICD doesn't support the extension, create instance should fail
 TEST_F(WsiTests, CreateSurfaceWin32NoICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.enable_icd_wsi = false;
 
@@ -63,7 +63,7 @@ TEST_F(WsiTests, CreateSurfaceWin32NoICDSupport) {
 // When ICD doesn't support the surface creation, the loader should handle it
 TEST_F(WsiTests, CreateSurfaceWin32NoICDCreateSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
@@ -85,7 +85,7 @@ TEST_F(WsiTests, CreateSurfaceWin32NoICDCreateSupport) {
 // When ICD does support the surface creation, the loader should  delegat handle it to the ICD
 TEST_F(WsiTests, CreateSurfaceWin32ICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
@@ -135,7 +135,7 @@ TEST_F(WsiTests, CreateSurfaceWin32MixedICDSupport) {
 
 TEST_F(WsiTests, GetPhysicalDeviceWin32PresentNoICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
@@ -156,7 +156,7 @@ TEST_F(WsiTests, GetPhysicalDeviceWin32PresentNoICDSupport) {
 
 TEST_F(WsiTests, GetPhysicalDeviceWin32PresentICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
@@ -180,7 +180,7 @@ TEST_F(WsiTests, GetPhysicalDeviceWin32PresentICDSupport) {
 // When ICD doesn't support the extension, create instance should fail
 TEST_F(WsiTests, CreateSurfaceXCBNoICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.enable_icd_wsi = false;
 
@@ -197,7 +197,7 @@ TEST_F(WsiTests, CreateSurfaceXCBNoICDSupport) {
 // When ICD doesn't support the surface creation, the loader should handle it
 TEST_F(WsiTests, CreateSurfaceXCBNoICDCreateSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
@@ -219,7 +219,7 @@ TEST_F(WsiTests, CreateSurfaceXCBNoICDCreateSupport) {
 // When ICD does support the surface creation, the loader should  delegat handle it to the ICD
 TEST_F(WsiTests, CreateSurfaceXCBICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
@@ -269,7 +269,7 @@ TEST_F(WsiTests, CreateSurfaceXCBMixedICDSupport) {
 
 TEST_F(WsiTests, GetPhysicalDeviceXcbPresentNoICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
@@ -290,7 +290,7 @@ TEST_F(WsiTests, GetPhysicalDeviceXcbPresentNoICDSupport) {
 
 TEST_F(WsiTests, GetPhysicalDeviceXcbPresentICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
@@ -314,7 +314,7 @@ TEST_F(WsiTests, GetPhysicalDeviceXcbPresentICDSupport) {
 // When ICD doesn't support the extension, create instance should fail
 TEST_F(WsiTests, CreateSurfaceXLIBNoICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.enable_icd_wsi = false;
 
@@ -331,7 +331,7 @@ TEST_F(WsiTests, CreateSurfaceXLIBNoICDSupport) {
 // When ICD doesn't support the surface creation, the loader should handle it
 TEST_F(WsiTests, CreateSurfaceXLIBNoICDCreateSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
@@ -353,7 +353,7 @@ TEST_F(WsiTests, CreateSurfaceXLIBNoICDCreateSupport) {
 // When ICD does support the surface creation, the loader should  delegat handle it to the ICD
 TEST_F(WsiTests, CreateSurfaceXLIBICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
@@ -403,7 +403,7 @@ TEST_F(WsiTests, CreateSurfaceXLIBMixedICDSupport) {
 
 TEST_F(WsiTests, GetPhysicalDeviceXlibPresentNoICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
@@ -424,7 +424,7 @@ TEST_F(WsiTests, GetPhysicalDeviceXlibPresentNoICDSupport) {
 
 TEST_F(WsiTests, GetPhysicalDeviceXlibPresentICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
@@ -448,7 +448,7 @@ TEST_F(WsiTests, GetPhysicalDeviceXlibPresentICDSupport) {
 // When ICD doesn't support the extension, create instance should fail
 TEST_F(WsiTests, CreateSurfaceWaylandNoICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.enable_icd_wsi = false;
 
@@ -465,7 +465,7 @@ TEST_F(WsiTests, CreateSurfaceWaylandNoICDSupport) {
 // When ICD doesn't support the surface creation, the loader should handle it
 TEST_F(WsiTests, CreateSurfaceWaylandNoICDCreateSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
@@ -487,7 +487,7 @@ TEST_F(WsiTests, CreateSurfaceWaylandNoICDCreateSupport) {
 // When ICD does support the surface creation, the loader should  delegat handle it to the ICD
 TEST_F(WsiTests, CreateSurfaceWaylandICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
@@ -537,7 +537,7 @@ TEST_F(WsiTests, CreateSurfaceWaylandMixedICDSupport) {
 
 TEST_F(WsiTests, GetPhysicalDeviceWaylandPresentNoICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
@@ -558,7 +558,7 @@ TEST_F(WsiTests, GetPhysicalDeviceWaylandPresentNoICDSupport) {
 
 TEST_F(WsiTests, GetPhysicalDeviceWaylandPresentICDSupport) {
     auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_MAKE_VERSION(1, 0, 0));
+    driver.set_icd_api_version(VK_API_VERSION_1_0);
     driver.set_min_icd_interface_version(5);
     driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     driver.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});


### PR DESCRIPTION
The 1.2.175 header release saw the addition of API Variants. For the purposes 
of the loader, this should always be set to 0, for applications, layers and drivers.

The loader will warn an application if the variant of the apiVersion provided in VkApplicationInfo
is non zero. It will also skip over any ICD's found which have a non-zero variant version. And
any implicit layers found which do not have a zero for their variant will be not be loaded.

Fixes #799