### PR TITLE
loader: Add unicode support

### DIFF
--- a/loader/allocation.h
+++ b/loader/allocation.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "loader_common.h"
+#include "stack_allocation.h"
 
 void *loader_instance_heap_alloc(const struct loader_instance *instance, size_t size, VkSystemAllocationScope allocation_scope);
 void *loader_instance_heap_calloc(const struct loader_instance *instance, size_t size, VkSystemAllocationScope allocation_scope);
@@ -59,9 +60,3 @@ void loader_free_with_instance_fallback(const VkAllocationCallbacks *pAllocator,
                                         void *pMemory);
 void *loader_realloc_with_instance_fallback(const VkAllocationCallbacks *pAllocator, const struct loader_instance *instance,
                                             void *pMemory, size_t orig_size, size_t size, VkSystemAllocationScope allocation_scope);
-
-#if defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNXNTO__) || defined(__FreeBSD__)
-#define loader_stack_alloc(size) alloca(size)
-#elif defined(_WIN32)
-#define loader_stack_alloc(size) _alloca(size)
-#endif  // defined(_WIN32)

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1644,7 +1644,18 @@ static VkResult loader_get_json(const struct loader_instance *inst, const char *
 
     *json = NULL;
 
+#if defined(_WIN32)
+    int filename_utf16_size = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+    if (filename_utf16_size > 0) {
+        wchar_t *filename_utf16 = (wchar_t *)loader_stack_alloc(filename_utf16_size * sizeof(wchar_t));
+        if (MultiByteToWideChar(CP_UTF8, 0, filename, -1, filename_utf16, filename_utf16_size) == filename_utf16_size) {
+            file = _wfopen(filename_utf16, L"rb");
+        }
+    }
+#else
     file = fopen(filename, "rb");
+#endif
+
     if (!file) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "loader_get_json: Failed to open JSON file %s", filename);
         res = VK_ERROR_INITIALIZATION_FAILED;

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -73,10 +73,10 @@ void windows_initialization(void) {
     // and not after the first call that has been statically linked
     LoadLibrary("gdi32.dll");
 
-    TCHAR systemPath[MAX_PATH] = "";
-    GetSystemDirectory(systemPath, MAX_PATH);
-    StringCchCat(systemPath, MAX_PATH, TEXT("\\dxgi.dll"));
-    HMODULE dxgi_module = LoadLibrary(systemPath);
+    wchar_t systemPath[MAX_PATH] = L"";
+    GetSystemDirectoryW(systemPath, MAX_PATH);
+    StringCchCatW(systemPath, MAX_PATH, L"\\dxgi.dll");
+    HMODULE dxgi_module = LoadLibraryW(systemPath);
     fpCreateDXGIFactory1 = dxgi_module == NULL ? NULL : (PFN_CreateDXGIFactory1)GetProcAddress(dxgi_module, "CreateDXGIFactory1");
 
 #if !defined(NDEBUG)

--- a/loader/stack_allocation.h
+++ b/loader/stack_allocation.h
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright (c) 2014-2022 The Khronos Group Inc.
+ * Copyright (c) 2014-2022 Valve Corporation
+ * Copyright (c) 2014-2022 LunarG, Inc.
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Jon Ashburn <jon@lunarg.com>
+ * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
+ * Author: Chia-I Wu <olvaffe@gmail.com>
+ * Author: Chia-I Wu <olv@lunarg.com>
+ * Author: Mark Lobodzinski <mark@LunarG.com>
+ * Author: Lenny Komow <lenny@lunarg.com>
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#pragma once
+
+#if defined(_WIN32)
+#include <malloc.h>
+#else
+#include <alloca.h>
+#endif
+
+#if defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNXNTO__) || defined(__FreeBSD__)
+#define loader_stack_alloc(size) alloca(size)
+#elif defined(_WIN32)
+#define loader_stack_alloc(size) _alloca(size)
+#endif  // defined(_WIN32)

--- a/tests/framework/framework_config.h.in
+++ b/tests/framework/framework_config.h.in
@@ -41,6 +41,10 @@
 
 #define TEST_ICD_PATH_VERSION_2 "$<TARGET_FILE:test_icd_version_2>"
 
+#define TEST_JSON_NAME_VERSION_2_UNICODE "\xf0\x9f\x8c\x8b"
+#define TEST_ICD_PATH_VERSION_2_UNICODE \
+    "$<TARGET_FILE_DIR:test_icd_version_2>/" TEST_JSON_NAME_VERSION_2_UNICODE "$<TARGET_FILE_SUFFIX:test_icd_version_2>"
+
 // assumes version 2 exports
 #define TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA "$<TARGET_FILE:test_icd_version_2_export_icd_gpdpa>"
 

--- a/tests/framework/icd/CMakeLists.txt
+++ b/tests/framework/icd/CMakeLists.txt
@@ -39,3 +39,9 @@ AddSharedLibrary(test_icd_version_2_export_icd_gpdpa DEF_FILE test_icd_2_gpdpa
 AddSharedLibrary(test_icd_version_6 DEF_FILE test_icd_6
     SOURCES test_icd.cpp
     DEFINITIONS TEST_ICD_EXPORT_ICD_GPDPA=1 TEST_ICD_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES=1 ${TEST_ICD_VERSION_2_DEFINES})
+
+add_custom_command(TARGET test_icd_version_2 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+        "$<TARGET_FILE:test_icd_version_2>"
+        "$<TARGET_FILE_DIR:test_icd_version_2>/🌋${CMAKE_SHARED_LIBRARY_SUFFIX}"
+)

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -90,6 +90,19 @@ TEST(EnvVarICDOverrideSetup, version_2_negotiate_interface_version_and_icd_gipa)
     ASSERT_EQ(env.get_test_icd(0).called_vk_icd_gipa, CalledICDGIPA::vk_icd_gipa);
 }
 
+// export vk_icdNegotiateLoaderICDInterfaceVersion and vk_icdGetInstanceProcAddr
+TEST(EnvVarICDOverrideSetup, version_2_negotiate_interface_version_and_icd_gipa_unicode) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_UNICODE)
+                    .set_discovery_type(ManifestDiscoveryType::env_var)
+                    .set_json_name(TEST_JSON_NAME_VERSION_2_UNICODE));
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.CheckCreate();
+
+    ASSERT_EQ(env.get_test_icd(0).called_vk_icd_gipa, CalledICDGIPA::vk_icd_gipa);
+}
+
 // Test VK_DRIVER_FILES environment variable
 TEST(EnvVarICDOverrideSetup, TestOnlyDriverEnvVar) {
     FrameworkEnvironment env{};


### PR DESCRIPTION
Vulkan-Loader cannot load SwiftShader via VK_ICD_FILENAMES if there are unicode characters in the path.