### PR TITLE
Verify GIPA on device extensions

### DIFF
--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021 The Khronos Group Inc.
- * Copyright (c) 2021 Valve Corporation
- * Copyright (c) 2021 LunarG, Inc.
+ * Copyright (c) 2021-2022 The Khronos Group Inc.
+ * Copyright (c) 2021-2022 Valve Corporation
+ * Copyright (c) 2021-2022 LunarG, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and/or associated documentation files (the "Materials"), to
@@ -71,6 +71,7 @@ TEST(GetProcAddr, VerifyGetDeviceProcAddr) {
         reinterpret_cast<PFN_vkGetDeviceProcAddr>(env.vulkan_functions.vkGetDeviceProcAddr(dev.dev, "vkGetDeviceProcAddr"));
     ASSERT_EQ(gdpa_loader, gdpa_dev_queried);
 }
+
 // Load the global function pointers with and without a NULL vkInstance handle.
 // Call the function to make sure it is callable, don't care about what is returned.
 TEST(GetProcAddr, GlobalFunctions) {

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -1631,14 +1631,42 @@ TEST_F(LayerExtensions, ImplicitNoAdditionalDeviceExtension) {
         }
     }
 
+    // Device functions queried using vkGetInstanceProcAddr should be non-NULL since this could be available for any attached
+    // physical device.
+    PFN_vkTrimCommandPoolKHR pfn_vkTrimCommandPool =
+        reinterpret_cast<PFN_vkTrimCommandPoolKHR>(inst->vkGetInstanceProcAddr(inst.inst, "vkTrimCommandPoolKHR"));
+    PFN_vkGetSwapchainStatusKHR pfn_vkGetSwapchainStatus =
+        reinterpret_cast<PFN_vkGetSwapchainStatusKHR>(inst->vkGetInstanceProcAddr(inst.inst, "vkGetSwapchainStatusKHR"));
+    PFN_vkSetDeviceMemoryPriorityEXT pfn_vkSetDeviceMemoryPriority =
+        reinterpret_cast<PFN_vkSetDeviceMemoryPriorityEXT>(inst->vkGetInstanceProcAddr(inst.inst, "vkSetDeviceMemoryPriorityEXT"));
+    handle_assert_has_value(pfn_vkTrimCommandPool);
+    handle_assert_has_value(pfn_vkGetSwapchainStatus);
+    handle_assert_has_value(pfn_vkSetDeviceMemoryPriority);
+
     DeviceWrapper dev{inst};
     dev.create_info.add_device_queue(DeviceQueueCreateInfo{}.add_priority(0.0f));
     dev.CheckCreate(phys_dev);
 
-    // Make sure all the function pointers are NULL as well
+    // Query again after create device to make sure the value returned by vkGetInstanceProcAddr did not change
+    PFN_vkTrimCommandPoolKHR pfn_vkTrimCommandPool2 =
+        reinterpret_cast<PFN_vkTrimCommandPoolKHR>(inst->vkGetInstanceProcAddr(inst.inst, "vkTrimCommandPoolKHR"));
+    PFN_vkGetSwapchainStatusKHR pfn_vkGetSwapchainStatus2 =
+        reinterpret_cast<PFN_vkGetSwapchainStatusKHR>(inst->vkGetInstanceProcAddr(inst.inst, "vkGetSwapchainStatusKHR"));
+    PFN_vkSetDeviceMemoryPriorityEXT pfn_vkSetDeviceMemoryPriority2 =
+        reinterpret_cast<PFN_vkSetDeviceMemoryPriorityEXT>(inst->vkGetInstanceProcAddr(inst.inst, "vkSetDeviceMemoryPriorityEXT"));
+    ASSERT_EQ(pfn_vkTrimCommandPool, pfn_vkTrimCommandPool2);
+    ASSERT_EQ(pfn_vkGetSwapchainStatus, pfn_vkGetSwapchainStatus2);
+    ASSERT_EQ(pfn_vkSetDeviceMemoryPriority, pfn_vkSetDeviceMemoryPriority2);
+
+    // Make sure all the function pointers returned by vkGetDeviceProcAddr for non-enabled extensions are NULL
     handle_assert_null(dev->vkGetDeviceProcAddr(dev.dev, "vkTrimCommandPoolKHR"));
     handle_assert_null(dev->vkGetDeviceProcAddr(dev.dev, "vkGetSwapchainStatusKHR"));
     handle_assert_null(dev->vkGetDeviceProcAddr(dev.dev, "vkSetDeviceMemoryPriorityEXT"));
+
+    // Even though the instance functions returned are non-NULL.  They should not work if we haven't enabled the extensions.
+    ASSERT_DEATH(pfn_vkTrimCommandPool(dev.dev, VK_NULL_HANDLE, 0), "");
+    ASSERT_DEATH(pfn_vkGetSwapchainStatus(dev.dev, VK_NULL_HANDLE), "");
+    ASSERT_DEATH(pfn_vkSetDeviceMemoryPriority(dev.dev, VK_NULL_HANDLE, 0.f), "");
 
     remove_env_var(enable_env_var);
 }
@@ -2107,10 +2135,16 @@ TEST_F(LayerExtensions, ExplicitBothDeviceExtensions) {
     // Make sure only the appropriate function pointers are NULL as well
     handle_assert_has_value(dev->vkGetDeviceProcAddr(dev.dev, "vkTrimCommandPoolKHR"));
 
-    PFN_vkGetSwapchainStatusKHR pfnGetSwapchainStatusKHR =
+    PFN_vkGetSwapchainStatusKHR gipa_pfnGetSwapchainStatusKHR =
+        reinterpret_cast<PFN_vkGetSwapchainStatusKHR>(inst->vkGetInstanceProcAddr(inst.inst, "vkGetSwapchainStatusKHR"));
+    PFN_vkGetSwapchainStatusKHR gdpa_pfnGetSwapchainStatusKHR =
         reinterpret_cast<PFN_vkGetSwapchainStatusKHR>(dev->vkGetDeviceProcAddr(dev.dev, "vkGetSwapchainStatusKHR"));
-    handle_assert_has_value(pfnGetSwapchainStatusKHR);
-    ASSERT_EQ(VK_ERROR_NATIVE_WINDOW_IN_USE_KHR, pfnGetSwapchainStatusKHR(dev.dev, VK_NULL_HANDLE));
+    handle_assert_has_value(gipa_pfnGetSwapchainStatusKHR);
+    handle_assert_has_value(gdpa_pfnGetSwapchainStatusKHR);
+
+    // Make sure both versions (from vkGetInstanceProcAddr and vkGetDeviceProcAddr) return the same value.
+    ASSERT_EQ(VK_ERROR_NATIVE_WINDOW_IN_USE_KHR, gipa_pfnGetSwapchainStatusKHR(dev.dev, VK_NULL_HANDLE));
+    ASSERT_EQ(VK_ERROR_NATIVE_WINDOW_IN_USE_KHR, gdpa_pfnGetSwapchainStatusKHR(dev.dev, VK_NULL_HANDLE));
 }
 
 TEST(TestLayers, ExplicitlyEnableImplicitLayer) {


### PR DESCRIPTION
Verify that using vkGetInstanceProcAddr to get an entrypoint to a device
extension works when the extension is enabled, and crashes when the
extension isn't enabled.

Also, update a copyright notice date for my last commit.