### PR TITLE
Clarify behavior of override_paths + VK_LAYER_PATH

### DIFF
--- a/docs/LoaderLayerInterface.md
+++ b/docs/LoaderLayerInterface.md
@@ -1038,7 +1038,7 @@ override layer global and applies it to every application upon startup.
 If the override layer contains `override_paths`, then it uses this list of
 paths exclusively for component layers.
 Thus, it ignores both the default explicit and implicit layer layer search
-locations.
+locations as well as paths set by environment variables like `VK_LAYER_PATH`.
 If any component layer is not present in the provided override paths, the meta
 layer is disabled.
 
@@ -1379,6 +1379,12 @@ layer is not applied.
 So if an override meta layer wants to mix default and custom layer locations,
 the override paths must contain both custom and default layer locations.
 
+* If the override layer is both present and contains `override_paths`, the
+paths from the environment variable `VK_LAYER_PATH` are ignored when searching
+for explicit layers.
+For example, when both the meta layer override paths and `VK_LAYER_PATH` are
+present, none of the layers in `VK_LAYER_PATH` are discoverable, and the
+loader will not find them.
 ## Layer Manifest File Format
 
 The Khronos loader uses manifest files to discover available layer libraries

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -221,10 +221,14 @@ void FrameworkEnvironment::add_fake_explicit_layer(ManifestLayer layer_manifest,
     add_layer_impl(fake_details, explicit_layer_folder, ManifestCategory::explicit_layer);
 }
 void FrameworkEnvironment::add_implicit_layer(TestLayerDetails layer_details) noexcept {
-    add_layer_impl(layer_details, implicit_layer_folder, ManifestCategory::implicit_layer);
+    add_layer_impl(layer_details,
+                   layer_details.destination_folder == nullptr ? implicit_layer_folder : *layer_details.destination_folder,
+                   ManifestCategory::implicit_layer);
 }
 void FrameworkEnvironment::add_explicit_layer(TestLayerDetails layer_details) noexcept {
-    add_layer_impl(layer_details, explicit_layer_folder, ManifestCategory::explicit_layer);
+    add_layer_impl(layer_details,
+                   layer_details.destination_folder == nullptr ? explicit_layer_folder : *layer_details.destination_folder,
+                   ManifestCategory::explicit_layer);
 }
 
 void FrameworkEnvironment::add_layer_impl(TestLayerDetails layer_details, fs::FolderManager& folder_manager,

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -304,6 +304,7 @@ struct TestLayerDetails {
         : layer_manifest(layer_manifest), json_name(json_name) {}
     BUILDER_VALUE(TestLayerDetails, ManifestLayer, layer_manifest, {});
     BUILDER_VALUE(TestLayerDetails, std::string, json_name, "test_layer");
+    BUILDER_VALUE(TestLayerDetails, fs::FolderManager*, destination_folder, nullptr);
     BUILDER_VALUE(TestLayerDetails, bool, add_to_regular_search_paths, true);
     BUILDER_VALUE(TestLayerDetails, bool, is_fake, false);
 };

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -1115,6 +1115,8 @@ TEST(EnvironmentVariables, VK_LAYER_PATH) {
     EXPECT_TRUE(env.debug_log.find("/tmp/carol"));
     EXPECT_TRUE(env.debug_log.find("/tandy"));
     EXPECT_TRUE(env.debug_log.find((HOME / "/ with spaces/").str()));
+
+    remove_env_var("VK_LAYER_PATH");
 }
 #endif
 


### PR DESCRIPTION
If a meta layer which contains `override_paths` is active, all of the paths in
VK_LAYER_PATH are ignored when searchign for explicit layers. This may be changed
changed in the future but for now is better tested and documented.