### PR TITLE
Make vkGetInstanceProcAddr able to get itself

### DIFF
--- a/loader/gpa_helper.c
+++ b/loader/gpa_helper.c
@@ -273,7 +273,6 @@ void *globalGetProcAddr(const char *name) {
     if (!strcmp(name, "EnumerateInstanceExtensionProperties")) return vkEnumerateInstanceExtensionProperties;
     if (!strcmp(name, "EnumerateInstanceLayerProperties")) return vkEnumerateInstanceLayerProperties;
     if (!strcmp(name, "EnumerateInstanceVersion")) return vkEnumerateInstanceVersion;
-    if (!strcmp(name, "GetInstanceProcAddr")) return vkGetInstanceProcAddr;
 
     return NULL;
 }

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -61,6 +61,9 @@
  * instances with a newer version will get the new behavior.
  */
 LOADER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *pName) {
+    // Always should be able to get vkGetInstanceProcAddr if queried, regardless of the value of instance
+    if (!strcmp(pName, "vkGetInstanceProcAddr")) return (PFN_vkVoidFunction)vkGetInstanceProcAddr;
+
     // Get entrypoint addresses that are global (no dispatchable object)
     void *addr = globalGetProcAddr(pName);
     if (addr != VK_NULL_HANDLE) {


### PR DESCRIPTION
There was a regression with 1.3 that meant vkGetInstanceProcAddr wouldn't be
able to query itself if instance was set for 1.3. This commit makes it possible
to query for vkGetInstanceProcAddr with itself no matter the value of instance.

@zaiste-linganer Can you review and make sure it works as you expect?