### PR TITLE
docs: Fix typo

### DIFF
--- a/docs/LoaderApplicationInterface.md
+++ b/docs/LoaderApplicationInterface.md
@@ -892,7 +892,7 @@ names.
 
 ## Physical Device Ordering
 
-Prior to the 1.2.204 loader, physical devices on Linux could be returned in an
+Prior to the 1.3.204 loader, physical devices on Linux could be returned in an
 inconsistent order.
 To remedy this, the Vulkan loader will now sort devices once they have been
 received from the drivers (before returning the information to any enabled


### PR DESCRIPTION
The behavior change to physical device ordering happened in v1.3.204.

cc: @MarkY-LunarG 