### PR TITLE
Remove LDP_DRIVER_6

### DIFF
--- a/docs/LoaderDriverInterface.md
+++ b/docs/LoaderDriverInterface.md
@@ -1334,29 +1334,12 @@ Android Vulkan documentation</a>.
   </tr>
   <tr>
     <td><small><b>LDP_DRIVER_6</b></small></td>
-    <td>A driver supporting loader/driver interface version 1 or newer <b>must
-        not</b> directly export standard Vulkan entry-points.
-        <br/>
-        Instead, it <b>must</b> export only the loader interface functions
-        required by the interface versions it does support (for example
-        <i>vk_icdGetInstanceProcAddr</i>). <br/>
-        This is because the dynamic linking on some platforms has been
-        problematic in the past and incorrectly links to exported functions from
-        the wrong dynamic library at times. <br/>
-        <b>NOTE:</b> This is actually true for all exports.
-        When in doubt, don't export any items from a driver that could cause
-        conflicts in other libraries.
+    <td>Removed - See <a href="#removed-driver-policies">Removed Driver Policies</a>
     </td>
-    <td>The behavior is undefined and may result in crashes or corruption.</td>
-    <td>Yes (except it always applies)</td>
-    <td>Yes</td>
-    <td><small>
-        <a href="#loader-and-driver-interface-negotiation">
-        Interface Negotiation</a></small>
-        and
-        <a href="#driver-vulkan-entry-point-discovery">
-        Vulkan Entry-point Discovery</a></small>
-    </td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
   </tr>
   <tr>
     <td><small><b>LDP_DRIVER_7</b></small></td>
@@ -1460,6 +1443,39 @@ Android Vulkan documentation</a>.
   </tr>
 </table>
 
+#### Removed Driver Policies
+
+These policies were in the loader source at some point but later removed. They are documented here for reference.
+
+<table>
+  <tr>
+    <th>Requirement Number</th>
+    <th>Requirement Description</th>
+    <th>Removal Reason</th>
+  </tr>
+  <tr>
+    <td><small><b>LDP_DRIVER_6</b></small></td>
+    <td>A driver supporting loader/driver interface version 1 or newer <b>must
+        not</b> directly export standard Vulkan entry-points.
+        <br/>
+        Instead, it <b>must</b> export only the loader interface functions
+        required by the interface versions it does support (for example
+        <i>vk_icdGetInstanceProcAddr</i>). <br/>
+        This is because the dynamic linking on some platforms has been
+        problematic in the past and incorrectly links to exported functions from
+        the wrong dynamic library at times. <br/>
+        <b>NOTE:</b> This is actually true for all exports.
+        When in doubt, don't export any items from a driver that could cause
+        conflicts in other libraries.<br/>
+    </td>
+    <td>
+        This policy has been removed due to there being valid circumstances for
+        drivers to export core entrypoints.
+        Additionally, it was not found that dynamic linking would cause many
+        issues in practice.
+    </td>
+  </tr>
+</table>
 
 ### Requirements of a Well-Behaved Loader
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1483,20 +1483,6 @@ static VkResult loader_scanned_icd_add(const struct loader_instance *inst, struc
                    " Interface version 5 or newer required to support this version of Vulkan (Policy #LDP_DRIVER_7)",
                    filename, major_version, minor_version, interface_vers);
     }
-    if (interface_vers >= 1) {
-        if ((loader_platform_get_proc_address(handle, "vkEnumerateInstanceExtensionProperties") != NULL) ||
-            (loader_platform_get_proc_address(handle, "vkEnumerateInstanceLayerProperties") != NULL) ||
-            (loader_platform_get_proc_address(handle, "vkEnumerateInstanceVersion") != NULL) ||
-            (loader_platform_get_proc_address(handle, "vkGetInstanceProcAddr") != NULL) ||
-            (loader_platform_get_proc_address(handle, "vkCreateInstance") != NULL) ||
-            (loader_platform_get_proc_address(handle, "vkGetDeviceProcAddr") != NULL) ||
-            (loader_platform_get_proc_address(handle, "vkCreateDevice") != NULL)) {
-            loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
-                       "loader_scanned_icd_add: Driver %s says it supports interface version %u but still exports core "
-                       "entrypoints (Policy #LDP_DRIVER_6)",
-                       filename, interface_vers);
-        }
-    }
 
     new_scanned_icd = &(icd_tramp_list->scanned_list[icd_tramp_list->count]);
     new_scanned_icd->handle = handle;


### PR DESCRIPTION
The cause for this policy was due to dynamic linker behavior which could have
resulted in the wrong symbols being used. However, this didn't occur in
practical usage of the dynamic linker. Also drivers exporting Vulkan
entrypoints was a useful behavior to enable testing and more flexible usage
that this policy actively interfered with.

Resolves #797 