### PR TITLE
Add a few device layer tests

### DIFF
--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -136,6 +136,10 @@ struct InstWrapper {
     operator VkInstance() { return inst; }
     VulkanFunctions* operator->() { return functions; }
 
+    FromVoidStarFunc load(const char* func_name) {
+        return FromVoidStarFunc(functions->vkGetInstanceProcAddr(inst, func_name));
+    }
+
     // Enumerate physical devices using googletest to assert if it succeeded
     std::vector<VkPhysicalDevice> GetPhysDevs(VkResult result_to_check = VK_SUCCESS);  // query all physical devices
     std::vector<VkPhysicalDevice> GetPhysDevs(uint32_t phys_dev_count,
@@ -168,6 +172,10 @@ struct DeviceWrapper {
     // Convenience
     operator VkDevice() { return dev; }
     VulkanFunctions* operator->() { return functions; }
+
+    FromVoidStarFunc load(const char* func_name) {
+        return FromVoidStarFunc(functions->vkGetDeviceProcAddr(dev, func_name));
+    }
 
     VulkanFunctions* functions = nullptr;
     VkDevice dev = VK_NULL_HANDLE;

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -2578,7 +2578,7 @@ TEST(TestLayers, EnvironEnableExplicitLayer) {
     for (uint32_t ext = 0; ext < extension_count; ++ext) {
         if (string_eq(extensions[ext].extensionName, VK_KHR_MAINTENANCE1_EXTENSION_NAME) ||
             string_eq(extensions[ext].extensionName, VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME)) {
-            ASSERT_EQ(false, true);
+            FAIL() << "Extension should not be present";
         }
     }
 
@@ -2668,7 +2668,7 @@ TEST(TestLayers, DoNotUseDeviceLayer) {
     for (uint32_t ext = 0; ext < extension_count; ++ext) {
         if (string_eq(extensions[ext].extensionName, VK_KHR_MAINTENANCE1_EXTENSION_NAME) ||
             string_eq(extensions[ext].extensionName, VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME)) {
-            ASSERT_EQ(false, true);
+            FAIL() << "Extension should not be present";
         }
     }
 
@@ -2694,7 +2694,7 @@ TEST(TestLayers, DoNotUseDeviceLayer) {
     for (uint32_t ext = 0; ext < extension_count; ++ext) {
         if (string_eq(extensions[ext].extensionName, VK_KHR_MAINTENANCE1_EXTENSION_NAME) ||
             string_eq(extensions[ext].extensionName, VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME)) {
-            ASSERT_EQ(false, true);
+            FAIL() << "Extension should not be present";
         }
     }
 


### PR DESCRIPTION
Since device layers are pretty much ignored, make sure that they don't
change any behavior.
Also add a few "load" entrypoint helper routines based on what was already
done elsewhere in the test system.