### PR TITLE
Fix non-sorted surface indexing

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5928,6 +5928,7 @@ VkResult setup_loader_term_phys_devs(struct loader_instance *inst) {
         }
         inst->total_gpu_count += icd_phys_dev_array[icd_idx].device_count;
         icd_phys_dev_array[icd_idx].icd_term = icd_term;
+        icd_phys_dev_array[icd_idx].icd_index = icd_idx;
         icd_term = icd_term->next;
         ++icd_idx;
     }

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -224,8 +224,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceSupportKH
         abort(); /* Intentionally fail so user can correct issue. */
     }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
-    VkResult res = disp->GetPhysicalDeviceSurfaceSupportKHR(unwrapped_phys_dev, queueFamilyIndex, surface, pSupported);
-    return res;
+    return disp->GetPhysicalDeviceSurfaceSupportKHR(unwrapped_phys_dev, queueFamilyIndex, surface, pSupported);
 }
 
 // This is the instance chain terminator function for
@@ -277,8 +276,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceCapabilit
         abort(); /* Intentionally fail so user can correct issue. */
     }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
-    VkResult res = disp->GetPhysicalDeviceSurfaceCapabilitiesKHR(unwrapped_phys_dev, surface, pSurfaceCapabilities);
-    return res;
+    return disp->GetPhysicalDeviceSurfaceCapabilitiesKHR(unwrapped_phys_dev, surface, pSurfaceCapabilities);
 }
 
 // This is the instance chain terminator function for
@@ -331,8 +329,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceFormatsKH
         abort(); /* Intentionally fail so user can correct issue. */
     }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
-    VkResult res = disp->GetPhysicalDeviceSurfaceFormatsKHR(unwrapped_phys_dev, surface, pSurfaceFormatCount, pSurfaceFormats);
-    return res;
+    return disp->GetPhysicalDeviceSurfaceFormatsKHR(unwrapped_phys_dev, surface, pSurfaceFormatCount, pSurfaceFormats);
 }
 
 // This is the instance chain terminator function for
@@ -387,8 +384,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfacePresentMo
         abort(); /* Intentionally fail so user can correct issue. */
     }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
-    VkResult res = disp->GetPhysicalDeviceSurfacePresentModesKHR(unwrapped_phys_dev, surface, pPresentModeCount, pPresentModes);
-    return res;
+    return disp->GetPhysicalDeviceSurfacePresentModesKHR(unwrapped_phys_dev, surface, pPresentModeCount, pPresentModes);
 }
 
 // This is the instance chain terminator function for
@@ -414,7 +410,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfacePresentModesKH
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfacePresentModesKHR) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "ICD for selected physical device does not exportvkGetPhysicalDeviceSurfacePresentModesKHR!\n");
+                   "ICD for selected physical device does not export vkGetPhysicalDeviceSurfacePresentModesKHR!\n");
         abort();
     }
 
@@ -771,7 +767,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceWaylandPresentationSu
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceWaylandPresentationSupportKHR) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "ICD for selected physical device does not exportvkGetPhysicalDeviceWaylandPresentationSupportKHR!\n");
+                   "ICD for selected physical device does not export vkGetPhysicalDeviceWaylandPresentationSupportKHR!\n");
         abort();
     }
 
@@ -893,7 +889,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceXcbPresentationSuppor
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceXcbPresentationSupportKHR) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "ICD for selected physical device does not exportvkGetPhysicalDeviceXcbPresentationSupportKHR!\n");
+                   "ICD for selected physical device does not export vkGetPhysicalDeviceXcbPresentationSupportKHR!\n");
         abort();
     }
 
@@ -1014,7 +1010,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceXlibPresentationSuppo
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceXlibPresentationSupportKHR) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "ICD for selected physical device does not exportvkGetPhysicalDeviceXlibPresentationSupportKHR!\n");
+                   "ICD for selected physical device does not export vkGetPhysicalDeviceXlibPresentationSupportKHR!\n");
         abort();
     }
 
@@ -1138,7 +1134,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceDirectFBPresentationS
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceDirectFBPresentationSupportEXT) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "ICD for selected physical device does not exportvkGetPhysicalDeviceDirectFBPresentationSupportEXT!\n");
+                   "ICD for selected physical device does not export vkGetPhysicalDeviceDirectFBPresentationSupportEXT!\n");
         abort();
     }
 
@@ -1653,7 +1649,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceScreenPresentationSup
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceScreenPresentationSupportQNX) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "ICD for selected physical device does not exportvkGetPhysicalDeviceScreenPresentationSupportQNX!\n");
+                   "ICD for selected physical device does not export vkGetPhysicalDeviceScreenPresentationSupportQNX!\n");
         abort();
     }
 

--- a/tests/loader_phys_dev_inst_ext_tests.cpp
+++ b/tests/loader_phys_dev_inst_ext_tests.cpp
@@ -2727,8 +2727,11 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRInstanceAndICDSupport) {
     Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME};
     Extension third_ext{VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME};
-    env.get_test_icd(0).add_instance_extensions({first_ext, second_ext, third_ext});
-    env.get_test_icd(0).physical_devices.push_back({});
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.add_instance_extensions({first_ext, second_ext, third_ext});
+    cur_icd.physical_devices.push_back({});
+    cur_icd.min_icd_interface_version = 3;
+    cur_icd.enable_icd_wsi = true;
     FillInRandomSurfaceCapsData(env.get_test_icd(0).physical_devices.back().surface_capabilities);
 
     InstWrapper instance(env.vulkan_functions);
@@ -2795,6 +2798,8 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRMixed) {
         env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
+        cur_icd.min_icd_interface_version = 3;
+        cur_icd.enable_icd_wsi = true;
         cur_icd.add_instance_extensions({first_ext, third_ext});
 
         // ICD 1 should not have 1.1
@@ -2928,8 +2933,11 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRInstanceAndICDSupport) {
     Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME};
     Extension third_ext{VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME};
-    env.get_test_icd(0).add_instance_extensions({first_ext, second_ext, third_ext});
-    env.get_test_icd(0).physical_devices.push_back({});
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.add_instance_extensions({first_ext, second_ext, third_ext});
+    cur_icd.physical_devices.push_back({});
+    cur_icd.min_icd_interface_version = 3;
+    cur_icd.enable_icd_wsi = true;
     FillInRandomSurfaceFormatsData(env.get_test_icd(0).physical_devices.back().surface_formats);
 
     InstWrapper instance(env.vulkan_functions);
@@ -3005,6 +3013,8 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRMixed) {
         env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
+        cur_icd.enable_icd_wsi = true;
+        cur_icd.min_icd_interface_version = 3;
         cur_icd.add_instance_extensions({first_ext, third_ext});
 
         // ICD 1 should not have 1.1

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021 The Khronos Group Inc.
- * Copyright (c) 2021 Valve Corporation
- * Copyright (c) 2021 LunarG, Inc.
+ * Copyright (c) 2021-2022 The Khronos Group Inc.
+ * Copyright (c) 2021-2022 Valve Corporation
+ * Copyright (c) 2021-2022 LunarG, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and/or associated documentation files (the "Materials"), to
@@ -27,85 +27,78 @@
 
 #include "test_environment.h"
 
-class WsiTests : public ::testing::Test {
-   protected:
-    virtual void SetUp() {
-        env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
-        env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
-    }
-
-    virtual void TearDown() { env.reset(); }
-    std::unique_ptr<FrameworkEnvironment> env;
-
-    int width = 100;
-    int height = 100;
-};
+class WsiTests : public ::testing::Test {};
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 
 // When ICD doesn't support the extension, create instance should fail
-TEST_F(WsiTests, CreateSurfaceWin32NoICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, CreateSurfaceWin32NoICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
     inst.CheckCreate(VK_ERROR_EXTENSION_NOT_PRESENT);
 
-    InstWrapper inst2{env->vulkan_functions};
+    InstWrapper inst2{env.vulkan_functions};
     inst2.CheckCreate();
 
-    ASSERT_EQ(nullptr, env->vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkCreateWin32SurfaceKHR"));
+    ASSERT_EQ(nullptr, env.vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkCreateWin32SurfaceKHR"));
 }
 
 // When ICD doesn't support the surface creation, the loader should handle it
-TEST_F(WsiTests, CreateSurfaceWin32NoICDCreateSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, CreateSurfaceWin32NoICDCreateSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
+    cur_icd.enable_icd_wsi = false;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
     VkSurfaceKHR surface{VK_NULL_HANDLE};
     VkWin32SurfaceCreateInfoKHR surf_create_info{VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR};
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkCreateWin32SurfaceKHR(inst, &surf_create_info, nullptr, &surface));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateWin32SurfaceKHR(inst, &surf_create_info, nullptr, &surface));
     ASSERT_TRUE(surface != VK_NULL_HANDLE);
-    //    ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
+    //    ASSERT_EQ(cur_icd.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
 
-    env->vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
+    env.vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
 }
 
 // When ICD does support the surface creation, the loader should  delegat handle it to the ICD
-TEST_F(WsiTests, CreateSurfaceWin32ICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
-    driver.enable_icd_wsi = true;
+TEST(WsiTests, CreateSurfaceWin32ICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
+    cur_icd.enable_icd_wsi = true;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
     VkSurfaceKHR surface{VK_NULL_HANDLE};
     VkWin32SurfaceCreateInfoKHR surf_create_info{VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR};
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkCreateWin32SurfaceKHR(inst, &surf_create_info, nullptr, &surface));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateWin32SurfaceKHR(inst, &surf_create_info, nullptr, &surface));
     ASSERT_TRUE(surface != VK_NULL_HANDLE);
-    //    ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
+    //    ASSERT_EQ(cur_icd.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
 
-    env->vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
+    env.vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
 }
 
 // Some drivers supporting vkCreateWin32SurfaceKHR, and at least one that doesn't
-TEST_F(WsiTests, CreateSurfaceWin32MixedICDSupport) {
+TEST(WsiTests, CreateSurfaceWin32MixedICDSupport) {
     FrameworkEnvironment env{};
     for (uint32_t icd = 0; icd < 3; ++icd) {
         Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
@@ -128,21 +121,23 @@ TEST_F(WsiTests, CreateSurfaceWin32MixedICDSupport) {
     VkWin32SurfaceCreateInfoKHR surf_create_info{VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR};
     ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateWin32SurfaceKHR(instance.inst, &surf_create_info, nullptr, &surface));
     ASSERT_TRUE(surface != VK_NULL_HANDLE);
-    //    ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
+    //    ASSERT_EQ(cur_icd.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
 
     env.vulkan_functions.vkDestroySurfaceKHR(instance.inst, surface, nullptr);
 }
 
-TEST_F(WsiTests, GetPhysicalDeviceWin32PresentNoICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
-    driver.physical_devices.emplace_back("physical_device_0");
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, GetPhysicalDeviceWin32PresentNoICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
+    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.enable_icd_wsi = false;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
@@ -151,20 +146,22 @@ TEST_F(WsiTests, GetPhysicalDeviceWin32PresentNoICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1);
 
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceWin32PresentationSupportKHR(physical_device, 0),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceWin32PresentationSupportKHR(physical_device, 0),
                  "ICD for selected physical device does not export vkGetPhysicalDeviceWin32PresentationSupportKHR!");
 }
 
-TEST_F(WsiTests, GetPhysicalDeviceWin32PresentICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
-    driver.physical_devices.emplace_back("physical_device_0");
-    driver.enable_icd_wsi = true;
+TEST(WsiTests, GetPhysicalDeviceWin32PresentICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
+    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.enable_icd_wsi = true;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
@@ -173,74 +170,120 @@ TEST_F(WsiTests, GetPhysicalDeviceWin32PresentICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1);
 
-    ASSERT_EQ(VK_TRUE, env->vulkan_functions.vkGetPhysicalDeviceWin32PresentationSupportKHR(physical_device, 0));
+    ASSERT_EQ(VK_TRUE, env.vulkan_functions.vkGetPhysicalDeviceWin32PresentationSupportKHR(physical_device, 0));
+}
+
+TEST(WsiTests, Win32GetPhysicalDeviceSurfaceSupportKHR) {
+    FrameworkEnvironment env{};
+    const uint32_t max_device_count = 4;
+    for (uint32_t icd = 0; icd < max_device_count; ++icd) {
+        Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
+        Extension second_ext{VK_KHR_WIN32_SURFACE_EXTENSION_NAME};
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+        auto& cur_icd = env.get_test_icd(icd);
+        cur_icd.icd_api_version = VK_API_VERSION_1_0;
+        cur_icd.set_min_icd_interface_version(5);
+        cur_icd.add_instance_extensions({first_ext, second_ext});
+        std::string dev_name = "phys_dev_" + icd;
+        cur_icd.physical_devices.emplace_back(dev_name.c_str());
+        cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
+        cur_icd.enable_icd_wsi = true;
+    }
+
+    InstWrapper instance(env.vulkan_functions);
+    instance.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
+    instance.CheckCreate();
+
+    VkSurfaceKHR surface{VK_NULL_HANDLE};
+    VkWin32SurfaceCreateInfoKHR surf_create_info{VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR};
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateWin32SurfaceKHR(instance.inst, &surf_create_info, nullptr, &surface));
+    ASSERT_TRUE(surface != VK_NULL_HANDLE);
+    //    ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
+
+    uint32_t device_count = max_device_count;
+    std::array<VkPhysicalDevice, max_device_count> phys_devs;
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumeratePhysicalDevices(instance.inst, &device_count, phys_devs.data()));
+    ASSERT_EQ(device_count, max_device_count);
+
+    for (uint32_t pd = 0; pd < max_device_count; ++pd) {
+        VkBool32 supported = VK_FALSE;
+        ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkGetPhysicalDeviceSurfaceSupportKHR(phys_devs[pd], 0, surface, &supported));
+    }
+
+    env.vulkan_functions.vkDestroySurfaceKHR(instance.inst, surface, nullptr);
 }
 #endif
 
 #if defined(VK_USE_PLATFORM_XCB_KHR)
 // When ICD doesn't support the extension, create instance should fail
-TEST_F(WsiTests, CreateSurfaceXCBNoICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, CreateSurfaceXCBNoICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.enable_icd_wsi = false;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
     inst.CheckCreate(VK_ERROR_EXTENSION_NOT_PRESENT);
 
-    InstWrapper inst2{env->vulkan_functions};
+    InstWrapper inst2{env.vulkan_functions};
     inst2.CheckCreate();
 
-    ASSERT_EQ(nullptr, env->vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkCreateXcbSurfaceKHR"));
+    ASSERT_EQ(nullptr, env.vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkCreateXcbSurfaceKHR"));
 }
 
 // When ICD doesn't support the surface creation, the loader should handle it
-TEST_F(WsiTests, CreateSurfaceXCBNoICDCreateSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, CreateSurfaceXCBNoICDCreateSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
+    cur_icd.enable_icd_wsi = false;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XCB_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
     VkXcbSurfaceCreateInfoKHR xcb_createInfo{VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR};
 
     VkSurfaceKHR surface{VK_NULL_HANDLE};
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkCreateXcbSurfaceKHR(inst, &xcb_createInfo, nullptr, &surface));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateXcbSurfaceKHR(inst, &xcb_createInfo, nullptr, &surface));
     ASSERT_TRUE(surface != VK_NULL_HANDLE);
 
-    env->vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
+    env.vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
 }
 
 // When ICD does support the surface creation, the loader should  delegat handle it to the ICD
-TEST_F(WsiTests, CreateSurfaceXCBICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
-    driver.enable_icd_wsi = true;
+TEST(WsiTests, CreateSurfaceXCBICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
+    cur_icd.enable_icd_wsi = true;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XCB_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
     VkXcbSurfaceCreateInfoKHR xcb_createInfo{VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR};
 
     VkSurfaceKHR surface{VK_NULL_HANDLE};
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkCreateXcbSurfaceKHR(inst, &xcb_createInfo, nullptr, &surface));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateXcbSurfaceKHR(inst, &xcb_createInfo, nullptr, &surface));
     ASSERT_TRUE(surface != VK_NULL_HANDLE);
 
-    env->vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
+    env.vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
 }
 
 // Some drivers supporting vkCreateXcbSurfaceKHR, and at least one that doesn't
-TEST_F(WsiTests, CreateSurfaceXCBMixedICDSupport) {
+TEST(WsiTests, CreateSurfaceXCBMixedICDSupport) {
     FrameworkEnvironment env{};
     for (uint32_t icd = 0; icd < 3; ++icd) {
         Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
@@ -268,16 +311,18 @@ TEST_F(WsiTests, CreateSurfaceXCBMixedICDSupport) {
     env.vulkan_functions.vkDestroySurfaceKHR(instance.inst, surface, nullptr);
 }
 
-TEST_F(WsiTests, GetPhysicalDeviceXcbPresentNoICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
-    driver.physical_devices.emplace_back("physical_device_0");
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, GetPhysicalDeviceXcbPresentNoICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
+    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.enable_icd_wsi = false;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XCB_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
@@ -286,20 +331,22 @@ TEST_F(WsiTests, GetPhysicalDeviceXcbPresentNoICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1);
 
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceXcbPresentationSupportKHR(physical_device, 0, nullptr, 0),
-                 "ICD for selected physical device does not exportvkGetPhysicalDeviceXcbPresentationSupportKHR!");
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceXcbPresentationSupportKHR(physical_device, 0, nullptr, 0),
+                 "ICD for selected physical device does not export vkGetPhysicalDeviceXcbPresentationSupportKHR!");
 }
 
-TEST_F(WsiTests, GetPhysicalDeviceXcbPresentICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
-    driver.physical_devices.emplace_back("physical_device_0");
-    driver.enable_icd_wsi = true;
+TEST(WsiTests, GetPhysicalDeviceXcbPresentICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
+    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.enable_icd_wsi = true;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XCB_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
@@ -308,74 +355,120 @@ TEST_F(WsiTests, GetPhysicalDeviceXcbPresentICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1);
 
-    ASSERT_EQ(VK_TRUE, env->vulkan_functions.vkGetPhysicalDeviceXcbPresentationSupportKHR(physical_device, 0, nullptr, 0));
+    ASSERT_EQ(VK_TRUE, env.vulkan_functions.vkGetPhysicalDeviceXcbPresentationSupportKHR(physical_device, 0, nullptr, 0));
+}
+
+TEST(WsiTests, XcbGetPhysicalDeviceSurfaceSupportKHR) {
+    FrameworkEnvironment env{};
+    const uint32_t max_device_count = 4;
+    for (uint32_t icd = 0; icd < max_device_count; ++icd) {
+        Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
+        Extension second_ext{VK_KHR_XCB_SURFACE_EXTENSION_NAME};
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+        auto& cur_icd = env.get_test_icd(icd);
+        cur_icd.icd_api_version = VK_API_VERSION_1_0;
+        cur_icd.set_min_icd_interface_version(5);
+        cur_icd.add_instance_extensions({first_ext, second_ext});
+        std::string dev_name = "phys_dev_" + icd;
+        cur_icd.physical_devices.emplace_back(dev_name.c_str());
+        cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
+        cur_icd.enable_icd_wsi = true;
+    }
+
+    InstWrapper instance(env.vulkan_functions);
+    instance.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XCB_SURFACE_EXTENSION_NAME});
+    instance.CheckCreate();
+
+    VkSurfaceKHR surface{VK_NULL_HANDLE};
+    VkXcbSurfaceCreateInfoKHR xcb_createInfo{VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR};
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateXcbSurfaceKHR(instance.inst, &xcb_createInfo, nullptr, &surface));
+    ASSERT_TRUE(surface != VK_NULL_HANDLE);
+    //    ASSERT_EQ(cur_icd.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
+
+    uint32_t device_count = max_device_count;
+    std::array<VkPhysicalDevice, max_device_count> phys_devs;
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumeratePhysicalDevices(instance.inst, &device_count, phys_devs.data()));
+    ASSERT_EQ(device_count, max_device_count);
+
+    for (uint32_t pd = 0; pd < max_device_count; ++pd) {
+        VkBool32 supported = VK_FALSE;
+        ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkGetPhysicalDeviceSurfaceSupportKHR(phys_devs[pd], 0, surface, &supported));
+    }
+
+    env.vulkan_functions.vkDestroySurfaceKHR(instance.inst, surface, nullptr);
 }
 #endif
 
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
 // When ICD doesn't support the extension, create instance should fail
-TEST_F(WsiTests, CreateSurfaceXLIBNoICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, CreateSurfaceXLIBNoICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.enable_icd_wsi = false;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
     inst.CheckCreate(VK_ERROR_EXTENSION_NOT_PRESENT);
 
-    InstWrapper inst2{env->vulkan_functions};
+    InstWrapper inst2{env.vulkan_functions};
     inst2.CheckCreate();
 
-    ASSERT_EQ(nullptr, env->vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkCreateXlibSurfaceKHR"));
+    ASSERT_EQ(nullptr, env.vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkCreateXlibSurfaceKHR"));
 }
 
 // When ICD doesn't support the surface creation, the loader should handle it
-TEST_F(WsiTests, CreateSurfaceXLIBNoICDCreateSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, CreateSurfaceXLIBNoICDCreateSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
+    cur_icd.enable_icd_wsi = false;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
     VkXlibSurfaceCreateInfoKHR createInfo{VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR};
 
     VkSurfaceKHR surface;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkCreateXlibSurfaceKHR(inst, &createInfo, nullptr, &surface));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateXlibSurfaceKHR(inst, &createInfo, nullptr, &surface));
     ASSERT_TRUE(surface != VK_NULL_HANDLE);
 
-    env->vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
+    env.vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
 }
 
 // When ICD does support the surface creation, the loader should  delegat handle it to the ICD
-TEST_F(WsiTests, CreateSurfaceXLIBICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
-    driver.enable_icd_wsi = true;
+TEST(WsiTests, CreateSurfaceXLIBICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
+    cur_icd.enable_icd_wsi = true;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
     VkXlibSurfaceCreateInfoKHR createInfo{VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR};
 
     VkSurfaceKHR surface;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkCreateXlibSurfaceKHR(inst, &createInfo, nullptr, &surface));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateXlibSurfaceKHR(inst, &createInfo, nullptr, &surface));
     ASSERT_TRUE(surface != VK_NULL_HANDLE);
 
-    env->vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
+    env.vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
 }
 
 // Some drivers supporting vkCreateXlibSurfaceKHR, and at least one that doesn't
-TEST_F(WsiTests, CreateSurfaceXLIBMixedICDSupport) {
+TEST(WsiTests, CreateSurfaceXLIBMixedICDSupport) {
     FrameworkEnvironment env{};
     for (uint32_t icd = 0; icd < 3; ++icd) {
         Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
@@ -403,16 +496,18 @@ TEST_F(WsiTests, CreateSurfaceXLIBMixedICDSupport) {
     env.vulkan_functions.vkDestroySurfaceKHR(instance.inst, surface, nullptr);
 }
 
-TEST_F(WsiTests, GetPhysicalDeviceXlibPresentNoICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
-    driver.physical_devices.emplace_back("physical_device_0");
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, GetPhysicalDeviceXlibPresentNoICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
+    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.enable_icd_wsi = false;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
@@ -421,20 +516,22 @@ TEST_F(WsiTests, GetPhysicalDeviceXlibPresentNoICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1);
 
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceXlibPresentationSupportKHR(physical_device, 0, nullptr, 0),
-                 "ICD for selected physical device does not exportvkGetPhysicalDeviceXlibPresentationSupportKHR!");
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceXlibPresentationSupportKHR(physical_device, 0, nullptr, 0),
+                 "ICD for selected physical device does not export vkGetPhysicalDeviceXlibPresentationSupportKHR!");
 }
 
-TEST_F(WsiTests, GetPhysicalDeviceXlibPresentICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
-    driver.physical_devices.emplace_back("physical_device_0");
-    driver.enable_icd_wsi = true;
+TEST(WsiTests, GetPhysicalDeviceXlibPresentICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
+    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.enable_icd_wsi = true;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
@@ -443,74 +540,120 @@ TEST_F(WsiTests, GetPhysicalDeviceXlibPresentICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1);
 
-    ASSERT_EQ(VK_TRUE, env->vulkan_functions.vkGetPhysicalDeviceXlibPresentationSupportKHR(physical_device, 0, nullptr, 0));
+    ASSERT_EQ(VK_TRUE, env.vulkan_functions.vkGetPhysicalDeviceXlibPresentationSupportKHR(physical_device, 0, nullptr, 0));
+}
+
+TEST(WsiTests, XlibGetPhysicalDeviceSurfaceSupportKHR) {
+    FrameworkEnvironment env{};
+    const uint32_t max_device_count = 4;
+    for (uint32_t icd = 0; icd < max_device_count; ++icd) {
+        Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
+        Extension second_ext{VK_KHR_XLIB_SURFACE_EXTENSION_NAME};
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+        auto& cur_icd = env.get_test_icd(icd);
+        cur_icd.icd_api_version = VK_API_VERSION_1_0;
+        cur_icd.set_min_icd_interface_version(5);
+        cur_icd.add_instance_extensions({first_ext, second_ext});
+        std::string dev_name = "phys_dev_" + icd;
+        cur_icd.physical_devices.emplace_back(dev_name.c_str());
+        cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
+        cur_icd.enable_icd_wsi = true;
+    }
+
+    InstWrapper instance(env.vulkan_functions);
+    instance.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
+    instance.CheckCreate();
+
+    VkSurfaceKHR surface{VK_NULL_HANDLE};
+    VkXlibSurfaceCreateInfoKHR createInfo{VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR};
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateXlibSurfaceKHR(instance.inst, &createInfo, nullptr, &surface));
+    ASSERT_TRUE(surface != VK_NULL_HANDLE);
+    //    ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
+
+    uint32_t device_count = max_device_count;
+    std::array<VkPhysicalDevice, max_device_count> phys_devs;
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumeratePhysicalDevices(instance.inst, &device_count, phys_devs.data()));
+    ASSERT_EQ(device_count, max_device_count);
+
+    for (uint32_t pd = 0; pd < max_device_count; ++pd) {
+        VkBool32 supported = VK_FALSE;
+        ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkGetPhysicalDeviceSurfaceSupportKHR(phys_devs[pd], 0, surface, &supported));
+    }
+
+    env.vulkan_functions.vkDestroySurfaceKHR(instance.inst, surface, nullptr);
 }
 #endif
 
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
 // When ICD doesn't support the extension, create instance should fail
-TEST_F(WsiTests, CreateSurfaceWaylandNoICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, CreateSurfaceWaylandNoICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.enable_icd_wsi = false;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
     inst.CheckCreate(VK_ERROR_EXTENSION_NOT_PRESENT);
 
-    InstWrapper inst2{env->vulkan_functions};
+    InstWrapper inst2{env.vulkan_functions};
     inst2.CheckCreate();
 
-    ASSERT_EQ(nullptr, env->vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkCreateWaylandSurfaceKHR"));
+    ASSERT_EQ(nullptr, env.vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkCreateWaylandSurfaceKHR"));
 }
 
 // When ICD doesn't support the surface creation, the loader should handle it
-TEST_F(WsiTests, CreateSurfaceWaylandNoICDCreateSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, CreateSurfaceWaylandNoICDCreateSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
+    cur_icd.enable_icd_wsi = false;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
     VkWaylandSurfaceCreateInfoKHR createInfo{VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR};
 
     VkSurfaceKHR surface;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkCreateWaylandSurfaceKHR(inst, &createInfo, nullptr, &surface));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateWaylandSurfaceKHR(inst, &createInfo, nullptr, &surface));
     ASSERT_TRUE(surface != VK_NULL_HANDLE);
 
-    env->vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
+    env.vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
 }
 
 // When ICD does support the surface creation, the loader should  delegat handle it to the ICD
-TEST_F(WsiTests, CreateSurfaceWaylandICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
-    driver.enable_icd_wsi = true;
+TEST(WsiTests, CreateSurfaceWaylandICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
+    cur_icd.enable_icd_wsi = true;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
     VkWaylandSurfaceCreateInfoKHR createInfo{VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR};
 
     VkSurfaceKHR surface;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkCreateWaylandSurfaceKHR(inst, &createInfo, nullptr, &surface));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateWaylandSurfaceKHR(inst, &createInfo, nullptr, &surface));
     ASSERT_TRUE(surface != VK_NULL_HANDLE);
 
-    env->vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
+    env.vulkan_functions.vkDestroySurfaceKHR(inst, surface, nullptr);
 }
 
 // Some drivers supporting vkCreateWaylandSurfaceKHR, and at least one that doesn't
-TEST_F(WsiTests, CreateSurfaceWaylandMixedICDSupport) {
+TEST(WsiTests, CreateSurfaceWaylandMixedICDSupport) {
     FrameworkEnvironment env{};
     for (uint32_t icd = 0; icd < 3; ++icd) {
         Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
@@ -538,16 +681,18 @@ TEST_F(WsiTests, CreateSurfaceWaylandMixedICDSupport) {
     env.vulkan_functions.vkDestroySurfaceKHR(instance.inst, surface, nullptr);
 }
 
-TEST_F(WsiTests, GetPhysicalDeviceWaylandPresentNoICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
-    driver.physical_devices.emplace_back("physical_device_0");
-    driver.enable_icd_wsi = false;
+TEST(WsiTests, GetPhysicalDeviceWaylandPresentNoICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
+    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.enable_icd_wsi = false;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
@@ -556,20 +701,22 @@ TEST_F(WsiTests, GetPhysicalDeviceWaylandPresentNoICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1);
 
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceWaylandPresentationSupportKHR(physical_device, 0, nullptr),
-                 "ICD for selected physical device does not exportvkGetPhysicalDeviceWaylandPresentationSupportKHR!");
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceWaylandPresentationSupportKHR(physical_device, 0, nullptr),
+                 "ICD for selected physical device does not export vkGetPhysicalDeviceWaylandPresentationSupportKHR!");
 }
 
-TEST_F(WsiTests, GetPhysicalDeviceWaylandPresentICDSupport) {
-    auto& driver = env->get_test_icd();
-    driver.set_icd_api_version(VK_API_VERSION_1_0);
-    driver.set_min_icd_interface_version(5);
-    driver.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
-    driver.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
-    driver.physical_devices.emplace_back("physical_device_0");
-    driver.enable_icd_wsi = true;
+TEST(WsiTests, GetPhysicalDeviceWaylandPresentICDSupport) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& cur_icd = env.get_test_icd(0);
+    cur_icd.set_min_icd_interface_version(5);
+    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
+    cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
+    cur_icd.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
+    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.enable_icd_wsi = true;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
     inst.CheckCreate();
 
@@ -578,6 +725,47 @@ TEST_F(WsiTests, GetPhysicalDeviceWaylandPresentICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1);
 
-    ASSERT_EQ(VK_TRUE, env->vulkan_functions.vkGetPhysicalDeviceWaylandPresentationSupportKHR(physical_device, 0, nullptr));
+    ASSERT_EQ(VK_TRUE, env.vulkan_functions.vkGetPhysicalDeviceWaylandPresentationSupportKHR(physical_device, 0, nullptr));
+}
+
+TEST(WsiTests, WaylandGetPhysicalDeviceSurfaceSupportKHR) {
+    FrameworkEnvironment env{};
+    const uint32_t max_device_count = 4;
+    for (uint32_t icd = 0; icd < max_device_count; ++icd) {
+        Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
+        Extension second_ext{VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME};
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+        auto& cur_icd = env.get_test_icd(icd);
+        cur_icd.icd_api_version = VK_API_VERSION_1_0;
+        cur_icd.set_min_icd_interface_version(5);
+        cur_icd.add_instance_extensions({first_ext, second_ext});
+        std::string dev_name = "phys_dev_" + icd;
+        cur_icd.physical_devices.emplace_back(dev_name.c_str());
+        cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
+        cur_icd.enable_icd_wsi = true;
+    }
+
+    InstWrapper instance(env.vulkan_functions);
+    instance.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
+    instance.CheckCreate();
+
+    VkSurfaceKHR surface{VK_NULL_HANDLE};
+    VkWaylandSurfaceCreateInfoKHR createInfo{VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR};
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkCreateWaylandSurfaceKHR(instance.inst, &createInfo, nullptr, &surface));
+    ASSERT_TRUE(surface != VK_NULL_HANDLE);
+    //    ASSERT_EQ(cur_icd.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
+
+    uint32_t device_count = max_device_count;
+    std::array<VkPhysicalDevice, max_device_count> phys_devs;
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumeratePhysicalDevices(instance.inst, &device_count, phys_devs.data()));
+    ASSERT_EQ(device_count, max_device_count);
+
+    for (uint32_t pd = 0; pd < max_device_count; ++pd) {
+        VkBool32 supported = VK_FALSE;
+        ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkGetPhysicalDeviceSurfaceSupportKHR(phys_devs[pd], 0, surface, &supported));
+    }
+
+    env.vulkan_functions.vkDestroySurfaceKHR(instance.inst, surface, nullptr);
 }
 #endif
+


### PR DESCRIPTION
The physical device terminator was missing the ICD index in the
non-sorted path.  This caused crashes in Angle before it was realized
that the sorting code was unintentionally disabled in that build
path.

Also, add tests to catch this case in the future.

Fixes #863 for non-sorting paths