### PR TITLE
Add debug extension tests

### DIFF
--- a/loader/extension_manual.c
+++ b/loader/extension_manual.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceExternalImageFormatPropertiesNV(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceExternalImageFormatPropertiesNV: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceExternalImageFormatPropertiesNV-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -96,7 +96,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysic
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceExternalImageFormatPropertiesNV: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceSurfaceCapabilities2EXT-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -161,7 +161,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseDisplayEXT(VkPhysicalDevice physicalDevice
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkReleaseDisplayEXT: Invalid physicalDevice [VUID-vkReleaseDisplayEXT-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -190,7 +190,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireXlibDisplayEXT(VkPhysicalDevice physicalDe
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkAcquireXlibDisplayEXT: Invalid physicalDevice [VUID-vkAcquireXlibDisplayEXT-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -221,7 +221,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(VkPhysicalDevice physica
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetRandROutputDisplayEXT: Invalid physicalDevice [VUID-vkGetRandROutputDisplayEXT-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -259,7 +259,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModes2EXT(VkPhysic
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceSurfacePresentModes2EXT: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceSurfacePresentModes2EXT-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -298,7 +298,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModes2EXT(VkDevice de
                                                                      VkDeviceGroupPresentModeFlagsKHR *pModes) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceGroupSurfacePresentModes2EXT: Invalid device "
                    "[VUID-vkGetDeviceGroupSurfacePresentModes2EXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -336,7 +336,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevi
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceToolPropertiesEXT: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceToolPropertiesEXT-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */

--- a/loader/generated/vk_layer_dispatch_table.h
+++ b/loader/generated/vk_layer_dispatch_table.h
@@ -2,9 +2,9 @@
 // See loader_extension_generator.py for modifications
 
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -2,9 +2,9 @@
 // See loader_extension_generator.py for modifications
 
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2220,7 +2220,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoCapabilitiesKHR(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceVideoCapabilitiesKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2252,7 +2252,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceVideoFormatPropertiesKHR(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceVideoFormatPropertiesKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceVideoFormatPropertiesKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2284,7 +2284,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionKHR(
     VkVideoSessionKHR*                          pVideoSession) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateVideoSessionKHR: Invalid device "
                    "[VUID-vkCreateVideoSessionKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2300,7 +2300,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionKHR(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyVideoSessionKHR: Invalid device "
                    "[VUID-vkDestroyVideoSessionKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2317,7 +2317,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetVideoSessionMemoryRequirementsKHR(
     VkVideoGetMemoryPropertiesKHR*              pVideoSessionMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetVideoSessionMemoryRequirementsKHR: Invalid device "
                    "[VUID-vkGetVideoSessionMemoryRequirementsKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2334,7 +2334,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindVideoSessionMemoryKHR(
     const VkVideoBindMemoryKHR*                 pVideoSessionBindMemories) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkBindVideoSessionMemoryKHR: Invalid device "
                    "[VUID-vkBindVideoSessionMemoryKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2351,7 +2351,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateVideoSessionParametersKHR(
     VkVideoSessionParametersKHR*                pVideoSessionParameters) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateVideoSessionParametersKHR: Invalid device "
                    "[VUID-vkCreateVideoSessionParametersKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2367,7 +2367,7 @@ VKAPI_ATTR VkResult VKAPI_CALL UpdateVideoSessionParametersKHR(
     const VkVideoSessionParametersUpdateInfoKHR* pUpdateInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkUpdateVideoSessionParametersKHR: Invalid device "
                    "[VUID-vkUpdateVideoSessionParametersKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2383,7 +2383,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyVideoSessionParametersKHR(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyVideoSessionParametersKHR: Invalid device "
                    "[VUID-vkDestroyVideoSessionParametersKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2398,7 +2398,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginVideoCodingKHR(
     const VkVideoBeginCodingInfoKHR*            pBeginInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBeginVideoCodingKHR: Invalid commandBuffer "
                    "[VUID-vkCmdBeginVideoCodingKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2413,7 +2413,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndVideoCodingKHR(
     const VkVideoEndCodingInfoKHR*              pEndCodingInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdEndVideoCodingKHR: Invalid commandBuffer "
                    "[VUID-vkCmdEndVideoCodingKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2428,7 +2428,7 @@ VKAPI_ATTR void VKAPI_CALL CmdControlVideoCodingKHR(
     const VkVideoCodingControlInfoKHR*          pCodingControlInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdControlVideoCodingKHR: Invalid commandBuffer "
                    "[VUID-vkCmdControlVideoCodingKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2446,7 +2446,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDecodeVideoKHR(
     const VkVideoDecodeInfoKHR*                 pFrameInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDecodeVideoKHR: Invalid commandBuffer "
                    "[VUID-vkCmdDecodeVideoKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2463,7 +2463,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderingKHR(
     const VkRenderingInfo*                      pRenderingInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBeginRenderingKHR: Invalid commandBuffer "
                    "[VUID-vkCmdBeginRenderingKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2475,7 +2475,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderingKHR(
     VkCommandBuffer                             commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdEndRenderingKHR: Invalid commandBuffer "
                    "[VUID-vkCmdEndRenderingKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2494,7 +2494,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceGroupPeerMemoryFeaturesKHR(
     VkPeerMemoryFeatureFlags*                   pPeerMemoryFeatures) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceGroupPeerMemoryFeaturesKHR: Invalid device "
                    "[VUID-vkGetDeviceGroupPeerMemoryFeaturesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2507,7 +2507,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMaskKHR(
     uint32_t                                    deviceMask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetDeviceMaskKHR: Invalid commandBuffer "
                    "[VUID-vkCmdSetDeviceMaskKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2525,7 +2525,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBaseKHR(
     uint32_t                                    groupCountZ) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDispatchBaseKHR: Invalid commandBuffer "
                    "[VUID-vkCmdDispatchBaseKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2542,7 +2542,7 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPoolKHR(
     VkCommandPoolTrimFlags                      flags) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkTrimCommandPoolKHR: Invalid device "
                    "[VUID-vkTrimCommandPoolKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2560,7 +2560,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleKHR(
     HANDLE*                                     pHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetMemoryWin32HandleKHR: Invalid device "
                    "[VUID-vkGetMemoryWin32HandleKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2577,7 +2577,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandlePropertiesKHR(
     VkMemoryWin32HandlePropertiesKHR*           pMemoryWin32HandleProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetMemoryWin32HandlePropertiesKHR: Invalid device "
                    "[VUID-vkGetMemoryWin32HandlePropertiesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2595,7 +2595,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHR(
     int*                                        pFd) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetMemoryFdKHR: Invalid device "
                    "[VUID-vkGetMemoryFdKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2610,7 +2610,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdPropertiesKHR(
     VkMemoryFdPropertiesKHR*                    pMemoryFdProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetMemoryFdPropertiesKHR: Invalid device "
                    "[VUID-vkGetMemoryFdPropertiesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2627,7 +2627,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreWin32HandleKHR(
     const VkImportSemaphoreWin32HandleInfoKHR*  pImportSemaphoreWin32HandleInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkImportSemaphoreWin32HandleKHR: Invalid device "
                    "[VUID-vkImportSemaphoreWin32HandleKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2643,7 +2643,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreWin32HandleKHR(
     HANDLE*                                     pHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetSemaphoreWin32HandleKHR: Invalid device "
                    "[VUID-vkGetSemaphoreWin32HandleKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2660,7 +2660,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreFdKHR(
     const VkImportSemaphoreFdInfoKHR*           pImportSemaphoreFdInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkImportSemaphoreFdKHR: Invalid device "
                    "[VUID-vkImportSemaphoreFdKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2674,7 +2674,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreFdKHR(
     int*                                        pFd) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetSemaphoreFdKHR: Invalid device "
                    "[VUID-vkGetSemaphoreFdKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2694,7 +2694,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetKHR(
     const VkWriteDescriptorSet*                 pDescriptorWrites) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdPushDescriptorSetKHR: Invalid commandBuffer "
                    "[VUID-vkCmdPushDescriptorSetKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2710,7 +2710,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetWithTemplateKHR(
     const void*                                 pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdPushDescriptorSetWithTemplateKHR: Invalid commandBuffer "
                    "[VUID-vkCmdPushDescriptorSetWithTemplateKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2728,7 +2728,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(
     VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateDescriptorUpdateTemplateKHR: Invalid device "
                    "[VUID-vkCreateDescriptorUpdateTemplateKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2742,7 +2742,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyDescriptorUpdateTemplateKHR: Invalid device "
                    "[VUID-vkDestroyDescriptorUpdateTemplateKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2757,7 +2757,7 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplateKHR(
     const void*                                 pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkUpdateDescriptorSetWithTemplateKHR: Invalid device "
                    "[VUID-vkUpdateDescriptorSetWithTemplateKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2775,7 +2775,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
     VkRenderPass*                               pRenderPass) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateRenderPass2KHR: Invalid device "
                    "[VUID-vkCreateRenderPass2KHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2789,7 +2789,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2KHR(
     const VkSubpassBeginInfo*                   pSubpassBeginInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBeginRenderPass2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdBeginRenderPass2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2803,7 +2803,7 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2KHR(
     const VkSubpassEndInfo*                     pSubpassEndInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdNextSubpass2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdNextSubpass2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2816,7 +2816,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2KHR(
     const VkSubpassEndInfo*                     pSubpassEndInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdEndRenderPass2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdEndRenderPass2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2832,7 +2832,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainStatusKHR(
     VkSwapchainKHR                              swapchain) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetSwapchainStatusKHR: Invalid device "
                    "[VUID-vkGetSwapchainStatusKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2849,7 +2849,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceWin32HandleKHR(
     const VkImportFenceWin32HandleInfoKHR*      pImportFenceWin32HandleInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkImportFenceWin32HandleKHR: Invalid device "
                    "[VUID-vkImportFenceWin32HandleKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2865,7 +2865,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceWin32HandleKHR(
     HANDLE*                                     pHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetFenceWin32HandleKHR: Invalid device "
                    "[VUID-vkGetFenceWin32HandleKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2882,7 +2882,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceFdKHR(
     const VkImportFenceFdInfoKHR*               pImportFenceFdInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkImportFenceFdKHR: Invalid device "
                    "[VUID-vkImportFenceFdKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2896,7 +2896,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceFdKHR(
     int*                                        pFd) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetFenceFdKHR: Invalid device "
                    "[VUID-vkGetFenceFdKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2916,7 +2916,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceQueueFamilyPerformanceQuer
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR: Invalid physicalDevice "
                    "[VUID-vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2947,7 +2947,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2974,7 +2974,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireProfilingLockKHR(
     const VkAcquireProfilingLockInfoKHR*        pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkAcquireProfilingLockKHR: Invalid device "
                    "[VUID-vkAcquireProfilingLockKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2986,7 +2986,7 @@ VKAPI_ATTR void VKAPI_CALL ReleaseProfilingLockKHR(
     VkDevice                                    device) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkReleaseProfilingLockKHR: Invalid device "
                    "[VUID-vkReleaseProfilingLockKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3003,7 +3003,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2KHR(
     VkMemoryRequirements2*                      pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetImageMemoryRequirements2KHR: Invalid device "
                    "[VUID-vkGetImageMemoryRequirements2KHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3017,7 +3017,7 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2KHR(
     VkMemoryRequirements2*                      pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetBufferMemoryRequirements2KHR: Invalid device "
                    "[VUID-vkGetBufferMemoryRequirements2KHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3032,7 +3032,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2KHR(
     VkSparseImageMemoryRequirements2*           pSparseMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetImageSparseMemoryRequirements2KHR: Invalid device "
                    "[VUID-vkGetImageSparseMemoryRequirements2KHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3050,7 +3050,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
     VkSamplerYcbcrConversion*                   pYcbcrConversion) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateSamplerYcbcrConversionKHR: Invalid device "
                    "[VUID-vkCreateSamplerYcbcrConversionKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3064,7 +3064,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroySamplerYcbcrConversionKHR: Invalid device "
                    "[VUID-vkDestroySamplerYcbcrConversionKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3081,7 +3081,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(
     const VkBindBufferMemoryInfo*               pBindInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkBindBufferMemory2KHR: Invalid device "
                    "[VUID-vkBindBufferMemory2KHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3095,7 +3095,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2KHR(
     const VkBindImageMemoryInfo*                pBindInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkBindImageMemory2KHR: Invalid device "
                    "[VUID-vkBindImageMemory2KHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3112,7 +3112,7 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupportKHR(
     VkDescriptorSetLayoutSupport*               pSupport) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDescriptorSetLayoutSupportKHR: Invalid device "
                    "[VUID-vkGetDescriptorSetLayoutSupportKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3133,7 +3133,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountKHR(
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawIndirectCountKHR: Invalid commandBuffer "
                    "[VUID-vkCmdDrawIndirectCountKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3151,7 +3151,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountKHR(
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawIndexedIndirectCountKHR: Invalid commandBuffer "
                    "[VUID-vkCmdDrawIndexedIndirectCountKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3168,7 +3168,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValueKHR(
     uint64_t*                                   pValue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetSemaphoreCounterValueKHR: Invalid device "
                    "[VUID-vkGetSemaphoreCounterValueKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3182,7 +3182,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphoresKHR(
     uint64_t                                    timeout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkWaitSemaphoresKHR: Invalid device "
                    "[VUID-vkWaitSemaphoresKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3195,7 +3195,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SignalSemaphoreKHR(
     const VkSemaphoreSignalInfo*                pSignalInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkSignalSemaphoreKHR: Invalid device "
                    "[VUID-vkSignalSemaphoreKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3213,7 +3213,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceFragmentShadingRatesKHR(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceFragmentShadingRatesKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceFragmentShadingRatesKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3241,7 +3241,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateKHR(
     const VkFragmentShadingRateCombinerOpKHR    combinerOps[2]) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetFragmentShadingRateKHR: Invalid commandBuffer "
                    "[VUID-vkCmdSetFragmentShadingRateKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3259,7 +3259,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitForPresentKHR(
     uint64_t                                    timeout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkWaitForPresentKHR: Invalid device "
                    "[VUID-vkWaitForPresentKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3275,7 +3275,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressKHR(
     const VkBufferDeviceAddressInfo*            pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetBufferDeviceAddressKHR: Invalid device "
                    "[VUID-vkGetBufferDeviceAddressKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3288,7 +3288,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetBufferOpaqueCaptureAddressKHR(
     const VkBufferDeviceAddressInfo*            pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetBufferOpaqueCaptureAddressKHR: Invalid device "
                    "[VUID-vkGetBufferOpaqueCaptureAddressKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3301,7 +3301,7 @@ VKAPI_ATTR uint64_t VKAPI_CALL GetDeviceMemoryOpaqueCaptureAddressKHR(
     const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceMemoryOpaqueCaptureAddressKHR: Invalid device "
                    "[VUID-vkGetDeviceMemoryOpaqueCaptureAddressKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3318,7 +3318,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDeferredOperationKHR(
     VkDeferredOperationKHR*                     pDeferredOperation) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateDeferredOperationKHR: Invalid device "
                    "[VUID-vkCreateDeferredOperationKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3332,7 +3332,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDeferredOperationKHR(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyDeferredOperationKHR: Invalid device "
                    "[VUID-vkDestroyDeferredOperationKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3345,7 +3345,7 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetDeferredOperationMaxConcurrencyKHR(
     VkDeferredOperationKHR                      operation) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeferredOperationMaxConcurrencyKHR: Invalid device "
                    "[VUID-vkGetDeferredOperationMaxConcurrencyKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3358,7 +3358,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeferredOperationResultKHR(
     VkDeferredOperationKHR                      operation) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeferredOperationResultKHR: Invalid device "
                    "[VUID-vkGetDeferredOperationResultKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3371,7 +3371,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DeferredOperationJoinKHR(
     VkDeferredOperationKHR                      operation) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDeferredOperationJoinKHR: Invalid device "
                    "[VUID-vkDeferredOperationJoinKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3389,7 +3389,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutablePropertiesKHR(
     VkPipelineExecutablePropertiesKHR*          pProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPipelineExecutablePropertiesKHR: Invalid device "
                    "[VUID-vkGetPipelineExecutablePropertiesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3404,7 +3404,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableStatisticsKHR(
     VkPipelineExecutableStatisticKHR*           pStatistics) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPipelineExecutableStatisticsKHR: Invalid device "
                    "[VUID-vkGetPipelineExecutableStatisticsKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3419,7 +3419,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutableInternalRepresentationsKHR(
     VkPipelineExecutableInternalRepresentationKHR* pInternalRepresentations) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPipelineExecutableInternalRepresentationsKHR: Invalid device "
                    "[VUID-vkGetPipelineExecutableInternalRepresentationsKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3436,7 +3436,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEncodeVideoKHR(
     const VkVideoEncodeInfoKHR*                 pEncodeInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdEncodeVideoKHR: Invalid commandBuffer "
                    "[VUID-vkCmdEncodeVideoKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3454,7 +3454,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent2KHR(
     const VkDependencyInfo*                     pDependencyInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetEvent2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdSetEvent2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3468,7 +3468,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent2KHR(
     VkPipelineStageFlags2                       stageMask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdResetEvent2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdResetEvent2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3483,7 +3483,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents2KHR(
     const VkDependencyInfo*                     pDependencyInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdWaitEvents2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdWaitEvents2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3496,7 +3496,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier2KHR(
     const VkDependencyInfo*                     pDependencyInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdPipelineBarrier2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdPipelineBarrier2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3511,7 +3511,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2KHR(
     uint32_t                                    query) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdWriteTimestamp2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdWriteTimestamp2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3526,7 +3526,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(
     VkFence                                     fence) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkQueueSubmit2KHR: Invalid queue "
                    "[VUID-vkQueueSubmit2KHR-queue-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3542,7 +3542,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarker2AMD(
     uint32_t                                    marker) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdWriteBufferMarker2AMD: Invalid commandBuffer "
                    "[VUID-vkCmdWriteBufferMarker2AMD-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3556,7 +3556,7 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointData2NV(
     VkCheckpointData2NV*                        pCheckpointData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetQueueCheckpointData2NV: Invalid queue "
                    "[VUID-vkGetQueueCheckpointData2NV-queue-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3572,7 +3572,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer2KHR(
     const VkCopyBufferInfo2*                    pCopyBufferInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyBuffer2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdCopyBuffer2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3585,7 +3585,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage2KHR(
     const VkCopyImageInfo2*                     pCopyImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyImage2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdCopyImage2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3598,7 +3598,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage2KHR(
     const VkCopyBufferToImageInfo2*             pCopyBufferToImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyBufferToImage2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdCopyBufferToImage2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3611,7 +3611,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer2KHR(
     const VkCopyImageToBufferInfo2*             pCopyImageToBufferInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyImageToBuffer2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdCopyImageToBuffer2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3624,7 +3624,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage2KHR(
     const VkBlitImageInfo2*                     pBlitImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBlitImage2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdBlitImage2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3637,7 +3637,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage2KHR(
     const VkResolveImageInfo2*                  pResolveImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdResolveImage2KHR: Invalid commandBuffer "
                    "[VUID-vkCmdResolveImage2KHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3654,7 +3654,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceBufferMemoryRequirementsKHR(
     VkMemoryRequirements2*                      pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceBufferMemoryRequirementsKHR: Invalid device "
                    "[VUID-vkGetDeviceBufferMemoryRequirementsKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3668,7 +3668,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageMemoryRequirementsKHR(
     VkMemoryRequirements2*                      pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceImageMemoryRequirementsKHR: Invalid device "
                    "[VUID-vkGetDeviceImageMemoryRequirementsKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3683,7 +3683,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceImageSparseMemoryRequirementsKHR(
     VkSparseImageMemoryRequirements2*           pSparseMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceImageSparseMemoryRequirementsKHR: Invalid device "
                    "[VUID-vkGetDeviceImageSparseMemoryRequirementsKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3699,7 +3699,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
     const VkDebugMarkerObjectTagInfoEXT*        pTagInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDebugMarkerSetObjectTagEXT: Invalid device "
                    "[VUID-vkDebugMarkerSetObjectTagEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3747,7 +3747,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(
     const VkDebugMarkerObjectNameInfoEXT*       pNameInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDebugMarkerSetObjectNameEXT: Invalid device "
                    "[VUID-vkDebugMarkerSetObjectNameEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3795,7 +3795,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerBeginEXT(
     const VkDebugMarkerMarkerInfoEXT*           pMarkerInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDebugMarkerBeginEXT: Invalid commandBuffer "
                    "[VUID-vkCmdDebugMarkerBeginEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3807,7 +3807,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerEndEXT(
     VkCommandBuffer                             commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDebugMarkerEndEXT: Invalid commandBuffer "
                    "[VUID-vkCmdDebugMarkerEndEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3820,7 +3820,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerInsertEXT(
     const VkDebugMarkerMarkerInfoEXT*           pMarkerInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDebugMarkerInsertEXT: Invalid commandBuffer "
                    "[VUID-vkCmdDebugMarkerInsertEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3840,7 +3840,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindTransformFeedbackBuffersEXT(
     const VkDeviceSize*                         pSizes) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBindTransformFeedbackBuffersEXT: Invalid commandBuffer "
                    "[VUID-vkCmdBindTransformFeedbackBuffersEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3856,7 +3856,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginTransformFeedbackEXT(
     const VkDeviceSize*                         pCounterBufferOffsets) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBeginTransformFeedbackEXT: Invalid commandBuffer "
                    "[VUID-vkCmdBeginTransformFeedbackEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3872,7 +3872,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndTransformFeedbackEXT(
     const VkDeviceSize*                         pCounterBufferOffsets) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdEndTransformFeedbackEXT: Invalid commandBuffer "
                    "[VUID-vkCmdEndTransformFeedbackEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3888,7 +3888,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQueryIndexedEXT(
     uint32_t                                    index) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBeginQueryIndexedEXT: Invalid commandBuffer "
                    "[VUID-vkCmdBeginQueryIndexedEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3903,7 +3903,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQueryIndexedEXT(
     uint32_t                                    index) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdEndQueryIndexedEXT: Invalid commandBuffer "
                    "[VUID-vkCmdEndQueryIndexedEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3921,7 +3921,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectByteCountEXT(
     uint32_t                                    vertexStride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawIndirectByteCountEXT: Invalid commandBuffer "
                    "[VUID-vkCmdDrawIndirectByteCountEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3939,7 +3939,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCuModuleNVX(
     VkCuModuleNVX*                              pModule) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateCuModuleNVX: Invalid device "
                    "[VUID-vkCreateCuModuleNVX-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3954,7 +3954,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCuFunctionNVX(
     VkCuFunctionNVX*                            pFunction) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateCuFunctionNVX: Invalid device "
                    "[VUID-vkCreateCuFunctionNVX-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3968,7 +3968,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyCuModuleNVX(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyCuModuleNVX: Invalid device "
                    "[VUID-vkDestroyCuModuleNVX-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3982,7 +3982,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyCuFunctionNVX(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyCuFunctionNVX: Invalid device "
                    "[VUID-vkDestroyCuFunctionNVX-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -3995,7 +3995,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCuLaunchKernelNVX(
     const VkCuLaunchInfoNVX*                    pLaunchInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCuLaunchKernelNVX: Invalid commandBuffer "
                    "[VUID-vkCmdCuLaunchKernelNVX-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4011,7 +4011,7 @@ VKAPI_ATTR uint32_t VKAPI_CALL GetImageViewHandleNVX(
     const VkImageViewHandleInfoNVX*             pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetImageViewHandleNVX: Invalid device "
                    "[VUID-vkGetImageViewHandleNVX-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4025,7 +4025,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageViewAddressNVX(
     VkImageViewAddressPropertiesNVX*            pProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetImageViewAddressNVX: Invalid device "
                    "[VUID-vkGetImageViewAddressNVX-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4046,7 +4046,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawIndirectCountAMD: Invalid commandBuffer "
                    "[VUID-vkCmdDrawIndirectCountAMD-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4064,7 +4064,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountAMD(
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawIndexedIndirectCountAMD: Invalid commandBuffer "
                    "[VUID-vkCmdDrawIndexedIndirectCountAMD-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4084,7 +4084,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetShaderInfoAMD(
     void*                                       pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetShaderInfoAMD: Invalid device "
                    "[VUID-vkGetShaderInfoAMD-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4103,7 +4103,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleNV(
     HANDLE*                                     pHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetMemoryWin32HandleNV: Invalid device "
                    "[VUID-vkGetMemoryWin32HandleNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4120,7 +4120,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
     const VkConditionalRenderingBeginInfoEXT*   pConditionalRenderingBegin) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBeginConditionalRenderingEXT: Invalid commandBuffer "
                    "[VUID-vkCmdBeginConditionalRenderingEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4132,7 +4132,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndConditionalRenderingEXT(
     VkCommandBuffer                             commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdEndConditionalRenderingEXT: Invalid commandBuffer "
                    "[VUID-vkCmdEndConditionalRenderingEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4150,7 +4150,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingNV(
     const VkViewportWScalingNV*                 pViewportWScalings) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetViewportWScalingNV: Invalid commandBuffer "
                    "[VUID-vkCmdSetViewportWScalingNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4167,7 +4167,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DisplayPowerControlEXT(
     const VkDisplayPowerInfoEXT*                pDisplayPowerInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDisplayPowerControlEXT: Invalid device "
                    "[VUID-vkDisplayPowerControlEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4182,7 +4182,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(
     VkFence*                                    pFence) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkRegisterDeviceEventEXT: Invalid device "
                    "[VUID-vkRegisterDeviceEventEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4198,7 +4198,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(
     VkFence*                                    pFence) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkRegisterDisplayEventEXT: Invalid device "
                    "[VUID-vkRegisterDisplayEventEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4213,7 +4213,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainCounterEXT(
     uint64_t*                                   pCounterValue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetSwapchainCounterEXT: Invalid device "
                    "[VUID-vkGetSwapchainCounterEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4230,7 +4230,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRefreshCycleDurationGOOGLE(
     VkRefreshCycleDurationGOOGLE*               pDisplayTimingProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetRefreshCycleDurationGOOGLE: Invalid device "
                    "[VUID-vkGetRefreshCycleDurationGOOGLE-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4245,7 +4245,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPastPresentationTimingGOOGLE(
     VkPastPresentationTimingGOOGLE*             pPresentationTimings) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPastPresentationTimingGOOGLE: Invalid device "
                    "[VUID-vkGetPastPresentationTimingGOOGLE-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4263,7 +4263,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEXT(
     const VkRect2D*                             pDiscardRectangles) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetDiscardRectangleEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetDiscardRectangleEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4281,7 +4281,7 @@ VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(
     const VkHdrMetadataEXT*                     pMetadata) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkSetHdrMetadataEXT: Invalid device "
                    "[VUID-vkSetHdrMetadataEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4297,7 +4297,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
     const VkDebugUtilsObjectNameInfoEXT*        pNameInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkSetDebugUtilsObjectNameEXT: Invalid device "
                    "[VUID-vkSetDebugUtilsObjectNameEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4349,7 +4349,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectTagEXT(
     const VkDebugUtilsObjectTagInfoEXT*         pTagInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkSetDebugUtilsObjectTagEXT: Invalid device "
                    "[VUID-vkSetDebugUtilsObjectTagEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4401,7 +4401,7 @@ VKAPI_ATTR void VKAPI_CALL QueueBeginDebugUtilsLabelEXT(
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkQueueBeginDebugUtilsLabelEXT: Invalid queue "
                    "[VUID-vkQueueBeginDebugUtilsLabelEXT-queue-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4426,7 +4426,7 @@ VKAPI_ATTR void VKAPI_CALL QueueEndDebugUtilsLabelEXT(
     VkQueue                                     queue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkQueueEndDebugUtilsLabelEXT: Invalid queue "
                    "[VUID-vkQueueEndDebugUtilsLabelEXT-queue-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4451,7 +4451,7 @@ VKAPI_ATTR void VKAPI_CALL QueueInsertDebugUtilsLabelEXT(
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkQueueInsertDebugUtilsLabelEXT: Invalid queue "
                    "[VUID-vkQueueInsertDebugUtilsLabelEXT-queue-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4477,7 +4477,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginDebugUtilsLabelEXT(
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBeginDebugUtilsLabelEXT: Invalid commandBuffer "
                    "[VUID-vkCmdBeginDebugUtilsLabelEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4502,7 +4502,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndDebugUtilsLabelEXT(
     VkCommandBuffer                             commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdEndDebugUtilsLabelEXT: Invalid commandBuffer "
                    "[VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4527,7 +4527,7 @@ VKAPI_ATTR void VKAPI_CALL CmdInsertDebugUtilsLabelEXT(
     const VkDebugUtilsLabelEXT*                 pLabelInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdInsertDebugUtilsLabelEXT: Invalid commandBuffer "
                    "[VUID-vkCmdInsertDebugUtilsLabelEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4558,7 +4558,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAndroidHardwareBufferPropertiesANDROID(
     VkAndroidHardwareBufferPropertiesANDROID*   pProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetAndroidHardwareBufferPropertiesANDROID: Invalid device "
                    "[VUID-vkGetAndroidHardwareBufferPropertiesANDROID-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4574,7 +4574,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryAndroidHardwareBufferANDROID(
     struct AHardwareBuffer**                    pBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetMemoryAndroidHardwareBufferANDROID: Invalid device "
                    "[VUID-vkGetMemoryAndroidHardwareBufferANDROID-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4591,7 +4591,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEXT(
     const VkSampleLocationsInfoEXT*             pSampleLocationsInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetSampleLocationsEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetSampleLocationsEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4606,7 +4606,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMultisamplePropertiesEXT(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceMultisamplePropertiesEXT: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceMultisamplePropertiesEXT-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4637,7 +4637,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageDrmFormatModifierPropertiesEXT(
     VkImageDrmFormatModifierPropertiesEXT*      pProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetImageDrmFormatModifierPropertiesEXT: Invalid device "
                    "[VUID-vkGetImageDrmFormatModifierPropertiesEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4655,7 +4655,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(
     VkValidationCacheEXT*                       pValidationCache) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateValidationCacheEXT: Invalid device "
                    "[VUID-vkCreateValidationCacheEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4669,7 +4669,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyValidationCacheEXT: Invalid device "
                    "[VUID-vkDestroyValidationCacheEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4684,7 +4684,7 @@ VKAPI_ATTR VkResult VKAPI_CALL MergeValidationCachesEXT(
     const VkValidationCacheEXT*                 pSrcCaches) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkMergeValidationCachesEXT: Invalid device "
                    "[VUID-vkMergeValidationCachesEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4699,7 +4699,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetValidationCacheDataEXT(
     void*                                       pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetValidationCacheDataEXT: Invalid device "
                    "[VUID-vkGetValidationCacheDataEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4716,7 +4716,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadingRateImageNV(
     VkImageLayout                               imageLayout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBindShadingRateImageNV: Invalid commandBuffer "
                    "[VUID-vkCmdBindShadingRateImageNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4731,7 +4731,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportShadingRatePaletteNV(
     const VkShadingRatePaletteNV*               pShadingRatePalettes) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetViewportShadingRatePaletteNV: Invalid commandBuffer "
                    "[VUID-vkCmdSetViewportShadingRatePaletteNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4746,7 +4746,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoarseSampleOrderNV(
     const VkCoarseSampleOrderCustomNV*          pCustomSampleOrders) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetCoarseSampleOrderNV: Invalid commandBuffer "
                    "[VUID-vkCmdSetCoarseSampleOrderNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4764,7 +4764,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureNV(
     VkAccelerationStructureNV*                  pAccelerationStructure) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateAccelerationStructureNV: Invalid device "
                    "[VUID-vkCreateAccelerationStructureNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4778,7 +4778,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyAccelerationStructureNV: Invalid device "
                    "[VUID-vkDestroyAccelerationStructureNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4792,7 +4792,7 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureMemoryRequirementsNV(
     VkMemoryRequirements2KHR*                   pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetAccelerationStructureMemoryRequirementsNV: Invalid device "
                    "[VUID-vkGetAccelerationStructureMemoryRequirementsNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4806,7 +4806,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindAccelerationStructureMemoryNV(
     const VkBindAccelerationStructureMemoryInfoNV* pBindInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkBindAccelerationStructureMemoryNV: Invalid device "
                    "[VUID-vkBindAccelerationStructureMemoryNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4826,7 +4826,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructureNV(
     VkDeviceSize                                scratchOffset) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBuildAccelerationStructureNV: Invalid commandBuffer "
                    "[VUID-vkCmdBuildAccelerationStructureNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4841,7 +4841,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureNV(
     VkCopyAccelerationStructureModeKHR          mode) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyAccelerationStructureNV: Invalid commandBuffer "
                    "[VUID-vkCmdCopyAccelerationStructureNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4867,7 +4867,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysNV(
     uint32_t                                    depth) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdTraceRaysNV: Invalid commandBuffer "
                    "[VUID-vkCmdTraceRaysNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4884,7 +4884,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(
     VkPipeline*                                 pPipelines) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateRayTracingPipelinesNV: Invalid device "
                    "[VUID-vkCreateRayTracingPipelinesNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4901,7 +4901,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesKHR(
     void*                                       pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetRayTracingShaderGroupHandlesKHR: Invalid device "
                    "[VUID-vkGetRayTracingShaderGroupHandlesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4918,7 +4918,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesNV(
     void*                                       pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetRayTracingShaderGroupHandlesNV: Invalid device "
                    "[VUID-vkGetRayTracingShaderGroupHandlesNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4933,7 +4933,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAccelerationStructureHandleNV(
     void*                                       pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetAccelerationStructureHandleNV: Invalid device "
                    "[VUID-vkGetAccelerationStructureHandleNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4950,7 +4950,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesNV(
     uint32_t                                    firstQuery) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdWriteAccelerationStructuresPropertiesNV: Invalid commandBuffer "
                    "[VUID-vkCmdWriteAccelerationStructuresPropertiesNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4964,7 +4964,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CompileDeferredNV(
     uint32_t                                    shader) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCompileDeferredNV: Invalid device "
                    "[VUID-vkCompileDeferredNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -4982,7 +4982,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryHostPointerPropertiesEXT(
     VkMemoryHostPointerPropertiesEXT*           pMemoryHostPointerProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetMemoryHostPointerPropertiesEXT: Invalid device "
                    "[VUID-vkGetMemoryHostPointerPropertiesEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5001,7 +5001,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarkerAMD(
     uint32_t                                    marker) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdWriteBufferMarkerAMD: Invalid commandBuffer "
                    "[VUID-vkCmdWriteBufferMarkerAMD-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5019,7 +5019,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCalibrateableTimeDomainsEXT(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceCalibrateableTimeDomainsEXT-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5049,7 +5049,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetCalibratedTimestampsEXT(
     uint64_t*                                   pMaxDeviation) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetCalibratedTimestampsEXT: Invalid device "
                    "[VUID-vkGetCalibratedTimestampsEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5066,7 +5066,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksNV(
     uint32_t                                    firstTask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawMeshTasksNV: Invalid commandBuffer "
                    "[VUID-vkCmdDrawMeshTasksNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5082,7 +5082,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectNV(
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawMeshTasksIndirectNV: Invalid commandBuffer "
                    "[VUID-vkCmdDrawMeshTasksIndirectNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5100,7 +5100,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountNV(
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawMeshTasksIndirectCountNV: Invalid commandBuffer "
                    "[VUID-vkCmdDrawMeshTasksIndirectCountNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5118,7 +5118,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorNV(
     const VkRect2D*                             pExclusiveScissors) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetExclusiveScissorNV: Invalid commandBuffer "
                    "[VUID-vkCmdSetExclusiveScissorNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5134,7 +5134,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCheckpointNV(
     const void*                                 pCheckpointMarker) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetCheckpointNV: Invalid commandBuffer "
                    "[VUID-vkCmdSetCheckpointNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5148,7 +5148,7 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointDataNV(
     VkCheckpointDataNV*                         pCheckpointData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetQueueCheckpointDataNV: Invalid queue "
                    "[VUID-vkGetQueueCheckpointDataNV-queue-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5164,7 +5164,7 @@ VKAPI_ATTR VkResult VKAPI_CALL InitializePerformanceApiINTEL(
     const VkInitializePerformanceApiInfoINTEL*  pInitializeInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkInitializePerformanceApiINTEL: Invalid device "
                    "[VUID-vkInitializePerformanceApiINTEL-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5176,7 +5176,7 @@ VKAPI_ATTR void VKAPI_CALL UninitializePerformanceApiINTEL(
     VkDevice                                    device) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkUninitializePerformanceApiINTEL: Invalid device "
                    "[VUID-vkUninitializePerformanceApiINTEL-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5189,7 +5189,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceMarkerINTEL(
     const VkPerformanceMarkerInfoINTEL*         pMarkerInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetPerformanceMarkerINTEL: Invalid commandBuffer "
                    "[VUID-vkCmdSetPerformanceMarkerINTEL-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5202,7 +5202,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceStreamMarkerINTEL(
     const VkPerformanceStreamMarkerInfoINTEL*   pMarkerInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetPerformanceStreamMarkerINTEL: Invalid commandBuffer "
                    "[VUID-vkCmdSetPerformanceStreamMarkerINTEL-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5215,7 +5215,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CmdSetPerformanceOverrideINTEL(
     const VkPerformanceOverrideInfoINTEL*       pOverrideInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetPerformanceOverrideINTEL: Invalid commandBuffer "
                    "[VUID-vkCmdSetPerformanceOverrideINTEL-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5229,7 +5229,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquirePerformanceConfigurationINTEL(
     VkPerformanceConfigurationINTEL*            pConfiguration) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkAcquirePerformanceConfigurationINTEL: Invalid device "
                    "[VUID-vkAcquirePerformanceConfigurationINTEL-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5242,7 +5242,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleasePerformanceConfigurationINTEL(
     VkPerformanceConfigurationINTEL             configuration) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkReleasePerformanceConfigurationINTEL: Invalid device "
                    "[VUID-vkReleasePerformanceConfigurationINTEL-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5255,7 +5255,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSetPerformanceConfigurationINTEL(
     VkPerformanceConfigurationINTEL             configuration) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkQueueSetPerformanceConfigurationINTEL: Invalid queue "
                    "[VUID-vkQueueSetPerformanceConfigurationINTEL-queue-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5269,7 +5269,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPerformanceParameterINTEL(
     VkPerformanceValueINTEL*                    pValue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPerformanceParameterINTEL: Invalid device "
                    "[VUID-vkGetPerformanceParameterINTEL-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5286,7 +5286,7 @@ VKAPI_ATTR void VKAPI_CALL SetLocalDimmingAMD(
     VkBool32                                    localDimmingEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkSetLocalDimmingAMD: Invalid device "
                    "[VUID-vkSetLocalDimmingAMD-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5302,7 +5302,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
     const VkBufferDeviceAddressInfo*            pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetBufferDeviceAddressEXT: Invalid device "
                    "[VUID-vkGetBufferDeviceAddressEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5320,7 +5320,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesNV(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceCooperativeMatrixPropertiesNV-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5352,7 +5352,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSupportedFramebufferMixedSamples
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5383,7 +5383,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireFullScreenExclusiveModeEXT(
     VkSwapchainKHR                              swapchain) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkAcquireFullScreenExclusiveModeEXT: Invalid device "
                    "[VUID-vkAcquireFullScreenExclusiveModeEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5398,7 +5398,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseFullScreenExclusiveModeEXT(
     VkSwapchainKHR                              swapchain) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkReleaseFullScreenExclusiveModeEXT: Invalid device "
                    "[VUID-vkReleaseFullScreenExclusiveModeEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5416,7 +5416,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineStippleEXT(
     uint16_t                                    lineStipplePattern) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetLineStippleEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetLineStippleEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5434,7 +5434,7 @@ VKAPI_ATTR void VKAPI_CALL ResetQueryPoolEXT(
     uint32_t                                    queryCount) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkResetQueryPoolEXT: Invalid device "
                    "[VUID-vkResetQueryPoolEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5450,7 +5450,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCullModeEXT(
     VkCullModeFlags                             cullMode) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetCullModeEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetCullModeEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5463,7 +5463,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFrontFaceEXT(
     VkFrontFace                                 frontFace) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetFrontFaceEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetFrontFaceEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5476,7 +5476,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveTopologyEXT(
     VkPrimitiveTopology                         primitiveTopology) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetPrimitiveTopologyEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetPrimitiveTopologyEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5490,7 +5490,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWithCountEXT(
     const VkViewport*                           pViewports) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetViewportWithCountEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetViewportWithCountEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5504,7 +5504,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissorWithCountEXT(
     const VkRect2D*                             pScissors) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetScissorWithCountEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetScissorWithCountEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5522,7 +5522,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers2EXT(
     const VkDeviceSize*                         pStrides) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBindVertexBuffers2EXT: Invalid commandBuffer "
                    "[VUID-vkCmdBindVertexBuffers2EXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5535,7 +5535,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthTestEnableEXT(
     VkBool32                                    depthTestEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetDepthTestEnableEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetDepthTestEnableEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5548,7 +5548,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthWriteEnableEXT(
     VkBool32                                    depthWriteEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetDepthWriteEnableEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetDepthWriteEnableEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5561,7 +5561,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthCompareOpEXT(
     VkCompareOp                                 depthCompareOp) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetDepthCompareOpEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetDepthCompareOpEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5574,7 +5574,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBoundsTestEnableEXT(
     VkBool32                                    depthBoundsTestEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetDepthBoundsTestEnableEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetDepthBoundsTestEnableEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5587,7 +5587,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilTestEnableEXT(
     VkBool32                                    stencilTestEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetStencilTestEnableEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetStencilTestEnableEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5604,7 +5604,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilOpEXT(
     VkCompareOp                                 compareOp) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetStencilOpEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetStencilOpEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5621,7 +5621,7 @@ VKAPI_ATTR void VKAPI_CALL GetGeneratedCommandsMemoryRequirementsNV(
     VkMemoryRequirements2*                      pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetGeneratedCommandsMemoryRequirementsNV: Invalid device "
                    "[VUID-vkGetGeneratedCommandsMemoryRequirementsNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5634,7 +5634,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPreprocessGeneratedCommandsNV(
     const VkGeneratedCommandsInfoNV*            pGeneratedCommandsInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdPreprocessGeneratedCommandsNV: Invalid commandBuffer "
                    "[VUID-vkCmdPreprocessGeneratedCommandsNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5648,7 +5648,7 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteGeneratedCommandsNV(
     const VkGeneratedCommandsInfoNV*            pGeneratedCommandsInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdExecuteGeneratedCommandsNV: Invalid commandBuffer "
                    "[VUID-vkCmdExecuteGeneratedCommandsNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5663,7 +5663,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipelineShaderGroupNV(
     uint32_t                                    groupIndex) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBindPipelineShaderGroupNV: Invalid commandBuffer "
                    "[VUID-vkCmdBindPipelineShaderGroupNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5678,7 +5678,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNV(
     VkIndirectCommandsLayoutNV*                 pIndirectCommandsLayout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateIndirectCommandsLayoutNV: Invalid device "
                    "[VUID-vkCreateIndirectCommandsLayoutNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5692,7 +5692,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNV(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyIndirectCommandsLayoutNV: Invalid device "
                    "[VUID-vkDestroyIndirectCommandsLayoutNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5710,7 +5710,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireDrmDisplayEXT(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkAcquireDrmDisplayEXT: Invalid physicalDevice "
                    "[VUID-vkAcquireDrmDisplayEXT-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5741,7 +5741,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDrmDisplayEXT(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDrmDisplayEXT: Invalid physicalDevice "
                    "[VUID-vkGetDrmDisplayEXT-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5775,7 +5775,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePrivateDataSlotEXT(
     VkPrivateDataSlot*                          pPrivateDataSlot) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreatePrivateDataSlotEXT: Invalid device "
                    "[VUID-vkCreatePrivateDataSlotEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5789,7 +5789,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPrivateDataSlotEXT(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyPrivateDataSlotEXT: Invalid device "
                    "[VUID-vkDestroyPrivateDataSlotEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5805,7 +5805,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateDataEXT(
     uint64_t                                    data) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkSetPrivateDataEXT: Invalid device "
                    "[VUID-vkSetPrivateDataEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5821,7 +5821,7 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateDataEXT(
     uint64_t*                                   pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPrivateDataEXT: Invalid device "
                    "[VUID-vkGetPrivateDataEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5838,7 +5838,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetFragmentShadingRateEnumNV(
     const VkFragmentShadingRateCombinerOpKHR    combinerOps[2]) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetFragmentShadingRateEnumNV: Invalid commandBuffer "
                    "[VUID-vkCmdSetFragmentShadingRateEnumNV-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5856,7 +5856,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireWinrtDisplayNV(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkAcquireWinrtDisplayNV: Invalid physicalDevice "
                    "[VUID-vkAcquireWinrtDisplayNV-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5886,7 +5886,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetWinrtDisplayNV(
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetWinrtDisplayNV: Invalid physicalDevice "
                    "[VUID-vkGetWinrtDisplayNV-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5920,7 +5920,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetVertexInputEXT(
     const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetVertexInputEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetVertexInputEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5938,7 +5938,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandleFUCHSIA(
     zx_handle_t*                                pZirconHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetMemoryZirconHandleFUCHSIA: Invalid device "
                    "[VUID-vkGetMemoryZirconHandleFUCHSIA-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5955,7 +5955,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryZirconHandlePropertiesFUCHSIA(
     VkMemoryZirconHandlePropertiesFUCHSIA*      pMemoryZirconHandleProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetMemoryZirconHandlePropertiesFUCHSIA: Invalid device "
                    "[VUID-vkGetMemoryZirconHandlePropertiesFUCHSIA-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5973,7 +5973,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreZirconHandleFUCHSIA(
     const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkImportSemaphoreZirconHandleFUCHSIA: Invalid device "
                    "[VUID-vkImportSemaphoreZirconHandleFUCHSIA-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -5989,7 +5989,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreZirconHandleFUCHSIA(
     zx_handle_t*                                pZirconHandle) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetSemaphoreZirconHandleFUCHSIA: Invalid device "
                    "[VUID-vkGetSemaphoreZirconHandleFUCHSIA-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6009,7 +6009,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferCollectionFUCHSIA(
     VkBufferCollectionFUCHSIA*                  pCollection) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateBufferCollectionFUCHSIA: Invalid device "
                    "[VUID-vkCreateBufferCollectionFUCHSIA-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6025,7 +6025,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetBufferCollectionImageConstraintsFUCHSIA(
     const VkImageConstraintsInfoFUCHSIA*        pImageConstraintsInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkSetBufferCollectionImageConstraintsFUCHSIA: Invalid device "
                    "[VUID-vkSetBufferCollectionImageConstraintsFUCHSIA-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6041,7 +6041,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetBufferCollectionBufferConstraintsFUCHSIA(
     const VkBufferConstraintsInfoFUCHSIA*       pBufferConstraintsInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkSetBufferCollectionBufferConstraintsFUCHSIA: Invalid device "
                    "[VUID-vkSetBufferCollectionBufferConstraintsFUCHSIA-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6057,7 +6057,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferCollectionFUCHSIA(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyBufferCollectionFUCHSIA: Invalid device "
                    "[VUID-vkDestroyBufferCollectionFUCHSIA-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6073,7 +6073,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetBufferCollectionPropertiesFUCHSIA(
     VkBufferCollectionPropertiesFUCHSIA*        pProperties) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetBufferCollectionPropertiesFUCHSIA: Invalid device "
                    "[VUID-vkGetBufferCollectionPropertiesFUCHSIA-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6091,7 +6091,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(
     VkExtent2D*                                 pMaxWorkgroupSize) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI: Invalid device "
                    "[VUID-vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6103,7 +6103,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSubpassShadingHUAWEI(
     VkCommandBuffer                             commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSubpassShadingHUAWEI: Invalid commandBuffer "
                    "[VUID-vkCmdSubpassShadingHUAWEI-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6120,7 +6120,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindInvocationMaskHUAWEI(
     VkImageLayout                               imageLayout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBindInvocationMaskHUAWEI: Invalid commandBuffer "
                    "[VUID-vkCmdBindInvocationMaskHUAWEI-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6137,7 +6137,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryRemoteAddressNV(
     VkRemoteAddressNV*                          pAddress) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetMemoryRemoteAddressNV: Invalid device "
                    "[VUID-vkGetMemoryRemoteAddressNV-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6153,7 +6153,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPatchControlPointsEXT(
     uint32_t                                    patchControlPoints) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetPatchControlPointsEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetPatchControlPointsEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6166,7 +6166,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRasterizerDiscardEnableEXT(
     VkBool32                                    rasterizerDiscardEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetRasterizerDiscardEnableEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetRasterizerDiscardEnableEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6179,7 +6179,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBiasEnableEXT(
     VkBool32                                    depthBiasEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetDepthBiasEnableEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetDepthBiasEnableEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6192,7 +6192,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLogicOpEXT(
     VkLogicOp                                   logicOp) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetLogicOpEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetLogicOpEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6205,7 +6205,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetPrimitiveRestartEnableEXT(
     VkBool32                                    primitiveRestartEnable) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetPrimitiveRestartEnableEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetPrimitiveRestartEnableEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6222,7 +6222,7 @@ VKAPI_ATTR void                                    VKAPI_CALL CmdSetColorWriteEn
     const VkBool32*                             pColorWriteEnables) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetColorWriteEnableEXT: Invalid commandBuffer "
                    "[VUID-vkCmdSetColorWriteEnableEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6242,7 +6242,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiEXT(
     uint32_t                                    stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawMultiEXT: Invalid commandBuffer "
                    "[VUID-vkCmdDrawMultiEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6260,7 +6260,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMultiIndexedEXT(
     const int32_t*                              pVertexOffset) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawMultiIndexedEXT: Invalid commandBuffer "
                    "[VUID-vkCmdDrawMultiIndexedEXT-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6277,7 +6277,7 @@ VKAPI_ATTR void VKAPI_CALL SetDeviceMemoryPriorityEXT(
     float                                       priority) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkSetDeviceMemoryPriorityEXT: Invalid device "
                    "[VUID-vkSetDeviceMemoryPriorityEXT-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6295,7 +6295,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureKHR(
     VkAccelerationStructureKHR*                 pAccelerationStructure) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateAccelerationStructureKHR: Invalid device "
                    "[VUID-vkCreateAccelerationStructureKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6309,7 +6309,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureKHR(
     const VkAllocationCallbacks*                pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyAccelerationStructureKHR: Invalid device "
                    "[VUID-vkDestroyAccelerationStructureKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6324,7 +6324,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresKHR(
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBuildAccelerationStructuresKHR: Invalid commandBuffer "
                    "[VUID-vkCmdBuildAccelerationStructuresKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6341,7 +6341,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresIndirectKHR(
     const uint32_t* const*                      ppMaxPrimitiveCounts) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBuildAccelerationStructuresIndirectKHR: Invalid commandBuffer "
                    "[VUID-vkCmdBuildAccelerationStructuresIndirectKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6357,7 +6357,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BuildAccelerationStructuresKHR(
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkBuildAccelerationStructuresKHR: Invalid device "
                    "[VUID-vkBuildAccelerationStructuresKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6371,7 +6371,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureKHR(
     const VkCopyAccelerationStructureInfoKHR*   pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCopyAccelerationStructureKHR: Invalid device "
                    "[VUID-vkCopyAccelerationStructureKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6385,7 +6385,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureToMemoryKHR(
     const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCopyAccelerationStructureToMemoryKHR: Invalid device "
                    "[VUID-vkCopyAccelerationStructureToMemoryKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6399,7 +6399,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyMemoryToAccelerationStructureKHR(
     const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCopyMemoryToAccelerationStructureKHR: Invalid device "
                    "[VUID-vkCopyMemoryToAccelerationStructureKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6417,7 +6417,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WriteAccelerationStructuresPropertiesKHR(
     size_t                                      stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkWriteAccelerationStructuresPropertiesKHR: Invalid device "
                    "[VUID-vkWriteAccelerationStructuresPropertiesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6430,7 +6430,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureKHR(
     const VkCopyAccelerationStructureInfoKHR*   pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyAccelerationStructureKHR: Invalid commandBuffer "
                    "[VUID-vkCmdCopyAccelerationStructureKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6443,7 +6443,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureToMemoryKHR(
     const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyAccelerationStructureToMemoryKHR: Invalid commandBuffer "
                    "[VUID-vkCmdCopyAccelerationStructureToMemoryKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6456,7 +6456,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyMemoryToAccelerationStructureKHR(
     const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyMemoryToAccelerationStructureKHR: Invalid commandBuffer "
                    "[VUID-vkCmdCopyMemoryToAccelerationStructureKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6469,7 +6469,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetAccelerationStructureDeviceAddressKHR(
     const VkAccelerationStructureDeviceAddressInfoKHR* pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetAccelerationStructureDeviceAddressKHR: Invalid device "
                    "[VUID-vkGetAccelerationStructureDeviceAddressKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6486,7 +6486,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesKHR(
     uint32_t                                    firstQuery) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdWriteAccelerationStructuresPropertiesKHR: Invalid commandBuffer "
                    "[VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6500,7 +6500,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceAccelerationStructureCompatibilityKHR(
     VkAccelerationStructureCompatibilityKHR*    pCompatibility) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceAccelerationStructureCompatibilityKHR: Invalid device "
                    "[VUID-vkGetDeviceAccelerationStructureCompatibilityKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6516,7 +6516,7 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureBuildSizesKHR(
     VkAccelerationStructureBuildSizesInfoKHR*   pSizeInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetAccelerationStructureBuildSizesKHR: Invalid device "
                    "[VUID-vkGetAccelerationStructureBuildSizesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6538,7 +6538,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysKHR(
     uint32_t                                    depth) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdTraceRaysKHR: Invalid commandBuffer "
                    "[VUID-vkCmdTraceRaysKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6556,7 +6556,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(
     VkPipeline*                                 pPipelines) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateRayTracingPipelinesKHR: Invalid device "
                    "[VUID-vkCreateRayTracingPipelinesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6573,7 +6573,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingCaptureReplayShaderGroupHandlesKHR(
     void*                                       pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetRayTracingCaptureReplayShaderGroupHandlesKHR: Invalid device "
                    "[VUID-vkGetRayTracingCaptureReplayShaderGroupHandlesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6590,7 +6590,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysIndirectKHR(
     VkDeviceAddress                             indirectDeviceAddress) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdTraceRaysIndirectKHR: Invalid commandBuffer "
                    "[VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6605,7 +6605,7 @@ VKAPI_ATTR VkDeviceSize VKAPI_CALL GetRayTracingShaderGroupStackSizeKHR(
     VkShaderGroupShaderKHR                      groupShader) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetRayTracingShaderGroupStackSizeKHR: Invalid device "
                    "[VUID-vkGetRayTracingShaderGroupStackSizeKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -6618,7 +6618,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetRayTracingPipelineStackSizeKHR(
     uint32_t                                    pipelineStackSize) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetRayTracingPipelineStackSizeKHR: Invalid commandBuffer "
                    "[VUID-vkCmdSetRayTracingPipelineStackSizeKHR-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */

--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -2,9 +2,9 @@
 // See loader_extension_generator.py for modifications
 
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/log.c
+++ b/loader/log.c
@@ -121,7 +121,9 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
         if ((msg_type & VULKAN_LOADER_PERF_BIT) != 0) {
             type = VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
         } else if ((msg_type & VULKAN_LOADER_VALIDATION_BIT) != 0) {
-            type = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+            // For loader logging, if it's a validation message, we still want to also keep the general flag as well
+            // so messages of type validation can still be triggered for general message callbacks.
+            type = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
         } else {
             type = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
         }

--- a/loader/log.c
+++ b/loader/log.c
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2014-2021 The Khronos Group Inc.
- * Copyright (c) 2014-2021 Valve Corporation
- * Copyright (c) 2014-2021 LunarG, Inc.
+ * Copyright (c) 2014-2022 The Khronos Group Inc.
+ * Copyright (c) 2014-2022 Valve Corporation
+ * Copyright (c) 2014-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,6 +120,8 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
 
         if ((msg_type & VULKAN_LOADER_PERF_BIT) != 0) {
             type = VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+        } else if ((msg_type & VULKAN_LOADER_VALIDATION_BIT) != 0) {
+            type = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
         } else {
             type = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
         }

--- a/loader/log.h
+++ b/loader/log.h
@@ -36,6 +36,7 @@ enum vulkan_loader_debug_flags {
     VULKAN_LOADER_DEBUG_BIT = 0x10,
     VULKAN_LOADER_LAYER_BIT = 0x20,
     VULKAN_LOADER_DRIVER_BIT = 0x40,
+    VULKAN_LOADER_VALIDATION_BIT = 0x80,
 };
 
 // Checks for the environment variable VK_LOADER_DEBUG and sets up the current debug level accordingly

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -732,14 +732,16 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
     }
 
     if (messenger_setup) {
-        loader_log(ptr_instance, VULKAN_LOADER_INFO_BIT, 0, "vkDestroyInstance: destroying all debug util messengers");
+        loader_log(ptr_instance, VULKAN_LOADER_INFO_BIT, 0,
+                   "vkDestroyInstance: destroying temporary instance debug util messenger");
 
         util_DestroyDebugUtilsMessengers(ptr_instance, pAllocator, ptr_instance->num_tmp_messengers, ptr_instance->tmp_messengers);
         util_FreeDebugUtilsMessengerCreateInfos(pAllocator, ptr_instance->tmp_messenger_create_infos, ptr_instance->tmp_messengers);
     }
 
     if (callback_setup) {
-        loader_log(ptr_instance, VULKAN_LOADER_INFO_BIT, 0, "vkDestroyInstance: destroying all debug report callbacks");
+        loader_log(ptr_instance, VULKAN_LOADER_INFO_BIT, 0,
+                   "vkDestroyInstance: destroying temporary instance debug report callback");
 
         util_DestroyDebugReportCallbacks(ptr_instance, pAllocator, ptr_instance->num_tmp_report_callbacks,
                                          ptr_instance->tmp_report_callbacks);

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  * Copyright (C) 2015 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -94,7 +94,7 @@ LOADER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkI
         struct loader_instance *ptr_instance = loader_get_instance(instance);
         // If we've gotten here and the pointer is NULL, it's invalid
         if (ptr_instance == NULL) {
-            loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+            loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                        "vkGetInstanceProcAddr: Invalid instance [VUID-vkGetInstanceProcAddr-instance-parameter]");
             abort(); /* Intentionally fail so user can correct issue. */
         }
@@ -329,9 +329,9 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
     LOADER_PLATFORM_THREAD_ONCE(&once_init, loader_initialize);
 
     if (NULL == pApiVersion) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkEnumerateInstanceVersion: \'pApiVersion\' must not be NULL "
-                   "(VUVUID-vkEnumerateInstanceVersion-pApiVersion-parameter");
+                   "(VUID-vkEnumerateInstanceVersion-pApiVersion-parameter");
         // NOTE: This seems silly, but it's the only allowable failure
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
@@ -433,12 +433,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
     LOADER_PLATFORM_THREAD_ONCE(&once_init, loader_initialize);
 
     if (pCreateInfo == NULL) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateInstance: \'pCreateInfo\' is NULL (VUID-vkCreateInstance-pCreateInfo-parameter)");
         goto out;
     }
     if (pInstance == NULL) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateInstance \'pInstance\' not valid (VUID-vkCreateInstance-pInstance-parameter)");
         goto out;
     }
@@ -681,7 +681,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
 
     ptr_instance = loader_get_instance(instance);
     if (ptr_instance == NULL) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyInstance: Invalid instance [VUID-vkDestroyInstance-instance-parameter]");
         loader_platform_thread_unlock_mutex(&loader_lock);
         abort(); /* Intentionally fail so user can correct issue. */
@@ -732,11 +732,15 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
     }
 
     if (messenger_setup) {
+        loader_log(ptr_instance, VULKAN_LOADER_INFO_BIT, 0, "vkDestroyInstance: destroying all debug util messengers");
+
         util_DestroyDebugUtilsMessengers(ptr_instance, pAllocator, ptr_instance->num_tmp_messengers, ptr_instance->tmp_messengers);
         util_FreeDebugUtilsMessengerCreateInfos(pAllocator, ptr_instance->tmp_messenger_create_infos, ptr_instance->tmp_messengers);
     }
 
     if (callback_setup) {
+        loader_log(ptr_instance, VULKAN_LOADER_INFO_BIT, 0, "vkDestroyInstance: destroying all debug report callbacks");
+
         util_DestroyDebugReportCallbacks(ptr_instance, pAllocator, ptr_instance->num_tmp_report_callbacks,
                                          ptr_instance->tmp_report_callbacks);
         util_FreeDebugReportCreateInfos(pAllocator, ptr_instance->tmp_report_create_infos, ptr_instance->tmp_report_callbacks);
@@ -762,13 +766,13 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDevices(VkInstan
 
     inst = loader_get_instance(instance);
     if (NULL == inst) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkEnumeratePhysicalDevices: Invalid instance [VUID-vkEnumeratePhysicalDevices-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
     if (NULL == pPhysicalDeviceCount) {
-        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkEnumeratePhysicalDevices: Received NULL pointer for physical device count return value. "
                    "[VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter]");
         res = VK_ERROR_INITIALIZATION_FAILED;
@@ -822,7 +826,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFeatures(VkPhysicalD
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
         loader_log(
-            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
             "vkGetPhysicalDeviceFeatures: Invalid physicalDevice [VUID-vkGetPhysicalDeviceFeatures-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -835,7 +839,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFormatProperties(VkP
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceFormatProperties: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceFormatProperties-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -850,7 +854,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceImageFormatPrope
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceImageFormatProperties: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceImageFormatProperties-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -866,7 +870,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceProperties(VkPhysica
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
         loader_log(
-            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
             "vkGetPhysicalDeviceProperties: Invalid physicalDevice [VUID-vkGetPhysicalDeviceProperties-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -880,7 +884,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceQueueFamilyPropertie
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceQueueFamilyProperties: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceQueueFamilyProperties-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -894,7 +898,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceMemoryProperties(VkP
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceMemoryProperties: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceMemoryProperties-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -906,7 +910,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceMemoryProperties(VkP
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
                                                             const VkAllocationCallbacks *pAllocator, VkDevice *pDevice) {
     if (VK_NULL_HANDLE == loader_unwrap_physical_device(physicalDevice)) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateDevice: Invalid physicalDevice [VUID-vkCreateDevice-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -924,7 +928,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, const 
     }
     disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyDevice: Invalid device [VUID-vkDestroyDevice-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkDestroyDevice: Invalid device [VUID-vkDestroyDevice-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -943,7 +948,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionPropertie
     const VkLayerInstanceDispatchTable *disp;
     phys_dev = (struct loader_physical_device_tramp *)physicalDevice;
     if (VK_NULL_HANDLE == physicalDevice || PHYS_TRAMP_MAGIC_NUMBER != phys_dev->magic) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkEnumerateDeviceExtensionProperties: Invalid physicalDevice "
                    "[VUID-vkEnumerateDeviceExtensionProperties-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -978,7 +983,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(Vk
 
     phys_dev = (struct loader_physical_device_tramp *)physicalDevice;
     if (VK_NULL_HANDLE == physicalDevice || PHYS_TRAMP_MAGIC_NUMBER != phys_dev->magic) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkEnumerateDeviceLayerProperties: Invalid physicalDevice "
                    "[VUID-vkEnumerateDeviceLayerProperties-physicalDevice-parameter]");
         loader_platform_thread_unlock_mutex(&loader_lock);
@@ -1014,7 +1019,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceQueue(VkDevice device, uint3
                                                           VkQueue *pQueue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkGetDeviceQueue: Invalid device [VUID-vkGetDeviceQueue-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkGetDeviceQueue: Invalid device [VUID-vkGetDeviceQueue-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1028,7 +1034,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit(VkQueue queue, uint32
                                                            VkFence fence) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkQueueSubmit: Invalid queue [VUID-vkQueueSubmit-queue-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkQueueSubmit: Invalid queue [VUID-vkQueueSubmit-queue-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1038,7 +1045,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueueSubmit(VkQueue queue, uint32
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueueWaitIdle(VkQueue queue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkQueueWaitIdle: Invalid queue [VUID-vkQueueWaitIdle-queue-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkQueueWaitIdle: Invalid queue [VUID-vkQueueWaitIdle-queue-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1048,7 +1056,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueueWaitIdle(VkQueue queue) {
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkDeviceWaitIdle(VkDevice device) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDeviceWaitIdle: Invalid device [VUID-vkDeviceWaitIdle-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkDeviceWaitIdle: Invalid device [VUID-vkDeviceWaitIdle-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1059,7 +1068,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAllocateMemory(VkDevice device, c
                                                               const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkAllocateMemory: Invalid device [VUID-vkAllocateMemory-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkAllocateMemory: Invalid device [VUID-vkAllocateMemory-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1070,7 +1080,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkFreeMemory(VkDevice device, VkDeviceM
                                                       const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkFreeMemory: Invalid device [VUID-vkFreeMemory-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkFreeMemory: Invalid device [VUID-vkFreeMemory-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1081,7 +1092,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkMapMemory(VkDevice device, VkDevi
                                                          VkDeviceSize size, VkFlags flags, void **ppData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkMapMemory: Invalid device [VUID-vkMapMemory-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkMapMemory: Invalid device [VUID-vkMapMemory-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1091,7 +1103,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkMapMemory(VkDevice device, VkDevi
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkUnmapMemory(VkDevice device, VkDeviceMemory mem) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkUnmapMemory: Invalid device [VUID-vkUnmapMemory-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkUnmapMemory: Invalid device [VUID-vkUnmapMemory-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1102,7 +1115,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkFlushMappedMemoryRanges(VkDevice 
                                                                        const VkMappedMemoryRange *pMemoryRanges) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkFlushMappedMemoryRanges: Invalid device [VUID-vkFlushMappedMemoryRanges-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1114,7 +1127,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkInvalidateMappedMemoryRanges(VkDe
                                                                             const VkMappedMemoryRange *pMemoryRanges) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkInvalidateMappedMemoryRanges: Invalid device [VUID-vkInvalidateMappedMemoryRanges-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1126,7 +1139,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceMemoryCommitment(VkDevice de
                                                                      VkDeviceSize *pCommittedMemoryInBytes) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceMemoryCommitment: Invalid device [VUID-vkGetDeviceMemoryCommitment-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1138,7 +1151,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkBindBufferMemory(VkDevice device,
                                                                 VkDeviceSize offset) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkBindBufferMemory: Invalid device [VUID-vkBindBufferMemory-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1150,7 +1163,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkBindImageMemory(VkDevice device, 
                                                                VkDeviceSize offset) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkBindImageMemory: Invalid device [VUID-vkBindImageMemory-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkBindImageMemory: Invalid device [VUID-vkBindImageMemory-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1161,7 +1175,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetBufferMemoryRequirements(VkDevice 
                                                                        VkMemoryRequirements *pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetBufferMemoryRequirements: Invalid device [VUID-vkGetBufferMemoryRequirements-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1173,7 +1187,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetImageMemoryRequirements(VkDevice d
                                                                       VkMemoryRequirements *pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetImageMemoryRequirements: Invalid device [VUID-vkGetImageMemoryRequirements-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1186,7 +1200,7 @@ vkGetImageSparseMemoryRequirements(VkDevice device, VkImage image, uint32_t *pSp
                                    VkSparseImageMemoryRequirements *pSparseMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetImageSparseMemoryRequirements: Invalid device [VUID-vkGetImageSparseMemoryRequirements-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1200,7 +1214,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceSparseImageFormatPro
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceSparseImageFormatProperties: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceSparseImageFormatProperties-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -1215,7 +1229,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueueBindSparse(VkQueue queue, ui
                                                                const VkBindSparseInfo *pBindInfo, VkFence fence) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkQueueBindSparse: Invalid queue [VUID-vkQueueBindSparse-queue-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkQueueBindSparse: Invalid queue [VUID-vkQueueBindSparse-queue-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1226,7 +1241,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateFence(VkDevice device, cons
                                                            const VkAllocationCallbacks *pAllocator, VkFence *pFence) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateFence: Invalid device [VUID-vkCreateFence-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkCreateFence: Invalid device [VUID-vkCreateFence-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1236,7 +1252,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateFence(VkDevice device, cons
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyFence: Invalid device [VUID-vkDestroyFence-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkDestroyFence: Invalid device [VUID-vkDestroyFence-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1246,7 +1263,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyFence(VkDevice device, VkFence
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkResetFences: Invalid device [VUID-vkResetFences-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkResetFences: Invalid device [VUID-vkResetFences-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1256,7 +1274,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetFences(VkDevice device, uint
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetFenceStatus(VkDevice device, VkFence fence) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkGetFenceStatus: Invalid device [VUID-vkGetFenceStatus-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkGetFenceStatus: Invalid device [VUID-vkGetFenceStatus-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1267,7 +1286,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkWaitForFences(VkDevice device, ui
                                                              VkBool32 waitAll, uint64_t timeout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkWaitForFences: Invalid device [VUID-vkWaitForFences-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkWaitForFences: Invalid device [VUID-vkWaitForFences-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1278,7 +1298,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSemaphore(VkDevice device, 
                                                                const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateSemaphore: Invalid device [VUID-vkCreateSemaphore-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkCreateSemaphore: Invalid device [VUID-vkCreateSemaphore-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1289,7 +1310,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroySemaphore(VkDevice device, VkS
                                                             const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroySemaphore: Invalid device [VUID-vkDestroySemaphore-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1301,7 +1322,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateEvent(VkDevice device, cons
                                                            const VkAllocationCallbacks *pAllocator, VkEvent *pEvent) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateEvent: Invalid device [VUID-vkCreateEvent-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkCreateEvent: Invalid device [VUID-vkCreateEvent-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1311,7 +1333,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateEvent(VkDevice device, cons
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyEvent: Invalid device [VUID-vkDestroyEvent-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkDestroyEvent: Invalid device [VUID-vkDestroyEvent-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1321,7 +1344,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyEvent(VkDevice device, VkEvent
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetEventStatus(VkDevice device, VkEvent event) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkGetEventStatus: Invalid device [VUID-vkGetEventStatus-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkGetEventStatus: Invalid device [VUID-vkGetEventStatus-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1331,7 +1355,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetEventStatus(VkDevice device, V
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkSetEvent(VkDevice device, VkEvent event) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkSetEvent: Invalid device [VUID-vkSetEvent-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkSetEvent: Invalid device [VUID-vkSetEvent-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1341,7 +1366,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkSetEvent(VkDevice device, VkEvent
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetEvent(VkDevice device, VkEvent event) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkResetEvent: Invalid device [VUID-vkResetEvent-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkResetEvent: Invalid device [VUID-vkResetEvent-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1352,7 +1378,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateQueryPool(VkDevice device, 
                                                                const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateQueryPool: Invalid device [VUID-vkCreateQueryPool-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkCreateQueryPool: Invalid device [VUID-vkCreateQueryPool-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1363,7 +1390,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyQueryPool(VkDevice device, VkQ
                                                             const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyQueryPool: Invalid device [VUID-vkDestroyQueryPool-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1376,7 +1403,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetQueryPoolResults(VkDevice devi
                                                                    VkDeviceSize stride, VkQueryResultFlags flags) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetQueryPoolResults: Invalid device [VUID-vkGetQueryPoolResults-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1388,7 +1415,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateBuffer(VkDevice device, con
                                                             const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateBuffer: Invalid device [VUID-vkCreateBuffer-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkCreateBuffer: Invalid device [VUID-vkCreateBuffer-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1399,7 +1427,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyBuffer(VkDevice device, VkBuff
                                                          const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyBuffer: Invalid device [VUID-vkDestroyBuffer-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkDestroyBuffer: Invalid device [VUID-vkDestroyBuffer-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1410,7 +1439,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateBufferView(VkDevice device,
                                                                 const VkAllocationCallbacks *pAllocator, VkBufferView *pView) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateBufferView: Invalid device [VUID-vkCreateBufferView-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1422,7 +1451,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyBufferView(VkDevice device, Vk
                                                              const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyBufferView: Invalid device [VUID-vkDestroyBufferView-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1434,7 +1463,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateImage(VkDevice device, cons
                                                            const VkAllocationCallbacks *pAllocator, VkImage *pImage) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateImage: Invalid device [VUID-vkCreateImage-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkCreateImage: Invalid device [VUID-vkCreateImage-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1444,7 +1474,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateImage(VkDevice device, cons
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyImage: Invalid device [VUID-vkDestroyImage-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkDestroyImage: Invalid device [VUID-vkDestroyImage-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1456,7 +1487,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetImageSubresourceLayout(VkDevice de
                                                                      VkSubresourceLayout *pLayout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetImageSubresourceLayout: Invalid device [VUID-vkGetImageSubresourceLayout-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1468,7 +1499,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateImageView(VkDevice device, 
                                                                const VkAllocationCallbacks *pAllocator, VkImageView *pView) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateImageView: Invalid device [VUID-vkCreateImageView-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkCreateImageView: Invalid device [VUID-vkCreateImageView-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1479,7 +1511,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyImageView(VkDevice device, VkI
                                                             const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyImageView: Invalid device [VUID-vkDestroyImageView-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1492,7 +1524,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateShaderModule(VkDevice devic
                                                                   VkShaderModule *pShader) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateShaderModule: Invalid device [VUID-vkCreateShaderModule-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1504,7 +1536,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyShaderModule(VkDevice device, 
                                                                const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyShaderModule: Invalid device [VUID-vkDestroyShaderModule-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1517,7 +1549,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreatePipelineCache(VkDevice devi
                                                                    VkPipelineCache *pPipelineCache) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreatePipelineCache: Invalid device [VUID-vkCreatePipelineCache-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1529,7 +1561,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyPipelineCache(VkDevice device,
                                                                 const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyPipelineCache: Invalid device [VUID-vkDestroyPipelineCache-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1541,7 +1573,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPipelineCacheData(VkDevice dev
                                                                     size_t *pDataSize, void *pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPipelineCacheData: Invalid device [VUID-vkGetPipelineCacheData-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1553,7 +1585,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkMergePipelineCaches(VkDevice devi
                                                                    uint32_t srcCacheCount, const VkPipelineCache *pSrcCaches) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkMergePipelineCaches: Invalid device [VUID-vkMergePipelineCaches-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1568,7 +1600,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateGraphicsPipelines(VkDevice 
                                                                        VkPipeline *pPipelines) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateGraphicsPipelines: Invalid device [VUID-vkCreateGraphicsPipelines-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1583,7 +1615,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateComputePipelines(VkDevice d
                                                                       VkPipeline *pPipelines) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateComputePipelines: Invalid device [VUID-vkCreateComputePipelines-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1595,7 +1627,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyPipeline(VkDevice device, VkPi
                                                            const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroyPipeline: Invalid device [VUID-vkDestroyPipeline-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkDestroyPipeline: Invalid device [VUID-vkDestroyPipeline-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1607,7 +1640,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreatePipelineLayout(VkDevice dev
                                                                     VkPipelineLayout *pPipelineLayout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreatePipelineLayout: Invalid device [VUID-vkCreatePipelineLayout-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1619,7 +1652,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyPipelineLayout(VkDevice device
                                                                  const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyPipelineLayout: Invalid device [VUID-vkDestroyPipelineLayout-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1631,7 +1664,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSampler(VkDevice device, co
                                                              const VkAllocationCallbacks *pAllocator, VkSampler *pSampler) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCreateSampler: Invalid device [VUID-vkCreateSampler-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkCreateSampler: Invalid device [VUID-vkCreateSampler-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1642,7 +1676,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroySampler(VkDevice device, VkSam
                                                           const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkDestroySampler: Invalid device [VUID-vkDestroySampler-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkDestroySampler: Invalid device [VUID-vkDestroySampler-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -1655,7 +1690,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDescriptorSetLayout(VkDevic
                                                                          VkDescriptorSetLayout *pSetLayout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateDescriptorSetLayout: Invalid device [VUID-vkCreateDescriptorSetLayout-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1667,7 +1702,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDescriptorSetLayout(VkDevice d
                                                                       const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyDescriptorSetLayout: Invalid device [VUID-vkDestroyDescriptorSetLayout-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1680,7 +1715,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDescriptorPool(VkDevice dev
                                                                     VkDescriptorPool *pDescriptorPool) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateDescriptorPool: Invalid device [VUID-vkCreateDescriptorPool-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1692,7 +1727,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDescriptorPool(VkDevice device
                                                                  const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyDescriptorPool: Invalid device [VUID-vkDestroyDescriptorPool-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1704,7 +1739,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetDescriptorPool(VkDevice devi
                                                                    VkDescriptorPoolResetFlags flags) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkResetDescriptorPool: Invalid device [VUID-vkResetDescriptorPool-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1717,7 +1752,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAllocateDescriptorSets(VkDevice d
                                                                       VkDescriptorSet *pDescriptorSets) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkAllocateDescriptorSets: Invalid device [VUID-vkAllocateDescriptorSets-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1730,7 +1765,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkFreeDescriptorSets(VkDevice devic
                                                                   const VkDescriptorSet *pDescriptorSets) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkFreeDescriptorSets: Invalid device [VUID-vkFreeDescriptorSets-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1744,7 +1779,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkUpdateDescriptorSets(VkDevice device,
                                                                 const VkCopyDescriptorSet *pDescriptorCopies) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkUpdateDescriptorSets: Invalid device [VUID-vkUpdateDescriptorSets-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1757,7 +1792,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateFramebuffer(VkDevice device
                                                                  VkFramebuffer *pFramebuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateFramebuffer: Invalid device [VUID-vkCreateFramebuffer-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1769,7 +1804,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyFramebuffer(VkDevice device, V
                                                               const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyFramebuffer: Invalid device [VUID-vkDestroyFramebuffer-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1782,7 +1817,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateRenderPass(VkDevice device,
                                                                 VkRenderPass *pRenderPass) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateRenderPass: Invalid device [VUID-vkCreateRenderPass-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1794,7 +1829,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyRenderPass(VkDevice device, Vk
                                                              const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyRenderPass: Invalid device [VUID-vkDestroyRenderPass-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1806,7 +1841,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetRenderAreaGranularity(VkDevice dev
                                                                     VkExtent2D *pGranularity) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetRenderAreaGranularity: Invalid device [VUID-vkGetRenderAreaGranularity-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1819,7 +1854,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateCommandPool(VkDevice device
                                                                  VkCommandPool *pCommandPool) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateCommandPool: Invalid device [VUID-vkCreateCommandPool-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1831,7 +1866,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyCommandPool(VkDevice device, V
                                                               const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyCommandPool: Invalid device [VUID-vkDestroyCommandPool-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1843,7 +1878,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetCommandPool(VkDevice device,
                                                                 VkCommandPoolResetFlags flags) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkResetCommandPool: Invalid device [VUID-vkResetCommandPool-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1857,7 +1892,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAllocateCommandBuffers(VkDevice d
     VkResult res;
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkAllocateCommandBuffers: Invalid device [VUID-vkAllocateCommandBuffers-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1878,7 +1913,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkFreeCommandBuffers(VkDevice device, V
                                                               uint32_t commandBufferCount, const VkCommandBuffer *pCommandBuffers) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkFreeCommandBuffers: Invalid device [VUID-vkFreeCommandBuffers-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1892,7 +1927,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkBeginCommandBuffer(VkCommandBuffe
 
     disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkBeginCommandBuffer: Invalid commandBuffer [VUID-vkBeginCommandBuffer-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1903,7 +1938,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkBeginCommandBuffer(VkCommandBuffe
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEndCommandBuffer(VkCommandBuffer commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkEndCommandBuffer: Invalid commandBuffer [VUID-vkEndCommandBuffer-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1914,7 +1949,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEndCommandBuffer(VkCommandBuffer 
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkResetCommandBuffer: Invalid commandBuffer [VUID-vkResetCommandBuffer-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1926,7 +1961,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBindPipeline(VkCommandBuffer comma
                                                            VkPipeline pipeline) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBindPipeline: Invalid commandBuffer [VUID-vkCmdBindPipeline-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1938,7 +1973,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetViewport(VkCommandBuffer comman
                                                           uint32_t viewportCount, const VkViewport *pViewports) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetViewport: Invalid commandBuffer [VUID-vkCmdSetViewport-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1950,7 +1985,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetScissor(VkCommandBuffer command
                                                          uint32_t scissorCount, const VkRect2D *pScissors) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetScissor: Invalid commandBuffer [VUID-vkCmdSetScissor-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1961,7 +1996,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetScissor(VkCommandBuffer command
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetLineWidth: Invalid commandBuffer [VUID-vkCmdSetLineWidth-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1973,7 +2008,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetDepthBias(VkCommandBuffer comma
                                                            float depthBiasClamp, float depthBiasSlopeFactor) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetDepthBias: Invalid commandBuffer [VUID-vkCmdSetDepthBias-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1984,7 +2019,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetDepthBias(VkCommandBuffer comma
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetBlendConstants(VkCommandBuffer commandBuffer, const float blendConstants[4]) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetBlendConstants: Invalid commandBuffer [VUID-vkCmdSetBlendConstants-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1996,7 +2031,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetDepthBounds(VkCommandBuffer com
                                                              float maxDepthBounds) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetDepthBounds: Invalid commandBuffer [VUID-vkCmdSetDepthBounds-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2008,7 +2043,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetStencilCompareMask(VkCommandBuf
                                                                     uint32_t compareMask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetStencilCompareMask: Invalid commandBuffer [VUID-vkCmdSetStencilCompareMask-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2020,7 +2055,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetStencilWriteMask(VkCommandBuffe
                                                                   uint32_t writeMask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetStencilWriteMask: Invalid commandBuffer [VUID-vkCmdSetStencilWriteMask-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2032,7 +2067,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetStencilReference(VkCommandBuffe
                                                                   uint32_t reference) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetStencilReference: Invalid commandBuffer [VUID-vkCmdSetStencilReference-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2047,7 +2082,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBindDescriptorSets(VkCommandBuffer
                                                                  uint32_t dynamicOffsetCount, const uint32_t *pDynamicOffsets) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBindDescriptorSets: Invalid commandBuffer [VUID-vkCmdBindDescriptorSets-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2060,7 +2095,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBindIndexBuffer(VkCommandBuffer co
                                                               VkIndexType indexType) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBindIndexBuffer: Invalid commandBuffer [VUID-vkCmdBindIndexBuffer-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2073,7 +2108,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBindVertexBuffers(VkCommandBuffer 
                                                                 const VkDeviceSize *pOffsets) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBindVertexBuffers: Invalid commandBuffer [VUID-vkCmdBindVertexBuffers-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2085,7 +2120,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDraw(VkCommandBuffer commandBuffer
                                                    uint32_t firstVertex, uint32_t firstInstance) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkCmdDraw: Invalid commandBuffer [VUID-vkCmdDraw-commandBuffer-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkCmdDraw: Invalid commandBuffer [VUID-vkCmdDraw-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
 
@@ -2097,7 +2133,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexed(VkCommandBuffer comman
                                                           uint32_t firstInstance) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawIndexed: Invalid commandBuffer [VUID-vkCmdDrawIndexed-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2109,7 +2145,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndirect(VkCommandBuffer comma
                                                            uint32_t drawCount, uint32_t stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawIndirect: Invalid commandBuffer [VUID-vkCmdDrawIndirect-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2121,7 +2157,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexedIndirect(VkCommandBuffe
                                                                   VkDeviceSize offset, uint32_t drawCount, uint32_t stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawIndexedIndirect: Invalid commandBuffer [VUID-vkCmdDrawIndexedIndirect-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2132,7 +2168,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexedIndirect(VkCommandBuffe
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDispatch: Invalid commandBuffer [VUID-vkCmdDispatch-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2144,7 +2180,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDispatchIndirect(VkCommandBuffer c
                                                                VkDeviceSize offset) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDispatchIndirect: Invalid commandBuffer [VUID-vkCmdDispatchIndirect-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2156,7 +2192,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyBuffer(VkCommandBuffer command
                                                          uint32_t regionCount, const VkBufferCopy *pRegions) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyBuffer: Invalid commandBuffer [VUID-vkCmdCopyBuffer-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2170,7 +2206,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyImage(VkCommandBuffer commandB
                                                         const VkImageCopy *pRegions) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyImage: Invalid commandBuffer [VUID-vkCmdCopyImage-devcommandBufferice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2184,7 +2220,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBlitImage(VkCommandBuffer commandB
                                                         const VkImageBlit *pRegions, VkFilter filter) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBlitImage: Invalid commandBuffer [VUID-vkCmdBlitImage-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2197,7 +2233,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyBufferToImage(VkCommandBuffer 
                                                                 const VkBufferImageCopy *pRegions) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyBufferToImage: Invalid commandBuffer [VUID-vkCmdCopyBufferToImage-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2210,7 +2246,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyImageToBuffer(VkCommandBuffer 
                                                                 uint32_t regionCount, const VkBufferImageCopy *pRegions) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyImageToBuffer: Invalid commandBuffer [VUID-vkCmdCopyImageToBuffer-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2222,7 +2258,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdUpdateBuffer(VkCommandBuffer comma
                                                            VkDeviceSize dstOffset, VkDeviceSize dataSize, const void *pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdUpdateBuffer: Invalid commandBuffer [VUID-vkCmdUpdateBuffer-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2234,7 +2270,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdFillBuffer(VkCommandBuffer command
                                                          VkDeviceSize size, uint32_t data) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdFillBuffer: Invalid commandBuffer [VUID-vkCmdFillBuffer-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2247,7 +2283,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdClearColorImage(VkCommandBuffer co
                                                               uint32_t rangeCount, const VkImageSubresourceRange *pRanges) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdClearColorImage: Invalid commandBuffer [VUID-vkCmdClearColorImage-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2261,7 +2297,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdClearDepthStencilImage(VkCommandBu
                                                                      uint32_t rangeCount, const VkImageSubresourceRange *pRanges) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdClearDepthStencilImage: Invalid commandBuffer [VUID-vkCmdClearDepthStencilImage-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2274,7 +2310,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdClearAttachments(VkCommandBuffer c
                                                                const VkClearRect *pRects) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdClearAttachments: Invalid commandBuffer [VUID-vkCmdClearAttachments-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2288,7 +2324,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdResolveImage(VkCommandBuffer comma
                                                            const VkImageResolve *pRegions) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdResolveImage: Invalid commandBuffer [VUID-vkCmdResolveImage-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2300,7 +2336,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetEvent(VkCommandBuffer commandBu
                                                        VkPipelineStageFlags stageMask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetEvent: Invalid commandBuffer [VUID-vkCmdSetEvent-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2312,7 +2348,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdResetEvent(VkCommandBuffer command
                                                          VkPipelineStageFlags stageMask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdResetEvent: Invalid commandBuffer [VUID-vkCmdResetEvent-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2329,7 +2365,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdWaitEvents(VkCommandBuffer command
                                                          const VkImageMemoryBarrier *pImageMemoryBarriers) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdWaitEvents: Invalid commandBuffer [VUID-vkCmdWaitEvents-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2347,7 +2383,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdPipelineBarrier(VkCommandBuffer co
                                                               const VkImageMemoryBarrier *pImageMemoryBarriers) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdPipelineBarrier: Invalid commandBuffer [VUID-vkCmdPipelineBarrier-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2360,7 +2396,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBeginQuery(VkCommandBuffer command
                                                          VkFlags flags) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBeginQuery: Invalid commandBuffer [VUID-vkCmdBeginQuery-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2371,7 +2407,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBeginQuery(VkCommandBuffer command
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdEndQuery: Invalid commandBuffer [VUID-vkCmdEndQuery-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2383,7 +2419,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdResetQueryPool(VkCommandBuffer com
                                                              uint32_t firstQuery, uint32_t queryCount) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdResetQueryPool: Invalid commandBuffer [VUID-vkCmdResetQueryPool-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2395,7 +2431,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdWriteTimestamp(VkCommandBuffer com
                                                              VkQueryPool queryPool, uint32_t slot) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdWriteTimestamp: Invalid commandBuffer [VUID-vkCmdWriteTimestamp-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2408,7 +2444,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdCopyQueryPoolResults(VkCommandBuff
                                                                    VkDeviceSize dstOffset, VkDeviceSize stride, VkFlags flags) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdCopyQueryPoolResults: Invalid commandBuffer [VUID-vkCmdCopyQueryPoolResults-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2421,7 +2457,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdPushConstants(VkCommandBuffer comm
                                                             const void *pValues) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdPushConstants: Invalid commandBuffer [VUID-vkCmdPushConstants-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2434,7 +2470,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBeginRenderPass(VkCommandBuffer co
                                                               VkSubpassContents contents) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBeginRenderPass: Invalid commandBuffer [VUID-vkCmdBeginRenderPass-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2445,7 +2481,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBeginRenderPass(VkCommandBuffer co
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdNextSubpass: Invalid commandBuffer [VUID-vkCmdNextSubpass-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2456,7 +2492,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdNextSubpass(VkCommandBuffer comman
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdEndRenderPass(VkCommandBuffer commandBuffer) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdEndRenderPass: Invalid commandBuffer [VUID-vkCmdEndRenderPass-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2468,7 +2504,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdExecuteCommands(VkCommandBuffer co
                                                               const VkCommandBuffer *pCommandBuffers) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdExecuteCommands: Invalid commandBuffer [VUID-vkCmdExecuteCommands-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2672,7 +2708,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDeviceGroups(
     inst = loader_get_instance(instance);
     if (NULL == inst) {
         loader_log(
-            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
             "vkEnumeratePhysicalDeviceGroupsKHR: Invalid instance [VUID-vkEnumeratePhysicalDeviceGroups-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2720,7 +2756,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFeatures2(VkPhysical
                                                                       VkPhysicalDeviceFeatures2 *pFeatures) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceFeatures2: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceFeatures2-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2739,7 +2775,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceProperties2(VkPhysic
                                                                         VkPhysicalDeviceProperties2 *pProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceProperties2: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceProperties2-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2758,7 +2794,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceFormatProperties2(Vk
                                                                               VkFormatProperties2 *pFormatProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceFormatProperties2: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceFormatProperties2-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2778,7 +2814,7 @@ vkGetPhysicalDeviceImageFormatProperties2(VkPhysicalDevice physicalDevice, const
                                           VkImageFormatProperties2 *pImageFormatProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceImageFormatProperties2: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceImageFormatProperties2-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2797,7 +2833,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceQueueFamilyPropertie
     VkPhysicalDevice physicalDevice, uint32_t *pQueueFamilyPropertyCount, VkQueueFamilyProperties2 *pQueueFamilyProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceQueueFamilyProperties2: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceQueueFamilyProperties2-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2816,7 +2852,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL
 vkGetPhysicalDeviceMemoryProperties2(VkPhysicalDevice physicalDevice, VkPhysicalDeviceMemoryProperties2 *pMemoryProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceMemoryProperties2: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceMemoryProperties2-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2836,7 +2872,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceSparseImageFormatPro
     VkSparseImageFormatProperties2 *pProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceSparseImageFormatProperties2: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceSparseImageFormatProperties2-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2856,7 +2892,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalBufferProper
     VkExternalBufferProperties *pExternalBufferProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceExternalBufferProperties: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceExternalBufferProperties-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2876,7 +2912,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalSemaphorePro
     VkExternalSemaphoreProperties *pExternalSemaphoreProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceExternalSemaphoreProperties: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceExternalSemaphoreProperties-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2898,7 +2934,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalFencePropert
     VkExternalFenceProperties *pExternalFenceProperties) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceExternalFenceProperties: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceExternalFenceProperties-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2917,7 +2953,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkBindBufferMemory2(VkDevice device
                                                                  const VkBindBufferMemoryInfo *pBindInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkBindBufferMemory2: Invalid device [VUID-vkBindBufferMemory2-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2928,7 +2964,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkBindImageMemory2(VkDevice device,
                                                                 const VkBindImageMemoryInfo *pBindInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkBindImageMemory2: Invalid device [VUID-vkBindImageMemory2-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2940,7 +2976,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceGroupPeerMemoryFeatures(VkDe
                                                                             VkPeerMemoryFeatureFlags *pPeerMemoryFeatures) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceGroupPeerMemoryFeatures: Invalid device [VUID-vkGetDeviceGroupPeerMemoryFeatures-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2950,7 +2986,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceGroupPeerMemoryFeatures(VkDe
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdSetDeviceMask: Invalid commandBuffer [VUID-vkCmdSetDeviceMask-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2962,7 +2998,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDispatchBase(VkCommandBuffer comma
                                                            uint32_t groupCountZ) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDispatchBase: Invalid commandBuffer [VUID-vkCmdDispatchBase-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2973,7 +3009,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetImageMemoryRequirements2(VkDevice 
                                                                        VkMemoryRequirements2 *pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetImageMemoryRequirements2: Invalid device [VUID-vkGetImageMemoryRequirements2-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2985,7 +3021,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetBufferMemoryRequirements2(VkDevice
                                                                         VkMemoryRequirements2 *pMemoryRequirements) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetBufferMemoryRequirements2: Invalid device [VUID-vkGetBufferMemoryRequirements2-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2998,7 +3034,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetImageSparseMemoryRequirements2(
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
         loader_log(
-            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
             "vkGetImageSparseMemoryRequirements2: Invalid device [VUID-vkGetImageSparseMemoryRequirements2-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3009,7 +3045,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkTrimCommandPool(VkDevice device, VkCo
                                                            VkCommandPoolTrimFlags flags) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkTrimCommandPool: Invalid device [VUID-vkTrimCommandPool-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkTrimCommandPool: Invalid device [VUID-vkTrimCommandPool-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
     disp->TrimCommandPool(device, commandPool, flags);
@@ -3018,7 +3055,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkTrimCommandPool(VkDevice device, VkCo
 LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2 *pQueueInfo, VkQueue *pQueue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkGetDeviceQueue2: Invalid device [VUID-vkGetDeviceQueue2-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkGetDeviceQueue2: Invalid device [VUID-vkGetDeviceQueue2-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
     disp->GetDeviceQueue2(device, pQueueInfo, pQueue);
@@ -3033,7 +3071,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSamplerYcbcrConversion(VkDe
                                                                             VkSamplerYcbcrConversion *pYcbcrConversion) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateSamplerYcbcrConversion: Invalid device [VUID-vkCreateSamplerYcbcrConversion-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3044,7 +3082,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroySamplerYcbcrConversion(VkDevic
                                                                          const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroySamplerYcbcrConversion: Invalid device [VUID-vkDestroySamplerYcbcrConversion-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3056,7 +3094,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetDescriptorSetLayoutSupport(VkDevic
                                                                          VkDescriptorSetLayoutSupport *pSupport) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDescriptorSetLayoutSupport: Invalid device [VUID-vkGetDescriptorSetLayoutSupport-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3068,7 +3106,7 @@ vkCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTempla
                                  const VkAllocationCallbacks *pAllocator, VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateDescriptorUpdateTemplate: Invalid device [VUID-vkCreateDescriptorUpdateTemplate-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3080,7 +3118,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDescriptorUpdateTemplate(VkDev
                                                                            const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroyDescriptorUpdateTemplate: Invalid device [VUID-vkDestroyDescriptorUpdateTemplate-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3092,7 +3130,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkUpdateDescriptorSetWithTemplate(VkDev
                                                                            const void *pData) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkUpdateDescriptorSetWithTemplate: Invalid device [VUID-vkUpdateDescriptorSetWithTemplate-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3106,7 +3144,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateRenderPass2(VkDevice device
                                                                  VkRenderPass *pRenderPass) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateRenderPass2: Invalid device [VUID-vkCreateRenderPass2-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3118,7 +3156,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdBeginRenderPass2(VkCommandBuffer c
                                                                const VkSubpassBeginInfo *pSubpassBeginInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdBeginRenderPass2: Invalid commandBuffer [VUID-vkCmdBeginRenderPass2-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3130,7 +3168,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdNextSubpass2(VkCommandBuffer comma
                                                            const VkSubpassEndInfo *pSubpassEndInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdNextSubpass2: Invalid commandBuffer [VUID-vkCmdNextSubpass2-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3141,7 +3179,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdEndRenderPass2(VkCommandBuffer com
                                                              const VkSubpassEndInfo *pSubpassEndInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdEndRenderPass2: Invalid commandBuffer [VUID-vkCmdEndRenderPass2-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3153,7 +3191,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndirectCount(VkCommandBuffer 
                                                                 uint32_t maxDrawCount, uint32_t stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCmdDrawIndirectCount: Invalid commandBuffer [VUID-vkCmdDrawIndirectCount-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3167,7 +3205,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexedIndirectCount(VkCommand
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
         loader_log(
-            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
             "vkCmdDrawIndexedIndirectCount: Invalid commandBuffer [VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3177,7 +3215,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexedIndirectCount(VkCommand
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t *pValue) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetSemaphoreCounterValue: Invalid device [VUID-vkGetSemaphoreCounterValue-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3188,7 +3226,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkWaitSemaphores(VkDevice device, c
                                                               uint64_t timeout) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkWaitSemaphores: Invalid device [VUID-vkWaitSemaphores-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkWaitSemaphores: Invalid device [VUID-vkWaitSemaphores-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
     return disp->WaitSemaphores(device, pWaitInfo, timeout);
@@ -3197,7 +3236,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkWaitSemaphores(VkDevice device, c
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkSignalSemaphore: Invalid device [VUID-vkSignalSemaphore-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkSignalSemaphore: Invalid device [VUID-vkSignalSemaphore-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
     return disp->SignalSemaphore(device, pSignalInfo);
@@ -3207,7 +3247,7 @@ LOADER_EXPORT VKAPI_ATTR VkDeviceAddress VKAPI_CALL vkGetBufferDeviceAddress(VkD
                                                                              const VkBufferDeviceAddressInfo *pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetBufferDeviceAddress: Invalid device [VUID-vkGetBufferDeviceAddress-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3218,7 +3258,7 @@ LOADER_EXPORT VKAPI_ATTR uint64_t VKAPI_CALL vkGetBufferOpaqueCaptureAddress(VkD
                                                                              const VkBufferDeviceAddressInfo *pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetBufferOpaqueCaptureAddress: Invalid device [VUID-vkGetBufferOpaqueCaptureAddress-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3230,7 +3270,7 @@ vkGetDeviceMemoryOpaqueCaptureAddress(VkDevice device, const VkDeviceMemoryOpaqu
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
         loader_log(
-            NULL, VULKAN_LOADER_ERROR_BIT, 0,
+            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
             "vkGetDeviceMemoryOpaqueCaptureAddress: Invalid device [VUID-vkGetDeviceMemoryOpaqueCaptureAddress-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -3241,7 +3281,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkResetQueryPool(VkDevice device, VkQue
                                                           uint32_t queryCount) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0, "vkResetQueryPool: Invalid device [VUID-vkResetQueryPool-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkResetQueryPool: Invalid device [VUID-vkResetQueryPool-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
     disp->ResetQueryPool(device, queryPool, firstQuery, queryCount);

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,7 +173,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroySurfaceKHR(VkInstance instance
                                                              const VkAllocationCallbacks *pAllocator) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroySurfaceKHR: Invalid instance [VUID-vkDestroySurfaceKHR-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -218,7 +218,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceSupportKH
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceSurfaceSupportKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceSurfaceSupportKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -271,7 +271,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceCapabilit
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceSurfaceCapabilitiesKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceSurfaceCapabilitiesKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -325,7 +325,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceFormatsKH
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceSurfaceFormatsKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceSurfaceFormatsKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -381,7 +381,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfacePresentMo
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceSurfacePresentModesKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceSurfacePresentModesKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -436,7 +436,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSwapchainKHR(VkDevice devic
                                                                   VkSwapchainKHR *pSwapchain) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateSwapchainKHR: Invalid device [VUID-vkCreateSwapchainKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -474,7 +474,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroySwapchainKHR(VkDevice device, 
                                                                const VkAllocationCallbacks *pAllocator) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkDestroySwapchainKHR: Invalid device [VUID-vkDestroySwapchainKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -486,7 +486,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetSwapchainImagesKHR(VkDevice de
                                                                      uint32_t *pSwapchainImageCount, VkImage *pSwapchainImages) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetSwapchainImagesKHR: Invalid device [VUID-vkGetSwapchainImagesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -498,7 +498,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR(VkDevice devi
                                                                    VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkAcquireNextImageKHR: Invalid device [VUID-vkAcquireNextImageKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -509,7 +509,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR(VkDevice devi
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkQueuePresentKHR: Invalid queue [VUID-vkQueuePresentKHR-queue-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -550,7 +550,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateWin32SurfaceKHR(VkInstance 
                                                                      VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateWin32SurfaceKHR: Invalid instance [VUID-vkCreateWin32SurfaceKHR-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -626,7 +626,7 @@ LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWin32Presentatio
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceWin32PresentationSupportKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceWin32PresentationSupportKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -668,7 +668,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateWaylandSurfaceKHR(VkInstanc
                                                                        VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateWaylandSurfaceKHR: Invalid instance [VUID-vkCreateWaylandSurfaceKHR-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -744,7 +744,7 @@ LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWaylandPresentat
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceWaylandPresentationSupportKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceWaylandPresentationSupportKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -790,7 +790,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateXcbSurfaceKHR(VkInstance in
                                                                    VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateXcbSurfaceKHR: Invalid instance [VUID-vkCreateXcbSurfaceKHR-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -866,7 +866,7 @@ LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXcbPresentationS
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceXcbPresentationSupportKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceXcbPresentationSupportKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -913,7 +913,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateXlibSurfaceKHR(VkInstance i
                                                                     VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateXlibSurfaceKHR: Invalid instance [VUID-vkCreateXlibSurfaceKHR-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -988,7 +988,7 @@ LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXlibPresentation
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceXlibPresentationSupportKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceXlibPresentationSupportKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -1033,7 +1033,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDirectFBSurfaceEXT(VkInstan
                                                                         VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateDirectFBSurfaceEXT: Invalid instance [VUID-vkCreateDirectFBSurfaceEXT-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1111,7 +1111,7 @@ LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceDirectFBPresenta
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceDirectFBPresentationSupportEXT: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceDirectFBPresentationSupportEXT-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -1158,7 +1158,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateAndroidSurfaceKHR(VkInstanc
                                                                        VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateAndroidSurfaceKHR: Invalid instance [VUID-vkCreateAndroidSurfaceKHR-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1202,7 +1202,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateHeadlessSurfaceEXT(VkInstan
                                                                         VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateHeadlessSurfaceEXT: Invalid instance [VUID-vkCreateHeadlessSurfaceEXT-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1277,7 +1277,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateMacOSSurfaceMVK(VkInstance 
                                                                      VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateMacOSSurfaceMVK: Invalid instance [VUID-vkCreateMacOSSurfaceMVK-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1356,7 +1356,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateIOSSurfaceMVK(VkInstance in
                                                                    VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateIOSSurfaceMVK: Invalid instance [VUID-vkCreateIOSSurfaceMVK-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1402,7 +1402,7 @@ vkCreateStreamDescriptorSurfaceGGP(VkInstance instance, const VkStreamDescriptor
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
         loader_log(
-            NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
             "vkCreateStreamDescriptorSurfaceGGP: Invalid instance [VUID-vkCreateStreamDescriptorSurfaceGGP-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1479,7 +1479,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateMetalSurfaceEXT(VkInstance 
                                                                      VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateMetalSurfaceEXT: Invalid instance [VUID-vkCreateMetalSurfaceEXT-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1551,7 +1551,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateScreenSurfaceQNX(VkInstance
                                                                       VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateScreenSurfaceQNX: Invalid instance [VUID-vkCreateScreenSurfaceQNX-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -1626,7 +1626,7 @@ LOADER_EXPORT VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceScreenPresentati
                                                                                              struct _screen_window *window) {
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceScreenPresentationSupportQNX: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceScreenPresentationSupportQNX-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -1666,22 +1666,20 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceScreenPresentationSup
 // Functions for the VK_NN_vi_surface extension:
 
 // This is the trampoline entrypoint for CreateViSurfaceNN
-LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateViSurfaceNN(VkInstance instance,
-                                                                 const VkViSurfaceCreateInfoNN* pCreateInfo,
-                                                                 const VkAllocationCallbacks* pAllocator,
-                                                                 VkSurfaceKHR* pSurface) {
-    struct loader_instance* loader_inst = loader_get_instance(instance);
+LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateViSurfaceNN(VkInstance instance, const VkViSurfaceCreateInfoNN *pCreateInfo,
+                                                                 const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
+    struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateViSurfaceNN: Invalid instance [VUID-vkCreateViSurfaceNN-instance-parameter]");
-      abort(); /* Intentionally fail so user can correct issue. */
+        abort(); /* Intentionally fail so user can correct issue. */
     }
     return loader_inst->disp->layer_inst_disp.CreateViSurfaceNN(loader_inst->instance, pCreateInfo, pAllocator, pSurface);
 }
 
 // This is the instance chain terminator function for CreateViSurfaceNN
-VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateViSurfaceNN(VkInstance instance, const VkViSurfaceCreateInfoNN* pCreateInfo,
-                                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateViSurfaceNN(VkInstance instance, const VkViSurfaceCreateInfoNN *pCreateInfo,
+                                                            const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
     VkResult vkRes = VK_SUCCESS;
     VkIcdSurface *pIcdSurface = NULL;
     uint32_t i = 0;
@@ -1747,7 +1745,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceDisplayPropertie
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceDisplayPropertiesKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceDisplayPropertiesKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -1785,7 +1783,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceDisplayPlaneProp
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceDisplayPlanePropertiesKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceDisplayPlanePropertiesKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -1824,7 +1822,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDisplayPlaneSupportedDisplaysK
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDisplayPlaneSupportedDisplaysKHR: Invalid physicalDevice "
                    "[VUID-vkGetDisplayPlaneSupportedDisplaysKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -1862,7 +1860,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDisplayModePropertiesKHR(VkPhy
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDisplayModePropertiesKHR: Invalid physicalDevice "
                    "[VUID-vkGetDisplayModePropertiesKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -1902,7 +1900,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDisplayModeKHR(VkPhysicalDe
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateDisplayModeKHR: Invalid physicalDevice "
                    "[VUID-vkCreateDisplayModeKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -1941,7 +1939,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDisplayPlaneCapabilitiesKHR(Vk
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDisplayPlaneCapabilitiesKHR: Invalid physicalDevice "
                    "[VUID-vkGetDisplayPlaneCapabilitiesKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -1983,7 +1981,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateDisplayPlaneSurfaceKHR(VkIn
                                                                             VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateDisplayPlaneSurfaceKHR: Invalid instance [VUID-vkCreateDisplayPlaneSurfaceKHR-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2064,7 +2062,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateSharedSwapchainsKHR(VkDevic
                                                                          VkSwapchainKHR *pSwapchains) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateSharedSwapchainsKHR: Invalid device [VUID-vkCreateSharedSwapchainsKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2105,7 +2103,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkGetDeviceGroupPresentCapabilitiesKHR(VkDevice device, VkDeviceGroupPresentCapabilitiesKHR *pDeviceGroupPresentCapabilities) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceGroupPresentCapabilitiesKHR: Invalid device "
                    "[VUID-vkGetDeviceGroupPresentCapabilitiesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2117,7 +2115,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDeviceGroupSurfacePresentModes
                                                                                     VkDeviceGroupPresentModeFlagsKHR *pModes) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDeviceGroupSurfacePresentModesKHR: Invalid device "
                    "[VUID-vkGetDeviceGroupSurfacePresentModesKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2147,7 +2145,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDevicePresentRectangle
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDevicePresentRectanglesKHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDevicePresentRectanglesKHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2179,7 +2177,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImage2KHR(VkDevice dev
                                                                     uint32_t *pImageIndex) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkAcquireNextImage2KHR: Invalid device [VUID-vkAcquireNextImage2KHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2194,7 +2192,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceDisplayPropertie
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceDisplayProperties2KHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceDisplayProperties2KHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2249,7 +2247,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceDisplayPlaneProp
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceDisplayPlaneProperties2KHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceDisplayPlaneProperties2KHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2306,7 +2304,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDisplayModeProperties2KHR(VkPh
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDisplayModeProperties2KHR: Invalid physicalDevice "
                    "[VUID-vkGetDisplayModeProperties2KHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2362,7 +2360,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetDisplayPlaneCapabilities2KHR(V
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetDisplayPlaneCapabilities2KHR: Invalid physicalDevice "
                    "[VUID-vkGetDisplayPlaneCapabilities2KHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2401,7 +2399,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateImagePipeSurfaceFUCHSIA(VkI
                                                                              VkSurfaceKHR *pSurface) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
     if (NULL == loader_inst) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateImagePipeSurfaceFUCHSIA: Invalid instance [VUID-vkCreateImagePipeSurfaceFUCHSIA-instance-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
@@ -2480,7 +2478,7 @@ vkGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice, cons
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceSurfaceCapabilities2KHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
@@ -2563,7 +2561,7 @@ vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, const VkP
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkGetPhysicalDeviceSurfaceFormats2KHR: Invalid physicalDevice "
                    "[VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2021 The Khronos Group Inc.
-# Copyright (c) 2015-2021 Valve Corporation
-# Copyright (c) 2015-2021 LunarG, Inc.
+# Copyright (c) 2015-2022 The Khronos Group Inc.
+# Copyright (c) 2015-2022 Valve Corporation
+# Copyright (c) 2015-2022 LunarG, Inc.
 # Copyright (c) 2015-2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -186,9 +186,9 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
 
         # Copyright Notice
         copyright =  '/*\n'
-        copyright += ' * Copyright (c) 2015-2021 The Khronos Group Inc.\n'
-        copyright += ' * Copyright (c) 2015-2021 Valve Corporation\n'
-        copyright += ' * Copyright (c) 2015-2021 LunarG, Inc.\n'
+        copyright += ' * Copyright (c) 2015-2022 The Khronos Group Inc.\n'
+        copyright += ' * Copyright (c) 2015-2022 Valve Corporation\n'
+        copyright += ' * Copyright (c) 2015-2022 LunarG, Inc.\n'
         copyright += ' *\n'
         copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
         copyright += ' * you may not use this file except in compliance with the License.\n'
@@ -1036,7 +1036,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     funcs += '    const VkLayerInstanceDispatchTable *disp;\n'
                     funcs += '    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(%s);\n' % (phys_dev_var_name)
                     funcs += '    if (VK_NULL_HANDLE == unwrapped_phys_dev) {\n'
-                    funcs += '        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,\n'
+                    funcs += '        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n'
                     funcs += '                   "%s: Invalid %s "\n' % (ext_cmd.name, phys_dev_var_name)
                     funcs += '                   "[VUID-%s-%s-parameter]");\n' % (ext_cmd.name, phys_dev_var_name)
                     funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
@@ -1046,7 +1046,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     funcs += '    struct loader_instance *inst = loader_get_instance(%s);\n' % (instance_var_name)
                     funcs += '    if (NULL == inst) {\n'
                     funcs += '        loader_log(\n'
-                    funcs += '            NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,\n'
+                    funcs += '            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n'
                     funcs += '            "%s: Invalid instance [VUID-%s-%s-parameter]");\n' % (ext_cmd.name, ext_cmd.name, instance_var_name)
                     funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
                     funcs += '    }\n'
@@ -1056,7 +1056,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     funcs += ext_cmd.params[0].name
                     funcs += ');\n'
                     funcs += '    if (NULL == disp) {\n'
-                    funcs += '        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,\n'
+                    funcs += '        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n'
                     funcs += '                   "%s: Invalid %s "\n' % (ext_cmd.name, ext_cmd.params[0].name)
                     funcs += '                   "[VUID-%s-%s-parameter]");\n' % (ext_cmd.name, ext_cmd.params[0].name)
                     funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
@@ -1234,7 +1234,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     funcs += '    struct loader_instance *inst = loader_get_instance(%s);\n' % (instance_var_name)
                     funcs += '    if (NULL == inst) {\n'
                     funcs += '        loader_log(\n'
-                    funcs += '            NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,\n'
+                    funcs += '            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n'
                     funcs += '            "%s: Invalid instance [VUID-%s-%s-parameter]");\n' % (ext_cmd.name, ext_cmd.name, instance_var_name)
                     funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
                     funcs += '    }\n'
@@ -1350,7 +1350,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 funcs += ext_cmd.params[0].name
                 funcs += ');\n'
                 funcs += '    if (NULL == disp) {\n'
-                funcs += '        loader_log(NULL, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,\n'
+                funcs += '        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n'
                 funcs += '                   "%s: Invalid %s "\n' % (ext_cmd.name, ext_cmd.params[0].name)
                 funcs += '                   "[VUID-%s-%s-parameter]");\n' % (ext_cmd.name, ext_cmd.params[0].name)
                 funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
         loader_testing_main.cpp
         loader_alloc_callback_tests.cpp
         loader_get_proc_addr_tests.cpp
+        loader_debug_ext_tests.cpp
         loader_handle_validation_tests.cpp
         loader_layer_tests.cpp
         loader_regression_tests.cpp

--- a/tests/loader_debug_ext_tests.cpp
+++ b/tests/loader_debug_ext_tests.cpp
@@ -29,461 +29,907 @@
 #include "test_environment.h"
 
 //
-// VK_EXT_debug_report
+// VK_EXT_debug_report specific tests
+// =========================================
 //
 
-struct ExpectedDebugReportMessage {
-    bool any_message = false;
-    std::string message;
-    VkDebugReportObjectTypeEXT object_type;
-    VkDebugReportFlagBitsEXT flag;
-    bool found = false;
-};
-static ExpectedDebugReportMessage expected_debug_report{};
+// Prototype declaration for callback so we can use it in class utility methods
+static VkBool32 VKAPI_CALL test_DebugReportCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType,
+                                                    uint64_t object, size_t location, int32_t messageCode, const char* pLayerPrefix,
+                                                    const char* pMessage, void* pUserData);
 
+class DebugReportTest : public ::testing::Test {
+   public:
+    void VerifyExpected(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT object_type, const std::string& message) {
+        if (object_type == expected_object_type && 0 < (flags | expected_flag)) {
+            if (allow_any_message || (std::string::npos != message.find(expected_message))) {
+                message_found = true;
+            }
+        }
+    }
+
+   protected:
+    virtual void SetUp() {
+        env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
+        for (uint32_t icd = 0; icd < 3; ++icd) {
+            env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_API_VERSION_1_0));
+            env->get_test_icd(icd).physical_devices.push_back({});
+            env->get_test_icd(icd).physical_devices.push_back({});
+        }
+        // Initialize the expected output
+        allow_any_message = false;
+        expected_message = "";
+        expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+        message_found = false;
+    }
+
+    VkResult CreateReportInstance(VkDebugReportFlagsEXT debug_report_flags, VkInstance* inst,
+                                  VkApplicationInfo* app_info = nullptr) {
+        std::vector<const char*> enabled_extensions;
+        enabled_extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+
+        // Setup the debug report struct
+        VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
+        debug_report_info.pNext = nullptr;
+        debug_report_info.flags = debug_report_flags;
+        debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
+        debug_report_info.pUserData = reinterpret_cast<void*>(this);
+
+        // Pass it into instance create struct
+        VkInstanceCreateInfo create_info{};
+        create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+        create_info.pNext = &debug_report_info;
+        create_info.pApplicationInfo = app_info;
+        create_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
+        create_info.ppEnabledExtensionNames = enabled_extensions.data();
+
+        return env->vulkan_functions.vkCreateInstance(&create_info, nullptr, inst);
+    }
+
+    VkResult CreateReportCallback(VkInstance inst, VkDebugReportFlagsEXT debug_report_flags, VkDebugReportCallbackEXT* callback) {
+        PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
+            env->vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
+        if (nullptr == create_debug_report) {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
+        debug_report_info.pNext = nullptr;
+        debug_report_info.flags = debug_report_flags;
+        debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
+        debug_report_info.pUserData = reinterpret_cast<void*>(this);
+        return create_debug_report(inst, &debug_report_info, nullptr, callback);
+    }
+
+    VkResult DestroyReportCallback(VkInstance inst, VkDebugReportCallbackEXT callback) {
+        PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
+            env->vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
+        if (nullptr == destroy_debug_report) {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        destroy_debug_report(inst, callback, nullptr);
+        return VK_SUCCESS;
+    }
+
+    virtual void TearDown() { env.reset(); }
+
+    std::unique_ptr<FrameworkEnvironment> env;
+    bool allow_any_message;
+    std::string expected_message;
+    VkDebugReportObjectTypeEXT expected_object_type;
+    VkDebugReportFlagBitsEXT expected_flag;
+    bool message_found;
+};
+
+// This is the actual callback prototyped above.
 static VkBool32 VKAPI_CALL test_DebugReportCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType,
                                                     uint64_t object, size_t location, int32_t messageCode, const char* pLayerPrefix,
                                                     const char* pMessage, void* pUserData) {
-    if (objectType == expected_debug_report.object_type && 0 < (flags | expected_debug_report.flag)) {
-        std::string message_str = pMessage;
-        if (expected_debug_report.any_message || (std::string::npos != message_str.find(expected_debug_report.message))) {
-            expected_debug_report.found = true;
-        }
-    }
+    DebugReportTest* debug_report_test = reinterpret_cast<DebugReportTest*>(pUserData);
+    debug_report_test->VerifyExpected(flags, objectType, pMessage);
     return VK_FALSE;
 }
 
-static void CreateDebugReportEnvironment(FrameworkEnvironment& env, VkDebugReportFlagsEXT flags,
-                                         VkInstanceCreateInfo& create_info) {
-    for (uint32_t icd = 0; icd < 3; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_API_VERSION_1_0));
-        env.get_test_icd(icd).physical_devices.push_back({});
-        env.get_test_icd(icd).physical_devices.push_back({});
-    }
+class CreateDestroyInstanceReport : public DebugReportTest {};
+class SeparateReport : public DebugReportTest {};
+class ManualReport : public DebugReportTest {};
 
-    // Initialize the expected output
-    expected_debug_report.any_message = false;
-    expected_debug_report.message = "";
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
-    expected_debug_report.found = false;
-
-    // Setup the debug report struct
-    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
-    debug_report_info.pNext = nullptr;
-    debug_report_info.flags = flags;
-    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
-    debug_report_info.pUserData = nullptr;
-
-    static std::vector<const char*> enabled_extensions;
-    enabled_extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
-    create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-    create_info.pNext = &debug_report_info;
-    create_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
-    create_info.ppEnabledExtensionNames = enabled_extensions.data();
-}
-
-// Test creating and destroying report with errors, but none should occur.
-TEST(DebugExtensionTests, NormalCreateDestroy) {
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
-
+// Test creating and destroying instance looking for errors, but none should occur.
+TEST_F(CreateDestroyInstanceReport, NoCallback) {
     // Make sure we don't find any errors
-    expected_debug_report.any_message = true;
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+    allow_any_message = true;
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
 
     VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_ERROR_BIT_EXT, &inst));
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 
-    ASSERT_EQ(false, expected_debug_report.found);
-}
-
-// Test report (error/warning) created in vkCreateInstance with warning in vkCreateInstance
-TEST(DebugExtensionTests, WarningInCreateInstance) {
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT, create_info);
-
-    VkApplicationInfo app_info;
-    app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
-    create_info.pApplicationInfo = &app_info;
-
-    // Make sure we find the invalid variant message
-    expected_debug_report.message = "The API Variant specified";
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_WARNING_BIT_EXT;
-
-    VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
-
-    // Should be found because we're reporting errors and warnings
-    ASSERT_EQ(true, expected_debug_report.found);
+    ASSERT_EQ(false, message_found);
 }
 
 // Test report (error) created in vkCreateInstance with warning in vkCreateInstance
-TEST(DebugExtensionTests, WarningInCreateInstanceNotLogged) {
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
+TEST_F(CreateDestroyInstanceReport, WarnInCreateIgnored) {
+    expected_message = "The API Variant specified";
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_WARNING_BIT_EXT;
 
     VkApplicationInfo app_info;
     app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
-    create_info.pApplicationInfo = &app_info;
-
-    // Make sure we find the invalid variant message
-    expected_debug_report.message = "The API Variant specified";
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_WARNING_BIT_EXT;
-
     VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_ERROR_BIT_EXT, &inst, &app_info));
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 
     // Message should NOT be found (because we only have errors reported in create)
-    ASSERT_EQ(false, expected_debug_report.found);
+    ASSERT_EQ(false, message_found);
+}
+
+// Test creating and destroying instance looking for errors, but none should occur.
+TEST_F(CreateDestroyInstanceReport, WarnInCreate) {
+    expected_message = "The API Variant specified";
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_WARNING_BIT_EXT;
+
+    VkApplicationInfo app_info;
+    app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_WARNING_BIT_EXT, &inst, &app_info));
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should be found (because we only have errors reported in create)
+    ASSERT_EQ(true, message_found);
 }
 
 // Test report (error/warning) created in vkCreateInstance with info in vkDestroyInstance
-TEST(DebugExtensionTests, InfoInDestroyInstanceNotLogged) {
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT, create_info);
-
-    expected_debug_report.message = "destroying all debug report callbacks";
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
+TEST_F(CreateDestroyInstanceReport, InfoInDestroyIgnored) {
+    expected_message = "destroying temporary instance debug report callback";
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
 
     VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT, &inst));
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 
     // Should be not be found
-    ASSERT_EQ(false, expected_debug_report.found);
+    ASSERT_EQ(false, message_found);
 }
 
 // Test report (info) created in vkCreateInstance with info in vkDestroyInstance
-TEST(DebugExtensionTests, InfoInDestroyInstanceLogged) {
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, create_info);
-
-    expected_debug_report.message = "destroying all debug report callbacks";
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
+TEST_F(CreateDestroyInstanceReport, InfoInDestroy) {
+    expected_message = "destroying temporary instance debug report callback";
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
 
     VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_INFORMATION_BIT_EXT, &inst));
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 
     // Message should be found
-    ASSERT_EQ(true, expected_debug_report.found);
+    ASSERT_EQ(true, message_found);
 }
 
 // Test report (error/warning) created in vkCreateInstance with error in vkEnumeratePhysicalDevices.
 // This should not be logged because we have only defined the debug report logging for vkCreateInstance
 // and vkDestroyInstance.
-TEST(DebugExtensionTests, ErrorInEnumDevsNotLogged) {
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
-
+TEST_F(SeparateReport, ErrorInEnumDevsNoCallback) {
     // Look for the invaid count param message
-    expected_debug_report.message = "VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter";
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+    expected_message = "VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter";
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
 
     VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_ERROR_BIT_EXT, &inst));
 
-    ASSERT_EQ(env.vulkan_functions.vkEnumeratePhysicalDevices(inst, nullptr, nullptr), VK_ERROR_INITIALIZATION_FAILED);
+    ASSERT_EQ(env->vulkan_functions.vkEnumeratePhysicalDevices(inst, nullptr, nullptr), VK_ERROR_INITIALIZATION_FAILED);
 
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 
     // Message should NOT be found (because we don't have a report callback setup outside of the create/destroy instance chain)
-    ASSERT_EQ(false, expected_debug_report.found);
+    ASSERT_EQ(false, message_found);
 }
 
 // Test report created outside of vkCreateInstance with error in vkEnumeratePhysicalDevices.
 // This should be logged now.
-TEST(DebugExtensionTests, ErrorInEnumDevsLogged) {
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
-
+TEST_F(SeparateReport, ErrorInEnumDevs) {
     // Look for the invaid count param message
-    expected_debug_report.message = "VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter";
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+    expected_message = "VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter";
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
 
     VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
-    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
-    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
-    ASSERT_NE(nullptr, create_debug_report);
-    ASSERT_NE(nullptr, destroy_debug_report);
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_ERROR_BIT_EXT, &inst));
 
-    // Setup the debug report struct
-    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
-    debug_report_info.pNext = nullptr;
-    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
-    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
-    debug_report_info.pUserData = nullptr;
+    VkDebugReportCallbackEXT callback;
+    ASSERT_EQ(VK_SUCCESS, CreateReportCallback(inst, VK_DEBUG_REPORT_ERROR_BIT_EXT, &callback));
 
-    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
-    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
-    ASSERT_EQ(env.vulkan_functions.vkEnumeratePhysicalDevices(inst, nullptr, nullptr), VK_ERROR_INITIALIZATION_FAILED);
-    destroy_debug_report(inst, callback, nullptr);
+    ASSERT_EQ(env->vulkan_functions.vkEnumeratePhysicalDevices(inst, nullptr, nullptr), VK_ERROR_INITIALIZATION_FAILED);
 
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+    ASSERT_EQ(VK_SUCCESS, DestroyReportCallback(inst, callback));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 
     // Message should be found
-    ASSERT_EQ(true, expected_debug_report.found);
+    ASSERT_EQ(true, message_found);
 }
 
 // Test report created outside of vkCreateInstance with info in vkEnumeratePhysicalDevices.
 // This should not be logged because type is wrong.
-TEST(DebugExtensionTests, InfoInEnumDevsNotLogged) {
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
-
-    expected_debug_report.message = "Trimming device count down by application request";
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+TEST_F(SeparateReport, InfoInEnumDevsIgnored) {
+    expected_message = "Trimming device count down by application request";
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
 
     VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
-    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
-    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
-    ASSERT_NE(nullptr, create_debug_report);
-    ASSERT_NE(nullptr, destroy_debug_report);
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_ERROR_BIT_EXT, &inst));
 
-    // Setup the debug report struct
-    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
-    debug_report_info.pNext = nullptr;
-    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
-    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
-    debug_report_info.pUserData = nullptr;
-
-    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
-    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
+    VkDebugReportCallbackEXT callback;
+    ASSERT_EQ(VK_SUCCESS, CreateReportCallback(inst, VK_DEBUG_REPORT_ERROR_BIT_EXT, &callback));
 
     uint32_t max_count = 5;
     std::array<VkPhysicalDevice, 5> devices;
-    ASSERT_EQ(env.vulkan_functions.vkEnumeratePhysicalDevices(inst, &max_count, devices.data()), VK_INCOMPLETE);
-    destroy_debug_report(inst, callback, nullptr);
+    ASSERT_EQ(env->vulkan_functions.vkEnumeratePhysicalDevices(inst, &max_count, devices.data()), VK_INCOMPLETE);
 
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+    ASSERT_EQ(VK_SUCCESS, DestroyReportCallback(inst, callback));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 
     // Message should not be found (because it's info)
-    ASSERT_EQ(false, expected_debug_report.found);
+    ASSERT_EQ(false, message_found);
 }
 
 // Test report created outside of vkCreateInstance with info in vkEnumeratePhysicalDevices.
 // This should be logged because type is correct.
-TEST(DebugExtensionTests, InfoInEnumDevLogged) {
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
-
-    expected_debug_report.message = "Trimming device count down by application request";
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+TEST_F(SeparateReport, InfoInEnumDevs) {
+    expected_message = "Trimming device count down by application request";
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
 
     VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
-    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
-    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
-    ASSERT_NE(nullptr, create_debug_report);
-    ASSERT_NE(nullptr, destroy_debug_report);
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_ERROR_BIT_EXT, &inst));
 
-    // Setup the debug report struct
-    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
-    debug_report_info.pNext = nullptr;
-    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
-    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
-    debug_report_info.pUserData = nullptr;
-
-    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
-    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
+    VkDebugReportCallbackEXT callback;
+    ASSERT_EQ(VK_SUCCESS, CreateReportCallback(inst, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, &callback));
 
     uint32_t max_count = 5;
     std::array<VkPhysicalDevice, 5> devices;
-    ASSERT_EQ(env.vulkan_functions.vkEnumeratePhysicalDevices(inst, &max_count, devices.data()), VK_INCOMPLETE);
-    destroy_debug_report(inst, callback, nullptr);
+    ASSERT_EQ(env->vulkan_functions.vkEnumeratePhysicalDevices(inst, &max_count, devices.data()), VK_INCOMPLETE);
 
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+    ASSERT_EQ(VK_SUCCESS, DestroyReportCallback(inst, callback));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 
     // Message should be found
-    ASSERT_EQ(true, expected_debug_report.found);
+    ASSERT_EQ(true, message_found);
 }
 
 // Test report created outside of vkCreateInstance with a manual info message of the wrong message flag type to be logged.
-TEST(DebugExtensionTests, ManualInfoMessageWrongMessageFlag) {
+TEST_F(ManualReport, InfoIgnoredWrongType) {
     const char my_message[] = "This is my special message!";
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
-
-    expected_debug_report.message = my_message;
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+    expected_message = my_message;
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
 
     VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
-    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
-    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_ERROR_BIT_EXT, &inst));
+
+    VkDebugReportCallbackEXT callback;
+    ASSERT_EQ(VK_SUCCESS, CreateReportCallback(inst, VK_DEBUG_REPORT_ERROR_BIT_EXT, &callback));
+
     PFN_vkDebugReportMessageEXT log_debug_report =
-        reinterpret_cast<PFN_vkDebugReportMessageEXT>(env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDebugReportMessageEXT"));
-    ASSERT_NE(nullptr, create_debug_report);
-    ASSERT_NE(nullptr, destroy_debug_report);
+        reinterpret_cast<PFN_vkDebugReportMessageEXT>(env->vulkan_functions.vkGetInstanceProcAddr(inst, "vkDebugReportMessageEXT"));
     ASSERT_NE(nullptr, log_debug_report);
-
-    // Setup the debug report struct
-    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
-    debug_report_info.pNext = nullptr;
-    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
-    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
-    debug_report_info.pUserData = nullptr;
-
-    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
-    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
-
     log_debug_report(inst, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, (uint64_t)(inst), 0, 0,
                      nullptr, my_message);
 
-    destroy_debug_report(inst, callback, nullptr);
+    ASSERT_EQ(VK_SUCCESS, DestroyReportCallback(inst, callback));
 
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 
     // Message should not be found
-    ASSERT_EQ(false, expected_debug_report.found);
+    ASSERT_EQ(false, message_found);
 }
 
 // Test report created outside of vkCreateInstance with a manual info message of the wrong object type to be logged.
-TEST(DebugExtensionTests, ManualInfoMessageWrongObjectType) {
+TEST_F(ManualReport, InfoIgnoredWrongObject) {
     const char my_message[] = "This is my special message!";
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
-
-    // Look for any message
-    expected_debug_report.any_message = true;
-    expected_debug_report.message = my_message;
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+    expected_message = my_message;
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
 
     VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
-    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
-    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_ERROR_BIT_EXT, &inst));
+
+    VkDebugReportCallbackEXT callback;
+    ASSERT_EQ(VK_SUCCESS, CreateReportCallback(inst, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, &callback));
+
     PFN_vkDebugReportMessageEXT log_debug_report =
-        reinterpret_cast<PFN_vkDebugReportMessageEXT>(env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDebugReportMessageEXT"));
-    ASSERT_NE(nullptr, create_debug_report);
-    ASSERT_NE(nullptr, destroy_debug_report);
+        reinterpret_cast<PFN_vkDebugReportMessageEXT>(env->vulkan_functions.vkGetInstanceProcAddr(inst, "vkDebugReportMessageEXT"));
     ASSERT_NE(nullptr, log_debug_report);
-
-    // Setup the debug report struct
-    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
-    debug_report_info.pNext = nullptr;
-    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
-    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
-    debug_report_info.pUserData = nullptr;
-
-    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
-    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
-
     log_debug_report(inst, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, (uint64_t)(inst), 0, 0,
                      nullptr, my_message);
 
-    destroy_debug_report(inst, callback, nullptr);
+    ASSERT_EQ(VK_SUCCESS, DestroyReportCallback(inst, callback));
 
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 
     // Message should not be found
-    ASSERT_EQ(false, expected_debug_report.found);
+    ASSERT_EQ(false, message_found);
 }
 
 // Test report created outside of vkCreateInstance with a manual info message to be logged.
-TEST(DebugExtensionTests, ManualInfoMessageLogged) {
+TEST_F(ManualReport, InfoMessage) {
     const char my_message[] = "This is my special message!";
-    FrameworkEnvironment env{};
-    VkInstanceCreateInfo create_info{};
-    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
-
-    expected_debug_report.message = my_message;
-    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
-    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+    expected_message = my_message;
+    expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_flag = VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
 
     VkInstance inst = VK_NULL_HANDLE;
-    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
-    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
-    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
-        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
+    ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_ERROR_BIT_EXT, &inst));
+
+    VkDebugReportCallbackEXT callback;
+    ASSERT_EQ(VK_SUCCESS, CreateReportCallback(inst, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, &callback));
+
     PFN_vkDebugReportMessageEXT log_debug_report =
-        reinterpret_cast<PFN_vkDebugReportMessageEXT>(env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDebugReportMessageEXT"));
-    ASSERT_NE(nullptr, create_debug_report);
-    ASSERT_NE(nullptr, destroy_debug_report);
+        reinterpret_cast<PFN_vkDebugReportMessageEXT>(env->vulkan_functions.vkGetInstanceProcAddr(inst, "vkDebugReportMessageEXT"));
     ASSERT_NE(nullptr, log_debug_report);
-
-    // Setup the debug report struct
-    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
-    debug_report_info.pNext = nullptr;
-    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
-    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
-    debug_report_info.pUserData = nullptr;
-
-    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
-    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
-
     log_debug_report(inst, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, (uint64_t)(inst), 0, 0,
                      nullptr, my_message);
 
-    destroy_debug_report(inst, callback, nullptr);
+    ASSERT_EQ(VK_SUCCESS, DestroyReportCallback(inst, callback));
 
-    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
 
     // Message should be found
-    ASSERT_EQ(true, expected_debug_report.found);
+    ASSERT_EQ(true, message_found);
 }
 
 //
-// VK_EXT_debug_utils
+// VK_EXT_debug_util specific tests
+// =========================================
 //
 
-// Test creating and destroying report (no logging)
+// Prototype declaration for callback so we can use it in class utility methods
+static VkBool32 VKAPI_CALL test_DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                   VkDebugUtilsMessageTypeFlagsEXT message_types,
+                                                   const VkDebugUtilsMessengerCallbackDataEXT* callback_data, void* user_data);
 
-// Test report (error/warning) created in vkCreateInstance with error in create instance (logging)
+class DebugUtilTest : public ::testing::Test {
+   public:
+    void VerifyExpected(VkDebugUtilsMessageTypeFlagsEXT message_flags, VkDebugUtilsMessageSeverityFlagsEXT severity_flags,
+                        const std::string& message, const VkDebugUtilsMessengerCallbackDataEXT* callback_data) {
+        if ((0 < (severity_flags | expected_severity_flags)) && (0 < (message_flags | expected_message_flags))) {
+            if (allow_any_message || (std::string::npos != message.find(expected_message))) {
+                for (uint32_t obj = 0; obj < callback_data->objectCount; ++obj) {
+                    if (callback_data->pObjects[obj].objectType == expected_object_type &&
+                        (!check_object_handle || callback_data->pObjects[obj].objectHandle == expected_object_handle)) {
+                        message_found = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
 
-// Test report (warning) created in vkCreateInstance with error in create instance (no logging)
+   protected:
+    virtual void SetUp() {
+        env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
+        for (uint32_t icd = 0; icd < 3; ++icd) {
+            env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_API_VERSION_1_0));
+            env->get_test_icd(icd).physical_devices.push_back({});
+            env->get_test_icd(icd).physical_devices.push_back({});
+        }
+        // Initialize the expected output
+        allow_any_message = false;
+        expected_message = "";
+        expected_object_type = VK_OBJECT_TYPE_UNKNOWN;
+        check_object_handle = false;
+        expected_object_handle = 0;
+        message_found = false;
+    }
 
-// Test report (error/warning) created in vkCreateInstance with error in destroy instance (logging)
+    VkResult CreateUtilsInstance(VkDebugUtilsMessageTypeFlagsEXT types, VkDebugUtilsMessageSeverityFlagsEXT severities,
+                                 VkInstance* inst, VkApplicationInfo* app_info = nullptr) {
+        std::vector<const char*> enabled_extensions;
+        enabled_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 
-// Test report (warning) created in vkCreateInstance with error in destroy instance (no logging)
+        // Setup the debug utils struct
+        VkDebugUtilsMessengerCreateInfoEXT debug_utils_info{VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT};
+        debug_utils_info.pNext = nullptr;
+        debug_utils_info.messageSeverity = severities;
+        debug_utils_info.messageType = types;
+        debug_utils_info.pfnUserCallback = reinterpret_cast<PFN_vkDebugUtilsMessengerCallbackEXT>(test_DebugUtilsCallback);
+        debug_utils_info.pUserData = reinterpret_cast<void*>(this);
 
-// Test report (error/warning) created in vkCreateInstance with error in vkEnumeratePhysicalDevices (logging)
-// (NULL == pPhysicalDeviceCount)
+        VkInstanceCreateInfo create_info{};
+        create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+        create_info.pNext = &debug_utils_info;
+        create_info.pApplicationInfo = app_info;
+        create_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
+        create_info.ppEnabledExtensionNames = enabled_extensions.data();
+        return env->vulkan_functions.vkCreateInstance(&create_info, nullptr, inst);
+    }
 
-// Test report (error/warning) created in vkCreateInstance with info in vkEnumeratePhysicalDevices (no logging)
-// (*pPhysicalDeviceCount < number)
+    VkResult CreateUtilsMessenger(VkInstance inst, VkDebugUtilsMessageTypeFlagsEXT types,
+                                  VkDebugUtilsMessageSeverityFlagsEXT severities, VkDebugUtilsMessengerEXT* messenger) {
+        PFN_vkCreateDebugUtilsMessengerEXT create_messenger = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(
+            env->vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugUtilsMessengerEXT"));
+        if (nullptr == create_messenger) {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        VkDebugUtilsMessengerCreateInfoEXT debug_utils_info{VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT};
+        debug_utils_info.pNext = nullptr;
+        debug_utils_info.messageSeverity = severities;
+        debug_utils_info.messageType = types;
+        debug_utils_info.pfnUserCallback = reinterpret_cast<PFN_vkDebugUtilsMessengerCallbackEXT>(test_DebugUtilsCallback);
+        debug_utils_info.pUserData = reinterpret_cast<void*>(this);
+        return create_messenger(inst, &debug_utils_info, nullptr, messenger);
+    }
 
-// Test report (error/warning/info) created in vkCreateInstance with info in vkEnumeratePhysicalDevices (logging)
-// (*pPhysicalDeviceCount < number)
+    VkResult DestroyUtilsMessenger(VkInstance inst, VkDebugUtilsMessengerEXT messenger) {
+        PFN_vkDestroyDebugUtilsMessengerEXT destroy_messenger = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(
+            env->vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugUtilsMessengerEXT"));
+        if (nullptr == destroy_messenger) {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+        destroy_messenger(inst, messenger, nullptr);
+        return VK_SUCCESS;
+    }
 
-//
-// VK_EXT_debug_utils
-//
+    virtual void TearDown() { env.reset(); }
+
+    std::unique_ptr<FrameworkEnvironment> env;
+    bool allow_any_message;
+    std::string expected_message;
+    VkObjectType expected_object_type;
+    bool check_object_handle;
+    uint64_t expected_object_handle;
+    VkDebugUtilsMessageTypeFlagsEXT expected_message_flags;
+    VkDebugUtilsMessageSeverityFlagsEXT expected_severity_flags;
+    bool message_found;
+};
+
+// This is the actual callback prototyped above.
+
+static VkBool32 VKAPI_CALL test_DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                   VkDebugUtilsMessageTypeFlagsEXT message_types,
+                                                   const VkDebugUtilsMessengerCallbackDataEXT* callback_data, void* user_data) {
+    DebugUtilTest* debug_util_test = reinterpret_cast<DebugUtilTest*>(user_data);
+    debug_util_test->VerifyExpected(message_types, message_severity, callback_data->pMessage, callback_data);
+    return VK_FALSE;
+}
+
+class CreateDestroyInstanceMessenger : public DebugUtilTest {};
+class SeparateMessenger : public DebugUtilTest {};
+class ManualMessage : public DebugUtilTest {};
+
+// Test creating and destroying instance looking for errors, but none should occur.
+TEST_F(CreateDestroyInstanceMessenger, NoCallback) {
+    // Make sure we don't find any errors
+    allow_any_message = true;
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+                                  VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst));
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    ASSERT_EQ(false, message_found);
+}
+
+// Test debug utils (error) created in vkCreateInstance with warning in vkCreateInstance
+TEST_F(CreateDestroyInstanceMessenger, WarnInCreateIgnored) {
+    expected_message = "The API Variant specified";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+
+    VkApplicationInfo app_info;
+    app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                              VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst, &app_info));
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    ASSERT_EQ(false, message_found);
+}
+
+// Test debug utils (error/warning) created in vkCreateInstance with warning in vkCreateInstance
+TEST_F(CreateDestroyInstanceMessenger, WarnInCreate) {
+    expected_message = "The API Variant specified";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+
+    VkApplicationInfo app_info;
+    app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                              VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT, &inst, &app_info));
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    ASSERT_EQ(true, message_found);
+}
+
+// Test debug utils error/warn created in vkCreateInstance with info in vkDestroyInstance
+TEST_F(CreateDestroyInstanceMessenger, DestroyInfoIgnoredSeverity) {
+    expected_message = "destroying temporary instance debug util messenger";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+
+    VkApplicationInfo app_info;
+    app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                  VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT,
+                                  &inst, &app_info));
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    ASSERT_EQ(false, message_found);
+}
+
+// Test debug utils info/performance created in vkCreateInstance with info/general in vkDestroyInstance
+TEST_F(CreateDestroyInstanceMessenger, DestroyInfoIgnoredType) {
+    expected_message = "destroying temporary instance debug util messenger";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+
+    VkApplicationInfo app_info;
+    app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT,
+                                              VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT, &inst, &app_info));
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    ASSERT_EQ(false, message_found);
+}
+
+// Test debug utils info/general created in vkCreateInstance with info/general in vkDestroyInstance
+TEST_F(CreateDestroyInstanceMessenger, DestroyInfo) {
+    expected_message = "destroying temporary instance debug util messenger";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+
+    VkApplicationInfo app_info;
+    app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                              VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT, &inst, &app_info));
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    ASSERT_EQ(true, message_found);
+}
+
+// Test debug utils error created in vkCreateInstance with error in vkEnumeratePhysicalDevices.
+// This should not be logged because we have only defined the debug utils logging for vkCreateInstance
+// and vkDestroyInstance.
+TEST_F(SeparateMessenger, ErrorInEnumDevsNoMessenger) {
+    expected_message = "VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+                                  VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst));
+
+    ASSERT_EQ(env->vulkan_functions.vkEnumeratePhysicalDevices(inst, nullptr, nullptr), VK_ERROR_INITIALIZATION_FAILED);
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should NOT be found (because we don't have a report callback setup outside of the create/destroy instance chain)
+    ASSERT_EQ(false, message_found);
+}
+
+// Test debug utils created outside of vkCreateInstance with error in vkEnumeratePhysicalDevices, but, with the wrong
+// message type so it still won't be logged.
+TEST_F(SeparateMessenger, ErrorInEnumDevsWrongType) {
+    expected_message = "VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+                                  VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst));
+
+    // Create the debug utils messenger to collect performance warnings and errors
+    VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsMessenger(inst, VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT,
+                                   VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT,
+                                   &messenger));
+
+    ASSERT_EQ(env->vulkan_functions.vkEnumeratePhysicalDevices(inst, nullptr, nullptr), VK_ERROR_INITIALIZATION_FAILED);
+
+    // Now that we should have gotten our message, destroy the messenger
+    ASSERT_EQ(VK_SUCCESS, DestroyUtilsMessenger(inst, messenger));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    ASSERT_EQ(false, message_found);
+}
+
+// Test debug utils created outside of vkCreateInstance with error in vkEnumeratePhysicalDevices, but, with the wrong
+// message severity so it still won't be logged.
+TEST_F(SeparateMessenger, ErrorInEnumDevsWrongSeverity) {
+    expected_message = "VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+                                  VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst));
+
+    // Create the debug utils messenger to collect only validation warnings
+    VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsMessenger(inst, VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+                                               VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT, &messenger));
+
+    ASSERT_EQ(env->vulkan_functions.vkEnumeratePhysicalDevices(inst, nullptr, nullptr), VK_ERROR_INITIALIZATION_FAILED);
+
+    // Now that we should have gotten our message, destroy the messenger
+    ASSERT_EQ(VK_SUCCESS, DestroyUtilsMessenger(inst, messenger));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    ASSERT_EQ(false, message_found);
+}
+
+// Test debug utils created outside of vkCreateInstance with error in vkEnumeratePhysicalDevices with the correct type.
+TEST_F(SeparateMessenger, ErrorInEnumDevs) {
+    expected_message = "VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+                                  VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst));
+
+    // Create the debug utils messenger to collect validation errors
+    VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsMessenger(inst, VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+                                               VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &messenger));
+
+    ASSERT_EQ(env->vulkan_functions.vkEnumeratePhysicalDevices(inst, nullptr, nullptr), VK_ERROR_INITIALIZATION_FAILED);
+
+    // Now that we should have gotten our message, destroy the messenger
+    ASSERT_EQ(VK_SUCCESS, DestroyUtilsMessenger(inst, messenger));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    ASSERT_EQ(true, message_found);
+}
+
+// Test debug utils created outside of vkCreateInstance with info in vkEnumeratePhysicalDevices.
+// This should not be logged because type is wrong.
+TEST_F(SeparateMessenger, InfoInEnumDevsIgnoredType) {
+    expected_message = "Trimming device count down by application request";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+                                  VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst));
+
+    // Create the debug utils messenger to collect validation info
+    VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsMessenger(inst, VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+                                               VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT, &messenger));
+
+    uint32_t max_count = 5;
+    std::array<VkPhysicalDevice, 5> devices;
+    ASSERT_EQ(env->vulkan_functions.vkEnumeratePhysicalDevices(inst, &max_count, devices.data()), VK_INCOMPLETE);
+
+    // Now that we should have gotten our message, destroy the messenger
+    ASSERT_EQ(VK_SUCCESS, DestroyUtilsMessenger(inst, messenger));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should not be found (because it's info)
+    ASSERT_EQ(false, message_found);
+}
+
+// Test debug utils created outside of vkCreateInstance with info in vkEnumeratePhysicalDevices.
+// This should not be logged because severity is wrong.
+TEST_F(SeparateMessenger, InfoInEnumDevsIgnoredSeverity) {
+    expected_message = "Trimming device count down by application request";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+                                  VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst));
+
+    // Create the debug utils messenger to collect general errors/warnings
+    VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsMessenger(inst, VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                   VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT,
+                                   &messenger));
+
+    uint32_t max_count = 5;
+    std::array<VkPhysicalDevice, 5> devices;
+    ASSERT_EQ(env->vulkan_functions.vkEnumeratePhysicalDevices(inst, &max_count, devices.data()), VK_INCOMPLETE);
+
+    // Now that we should have gotten our message, destroy the messenger
+    ASSERT_EQ(VK_SUCCESS, DestroyUtilsMessenger(inst, messenger));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should not be found (because it's info)
+    ASSERT_EQ(false, message_found);
+}
+
+// Test debug utils created outside of vkCreateInstance with info in vkEnumeratePhysicalDevices.
+TEST_F(SeparateMessenger, DebugUtilsInfoInEnumDevs) {
+    expected_message = "Trimming device count down by application request";
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT,
+                                  VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst));
+    ASSERT_EQ(false, message_found);
+
+    // Create the debug utils messenger to collect general errors/warnings
+    VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsMessenger(inst, VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                               VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT, &messenger));
+
+    uint32_t max_count = 5;
+    std::array<VkPhysicalDevice, 5> devices;
+    ASSERT_EQ(env->vulkan_functions.vkEnumeratePhysicalDevices(inst, &max_count, devices.data()), VK_INCOMPLETE);
+
+    // Now that we should have gotten our message, destroy the messenger
+    ASSERT_EQ(VK_SUCCESS, DestroyUtilsMessenger(inst, messenger));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should be found
+    ASSERT_EQ(true, message_found);
+}
+
+// Test messenger created outside of vkCreateInstance with a manual info message of the wrong message severity to be logged.
+TEST_F(ManualMessage, InfoMessageIgnoredSeverity) {
+    const char my_message[] = "This is my special message!";
+    expected_message = my_message;
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                              VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst));
+
+    // Create the debug utils messenger to collect general errors/warnings
+    VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS,
+              CreateUtilsMessenger(inst, VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                   VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT,
+                                   &messenger));
+
+    // Trigger the message
+    PFN_vkSubmitDebugUtilsMessageEXT submit_message = reinterpret_cast<PFN_vkSubmitDebugUtilsMessageEXT>(
+        env->vulkan_functions.vkGetInstanceProcAddr(inst, "vkSubmitDebugUtilsMessageEXT"));
+    ASSERT_NE(nullptr, submit_message);
+
+    VkDebugUtilsObjectNameInfoEXT object{VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT};
+    object.objectType = VK_OBJECT_TYPE_INSTANCE;
+    object.objectHandle = (uint64_t)inst;
+    VkDebugUtilsMessengerCallbackDataEXT message_data{VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT};
+    message_data.pMessage = my_message;
+    message_data.objectCount = 1;
+    message_data.pObjects = &object;
+    submit_message(inst, VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT, VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT, &message_data);
+
+    // Now that we should have gotten our message, destroy the messenger
+    ASSERT_EQ(VK_SUCCESS, DestroyUtilsMessenger(inst, messenger));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should not be found
+    ASSERT_EQ(false, message_found);
+}
+
+// Test messenger created outside of vkCreateInstance with a manual info message of the wrong object type to be logged.
+TEST_F(ManualMessage, InfoMessageIgnoredObject) {
+    const char my_message[] = "This is my special message!";
+    expected_message = my_message;
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                              VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst));
+
+    // Create the debug utils messenger to collect general errors/warnings
+    VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsMessenger(inst, VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                               VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT, &messenger));
+
+    // Trigger the message
+    PFN_vkSubmitDebugUtilsMessageEXT submit_message = reinterpret_cast<PFN_vkSubmitDebugUtilsMessageEXT>(
+        env->vulkan_functions.vkGetInstanceProcAddr(inst, "vkSubmitDebugUtilsMessageEXT"));
+    ASSERT_NE(nullptr, submit_message);
+
+    VkDebugUtilsObjectNameInfoEXT object{VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT};
+    object.objectType = VK_OBJECT_TYPE_COMMAND_POOL;
+    object.objectHandle = (uint64_t)inst;
+    VkDebugUtilsMessengerCallbackDataEXT message_data{VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT};
+    message_data.pMessage = my_message;
+    message_data.objectCount = 1;
+    message_data.pObjects = &object;
+    submit_message(inst, VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT, VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT, &message_data);
+
+    // Now that we should have gotten our message, destroy the messenger
+    ASSERT_EQ(VK_SUCCESS, DestroyUtilsMessenger(inst, messenger));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should not be found
+    ASSERT_EQ(false, message_found);
+}
+
+// Test messenger created outside of vkCreateInstance with a manual info message.
+TEST_F(ManualMessage, InfoMessage) {
+    const char my_message[] = "This is my special message!";
+    expected_message = my_message;
+    expected_object_type = VK_OBJECT_TYPE_INSTANCE;
+    expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsInstance(VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                              VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, &inst));
+
+    // Create the debug utils messenger to collect general errors/warnings
+    VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, CreateUtilsMessenger(inst, VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT,
+                                               VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT, &messenger));
+
+    // Trigger the message
+    PFN_vkSubmitDebugUtilsMessageEXT submit_message = reinterpret_cast<PFN_vkSubmitDebugUtilsMessageEXT>(
+        env->vulkan_functions.vkGetInstanceProcAddr(inst, "vkSubmitDebugUtilsMessageEXT"));
+    ASSERT_NE(nullptr, submit_message);
+
+    VkDebugUtilsObjectNameInfoEXT object{VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT};
+    object.objectType = VK_OBJECT_TYPE_INSTANCE;
+    object.objectHandle = (uint64_t)inst;
+    VkDebugUtilsMessengerCallbackDataEXT message_data{VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT};
+    message_data.pMessage = my_message;
+    message_data.objectCount = 1;
+    message_data.pObjects = &object;
+    submit_message(inst, VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT, VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT, &message_data);
+
+    // Now that we should have gotten our message, destroy the messenger
+    ASSERT_EQ(VK_SUCCESS, DestroyUtilsMessenger(inst, messenger));
+
+    env->vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should be found
+    ASSERT_EQ(true, message_found);
+}

--- a/tests/loader_debug_ext_tests.cpp
+++ b/tests/loader_debug_ext_tests.cpp
@@ -1,0 +1,489 @@
+/*
+ * Copyright (c) 2022 The Khronos Group Inc.
+ * Copyright (c) 2022 Valve Corporation
+ * Copyright (c) 2022 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ * Author: Mark Young <marky@lunarg.com>
+ */
+
+#include "test_environment.h"
+
+//
+// VK_EXT_debug_report
+//
+
+struct ExpectedDebugReportMessage {
+    bool any_message = false;
+    std::string message;
+    VkDebugReportObjectTypeEXT object_type;
+    VkDebugReportFlagBitsEXT flag;
+    bool found = false;
+};
+static ExpectedDebugReportMessage expected_debug_report{};
+
+static VkBool32 VKAPI_CALL test_DebugReportCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType,
+                                                    uint64_t object, size_t location, int32_t messageCode, const char* pLayerPrefix,
+                                                    const char* pMessage, void* pUserData) {
+    if (objectType == expected_debug_report.object_type && 0 < (flags | expected_debug_report.flag)) {
+        std::string message_str = pMessage;
+        if (expected_debug_report.any_message || (std::string::npos != message_str.find(expected_debug_report.message))) {
+            expected_debug_report.found = true;
+        }
+    }
+    return VK_FALSE;
+}
+
+static void CreateDebugReportEnvironment(FrameworkEnvironment& env, VkDebugReportFlagsEXT flags,
+                                         VkInstanceCreateInfo& create_info) {
+    for (uint32_t icd = 0; icd < 3; ++icd) {
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_API_VERSION_1_0));
+        env.get_test_icd(icd).physical_devices.push_back({});
+        env.get_test_icd(icd).physical_devices.push_back({});
+    }
+
+    // Initialize the expected output
+    expected_debug_report.any_message = false;
+    expected_debug_report.message = "";
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+    expected_debug_report.found = false;
+
+    // Setup the debug report struct
+    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
+    debug_report_info.pNext = nullptr;
+    debug_report_info.flags = flags;
+    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
+    debug_report_info.pUserData = nullptr;
+
+    static std::vector<const char*> enabled_extensions;
+    enabled_extensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+    create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    create_info.pNext = &debug_report_info;
+    create_info.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
+    create_info.ppEnabledExtensionNames = enabled_extensions.data();
+}
+
+// Test creating and destroying report with errors, but none should occur.
+TEST(DebugExtensionTests, NormalCreateDestroy) {
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
+
+    // Make sure we don't find any errors
+    expected_debug_report.any_message = true;
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    ASSERT_EQ(false, expected_debug_report.found);
+}
+
+// Test report (error/warning) created in vkCreateInstance with warning in vkCreateInstance
+TEST(DebugExtensionTests, WarningInCreateInstance) {
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT, create_info);
+
+    VkApplicationInfo app_info;
+    app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
+    create_info.pApplicationInfo = &app_info;
+
+    // Make sure we find the invalid variant message
+    expected_debug_report.message = "The API Variant specified";
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_WARNING_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Should be found because we're reporting errors and warnings
+    ASSERT_EQ(true, expected_debug_report.found);
+}
+
+// Test report (error) created in vkCreateInstance with warning in vkCreateInstance
+TEST(DebugExtensionTests, WarningInCreateInstanceNotLogged) {
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
+
+    VkApplicationInfo app_info;
+    app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
+    create_info.pApplicationInfo = &app_info;
+
+    // Make sure we find the invalid variant message
+    expected_debug_report.message = "The API Variant specified";
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_WARNING_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should NOT be found (because we only have errors reported in create)
+    ASSERT_EQ(false, expected_debug_report.found);
+}
+
+// Test report (error/warning) created in vkCreateInstance with info in vkDestroyInstance
+TEST(DebugExtensionTests, InfoInDestroyInstanceNotLogged) {
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT, create_info);
+
+    expected_debug_report.message = "destroying all debug report callbacks";
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Should be not be found
+    ASSERT_EQ(false, expected_debug_report.found);
+}
+
+// Test report (info) created in vkCreateInstance with info in vkDestroyInstance
+TEST(DebugExtensionTests, InfoInDestroyInstanceLogged) {
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, create_info);
+
+    expected_debug_report.message = "destroying all debug report callbacks";
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should be found
+    ASSERT_EQ(true, expected_debug_report.found);
+}
+
+// Test report (error/warning) created in vkCreateInstance with error in vkEnumeratePhysicalDevices.
+// This should not be logged because we have only defined the debug report logging for vkCreateInstance
+// and vkDestroyInstance.
+TEST(DebugExtensionTests, ErrorInEnumDevsNotLogged) {
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
+
+    // Look for the invaid count param message
+    expected_debug_report.message = "VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter";
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+
+    ASSERT_EQ(env.vulkan_functions.vkEnumeratePhysicalDevices(inst, nullptr, nullptr), VK_ERROR_INITIALIZATION_FAILED);
+
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should NOT be found (because we don't have a report callback setup outside of the create/destroy instance chain)
+    ASSERT_EQ(false, expected_debug_report.found);
+}
+
+// Test report created outside of vkCreateInstance with error in vkEnumeratePhysicalDevices.
+// This should be logged now.
+TEST(DebugExtensionTests, ErrorInEnumDevsLogged) {
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
+
+    // Look for the invaid count param message
+    expected_debug_report.message = "VUID-vkEnumeratePhysicalDevices-pPhysicalDeviceCount-parameter";
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
+    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
+    ASSERT_NE(nullptr, create_debug_report);
+    ASSERT_NE(nullptr, destroy_debug_report);
+
+    // Setup the debug report struct
+    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
+    debug_report_info.pNext = nullptr;
+    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
+    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
+    debug_report_info.pUserData = nullptr;
+
+    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
+    ASSERT_EQ(env.vulkan_functions.vkEnumeratePhysicalDevices(inst, nullptr, nullptr), VK_ERROR_INITIALIZATION_FAILED);
+    destroy_debug_report(inst, callback, nullptr);
+
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should be found
+    ASSERT_EQ(true, expected_debug_report.found);
+}
+
+// Test report created outside of vkCreateInstance with info in vkEnumeratePhysicalDevices.
+// This should not be logged because type is wrong.
+TEST(DebugExtensionTests, InfoInEnumDevsNotLogged) {
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
+
+    expected_debug_report.message = "Trimming device count down by application request";
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
+    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
+    ASSERT_NE(nullptr, create_debug_report);
+    ASSERT_NE(nullptr, destroy_debug_report);
+
+    // Setup the debug report struct
+    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
+    debug_report_info.pNext = nullptr;
+    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
+    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
+    debug_report_info.pUserData = nullptr;
+
+    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
+
+    uint32_t max_count = 5;
+    std::array<VkPhysicalDevice, 5> devices;
+    ASSERT_EQ(env.vulkan_functions.vkEnumeratePhysicalDevices(inst, &max_count, devices.data()), VK_INCOMPLETE);
+    destroy_debug_report(inst, callback, nullptr);
+
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should not be found (because it's info)
+    ASSERT_EQ(false, expected_debug_report.found);
+}
+
+// Test report created outside of vkCreateInstance with info in vkEnumeratePhysicalDevices.
+// This should be logged because type is correct.
+TEST(DebugExtensionTests, InfoInEnumDevLogged) {
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
+
+    expected_debug_report.message = "Trimming device count down by application request";
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
+    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
+    ASSERT_NE(nullptr, create_debug_report);
+    ASSERT_NE(nullptr, destroy_debug_report);
+
+    // Setup the debug report struct
+    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
+    debug_report_info.pNext = nullptr;
+    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
+    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
+    debug_report_info.pUserData = nullptr;
+
+    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
+
+    uint32_t max_count = 5;
+    std::array<VkPhysicalDevice, 5> devices;
+    ASSERT_EQ(env.vulkan_functions.vkEnumeratePhysicalDevices(inst, &max_count, devices.data()), VK_INCOMPLETE);
+    destroy_debug_report(inst, callback, nullptr);
+
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should be found
+    ASSERT_EQ(true, expected_debug_report.found);
+}
+
+// Test report created outside of vkCreateInstance with a manual info message of the wrong message flag type to be logged.
+TEST(DebugExtensionTests, ManualInfoMessageWrongMessageFlag) {
+    const char my_message[] = "This is my special message!";
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
+
+    expected_debug_report.message = my_message;
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
+    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
+    PFN_vkDebugReportMessageEXT log_debug_report =
+        reinterpret_cast<PFN_vkDebugReportMessageEXT>(env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDebugReportMessageEXT"));
+    ASSERT_NE(nullptr, create_debug_report);
+    ASSERT_NE(nullptr, destroy_debug_report);
+    ASSERT_NE(nullptr, log_debug_report);
+
+    // Setup the debug report struct
+    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
+    debug_report_info.pNext = nullptr;
+    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
+    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
+    debug_report_info.pUserData = nullptr;
+
+    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
+
+    log_debug_report(inst, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, (uint64_t)(inst), 0, 0,
+                     nullptr, my_message);
+
+    destroy_debug_report(inst, callback, nullptr);
+
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should not be found
+    ASSERT_EQ(false, expected_debug_report.found);
+}
+
+// Test report created outside of vkCreateInstance with a manual info message of the wrong object type to be logged.
+TEST(DebugExtensionTests, ManualInfoMessageWrongObjectType) {
+    const char my_message[] = "This is my special message!";
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
+
+    // Look for any message
+    expected_debug_report.any_message = true;
+    expected_debug_report.message = my_message;
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
+    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
+    PFN_vkDebugReportMessageEXT log_debug_report =
+        reinterpret_cast<PFN_vkDebugReportMessageEXT>(env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDebugReportMessageEXT"));
+    ASSERT_NE(nullptr, create_debug_report);
+    ASSERT_NE(nullptr, destroy_debug_report);
+    ASSERT_NE(nullptr, log_debug_report);
+
+    // Setup the debug report struct
+    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
+    debug_report_info.pNext = nullptr;
+    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
+    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
+    debug_report_info.pUserData = nullptr;
+
+    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
+
+    log_debug_report(inst, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, (uint64_t)(inst), 0, 0,
+                     nullptr, my_message);
+
+    destroy_debug_report(inst, callback, nullptr);
+
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should not be found
+    ASSERT_EQ(false, expected_debug_report.found);
+}
+
+// Test report created outside of vkCreateInstance with a manual info message to be logged.
+TEST(DebugExtensionTests, ManualInfoMessageLogged) {
+    const char my_message[] = "This is my special message!";
+    FrameworkEnvironment env{};
+    VkInstanceCreateInfo create_info{};
+    CreateDebugReportEnvironment(env, VK_DEBUG_REPORT_ERROR_BIT_EXT, create_info);
+
+    expected_debug_report.message = my_message;
+    expected_debug_report.object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    expected_debug_report.flag = VK_DEBUG_REPORT_ERROR_BIT_EXT;
+
+    VkInstance inst = VK_NULL_HANDLE;
+    ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&create_info, nullptr, &inst), VK_SUCCESS);
+    PFN_vkCreateDebugReportCallbackEXT create_debug_report = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkCreateDebugReportCallbackEXT"));
+    PFN_vkDestroyDebugReportCallbackEXT destroy_debug_report = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(
+        env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDestroyDebugReportCallbackEXT"));
+    PFN_vkDebugReportMessageEXT log_debug_report =
+        reinterpret_cast<PFN_vkDebugReportMessageEXT>(env.vulkan_functions.vkGetInstanceProcAddr(inst, "vkDebugReportMessageEXT"));
+    ASSERT_NE(nullptr, create_debug_report);
+    ASSERT_NE(nullptr, destroy_debug_report);
+    ASSERT_NE(nullptr, log_debug_report);
+
+    // Setup the debug report struct
+    static VkDebugReportCallbackCreateInfoEXT debug_report_info{VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT};
+    debug_report_info.pNext = nullptr;
+    debug_report_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
+    debug_report_info.pfnCallback = reinterpret_cast<PFN_vkDebugReportCallbackEXT>(test_DebugReportCallback);
+    debug_report_info.pUserData = nullptr;
+
+    VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, create_debug_report(inst, &debug_report_info, nullptr, &callback));
+
+    log_debug_report(inst, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, (uint64_t)(inst), 0, 0,
+                     nullptr, my_message);
+
+    destroy_debug_report(inst, callback, nullptr);
+
+    env.vulkan_functions.vkDestroyInstance(inst, nullptr);
+
+    // Message should be found
+    ASSERT_EQ(true, expected_debug_report.found);
+}
+
+//
+// VK_EXT_debug_utils
+//
+
+// Test creating and destroying report (no logging)
+
+// Test report (error/warning) created in vkCreateInstance with error in create instance (logging)
+
+// Test report (warning) created in vkCreateInstance with error in create instance (no logging)
+
+// Test report (error/warning) created in vkCreateInstance with error in destroy instance (logging)
+
+// Test report (warning) created in vkCreateInstance with error in destroy instance (no logging)
+
+// Test report (error/warning) created in vkCreateInstance with error in vkEnumeratePhysicalDevices (logging)
+// (NULL == pPhysicalDeviceCount)
+
+// Test report (error/warning) created in vkCreateInstance with info in vkEnumeratePhysicalDevices (no logging)
+// (*pPhysicalDeviceCount < number)
+
+// Test report (error/warning/info) created in vkCreateInstance with info in vkEnumeratePhysicalDevices (logging)
+// (*pPhysicalDeviceCount < number)
+
+//
+// VK_EXT_debug_utils
+//


### PR DESCRIPTION
Add tests to validate loader handling of debug report and debug utils messengers.  Also updates all loader VUID logging output to go to not only the GENERAL message path but also the VALIDATION message path.