### PR TITLE
Resolve Angle failure because it works around secure_getenv

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2969,19 +2969,13 @@ static VkResult read_data_files_in_search_paths(const struct loader_instance *in
     if (path_override != NULL) {
         override_path = path_override;
     } else if (env_override != NULL) {
-        // Don't allow setuid apps to use the env var
-        if (is_high_integrity()) {
-            loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
-                       "read_data_files_in_search_paths: Ignoring override %s due to high-integrity", env_override);
-        } else {
-            override_env = loader_secure_getenv(env_override, inst);
+        override_env = loader_secure_getenv(env_override, inst);
 
-            // The ICD override is actually a specific list of filenames, not directories
-            if (is_icd && NULL != override_env) {
-                is_directory_list = false;
-            }
-            override_path = override_env;
+        // The ICD override is actually a specific list of filenames, not directories
+        if (is_icd && NULL != override_env) {
+            is_directory_list = false;
         }
+        override_path = override_env;
     }
 
     // Add two by default for NULL terminator and one path separator on end (just in case)
@@ -3063,7 +3057,7 @@ static VkResult read_data_files_in_search_paths(const struct loader_instance *in
                         cur_path_ptr += rel_size;
                         *cur_path_ptr++ = PATH_SEPARATOR;
                         // only for ICD manifests
-                        if (!is_high_integrity() && env_override != NULL && strcmp(VK_ICD_FILENAMES_ENV_VAR, env_override) == 0) {
+                        if (env_override != NULL && strcmp(VK_ICD_FILENAMES_ENV_VAR, env_override) == 0) {
                             use_first_found_manifest = true;
                         }
                     }

--- a/tests/framework/shim/CMakeLists.txt
+++ b/tests/framework/shim/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 add_library(shim-common STATIC shim_common.cpp)
 target_link_libraries(shim-common PUBLIC testing_framework_util)
-target_include_directories(shim-common PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(shim-common PUBLIC ${CMAKE_BINARY_DIR}/loader ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 if (WIN32)
     # need adapters.h which is in the loader folder

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -2202,7 +2202,6 @@ TEST(EnvironmentVariables, VK_LAYER_PATH) {
     EXPECT_TRUE(env.debug_log.find("/tmp/carol"));
     EXPECT_TRUE(env.debug_log.find("/tandy"));
     EXPECT_TRUE(env.debug_log.find((HOME / "/ with spaces/").str()));
-    EXPECT_FALSE(env.debug_log.find("Ignoring override VK_LAYER_PATH due to high-integrity"));
 
     env.debug_log.clear();
 
@@ -2213,7 +2212,6 @@ TEST(EnvironmentVariables, VK_LAYER_PATH) {
     FillDebugUtilsCreateDetails(inst2.create_info, env.debug_log);
     inst2.CheckCreate();
 
-    EXPECT_TRUE(env.debug_log.find("Ignoring override VK_LAYER_PATH due to high-integrity"));
     EXPECT_FALSE(env.debug_log.find("/tmp/carol"));
 
     env.platform_shim->set_elevated_privilege(false);


### PR DESCRIPTION
Angle drops the security enforcement of the loader on environment
variables and the additional "is_high_integrity" checks on my
previous loader change caused failures in the Angle run.
Revert the high-integrity checks and update the layer test to
work properly.