### PR TITLE
Use the correct instance in setupLoaderTrampPhysDevGroups fixing a crash in a layer

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -2542,7 +2542,7 @@ VkResult setupLoaderTrampPhysDevGroups(VkInstance instance, struct loader_instan
     }
 
     // Call down and get the content
-    fpEnumeratePhysicalDeviceGroups(instance, &total_count, local_phys_dev_groups);
+    fpEnumeratePhysicalDeviceGroups(inst->instance, &total_count, local_phys_dev_groups);
     if (VK_SUCCESS != res) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "setupLoaderTrampPhysDevGroups:  Failed during dispatch call of "


### PR DESCRIPTION
We discovered a crash in a layer (https://github.com/LunarG/gfxreconstruct/issues/642), and then in debugging discovered the layer's EnumeratePhysicalDeviceGroups was being called in the two-call idiom from `setupLoaderTrampPhysDevGroups` in the loader with two different VkInstance values.  I think the instance parameter to the second call to `fpEnumeratePhysicalDeviceGroups` is supposed to be `inst->instance`, otherwise the layer is getting the loader's instance wrapper.