### PR TITLE
Test layer pre-instance functions

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2430,7 +2430,7 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
 
     // Read in the pre-instance stuff
     cJSON *pre_instance = cJSON_GetObjectItem(layer_node, "pre_instance_functions");
-    if (pre_instance) {
+    if (NULL != pre_instance) {
         if (!layer_json_supports_pre_instance_tag(&version)) {
             loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
                        "Found pre_instance_functions section in layer from \"%s\". This section is only valid in manifest version "
@@ -2443,9 +2443,9 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
                        filename);
         } else {
             cJSON *inst_ext_json = cJSON_GetObjectItem(pre_instance, "vkEnumerateInstanceExtensionProperties");
-            if (inst_ext_json) {
+            if (NULL != inst_ext_json) {
                 char *inst_ext_name = cJSON_Print(inst, inst_ext_json);
-                if (inst_ext_name == NULL) {
+                if (NULL == inst_ext_name) {
                     result = VK_ERROR_OUT_OF_HOST_MEMORY;
                     goto out;
                 }
@@ -2456,9 +2456,9 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
             }
 
             cJSON *inst_layer_json = cJSON_GetObjectItem(pre_instance, "vkEnumerateInstanceLayerProperties");
-            if (inst_layer_json) {
+            if (NULL != inst_layer_json) {
                 char *inst_layer_name = cJSON_Print(inst, inst_layer_json);
-                if (inst_layer_name == NULL) {
+                if (NULL == inst_layer_name) {
                     result = VK_ERROR_OUT_OF_HOST_MEMORY;
                     goto out;
                 }
@@ -2469,9 +2469,9 @@ static VkResult loader_read_layer_json(const struct loader_instance *inst, struc
             }
 
             cJSON *inst_version_json = cJSON_GetObjectItem(pre_instance, "vkEnumerateInstanceVersion");
-            if (inst_version_json) {
+            if (NULL != inst_version_json) {
                 char *inst_version_name = cJSON_Print(inst, inst_version_json);
-                if (inst_version_json == NULL) {
+                if (NULL == inst_version_name) {
                     result = VK_ERROR_OUT_OF_HOST_MEMORY;
                     goto out;
                 }

--- a/tests/framework/layer/export_definitions/test_layer_1.def
+++ b/tests/framework/layer/export_definitions/test_layer_1.def
@@ -8,3 +8,4 @@ EXPORTS
     test_layer_GetDeviceProcAddr
     GetInstanceProcAddr
     GetDeviceProcAddr
+    test_override_vkGetInstanceProcAddr

--- a/tests/framework/layer/export_definitions/test_layer_2.def
+++ b/tests/framework/layer/export_definitions/test_layer_2.def
@@ -10,3 +10,7 @@ EXPORTS
     GetDeviceProcAddr
     vk_layerGetPhysicalDeviceProcAddr
     vkNegotiateLoaderLayerInterfaceVersion
+    test_preinst_vkEnumerateInstanceLayerProperties
+    test_preinst_vkEnumerateInstanceExtensionProperties
+    test_preinst_vkEnumerateInstanceVersion
+    test_override_vkGetInstanceProcAddr

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -96,6 +96,9 @@ struct TestLayer {
 
     BUILDER_VALUE(TestLayer, std::string, unique_name, {})
     BUILDER_VALUE(TestLayer, uint32_t, api_version, VK_API_VERSION_1_0)
+    BUILDER_VALUE(TestLayer, uint32_t, reported_layer_props, 1)
+    BUILDER_VALUE(TestLayer, uint32_t, reported_extension_props, 1)
+    BUILDER_VALUE(TestLayer, uint32_t, reported_instance_version, VK_API_VERSION_1_0)
     BUILDER_VALUE(TestLayer, uint32_t, implementation_version, 2)
     BUILDER_VALUE(TestLayer, uint32_t, min_implementation_version, 0)
     BUILDER_VALUE(TestLayer, std::string, description, {})

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -97,6 +97,18 @@ std::string get_env_var(std::string const& name, bool report_failure) {
 #endif
 
 template <typename T>
+void print_list_of_t(std::string& out, const char* object_name, std::vector<T> const& vec) {
+    if (vec.size() > 0) {
+        out += std::string(",\n\t\t\"") + object_name + "\": {";
+        for (size_t i = 0; i < vec.size(); i++) {
+            if (i > 0) out += ",\t\t\t";
+            out += "\n\t\t\t" + vec.at(i).get_manifest_str();
+        }
+        out += "\n\t\t}";
+    }
+}
+
+template <typename T>
 void print_vector_of_t(std::string& out, const char* object_name, std::vector<T> const& vec) {
     if (vec.size() > 0) {
         out += std::string(",\n\t\t\"") + object_name + "\": [";
@@ -149,7 +161,7 @@ std::string ManifestLayer::LayerDescription::get_manifest_str() const {
     out += "\t\t\"api_version\": \"" + version_to_string(api_version) + "\",\n";
     out += "\t\t\"implementation_version\":\"" + std::to_string(implementation_version) + "\",\n";
     out += "\t\t\"description\": \"" + description + "\"";
-    print_vector_of_t(out, "functions", functions);
+    print_list_of_t(out, "functions", functions);
     print_vector_of_t(out, "instance_extensions", instance_extensions);
     print_vector_of_t(out, "device_extensions", device_extensions);
     if (!enable_environment.empty()) {
@@ -161,9 +173,10 @@ std::string ManifestLayer::LayerDescription::get_manifest_str() const {
     print_vector_of_strings(out, "component_layers", component_layers);
     print_vector_of_strings(out, "blacklisted_layers", blacklisted_layers);
     print_vector_of_strings(out, "override_paths", override_paths);
-    print_vector_of_strings(out, "pre_instance_functions", pre_instance_functions);
+    print_list_of_t(out, "pre_instance_functions", pre_instance_functions);
 
     out += "\n\t}";
+
     return out;
 }
 

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -541,7 +541,7 @@ struct ManifestLayer {
             BUILDER_VALUE(FunctionOverride, std::string, vk_func, {})
             BUILDER_VALUE(FunctionOverride, std::string, override_name, {})
 
-            std::string get_manifest_str() const { return std::string("{ \"") + vk_func + "\":\"" + override_name + "\" }"; }
+            std::string get_manifest_str() const { return std::string("\"") + vk_func + "\":\"" + override_name + "\""; }
         };
         struct Extension {
             Extension() noexcept {}
@@ -566,7 +566,7 @@ struct ManifestLayer {
         BUILDER_VECTOR(LayerDescription, std::string, component_layers, component_layer)
         BUILDER_VECTOR(LayerDescription, std::string, blacklisted_layers, blacklisted_layer)
         BUILDER_VECTOR(LayerDescription, std::string, override_paths, override_path)
-        BUILDER_VECTOR(LayerDescription, std::string, pre_instance_functions, pre_instance_function)
+        BUILDER_VECTOR(LayerDescription, FunctionOverride, pre_instance_functions, pre_instance_function)
 
         std::string get_manifest_str() const;
         VkLayerProperties get_layer_properties() const;


### PR DESCRIPTION
Add tests to verify that the 3 pre-instance functions are properly
intercepted by the layer when everything is well-defined.

Also include two fixes:
 1) Disable environment variable value of 0 should be treated the same as not present
 2) The vkEnumerateInstanceVersion override path was broken, missing a NULL check