### PR TITLE
Fix #888 crash in Lutris with Linux sorting

### DIFF
--- a/loader/loader_linux.c
+++ b/loader/loader_linux.c
@@ -237,7 +237,7 @@ VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32
                                             struct loader_physical_device_term **sorted_device_term) {
     VkResult res = VK_SUCCESS;
     bool app_is_vulkan_1_1 = false;
-    if (inst->app_api_major_version >= 1 && inst->app_api_minor_version >= 1) {
+    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
         app_is_vulkan_1_1 = true;
     }
 
@@ -249,8 +249,7 @@ VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32
     }
     memset(sorted_device_info, 0, inst->total_gpu_count * sizeof(struct LinuxSortedDeviceInfo));
 
-    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
-               "linux_read_sorted_physical_devices: (App Version %d.%d)", inst->app_api_major_version, inst->app_api_minor_version);
+    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "linux_read_sorted_physical_devices:");
     loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "     Original order:");
 
     // Grab all the necessary info we can about each device

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -73,13 +73,13 @@ bool CheckLayer(std::vector<LayerDefinition>& layers, std::string layerName) {
 bool IsInstanceExtensionSupported(const char* extension_name) {
     return icd.instance_extensions.end() !=
            std::find_if(icd.instance_extensions.begin(), icd.instance_extensions.end(),
-                        [extension_name](Extension const& ext) { return ext.extensionName == extension_name; });
+                        [extension_name](Extension const& ext) { return string_eq(&ext.extensionName[0], extension_name); });
 }
 
 bool IsInstanceExtensionEnabled(const char* extension_name) {
     return icd.enabled_instance_extensions.end() !=
            std::find_if(icd.enabled_instance_extensions.begin(), icd.enabled_instance_extensions.end(),
-                        [extension_name](Extension const& ext) { return ext.extensionName == extension_name; });
+                        [extension_name](Extension const& ext) { return string_eq(&ext.extensionName[0], extension_name); });
 }
 
 bool IsPhysicalDeviceExtensionAvailable(const char* extension_name) {

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -68,6 +68,7 @@ struct TestICD {
     BUILDER_VALUE(TestICD, uint32_t, icd_api_version, VK_API_VERSION_1_0)
     BUILDER_VECTOR(TestICD, LayerDefinition, instance_layers, instance_layer)
     BUILDER_VECTOR(TestICD, Extension, instance_extensions, instance_extension)
+    BUILDER_VECTOR(TestICD, Extension, enabled_instance_extensions, enabled_instance_extension)
 
     BUILDER_VECTOR_MOVE_ONLY(TestICD, PhysicalDevice, physical_devices, physical_device);
 


### PR DESCRIPTION
The sorting algorithm needed to take into account both the application
API version as well as the driver API version.

This required additional changes to the sorting algorithm for the fallback
since even if the instance supports the extension or Vulkan 1.1, the individual
drivers may not.

Also, add supporting tests which would catch these cases in the future.
In the process, I realized we assumed that the presence of an extension in the
test_icd indicated "enablement" which was incorrect.  So I separated out
that into a set of "enabled instance extensions"