### PR TITLE
Fix for https://github.com/KhronosGroup/Vulkan-Loader/issues/825

### DIFF
--- a/loader/gpa_helper.c
+++ b/loader/gpa_helper.c
@@ -273,7 +273,6 @@ void *globalGetProcAddr(const char *name) {
     if (!strcmp(name, "EnumerateInstanceExtensionProperties")) return vkEnumerateInstanceExtensionProperties;
     if (!strcmp(name, "EnumerateInstanceLayerProperties")) return vkEnumerateInstanceLayerProperties;
     if (!strcmp(name, "EnumerateInstanceVersion")) return vkEnumerateInstanceVersion;
-    if (!strcmp(name, "GetInstanceProcAddr")) return vkGetInstanceProcAddr;
 
     return NULL;
 }

--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -112,7 +112,7 @@ TEST(GetProcAddr, GlobalFunctions) {
         handle_assert_null(CreateInstance);
 
         auto GetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(gipa(inst, "vkGetInstanceProcAddr"));
-        handle_assert_null(GetInstanceProcAddr);
+        handle_assert_has_value(GetInstanceProcAddr);
 
         // get a non pre-instance function pointer
         auto EnumeratePhysicalDevices = reinterpret_cast<PFN_vkGetInstanceProcAddr>(gipa(inst, "vkEnumeratePhysicalDevices"));


### PR DESCRIPTION
According to latest spec clarifications, vkGetInstanceProcAddr is not a global function,
so should return valid pointer for provided valid instance as parameter.