### PR TITLE
Enable w4 warnings and make clang-cl compiler possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2014-2019 Valve Corporation
-# Copyright (c) 2014-2019 LunarG, Inc.
+# Copyright (c) 2014-2022 Valve Corporation
+# Copyright (c) 2014-2022 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -191,6 +191,17 @@ if(UNIX)
             "System-wide search directory. If not set or empty, CMAKE_INSTALL_FULL_SYSCONFDIR and /etc are used.")
 endif()
 
+# Because we use CMake 3.10.2, we can't use the policy which would disable adding /W3 by default. In the interim, replace the flags
+# When this project is updated to 3.15 and above, use the following line.
+#     cmake_policy(SET CMP0092 NEW)
+string(REGEX REPLACE "/W3" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+string(REGEX REPLACE "/W3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+# For MSVC/Windows, replace /GR with an empty string, this prevents warnings of /GR being overriden by /GR-
+# Newer CMake versions (3.20) have better solutions for this through policy - using the old
+# way while waiting for when updating can occur
+string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
 if(UNIX AND NOT APPLE) # i.e.: Linux
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
     option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
@@ -264,23 +275,33 @@ target_compile_features(loader_common_options INTERFACE cxx_std_11)
 set(LOADER_STANDARD_C_PROPERTIES PROPERTIES C_STANDARD 99 C_STANDARD_REQUIRED YES C_EXTENSIONS OFF)
 set(LOADER_STANDARD_CXX_PROPERTIES PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS OFF)
 
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-    target_compile_options(loader_common_options INTERFACE -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -fno-strict-aliasing -fno-builtin-memcmp)
+# Set warnings as errors and the main diagnostic flags
+# Must be set first so the warning silencing later on works properly
+# Note that clang-cl.exe should use MSVC flavor flags, not GNU
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC"))
+    target_compile_options(loader_common_options INTERFACE /WX /W4)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # using GCC or Clang with the regular front end
+    target_compile_options(loader_common_options INTERFACE -Werror -Wall -Wextra)
+endif()
 
-    target_compile_options(loader_common_options INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(loader_common_options INTERFACE -Wno-unused-parameter -Wno-unused-function -Wno-missing-field-initializers)
+
+    # need to prepend /clang: to compiler arguments when using clang-cl
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC")
+        target_compile_options(loader_common_options INTERFACE /clang:-fno-strict-aliasing /clang:-fno-builtin-memcmp)
+    else()
+        target_compile_options(loader_common_options INTERFACE -fno-strict-aliasing -fno-builtin-memcmp)
+    endif()
 
     # For GCC version 7.1 or greater, we need to disable the implicit fallthrough warning since there's no consistent way to satisfy
     # all compilers until they all accept the C++17 standard
-    if(CMAKE_COMPILER_IS_GNUCC)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         target_compile_options(loader_common_options INTERFACE -Wno-stringop-truncation -Wno-stringop-overflow)
         if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 7.1)
             target_compile_options(loader_common_options INTERFACE -Wimplicit-fallthrough=0)
         endif()
-    endif()
-
-    # clang-cl on Windows
-    if((CMAKE_C_COMPILER_ID MATCHES "Clang") AND (CMAKE_CXX_SIMULATE_ID MATCHES "MSVC"))
-        target_compile_options(loader_common_options INTERFACE -Xclang )
     endif()
 
     if(UNIX)
@@ -288,23 +309,15 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     endif()
 
     target_compile_options(loader_common_options INTERFACE -Wpointer-arith)
-
-    # Clang (and not gcc) warns about redefining a typedef with the same types, so disable that warning. Note that it will still
-    # throw an error if a typedef is redefined with a different type.
-    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-        target_compile_options(loader_common_options INTERFACE -Wno-typedef-redefinition)
-    endif()
 endif()
 
-if(MSVC)
-    # /WX: Treat warnings as errors
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC"))
     # /GR-: Disable RTTI
-    # /w34456: Warn about nested declarations
-    # /w34701, /w34703: Warn about potentially uninitialized variables
-    # /w34057: Warn about different indirection types.
-    # /w34245: Warn about signed/unsigned mismatch.
     # /guard:cf: Enable control flow guard
-    target_compile_options(loader_common_options INTERFACE /WX /GR- /w34456 /w34701 /w34703 /w34057 /w34245 /guard:cf)
+    # /wd4100: Disable warning on unreferenced formal parameter
+    # /wd4152: Disable warning on conversion of a function pointer to a data pointer
+    # /wd4201: Disable warning on anonymous struct/unions
+    target_compile_options(loader_common_options INTERFACE /GR- /guard:cf /wd4100 /wd4152 /wd4201)
 
     # Enable control flow guard
     if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.0")
@@ -316,11 +329,6 @@ if(MSVC)
 
     # Prevent <windows.h> from polluting the code. guards against things like MIN and MAX
     target_compile_definitions(loader_common_options INTERFACE WIN32_LEAN_AND_MEAN)
-
-    # Replace /GR with an empty string, prevents warnings of /GR being overriden by /GR-
-    # Newer CMake versions (3.20) have better solutions for this through policy - using the old
-    # way while waiting for when updating can occur
-    string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 endif()
 
 # DEBUG enables runtime loader ICD verification
@@ -476,6 +484,10 @@ if(BUILD_TESTS)
                 set_target_properties(detours PROPERTIES COMPILE_FLAGS /EHsc)
             endif()
 
+            # Silence errors found in clang-cl
+            if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC")
+                target_compile_options(detours PRIVATE -Wno-sizeof-pointer-memaccess -Wno-microsoft-goto -Wno-microsoft-cast)
+            endif()
         endif()
     endif()
 

--- a/loader/cJSON.c
+++ b/loader/cJSON.c
@@ -53,7 +53,8 @@ char *cJSON_strdup(const struct loader_instance *instance, const char *str) {
     char *copy;
 
     len = strlen(str) + 1;
-    if (!(copy = (char *)cJSON_malloc(instance, len))) return 0;
+    copy = (char *)cJSON_malloc(instance, len);
+    if (!copy) return 0;
     memcpy(copy, str, len);
     return copy;
 }
@@ -368,12 +369,14 @@ char *print_string_ptr(const struct loader_instance *instance, const char *str, 
         return out;
     }
     ptr = str;
-    while ((token = *ptr) && ++len) {
+    token = *ptr;
+    while (token && ++len) {
         if (strchr("\"\\\b\f\n\r\t", token))
             len++;
         else if (token < 32)
             len += 5;
         ptr++;
+        token = *ptr;
     }
 
     if (p)
@@ -597,7 +600,8 @@ const char *parse_array(const struct loader_instance *instance, cJSON *item, con
 
     while (*value == ',') {
         cJSON *new_item;
-        if (!(new_item = cJSON_New_Item(instance))) return 0; /* memory fail */
+        new_item = cJSON_New_Item(instance);
+        if (!new_item) return 0; /* memory fail */
         child->next = new_item;
         new_item->prev = child;
         child = new_item;
@@ -737,7 +741,8 @@ const char *parse_object(const struct loader_instance *instance, cJSON *item, co
 
     while (*value == ',') {
         cJSON *new_item;
-        if (!(new_item = cJSON_New_Item(instance))) return 0; /* memory fail */
+        new_item = cJSON_New_Item(instance);
+        if (!new_item) return 0; /* memory fail */
         child->next = new_item;
         new_item->prev = child;
         child = new_item;

--- a/loader/generated/vk_dispatch_table_helper.h
+++ b/loader/generated/vk_dispatch_table_helper.h
@@ -29,318 +29,318 @@
 #include <string.h>
 #include "vk_layer_dispatch_table.h"
 
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount, VkImage* pSwapchainImages) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetDeviceGroupPresentCapabilitiesKHR(VkDevice device, VkDeviceGroupPresentCapabilitiesKHR* pDeviceGroupPresentCapabilities) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetDeviceGroupSurfacePresentModesKHR(VkDevice device, VkSurfaceKHR surface, VkDeviceGroupPresentModeFlagsKHR* pModes) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo, uint32_t* pImageIndex) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount, const VkSwapchainCreateInfoKHR* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount, VkImage* pSwapchainImages) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetDeviceGroupPresentCapabilitiesKHR(VkDevice device, VkDeviceGroupPresentCapabilitiesKHR* pDeviceGroupPresentCapabilities) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetDeviceGroupSurfacePresentModesKHR(VkDevice device, VkSurfaceKHR surface, VkDeviceGroupPresentModeFlagsKHR* pModes) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo, uint32_t* pImageIndex) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount, const VkSwapchainCreateInfoKHR* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains) { return VK_SUCCESS; }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateVideoSessionKHR(VkDevice device, const VkVideoSessionCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkVideoSessionKHR* pVideoSession) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateVideoSessionKHR(VkDevice device, const VkVideoSessionCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkVideoSessionKHR* pVideoSession) { return VK_SUCCESS; }
 #endif // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR void VKAPI_CALL StubDestroyVideoSessionKHR(VkDevice device, VkVideoSessionKHR videoSession, const VkAllocationCallbacks* pAllocator) {  };
+static VKAPI_ATTR void VKAPI_CALL StubDestroyVideoSessionKHR(VkDevice device, VkVideoSessionKHR videoSession, const VkAllocationCallbacks* pAllocator) {  }
 #endif // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetVideoSessionMemoryRequirementsKHR(VkDevice device, VkVideoSessionKHR videoSession, uint32_t* pVideoSessionMemoryRequirementsCount, VkVideoGetMemoryPropertiesKHR* pVideoSessionMemoryRequirements) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetVideoSessionMemoryRequirementsKHR(VkDevice device, VkVideoSessionKHR videoSession, uint32_t* pVideoSessionMemoryRequirementsCount, VkVideoGetMemoryPropertiesKHR* pVideoSessionMemoryRequirements) { return VK_SUCCESS; }
 #endif // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR VkResult VKAPI_CALL StubBindVideoSessionMemoryKHR(VkDevice device, VkVideoSessionKHR videoSession, uint32_t videoSessionBindMemoryCount, const VkVideoBindMemoryKHR* pVideoSessionBindMemories) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubBindVideoSessionMemoryKHR(VkDevice device, VkVideoSessionKHR videoSession, uint32_t videoSessionBindMemoryCount, const VkVideoBindMemoryKHR* pVideoSessionBindMemories) { return VK_SUCCESS; }
 #endif // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateVideoSessionParametersKHR(VkDevice device, const VkVideoSessionParametersCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkVideoSessionParametersKHR* pVideoSessionParameters) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateVideoSessionParametersKHR(VkDevice device, const VkVideoSessionParametersCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkVideoSessionParametersKHR* pVideoSessionParameters) { return VK_SUCCESS; }
 #endif // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR VkResult VKAPI_CALL StubUpdateVideoSessionParametersKHR(VkDevice device, VkVideoSessionParametersKHR videoSessionParameters, const VkVideoSessionParametersUpdateInfoKHR* pUpdateInfo) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubUpdateVideoSessionParametersKHR(VkDevice device, VkVideoSessionParametersKHR videoSessionParameters, const VkVideoSessionParametersUpdateInfoKHR* pUpdateInfo) { return VK_SUCCESS; }
 #endif // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR void VKAPI_CALL StubDestroyVideoSessionParametersKHR(VkDevice device, VkVideoSessionParametersKHR videoSessionParameters, const VkAllocationCallbacks* pAllocator) {  };
+static VKAPI_ATTR void VKAPI_CALL StubDestroyVideoSessionParametersKHR(VkDevice device, VkVideoSessionParametersKHR videoSessionParameters, const VkAllocationCallbacks* pAllocator) {  }
 #endif // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR void VKAPI_CALL StubCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoBeginCodingInfoKHR* pBeginInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoBeginCodingInfoKHR* pBeginInfo) {  }
 #endif // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR void VKAPI_CALL StubCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoEndCodingInfoKHR* pEndCodingInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoEndCodingInfoKHR* pEndCodingInfo) {  }
 #endif // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR void VKAPI_CALL StubCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoCodingControlInfoKHR* pCodingControlInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoCodingControlInfoKHR* pCodingControlInfo) {  }
 #endif // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR void VKAPI_CALL StubCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR* pFrameInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR* pFrameInfo) {  }
 #endif // VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR void VKAPI_CALL StubCmdBeginRenderingKHR(VkCommandBuffer                   commandBuffer, const VkRenderingInfo*                              pRenderingInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdEndRenderingKHR(VkCommandBuffer                   commandBuffer) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetDeviceGroupPeerMemoryFeaturesKHR(VkDevice device, uint32_t heapIndex, uint32_t localDeviceIndex, uint32_t remoteDeviceIndex, VkPeerMemoryFeatureFlags* pPeerMemoryFeatures) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32_t deviceMask) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY, uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ) {  };
-static VKAPI_ATTR void VKAPI_CALL StubTrimCommandPoolKHR(VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdBeginRenderingKHR(VkCommandBuffer                   commandBuffer, const VkRenderingInfo*                              pRenderingInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdEndRenderingKHR(VkCommandBuffer                   commandBuffer) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetDeviceGroupPeerMemoryFeaturesKHR(VkDevice device, uint32_t heapIndex, uint32_t localDeviceIndex, uint32_t remoteDeviceIndex, VkPeerMemoryFeatureFlags* pPeerMemoryFeatures) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32_t deviceMask) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY, uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ) {  }
+static VKAPI_ATTR void VKAPI_CALL StubTrimCommandPoolKHR(VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags) {  }
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryWin32HandleKHR(VkDevice device, const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo, HANDLE* pHandle) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryWin32HandleKHR(VkDevice device, const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo, HANDLE* pHandle) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_WIN32_KHR
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryWin32HandlePropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, HANDLE handle, VkMemoryWin32HandlePropertiesKHR* pMemoryWin32HandleProperties) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryWin32HandlePropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, HANDLE handle, VkMemoryWin32HandlePropertiesKHR* pMemoryWin32HandleProperties) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR* pGetFdInfo, int* pFd) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryFdPropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, int fd, VkMemoryFdPropertiesKHR* pMemoryFdProperties) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR* pGetFdInfo, int* pFd) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryFdPropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, int fd, VkMemoryFdPropertiesKHR* pMemoryFdProperties) { return VK_SUCCESS; }
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubImportSemaphoreWin32HandleKHR(VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo) { return VK_SUCCESS; };
-#endif // VK_USE_PLATFORM_WIN32_KHR
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetSemaphoreWin32HandleKHR(VkDevice device, const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo, HANDLE* pHandle) { return VK_SUCCESS; };
-#endif // VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer, VkDescriptorUpdateTemplate descriptorUpdateTemplate, VkPipelineLayout layout, uint32_t set, const void* pData) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateDescriptorUpdateTemplateKHR(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubDestroyDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator) {  };
-static VKAPI_ATTR void VKAPI_CALL StubUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo*      pRenderPassBegin, const VkSubpassBeginInfo*      pSubpassBeginInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo*      pSubpassBeginInfo, const VkSubpassEndInfo*        pSubpassEndInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo*        pSubpassEndInfo) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetSwapchainStatusKHR(VkDevice device, VkSwapchainKHR swapchain) { return VK_SUCCESS; };
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubImportFenceWin32HandleKHR(VkDevice device, const VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubImportSemaphoreWin32HandleKHR(VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_WIN32_KHR
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo, HANDLE* pHandle) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetSemaphoreWin32HandleKHR(VkDevice device, const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo, HANDLE* pHandle) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR* pImportFenceFdInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubAcquireProfilingLockKHR(VkDevice device, const VkAcquireProfilingLockInfoKHR* pInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubReleaseProfilingLockKHR(VkDevice device) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetImageMemoryRequirements2KHR(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo, VkMemoryRequirements2* pMemoryRequirements) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetBufferMemoryRequirements2KHR(VkDevice device, const VkBufferMemoryRequirementsInfo2* pInfo, VkMemoryRequirements2* pMemoryRequirements) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetImageSparseMemoryRequirements2KHR(VkDevice device, const VkImageSparseMemoryRequirementsInfo2* pInfo, uint32_t* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2* pSparseMemoryRequirements) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateSamplerYcbcrConversionKHR(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSamplerYcbcrConversion* pYcbcrConversion) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubDestroySamplerYcbcrConversionKHR(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion, const VkAllocationCallbacks* pAllocator) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubGetDescriptorSetLayoutSupportKHR(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo, VkDescriptorSetLayoutSupport* pSupport) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t* pValue) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetFragmentShadingRateKHR(VkCommandBuffer           commandBuffer, const VkExtent2D*                           pFragmentSize, const VkFragmentShadingRateCombinerOpKHR    combinerOps[2]) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubWaitForPresentKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t presentId, uint64_t timeout) { return VK_SUCCESS; };
-static VKAPI_ATTR VkDeviceAddress VKAPI_CALL StubGetBufferDeviceAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo* pInfo) { return 0L; };
-static VKAPI_ATTR uint64_t VKAPI_CALL StubGetBufferOpaqueCaptureAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo* pInfo) { return 0L; };
-static VKAPI_ATTR uint64_t VKAPI_CALL StubGetDeviceMemoryOpaqueCaptureAddressKHR(VkDevice device, const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo) { return 0L; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateDeferredOperationKHR(VkDevice device, const VkAllocationCallbacks* pAllocator, VkDeferredOperationKHR* pDeferredOperation) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubDestroyDeferredOperationKHR(VkDevice device, VkDeferredOperationKHR operation, const VkAllocationCallbacks* pAllocator) {  };
-static VKAPI_ATTR uint32_t VKAPI_CALL StubGetDeferredOperationMaxConcurrencyKHR(VkDevice device, VkDeferredOperationKHR operation) { return 0; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetDeferredOperationResultKHR(VkDevice device, VkDeferredOperationKHR operation) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubDeferredOperationJoinKHR(VkDevice device, VkDeferredOperationKHR operation) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetPipelineExecutablePropertiesKHR(VkDevice                        device, const VkPipelineInfoKHR*        pPipelineInfo, uint32_t* pExecutableCount, VkPipelineExecutablePropertiesKHR* pProperties) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetPipelineExecutableStatisticsKHR(VkDevice                        device, const VkPipelineExecutableInfoKHR*  pExecutableInfo, uint32_t* pStatisticCount, VkPipelineExecutableStatisticKHR* pStatistics) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetPipelineExecutableInternalRepresentationsKHR(VkDevice                        device, const VkPipelineExecutableInfoKHR*  pExecutableInfo, uint32_t* pInternalRepresentationCount, VkPipelineExecutableInternalRepresentationKHR* pInternalRepresentations) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer, VkDescriptorUpdateTemplate descriptorUpdateTemplate, VkPipelineLayout layout, uint32_t set, const void* pData) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateDescriptorUpdateTemplateKHR(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubDestroyDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const VkAllocationCallbacks* pAllocator) {  }
+static VKAPI_ATTR void VKAPI_CALL StubUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo*      pRenderPassBegin, const VkSubpassBeginInfo*      pSubpassBeginInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo*      pSubpassBeginInfo, const VkSubpassEndInfo*        pSubpassEndInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo*        pSubpassEndInfo) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetSwapchainStatusKHR(VkDevice device, VkSwapchainKHR swapchain) { return VK_SUCCESS; }
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+static VKAPI_ATTR VkResult VKAPI_CALL StubImportFenceWin32HandleKHR(VkDevice device, const VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo) { return VK_SUCCESS; }
+#endif // VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo, HANDLE* pHandle) { return VK_SUCCESS; }
+#endif // VK_USE_PLATFORM_WIN32_KHR
+static VKAPI_ATTR VkResult VKAPI_CALL StubImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR* pImportFenceFdInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubAcquireProfilingLockKHR(VkDevice device, const VkAcquireProfilingLockInfoKHR* pInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubReleaseProfilingLockKHR(VkDevice device) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetImageMemoryRequirements2KHR(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo, VkMemoryRequirements2* pMemoryRequirements) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetBufferMemoryRequirements2KHR(VkDevice device, const VkBufferMemoryRequirementsInfo2* pInfo, VkMemoryRequirements2* pMemoryRequirements) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetImageSparseMemoryRequirements2KHR(VkDevice device, const VkImageSparseMemoryRequirementsInfo2* pInfo, uint32_t* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2* pSparseMemoryRequirements) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateSamplerYcbcrConversionKHR(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSamplerYcbcrConversion* pYcbcrConversion) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubDestroySamplerYcbcrConversionKHR(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion, const VkAllocationCallbacks* pAllocator) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubGetDescriptorSetLayoutSupportKHR(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo, VkDescriptorSetLayoutSupport* pSupport) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t* pValue) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetFragmentShadingRateKHR(VkCommandBuffer           commandBuffer, const VkExtent2D*                           pFragmentSize, const VkFragmentShadingRateCombinerOpKHR    combinerOps[2]) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubWaitForPresentKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t presentId, uint64_t timeout) { return VK_SUCCESS; }
+static VKAPI_ATTR VkDeviceAddress VKAPI_CALL StubGetBufferDeviceAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo* pInfo) { return 0L; }
+static VKAPI_ATTR uint64_t VKAPI_CALL StubGetBufferOpaqueCaptureAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo* pInfo) { return 0L; }
+static VKAPI_ATTR uint64_t VKAPI_CALL StubGetDeviceMemoryOpaqueCaptureAddressKHR(VkDevice device, const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo) { return 0L; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateDeferredOperationKHR(VkDevice device, const VkAllocationCallbacks* pAllocator, VkDeferredOperationKHR* pDeferredOperation) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubDestroyDeferredOperationKHR(VkDevice device, VkDeferredOperationKHR operation, const VkAllocationCallbacks* pAllocator) {  }
+static VKAPI_ATTR uint32_t VKAPI_CALL StubGetDeferredOperationMaxConcurrencyKHR(VkDevice device, VkDeferredOperationKHR operation) { return 0; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetDeferredOperationResultKHR(VkDevice device, VkDeferredOperationKHR operation) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubDeferredOperationJoinKHR(VkDevice device, VkDeferredOperationKHR operation) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetPipelineExecutablePropertiesKHR(VkDevice                        device, const VkPipelineInfoKHR*        pPipelineInfo, uint32_t* pExecutableCount, VkPipelineExecutablePropertiesKHR* pProperties) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetPipelineExecutableStatisticsKHR(VkDevice                        device, const VkPipelineExecutableInfoKHR*  pExecutableInfo, uint32_t* pStatisticCount, VkPipelineExecutableStatisticKHR* pStatistics) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetPipelineExecutableInternalRepresentationsKHR(VkDevice                        device, const VkPipelineExecutableInfoKHR*  pExecutableInfo, uint32_t* pInternalRepresentationCount, VkPipelineExecutableInternalRepresentationKHR* pInternalRepresentations) { return VK_SUCCESS; }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR void VKAPI_CALL StubCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR* pEncodeInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR* pEncodeInfo) {  }
 #endif // VK_ENABLE_BETA_EXTENSIONS
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetEvent2KHR(VkCommandBuffer                   commandBuffer, VkEvent                                             event, const VkDependencyInfo*                             pDependencyInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdResetEvent2KHR(VkCommandBuffer                   commandBuffer, VkEvent                                             event, VkPipelineStageFlags2               stageMask) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdWaitEvents2KHR(VkCommandBuffer                   commandBuffer, uint32_t                                            eventCount, const VkEvent*                     pEvents, const VkDependencyInfo*            pDependencyInfos) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdPipelineBarrier2KHR(VkCommandBuffer                   commandBuffer, const VkDependencyInfo*                             pDependencyInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdWriteTimestamp2KHR(VkCommandBuffer                   commandBuffer, VkPipelineStageFlags2               stage, VkQueryPool                                         queryPool, uint32_t                                            query) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubQueueSubmit2KHR(VkQueue                           queue, uint32_t                            submitCount, const VkSubmitInfo2*              pSubmits, VkFence           fence) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdWriteBufferMarker2AMD(VkCommandBuffer                   commandBuffer, VkPipelineStageFlags2               stage, VkBuffer                                            dstBuffer, VkDeviceSize                                        dstOffset, uint32_t                                            marker) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetQueueCheckpointData2NV(VkQueue queue, uint32_t* pCheckpointDataCount, VkCheckpointData2NV* pCheckpointData) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetDeviceBufferMemoryRequirementsKHR(VkDevice device, const VkDeviceBufferMemoryRequirements* pInfo, VkMemoryRequirements2* pMemoryRequirements) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetDeviceImageMemoryRequirementsKHR(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, VkMemoryRequirements2* pMemoryRequirements) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetDeviceImageSparseMemoryRequirementsKHR(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, uint32_t* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2* pSparseMemoryRequirements) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT* pTagInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT* pNameInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount, const VkBuffer* pBuffers, const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers, const VkDeviceSize* pCounterBufferOffsets) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers, const VkDeviceSize* pCounterBufferOffsets) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query, VkQueryControlFlags flags, uint32_t index) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query, uint32_t index) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount, uint32_t firstInstance, VkBuffer counterBuffer, VkDeviceSize counterBufferOffset, uint32_t counterOffset, uint32_t vertexStride) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateCuModuleNVX(VkDevice device, const VkCuModuleCreateInfoNVX* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkCuModuleNVX* pModule) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateCuFunctionNVX(VkDevice device, const VkCuFunctionCreateInfoNVX* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkCuFunctionNVX* pFunction) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubDestroyCuModuleNVX(VkDevice device, VkCuModuleNVX module, const VkAllocationCallbacks* pAllocator) {  };
-static VKAPI_ATTR void VKAPI_CALL StubDestroyCuFunctionNVX(VkDevice device, VkCuFunctionNVX function, const VkAllocationCallbacks* pAllocator) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCuLaunchKernelNVX(VkCommandBuffer commandBuffer, const VkCuLaunchInfoNVX* pLaunchInfo) {  };
-static VKAPI_ATTR uint32_t VKAPI_CALL StubGetImageViewHandleNVX(VkDevice device, const VkImageViewHandleInfoNVX* pInfo) { return 0; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetImageViewAddressNVX(VkDevice device, VkImageView imageView, VkImageViewAddressPropertiesNVX* pProperties) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetShaderInfoAMD(VkDevice device, VkPipeline pipeline, VkShaderStageFlagBits shaderStage, VkShaderInfoTypeAMD infoType, size_t* pInfoSize, void* pInfo) { return VK_SUCCESS; };
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetEvent2KHR(VkCommandBuffer                   commandBuffer, VkEvent                                             event, const VkDependencyInfo*                             pDependencyInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdResetEvent2KHR(VkCommandBuffer                   commandBuffer, VkEvent                                             event, VkPipelineStageFlags2               stageMask) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdWaitEvents2KHR(VkCommandBuffer                   commandBuffer, uint32_t                                            eventCount, const VkEvent*                     pEvents, const VkDependencyInfo*            pDependencyInfos) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdPipelineBarrier2KHR(VkCommandBuffer                   commandBuffer, const VkDependencyInfo*                             pDependencyInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdWriteTimestamp2KHR(VkCommandBuffer                   commandBuffer, VkPipelineStageFlags2               stage, VkQueryPool                                         queryPool, uint32_t                                            query) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubQueueSubmit2KHR(VkQueue                           queue, uint32_t                            submitCount, const VkSubmitInfo2*              pSubmits, VkFence           fence) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdWriteBufferMarker2AMD(VkCommandBuffer                   commandBuffer, VkPipelineStageFlags2               stage, VkBuffer                                            dstBuffer, VkDeviceSize                                        dstOffset, uint32_t                                            marker) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetQueueCheckpointData2NV(VkQueue queue, uint32_t* pCheckpointDataCount, VkCheckpointData2NV* pCheckpointData) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetDeviceBufferMemoryRequirementsKHR(VkDevice device, const VkDeviceBufferMemoryRequirements* pInfo, VkMemoryRequirements2* pMemoryRequirements) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetDeviceImageMemoryRequirementsKHR(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, VkMemoryRequirements2* pMemoryRequirements) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetDeviceImageSparseMemoryRequirementsKHR(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, uint32_t* pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2* pSparseMemoryRequirements) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT* pTagInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT* pNameInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount, const VkBuffer* pBuffers, const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers, const VkDeviceSize* pCounterBufferOffsets) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers, const VkDeviceSize* pCounterBufferOffsets) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query, VkQueryControlFlags flags, uint32_t index) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query, uint32_t index) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount, uint32_t firstInstance, VkBuffer counterBuffer, VkDeviceSize counterBufferOffset, uint32_t counterOffset, uint32_t vertexStride) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateCuModuleNVX(VkDevice device, const VkCuModuleCreateInfoNVX* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkCuModuleNVX* pModule) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateCuFunctionNVX(VkDevice device, const VkCuFunctionCreateInfoNVX* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkCuFunctionNVX* pFunction) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubDestroyCuModuleNVX(VkDevice device, VkCuModuleNVX module, const VkAllocationCallbacks* pAllocator) {  }
+static VKAPI_ATTR void VKAPI_CALL StubDestroyCuFunctionNVX(VkDevice device, VkCuFunctionNVX function, const VkAllocationCallbacks* pAllocator) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdCuLaunchKernelNVX(VkCommandBuffer commandBuffer, const VkCuLaunchInfoNVX* pLaunchInfo) {  }
+static VKAPI_ATTR uint32_t VKAPI_CALL StubGetImageViewHandleNVX(VkDevice device, const VkImageViewHandleInfoNVX* pInfo) { return 0; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetImageViewAddressNVX(VkDevice device, VkImageView imageView, VkImageViewAddressPropertiesNVX* pProperties) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetShaderInfoAMD(VkDevice device, VkPipeline pipeline, VkShaderStageFlagBits shaderStage, VkShaderInfoTypeAMD infoType, size_t* pInfoSize, void* pInfo) { return VK_SUCCESS; }
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryWin32HandleNV(VkDevice device, VkDeviceMemory memory, VkExternalMemoryHandleTypeFlagsNV handleType, HANDLE* pHandle) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryWin32HandleNV(VkDevice device, VkDeviceMemory memory, VkExternalMemoryHandleTypeFlagsNV handleType, HANDLE* pHandle) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR void VKAPI_CALL StubCmdBeginConditionalRenderingEXT(VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount, const VkViewportWScalingNV* pViewportWScalings) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubDisplayPowerControlEXT(VkDevice device, VkDisplayKHR display, const VkDisplayPowerInfoEXT* pDisplayPowerInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubRegisterDeviceEventEXT(VkDevice device, const VkDeviceEventInfoEXT* pDeviceEventInfo, const VkAllocationCallbacks* pAllocator, VkFence* pFence) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, const VkDisplayEventInfoEXT* pDisplayEventInfo, const VkAllocationCallbacks* pAllocator, VkFence* pFence) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchain, VkSurfaceCounterFlagBitsEXT counter, uint64_t* pCounterValue) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetRefreshCycleDurationGOOGLE(VkDevice device, VkSwapchainKHR swapchain, VkRefreshCycleDurationGOOGLE* pDisplayTimingProperties) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pPresentationTimingCount, VkPastPresentationTimingGOOGLE* pPresentationTimings) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle, uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles) {  };
-static VKAPI_ATTR void VKAPI_CALL StubSetHdrMetadataEXT(VkDevice device, uint32_t swapchainCount, const VkSwapchainKHR* pSwapchains, const VkHdrMetadataEXT* pMetadata) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdBeginConditionalRenderingEXT(VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount, const VkViewportWScalingNV* pViewportWScalings) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubDisplayPowerControlEXT(VkDevice device, VkDisplayKHR display, const VkDisplayPowerInfoEXT* pDisplayPowerInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubRegisterDeviceEventEXT(VkDevice device, const VkDeviceEventInfoEXT* pDeviceEventInfo, const VkAllocationCallbacks* pAllocator, VkFence* pFence) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, const VkDisplayEventInfoEXT* pDisplayEventInfo, const VkAllocationCallbacks* pAllocator, VkFence* pFence) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchain, VkSurfaceCounterFlagBitsEXT counter, uint64_t* pCounterValue) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetRefreshCycleDurationGOOGLE(VkDevice device, VkSwapchainKHR swapchain, VkRefreshCycleDurationGOOGLE* pDisplayTimingProperties) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pPresentationTimingCount, VkPastPresentationTimingGOOGLE* pPresentationTimings) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle, uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles) {  }
+static VKAPI_ATTR void VKAPI_CALL StubSetHdrMetadataEXT(VkDevice device, uint32_t swapchainCount, const VkSwapchainKHR* pSwapchains, const VkHdrMetadataEXT* pMetadata) {  }
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer, VkAndroidHardwareBufferPropertiesANDROID* pProperties) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer, VkAndroidHardwareBufferPropertiesANDROID* pProperties) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_ANDROID_KHR
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryAndroidHardwareBufferANDROID(VkDevice device, const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo, struct AHardwareBuffer** pBuffer) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryAndroidHardwareBufferANDROID(VkDevice device, const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo, struct AHardwareBuffer** pBuffer) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_ANDROID_KHR
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer, const VkSampleLocationsInfoEXT* pSampleLocationsInfo) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetImageDrmFormatModifierPropertiesEXT(VkDevice device, VkImage image, VkImageDrmFormatModifierPropertiesEXT* pProperties) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkValidationCacheEXT* pValidationCache) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubDestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache, const VkAllocationCallbacks* pAllocator) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubMergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT dstCache, uint32_t srcCacheCount, const VkValidationCacheEXT* pSrcCaches) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize, void* pData) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView, VkImageLayout imageLayout) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetViewportShadingRatePaletteNV(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount, const VkShadingRatePaletteNV* pShadingRatePalettes) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBuffer, VkCoarseSampleOrderTypeNV sampleOrderType, uint32_t customSampleOrderCount, const VkCoarseSampleOrderCustomNV* pCustomSampleOrders) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateAccelerationStructureNV(VkDevice device, const VkAccelerationStructureCreateInfoNV* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkAccelerationStructureNV* pAccelerationStructure) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubDestroyAccelerationStructureNV(VkDevice device, VkAccelerationStructureNV accelerationStructure, const VkAllocationCallbacks* pAllocator) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetAccelerationStructureMemoryRequirementsNV(VkDevice device, const VkAccelerationStructureMemoryRequirementsInfoNV* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount, const VkBindAccelerationStructureMemoryInfoNV* pBindInfos) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBuildAccelerationStructureNV(VkCommandBuffer commandBuffer, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkDeviceSize instanceOffset, VkBool32 update, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch, VkDeviceSize scratchOffset) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyAccelerationStructureNV(VkCommandBuffer commandBuffer, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkCopyAccelerationStructureModeKHR mode) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer, VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer, VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride, VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset, VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer, VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride, uint32_t width, uint32_t height, uint32_t depth) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkRayTracingPipelineCreateInfoNV* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetRayTracingShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetRayTracingShaderGroupHandlesNV(VkDevice device, VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetAccelerationStructureHandleNV(VkDevice device, VkAccelerationStructureNV accelerationStructure, size_t dataSize, void* pData) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdWriteAccelerationStructuresPropertiesNV(VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCompileDeferredNV(VkDevice device, VkPipeline pipeline, uint32_t shader) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryHostPointerPropertiesEXT(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, const void* pHostPointer, VkMemoryHostPointerPropertiesEXT* pMemoryHostPointerProperties) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage, VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT* pTimestampInfos, uint64_t* pTimestamps, uint64_t* pMaxDeviation) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount, uint32_t stride) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor, uint32_t exclusiveScissorCount, const VkRect2D* pExclusiveScissors) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetCheckpointNV(VkCommandBuffer commandBuffer, const void* pCheckpointMarker) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetQueueCheckpointDataNV(VkQueue queue, uint32_t* pCheckpointDataCount, VkCheckpointDataNV* pCheckpointData) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubInitializePerformanceApiINTEL(VkDevice device, const VkInitializePerformanceApiInfoINTEL* pInitializeInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubUninitializePerformanceApiINTEL(VkDevice device) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCmdSetPerformanceMarkerINTEL(VkCommandBuffer commandBuffer, const VkPerformanceMarkerInfoINTEL* pMarkerInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCmdSetPerformanceStreamMarkerINTEL(VkCommandBuffer commandBuffer, const VkPerformanceStreamMarkerInfoINTEL* pMarkerInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCmdSetPerformanceOverrideINTEL(VkCommandBuffer commandBuffer, const VkPerformanceOverrideInfoINTEL* pOverrideInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubAcquirePerformanceConfigurationINTEL(VkDevice device, const VkPerformanceConfigurationAcquireInfoINTEL* pAcquireInfo, VkPerformanceConfigurationINTEL* pConfiguration) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubReleasePerformanceConfigurationINTEL(VkDevice device, VkPerformanceConfigurationINTEL configuration) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubQueueSetPerformanceConfigurationINTEL(VkQueue queue, VkPerformanceConfigurationINTEL configuration) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetPerformanceParameterINTEL(VkDevice device, VkPerformanceParameterTypeINTEL parameter, VkPerformanceValueINTEL* pValue) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubSetLocalDimmingAMD(VkDevice device, VkSwapchainKHR swapChain, VkBool32 localDimmingEnable) {  };
-static VKAPI_ATTR VkDeviceAddress VKAPI_CALL StubGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfo* pInfo) { return 0L; };
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer, const VkSampleLocationsInfoEXT* pSampleLocationsInfo) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetImageDrmFormatModifierPropertiesEXT(VkDevice device, VkImage image, VkImageDrmFormatModifierPropertiesEXT* pProperties) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkValidationCacheEXT* pValidationCache) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubDestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache, const VkAllocationCallbacks* pAllocator) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubMergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT dstCache, uint32_t srcCacheCount, const VkValidationCacheEXT* pSrcCaches) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize, void* pData) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView, VkImageLayout imageLayout) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetViewportShadingRatePaletteNV(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount, const VkShadingRatePaletteNV* pShadingRatePalettes) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBuffer, VkCoarseSampleOrderTypeNV sampleOrderType, uint32_t customSampleOrderCount, const VkCoarseSampleOrderCustomNV* pCustomSampleOrders) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateAccelerationStructureNV(VkDevice device, const VkAccelerationStructureCreateInfoNV* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkAccelerationStructureNV* pAccelerationStructure) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubDestroyAccelerationStructureNV(VkDevice device, VkAccelerationStructureNV accelerationStructure, const VkAllocationCallbacks* pAllocator) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetAccelerationStructureMemoryRequirementsNV(VkDevice device, const VkAccelerationStructureMemoryRequirementsInfoNV* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount, const VkBindAccelerationStructureMemoryInfoNV* pBindInfos) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBuildAccelerationStructureNV(VkCommandBuffer commandBuffer, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkDeviceSize instanceOffset, VkBool32 update, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch, VkDeviceSize scratchOffset) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyAccelerationStructureNV(VkCommandBuffer commandBuffer, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkCopyAccelerationStructureModeKHR mode) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer, VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer, VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride, VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset, VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer, VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride, uint32_t width, uint32_t height, uint32_t depth) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkRayTracingPipelineCreateInfoNV* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetRayTracingShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetRayTracingShaderGroupHandlesNV(VkDevice device, VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetAccelerationStructureHandleNV(VkDevice device, VkAccelerationStructureNV accelerationStructure, size_t dataSize, void* pData) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdWriteAccelerationStructuresPropertiesNV(VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCompileDeferredNV(VkDevice device, VkPipeline pipeline, uint32_t shader) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryHostPointerPropertiesEXT(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, const void* pHostPointer, VkMemoryHostPointerPropertiesEXT* pMemoryHostPointerProperties) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage, VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT* pTimestampInfos, uint64_t* pTimestamps, uint64_t* pMaxDeviation) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount, uint32_t stride) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor, uint32_t exclusiveScissorCount, const VkRect2D* pExclusiveScissors) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetCheckpointNV(VkCommandBuffer commandBuffer, const void* pCheckpointMarker) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetQueueCheckpointDataNV(VkQueue queue, uint32_t* pCheckpointDataCount, VkCheckpointDataNV* pCheckpointData) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubInitializePerformanceApiINTEL(VkDevice device, const VkInitializePerformanceApiInfoINTEL* pInitializeInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubUninitializePerformanceApiINTEL(VkDevice device) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCmdSetPerformanceMarkerINTEL(VkCommandBuffer commandBuffer, const VkPerformanceMarkerInfoINTEL* pMarkerInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCmdSetPerformanceStreamMarkerINTEL(VkCommandBuffer commandBuffer, const VkPerformanceStreamMarkerInfoINTEL* pMarkerInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCmdSetPerformanceOverrideINTEL(VkCommandBuffer commandBuffer, const VkPerformanceOverrideInfoINTEL* pOverrideInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubAcquirePerformanceConfigurationINTEL(VkDevice device, const VkPerformanceConfigurationAcquireInfoINTEL* pAcquireInfo, VkPerformanceConfigurationINTEL* pConfiguration) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubReleasePerformanceConfigurationINTEL(VkDevice device, VkPerformanceConfigurationINTEL configuration) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubQueueSetPerformanceConfigurationINTEL(VkQueue queue, VkPerformanceConfigurationINTEL configuration) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetPerformanceParameterINTEL(VkDevice device, VkPerformanceParameterTypeINTEL parameter, VkPerformanceValueINTEL* pValue) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubSetLocalDimmingAMD(VkDevice device, VkSwapchainKHR swapChain, VkBool32 localDimmingEnable) {  }
+static VKAPI_ATTR VkDeviceAddress VKAPI_CALL StubGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfo* pInfo) { return 0L; }
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_WIN32_KHR
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_WIN32_KHR
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetDeviceGroupSurfacePresentModes2EXT(VkDevice device, const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, VkDeviceGroupPresentModeFlagsKHR* pModes) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetDeviceGroupSurfacePresentModes2EXT(VkDevice device, const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, VkDeviceGroupPresentModeFlagsKHR* pModes) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_WIN32_KHR
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor, uint16_t lineStipplePattern) {  };
-static VKAPI_ATTR void VKAPI_CALL StubResetQueryPoolEXT(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount, const VkViewport* pViewports) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, uint32_t scissorCount, const VkRect2D* pScissors) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBindVertexBuffers2EXT(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount, const VkBuffer* pBuffers, const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes, const VkDeviceSize* pStrides) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp, VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetGeneratedCommandsMemoryRequirementsNV(VkDevice device, const VkGeneratedCommandsMemoryRequirementsInfoNV* pInfo, VkMemoryRequirements2* pMemoryRequirements) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdPreprocessGeneratedCommandsNV(VkCommandBuffer commandBuffer, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdExecuteGeneratedCommandsNV(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline, uint32_t groupIndex) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateIndirectCommandsLayoutNV(VkDevice device, const VkIndirectCommandsLayoutCreateInfoNV* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkIndirectCommandsLayoutNV* pIndirectCommandsLayout) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubDestroyIndirectCommandsLayoutNV(VkDevice device, VkIndirectCommandsLayoutNV indirectCommandsLayout, const VkAllocationCallbacks* pAllocator) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreatePrivateDataSlotEXT(VkDevice device, const VkPrivateDataSlotCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkPrivateDataSlot* pPrivateDataSlot) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubDestroyPrivateDataSlotEXT(VkDevice device, VkPrivateDataSlot privateDataSlot, const VkAllocationCallbacks* pAllocator) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubSetPrivateDataEXT(VkDevice device, VkObjectType objectType, uint64_t objectHandle, VkPrivateDataSlot privateDataSlot, uint64_t data) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubGetPrivateDataEXT(VkDevice device, VkObjectType objectType, uint64_t objectHandle, VkPrivateDataSlot privateDataSlot, uint64_t* pData) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetFragmentShadingRateEnumNV(VkCommandBuffer           commandBuffer, VkFragmentShadingRateNV                     shadingRate, const VkFragmentShadingRateCombinerOpKHR    combinerOps[2]) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetVertexInputEXT(VkCommandBuffer commandBuffer, uint32_t vertexBindingDescriptionCount, const VkVertexInputBindingDescription2EXT* pVertexBindingDescriptions, uint32_t vertexAttributeDescriptionCount, const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor, uint16_t lineStipplePattern) {  }
+static VKAPI_ATTR void VKAPI_CALL StubResetQueryPoolEXT(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount, const VkViewport* pViewports) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, uint32_t scissorCount, const VkRect2D* pScissors) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBindVertexBuffers2EXT(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount, const VkBuffer* pBuffers, const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes, const VkDeviceSize* pStrides) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp, VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetGeneratedCommandsMemoryRequirementsNV(VkDevice device, const VkGeneratedCommandsMemoryRequirementsInfoNV* pInfo, VkMemoryRequirements2* pMemoryRequirements) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdPreprocessGeneratedCommandsNV(VkCommandBuffer commandBuffer, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdExecuteGeneratedCommandsNV(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed, const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline, uint32_t groupIndex) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateIndirectCommandsLayoutNV(VkDevice device, const VkIndirectCommandsLayoutCreateInfoNV* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkIndirectCommandsLayoutNV* pIndirectCommandsLayout) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubDestroyIndirectCommandsLayoutNV(VkDevice device, VkIndirectCommandsLayoutNV indirectCommandsLayout, const VkAllocationCallbacks* pAllocator) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreatePrivateDataSlotEXT(VkDevice device, const VkPrivateDataSlotCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkPrivateDataSlot* pPrivateDataSlot) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubDestroyPrivateDataSlotEXT(VkDevice device, VkPrivateDataSlot privateDataSlot, const VkAllocationCallbacks* pAllocator) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubSetPrivateDataEXT(VkDevice device, VkObjectType objectType, uint64_t objectHandle, VkPrivateDataSlot privateDataSlot, uint64_t data) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubGetPrivateDataEXT(VkDevice device, VkObjectType objectType, uint64_t objectHandle, VkPrivateDataSlot privateDataSlot, uint64_t* pData) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetFragmentShadingRateEnumNV(VkCommandBuffer           commandBuffer, VkFragmentShadingRateNV                     shadingRate, const VkFragmentShadingRateCombinerOpKHR    combinerOps[2]) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetVertexInputEXT(VkCommandBuffer commandBuffer, uint32_t vertexBindingDescriptionCount, const VkVertexInputBindingDescription2EXT* pVertexBindingDescriptions, uint32_t vertexAttributeDescriptionCount, const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions) {  }
 #ifdef VK_USE_PLATFORM_FUCHSIA
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryZirconHandleFUCHSIA(VkDevice device, const VkMemoryGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo, zx_handle_t* pZirconHandle) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryZirconHandleFUCHSIA(VkDevice device, const VkMemoryGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo, zx_handle_t* pZirconHandle) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_FUCHSIA
 #ifdef VK_USE_PLATFORM_FUCHSIA
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryZirconHandlePropertiesFUCHSIA(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, zx_handle_t zirconHandle, VkMemoryZirconHandlePropertiesFUCHSIA* pMemoryZirconHandleProperties) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryZirconHandlePropertiesFUCHSIA(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, zx_handle_t zirconHandle, VkMemoryZirconHandlePropertiesFUCHSIA* pMemoryZirconHandleProperties) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_FUCHSIA
 #ifdef VK_USE_PLATFORM_FUCHSIA
-static VKAPI_ATTR VkResult VKAPI_CALL StubImportSemaphoreZirconHandleFUCHSIA(VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubImportSemaphoreZirconHandleFUCHSIA(VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_FUCHSIA
 #ifdef VK_USE_PLATFORM_FUCHSIA
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetSemaphoreZirconHandleFUCHSIA(VkDevice device, const VkSemaphoreGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo, zx_handle_t* pZirconHandle) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetSemaphoreZirconHandleFUCHSIA(VkDevice device, const VkSemaphoreGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo, zx_handle_t* pZirconHandle) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_FUCHSIA
 #ifdef VK_USE_PLATFORM_FUCHSIA
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateBufferCollectionFUCHSIA(VkDevice device, const VkBufferCollectionCreateInfoFUCHSIA* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkBufferCollectionFUCHSIA* pCollection) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateBufferCollectionFUCHSIA(VkDevice device, const VkBufferCollectionCreateInfoFUCHSIA* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkBufferCollectionFUCHSIA* pCollection) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_FUCHSIA
 #ifdef VK_USE_PLATFORM_FUCHSIA
-static VKAPI_ATTR VkResult VKAPI_CALL StubSetBufferCollectionImageConstraintsFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection, const VkImageConstraintsInfoFUCHSIA* pImageConstraintsInfo) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubSetBufferCollectionImageConstraintsFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection, const VkImageConstraintsInfoFUCHSIA* pImageConstraintsInfo) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_FUCHSIA
 #ifdef VK_USE_PLATFORM_FUCHSIA
-static VKAPI_ATTR VkResult VKAPI_CALL StubSetBufferCollectionBufferConstraintsFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection, const VkBufferConstraintsInfoFUCHSIA* pBufferConstraintsInfo) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubSetBufferCollectionBufferConstraintsFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection, const VkBufferConstraintsInfoFUCHSIA* pBufferConstraintsInfo) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_FUCHSIA
 #ifdef VK_USE_PLATFORM_FUCHSIA
-static VKAPI_ATTR void VKAPI_CALL StubDestroyBufferCollectionFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection, const VkAllocationCallbacks* pAllocator) {  };
+static VKAPI_ATTR void VKAPI_CALL StubDestroyBufferCollectionFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection, const VkAllocationCallbacks* pAllocator) {  }
 #endif // VK_USE_PLATFORM_FUCHSIA
 #ifdef VK_USE_PLATFORM_FUCHSIA
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetBufferCollectionPropertiesFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection, VkBufferCollectionPropertiesFUCHSIA* pProperties) { return VK_SUCCESS; };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetBufferCollectionPropertiesFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection, VkBufferCollectionPropertiesFUCHSIA* pProperties) { return VK_SUCCESS; }
 #endif // VK_USE_PLATFORM_FUCHSIA
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(VkDevice device, VkRenderPass renderpass, VkExtent2D* pMaxWorkgroupSize) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, VkImageView imageView, VkImageLayout imageLayout) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryRemoteAddressNV(VkDevice device, const VkMemoryGetRemoteAddressInfoNV* pMemoryGetRemoteAddressInfo, VkRemoteAddressNV* pAddress) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetPatchControlPointsEXT(VkCommandBuffer commandBuffer, uint32_t patchControlPoints) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp logicOp) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetColorWriteEnableEXT(VkCommandBuffer       commandBuffer, uint32_t                                attachmentCount, const VkBool32*   pColorWriteEnables) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount, const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount, uint32_t firstInstance, uint32_t stride) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount, const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount, uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset) {  };
-static VKAPI_ATTR void VKAPI_CALL StubSetDeviceMemoryPriorityEXT(VkDevice       device, VkDeviceMemory memory, float          priority) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetDescriptorSetLayoutHostMappingInfoVALVE(VkDevice device, const VkDescriptorSetBindingReferenceVALVE* pBindingReference, VkDescriptorSetLayoutHostMappingInfoVALVE* pHostMapping) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetDescriptorSetHostMappingVALVE(VkDevice device, VkDescriptorSet descriptorSet, void** ppData) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateAccelerationStructureKHR(VkDevice                                           device, const VkAccelerationStructureCreateInfoKHR*        pCreateInfo, const VkAllocationCallbacks*       pAllocator, VkAccelerationStructureKHR*                        pAccelerationStructure) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubDestroyAccelerationStructureKHR(VkDevice device, VkAccelerationStructureKHR accelerationStructure, const VkAllocationCallbacks* pAllocator) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBuildAccelerationStructuresKHR(VkCommandBuffer                                    commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos, const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBuildAccelerationStructuresIndirectKHR(VkCommandBuffer                  commandBuffer, uint32_t                                           infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos, const VkDeviceAddress*             pIndirectDeviceAddresses, const uint32_t*                    pIndirectStrides, const uint32_t* const*             ppMaxPrimitiveCounts) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubBuildAccelerationStructuresKHR(VkDevice                                           device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos, const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation, const VkCopyAccelerationStructureInfoKHR* pInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCopyAccelerationStructureToMemoryKHR(VkDevice device, VkDeferredOperationKHR deferredOperation, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCopyMemoryToAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubWriteAccelerationStructuresPropertiesKHR(VkDevice device, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryType  queryType, size_t       dataSize, void* pData, size_t stride) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer, const VkCopyAccelerationStructureInfoKHR* pInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) {  };
-static VKAPI_ATTR VkDeviceAddress VKAPI_CALL StubGetAccelerationStructureDeviceAddressKHR(VkDevice device, const VkAccelerationStructureDeviceAddressInfoKHR* pInfo) { return 0L; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdWriteAccelerationStructuresPropertiesKHR(VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetDeviceAccelerationStructureCompatibilityKHR(VkDevice device, const VkAccelerationStructureVersionInfoKHR* pVersionInfo, VkAccelerationStructureCompatibilityKHR* pCompatibility) {  };
-static VKAPI_ATTR void VKAPI_CALL StubGetAccelerationStructureBuildSizesKHR(VkDevice                                            device, VkAccelerationStructureBuildTypeKHR                 buildType, const VkAccelerationStructureBuildGeometryInfoKHR*  pBuildInfo, const uint32_t*  pMaxPrimitiveCounts, VkAccelerationStructureBuildSizesInfoKHR*           pSizeInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdTraceRaysKHR(VkCommandBuffer commandBuffer, const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, uint32_t width, uint32_t height, uint32_t depth) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkRayTracingPipelineCreateInfoKHR* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines) { return VK_SUCCESS; };
-static VKAPI_ATTR VkResult VKAPI_CALL StubGetRayTracingCaptureReplayShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer, const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, VkDeviceAddress indirectDeviceAddress) {  };
-static VKAPI_ATTR VkDeviceSize VKAPI_CALL StubGetRayTracingShaderGroupStackSizeKHR(VkDevice device, VkPipeline pipeline, uint32_t group, VkShaderGroupShaderKHR groupShader) { return 0L; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer, uint32_t pipelineStackSize) {  };
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(VkDevice device, VkRenderPass renderpass, VkExtent2D* pMaxWorkgroupSize) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, VkImageView imageView, VkImageLayout imageLayout) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetMemoryRemoteAddressNV(VkDevice device, const VkMemoryGetRemoteAddressInfoNV* pMemoryGetRemoteAddressInfo, VkRemoteAddressNV* pAddress) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetPatchControlPointsEXT(VkCommandBuffer commandBuffer, uint32_t patchControlPoints) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp logicOp) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetColorWriteEnableEXT(VkCommandBuffer       commandBuffer, uint32_t                                attachmentCount, const VkBool32*   pColorWriteEnables) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount, const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount, uint32_t firstInstance, uint32_t stride) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount, const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount, uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset) {  }
+static VKAPI_ATTR void VKAPI_CALL StubSetDeviceMemoryPriorityEXT(VkDevice       device, VkDeviceMemory memory, float          priority) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetDescriptorSetLayoutHostMappingInfoVALVE(VkDevice device, const VkDescriptorSetBindingReferenceVALVE* pBindingReference, VkDescriptorSetLayoutHostMappingInfoVALVE* pHostMapping) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetDescriptorSetHostMappingVALVE(VkDevice device, VkDescriptorSet descriptorSet, void** ppData) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateAccelerationStructureKHR(VkDevice                                           device, const VkAccelerationStructureCreateInfoKHR*        pCreateInfo, const VkAllocationCallbacks*       pAllocator, VkAccelerationStructureKHR*                        pAccelerationStructure) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubDestroyAccelerationStructureKHR(VkDevice device, VkAccelerationStructureKHR accelerationStructure, const VkAllocationCallbacks* pAllocator) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBuildAccelerationStructuresKHR(VkCommandBuffer                                    commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos, const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdBuildAccelerationStructuresIndirectKHR(VkCommandBuffer                  commandBuffer, uint32_t                                           infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos, const VkDeviceAddress*             pIndirectDeviceAddresses, const uint32_t*                    pIndirectStrides, const uint32_t* const*             ppMaxPrimitiveCounts) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubBuildAccelerationStructuresKHR(VkDevice                                           device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos, const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation, const VkCopyAccelerationStructureInfoKHR* pInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCopyAccelerationStructureToMemoryKHR(VkDevice device, VkDeferredOperationKHR deferredOperation, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCopyMemoryToAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubWriteAccelerationStructuresPropertiesKHR(VkDevice device, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryType  queryType, size_t       dataSize, void* pData, size_t stride) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer, const VkCopyAccelerationStructureInfoKHR* pInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer, const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer, const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo) {  }
+static VKAPI_ATTR VkDeviceAddress VKAPI_CALL StubGetAccelerationStructureDeviceAddressKHR(VkDevice device, const VkAccelerationStructureDeviceAddressInfoKHR* pInfo) { return 0L; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdWriteAccelerationStructuresPropertiesKHR(VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures, VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetDeviceAccelerationStructureCompatibilityKHR(VkDevice device, const VkAccelerationStructureVersionInfoKHR* pVersionInfo, VkAccelerationStructureCompatibilityKHR* pCompatibility) {  }
+static VKAPI_ATTR void VKAPI_CALL StubGetAccelerationStructureBuildSizesKHR(VkDevice                                            device, VkAccelerationStructureBuildTypeKHR                 buildType, const VkAccelerationStructureBuildGeometryInfoKHR*  pBuildInfo, const uint32_t*  pMaxPrimitiveCounts, VkAccelerationStructureBuildSizesInfoKHR*           pSizeInfo) {  }
+static VKAPI_ATTR void VKAPI_CALL StubCmdTraceRaysKHR(VkCommandBuffer commandBuffer, const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, uint32_t width, uint32_t height, uint32_t depth) {  }
+static VKAPI_ATTR VkResult VKAPI_CALL StubCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkRayTracingPipelineCreateInfoKHR* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetRayTracingCaptureReplayShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData) { return VK_SUCCESS; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer, const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable, const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, VkDeviceAddress indirectDeviceAddress) {  }
+static VKAPI_ATTR VkDeviceSize VKAPI_CALL StubGetRayTracingShaderGroupStackSizeKHR(VkDevice device, VkPipeline pipeline, uint32_t group, VkShaderGroupShaderKHR groupShader) { return 0L; }
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer, uint32_t pipelineStackSize) {  }
 
 
 

--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -473,22 +473,19 @@ struct loader_icd_term_dispatch {
 #endif // VK_USE_PLATFORM_SCREEN_QNX
 };
 
-union loader_instance_extension_enables {
-    struct {
-        uint8_t khr_get_physical_device_properties2 : 1;
-        uint8_t khr_device_group_creation : 1;
-        uint8_t khr_external_memory_capabilities : 1;
-        uint8_t khr_external_semaphore_capabilities : 1;
-        uint8_t khr_external_fence_capabilities : 1;
-        uint8_t ext_debug_report : 1;
-        uint8_t nv_external_memory_capabilities : 1;
-        uint8_t ext_direct_mode_display : 1;
-        uint8_t ext_acquire_xlib_display : 1;
-        uint8_t ext_display_surface_counter : 1;
-        uint8_t ext_debug_utils : 1;
-        uint8_t ext_acquire_drm_display : 1;
-    };
-    uint64_t padding[4];
+struct loader_instance_extension_enables {
+    uint8_t khr_get_physical_device_properties2;
+    uint8_t khr_device_group_creation;
+    uint8_t khr_external_memory_capabilities;
+    uint8_t khr_external_semaphore_capabilities;
+    uint8_t khr_external_fence_capabilities;
+    uint8_t ext_debug_report;
+    uint8_t nv_external_memory_capabilities;
+    uint8_t ext_direct_mode_display;
+    uint8_t ext_acquire_xlib_display;
+    uint8_t ext_display_surface_counter;
+    uint8_t ext_debug_utils;
+    uint8_t ext_acquire_drm_display;
 };
 
 

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -39,15 +39,15 @@ typedef enum VkStringErrorFlagBits {
 } VkStringErrorFlagBits;
 typedef VkFlags VkStringErrorFlags;
 
-static const int MaxLoaderStringLength = 256;
-static const char UTF8_ONE_BYTE_CODE = 0xC0;
-static const char UTF8_ONE_BYTE_MASK = 0xE0;
-static const char UTF8_TWO_BYTE_CODE = 0xE0;
-static const char UTF8_TWO_BYTE_MASK = 0xF0;
-static const char UTF8_THREE_BYTE_CODE = 0xF0;
-static const char UTF8_THREE_BYTE_MASK = 0xF8;
-static const char UTF8_DATA_BYTE_CODE = 0x80;
-static const char UTF8_DATA_BYTE_MASK = 0xC0;
+static const int MaxLoaderStringLength = 256;           // 0xFF;
+static const unsigned char UTF8_ONE_BYTE_CODE = 192;    // 0xC0;
+static const unsigned char UTF8_ONE_BYTE_MASK = 224;    // 0xE0;
+static const unsigned char UTF8_TWO_BYTE_CODE = 224;    // 0xE0;
+static const unsigned char UTF8_TWO_BYTE_MASK = 240;    // 0xF0;
+static const unsigned char UTF8_THREE_BYTE_CODE = 240;  // 0xF0;
+static const unsigned char UTF8_THREE_BYTE_MASK = 248;  // 0xF8;
+static const unsigned char UTF8_DATA_BYTE_CODE = 128;   // 0x80;
+static const unsigned char UTF8_DATA_BYTE_MASK = 192;   // 0xC0;
 
 // form of all dynamic lists/arrays
 // only the list element should be changed
@@ -281,7 +281,7 @@ struct loader_instance {
     VkInstance instance;  // layers/ICD instance returned to trampoline
 
     struct loader_extension_list ext_list;  // icds and loaders extensions
-    union loader_instance_extension_enables enabled_known_extensions;
+    struct loader_instance_extension_enables enabled_known_extensions;
 
     VkLayerDbgFunctionNode *DbgFunctionHead;
     uint32_t num_tmp_report_callbacks;

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -346,7 +346,7 @@ VkResult windows_get_registry_files(const struct loader_instance *inst, char *lo
     // specified. This does disallow other vendors, but any new driver should use the device-specific registries anyway.
     static const struct {
         const char *filename;
-        int vendor_id;
+        unsigned int vendor_id;
     } known_drivers[] = {
 #if defined(_WIN64)
         {
@@ -455,7 +455,7 @@ VkResult windows_get_registry_files(const struct loader_instance *inst, char *lo
                                hive == DEFAULT_VK_REGISTRY_HIVE ? DEFAULT_VK_REGISTRY_HIVE_STR : SECONDARY_VK_REGISTRY_HIVE_STR,
                                location);
                     if (is_driver) {
-                        int i;
+                        uint32_t i = 0;
                         for (i = 0; i < sizeof(known_drivers) / sizeof(known_drivers[0]); ++i) {
                             if (!strcmp(name + strlen(name) - strlen(known_drivers[i].filename), known_drivers[i].filename)) {
                                 break;
@@ -607,12 +607,11 @@ VkResult windows_read_manifest_from_d3d_adapters(const struct loader_instance *i
             .physical_adapter_index = 0,
         };
         wcsncpy(filename_info.value_name, value_name, sizeof(filename_info.value_name) / sizeof(WCHAR));
-        LoaderQueryAdapterInfo query_info = {
-            .handle = adapters.adapters[i].handle,
-            .type = LOADER_QUERY_TYPE_REGISTRY,
-            .private_data = &filename_info,
-            .private_data_size = sizeof(filename_info),
-        };
+        LoaderQueryAdapterInfo query_info;
+        query_info.handle = adapters.adapters[i].handle;
+        query_info.type = LOADER_QUERY_TYPE_REGISTRY;
+        query_info.private_data = &filename_info;
+        query_info.private_data_size = sizeof(filename_info);
         status = fpLoaderQueryAdapterInfo(&query_info);
 
         // This error indicates that the type didn't match, so we'll try a REG_SZ

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -37,6 +37,7 @@
 #include <assert.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #if defined(__Fuchsia__)
 #include "dlopen_fuchsia.h"
@@ -96,7 +97,7 @@
 #endif
 
 // Environment Variable information
-#define VK_ICD_FILENAMES_ENV_VAR "VK_ICD_FILENAMES" // Deprecated
+#define VK_ICD_FILENAMES_ENV_VAR "VK_ICD_FILENAMES"  // Deprecated
 #define VK_DRIVER_FILES_ENV_VAR "VK_DRIVER_FILES"
 #define VK_ADDITIONAL_DRIVER_FILES_ENV_VAR "VK_ADD_DRIVER_FILES"
 #define VK_LAYER_PATH_ENV_VAR "VK_LAYER_PATH"
@@ -169,7 +170,7 @@ static inline char *loader_platform_executable_path(char *buffer, size_t size) {
     buffer[count] = '\0';
     return buffer;
 }
-#elif defined(__APPLE__) // defined(__linux__)
+#elif defined(__APPLE__)  // defined(__linux__)
 #include <libproc.h>
 static inline char *loader_platform_executable_path(char *buffer, size_t size) {
     pid_t pid = getpid();
@@ -193,8 +194,7 @@ static inline char *loader_platform_executable_path(char *buffer, size_t size) {
         -1,
 #endif
     };
-    if (sysctl(mib, sizeof(mib) / sizeof(mib[0]), buffer, &size, NULL, 0) < 0)
-        return NULL;
+    if (sysctl(mib, sizeof(mib) / sizeof(mib[0]), buffer, &size, NULL, 0) < 0) return NULL;
 
     return buffer;
 }

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -187,7 +187,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_DestroySurfaceKHR(VkInstance instance, VkS
                                                         const VkAllocationCallbacks *pAllocator) {
     struct loader_instance *loader_inst = loader_get_instance(instance);
 
-    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
+    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)(surface);
     if (NULL != icd_surface) {
         if (NULL != icd_surface->real_icd_surfaces) {
             uint32_t i = 0;
@@ -2160,9 +2160,9 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDevicePresentRectanglesKHR(
                    "ICD associated with VkPhysicalDevice does not support GetPhysicalDevicePresentRectanglesKHX");
         abort();
     }
-    VkIcdSurface *icd_surface = (VkIcdSurface *)(surface);
+    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)(surface);
     uint8_t icd_index = phys_dev_term->icd_index;
-    if (NULL != icd_surface->real_icd_surfaces && NULL != (void *)icd_surface->real_icd_surfaces[icd_index]) {
+    if (NULL != icd_surface->real_icd_surfaces && NULL != (void *)(uintptr_t)(icd_surface->real_icd_surfaces[icd_index])) {
         return icd_term->dispatch.GetPhysicalDevicePresentRectanglesKHR(
             phys_dev_term->phys_dev, icd_surface->real_icd_surfaces[icd_index], pRectCount, pRects);
     }
@@ -2496,7 +2496,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2K
         return VK_SUCCESS;
     }
 
-    VkIcdSurface *icd_surface = (VkIcdSurface *)(pSurfaceInfo->surface);
+    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)(pSurfaceInfo->surface);
     uint8_t icd_index = phys_dev_term->icd_index;
 
     if (icd_term->dispatch.GetPhysicalDeviceSurfaceCapabilities2KHR != NULL) {
@@ -2512,7 +2512,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2K
         }
 
         // Pass the call to the driver, possibly unwrapping the ICD surface
-        if (icd_surface->real_icd_surfaces != NULL && (void *)icd_surface->real_icd_surfaces[icd_index] != NULL) {
+        if (NULL != icd_surface->real_icd_surfaces && NULL != (void *)(uintptr_t)icd_surface->real_icd_surfaces[icd_index]) {
             VkPhysicalDeviceSurfaceInfo2KHR info_copy = *pSurfaceInfo;
             info_copy.surface = icd_surface->real_icd_surfaces[icd_index];
             return icd_term->dispatch.GetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev_term->phys_dev, &info_copy,
@@ -2536,7 +2536,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2K
 
         // Write to the VkSurfaceCapabilities2KHR struct
         VkSurfaceKHR surface = pSurfaceInfo->surface;
-        if (icd_surface->real_icd_surfaces != NULL && (void *)icd_surface->real_icd_surfaces[icd_index] != NULL) {
+        if (NULL != icd_surface->real_icd_surfaces && NULL != (void *)(uintptr_t)(icd_surface->real_icd_surfaces[icd_index])) {
             surface = icd_surface->real_icd_surfaces[icd_index];
         }
         VkResult res = icd_term->dispatch.GetPhysicalDeviceSurfaceCapabilitiesKHR(phys_dev_term->phys_dev, surface,
@@ -2580,12 +2580,12 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormats2KHR(Vk
         return VK_SUCCESS;
     }
 
-    VkIcdSurface *icd_surface = (VkIcdSurface *)(pSurfaceInfo->surface);
+    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)(pSurfaceInfo->surface);
     uint8_t icd_index = phys_dev_term->icd_index;
 
     if (icd_term->dispatch.GetPhysicalDeviceSurfaceFormats2KHR != NULL) {
         // Pass the call to the driver, possibly unwrapping the ICD surface
-        if (icd_surface->real_icd_surfaces != NULL && (void *)icd_surface->real_icd_surfaces[icd_index] != NULL) {
+        if (NULL != icd_surface->real_icd_surfaces && NULL != (void *)(uintptr_t)(icd_surface->real_icd_surfaces[icd_index])) {
             VkPhysicalDeviceSurfaceInfo2KHR info_copy = *pSurfaceInfo;
             info_copy.surface = icd_surface->real_icd_surfaces[icd_index];
             return icd_term->dispatch.GetPhysicalDeviceSurfaceFormats2KHR(phys_dev_term->phys_dev, &info_copy, pSurfaceFormatCount,
@@ -2607,7 +2607,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormats2KHR(Vk
         }
 
         VkSurfaceKHR surface = pSurfaceInfo->surface;
-        if (icd_surface->real_icd_surfaces != NULL && (void *)icd_surface->real_icd_surfaces[icd_index] != NULL) {
+        if (NULL != icd_surface->real_icd_surfaces && NULL != (void *)(uintptr_t)(icd_surface->real_icd_surfaces[icd_index])) {
             surface = icd_surface->real_icd_surfaces[icd_index];
         }
 

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -197,7 +197,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
                 decl = decl.split('*PFN_vk')[1]
                 decl = decl.replace(')(', '(')
                 decl = 'static VKAPI_ATTR ' + return_type + ' VKAPI_CALL Stub' + decl
-                func_body = ' { ' + return_statement + ' };'
+                func_body = ' { ' + return_statement + ' }'
                 decl = decl.replace (';', func_body)
                 if self.featureExtraProtect is not None:
                     self.dev_ext_stub_list.append('#ifdef %s' % self.featureExtraProtect)

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -706,17 +706,14 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
         extensions = self.instanceExtensions
 
         union = ''
-        union += 'union loader_instance_extension_enables {\n'
-        union += '    struct {\n'
+        union += 'struct loader_instance_extension_enables {\n'
         for ext in extensions:
             if ('VK_VERSION_' in ext.name or ext.name in WSI_EXT_NAMES or
                 ext.type == 'device' or ext.num_commands == 0):
                 continue
 
-            union += '        uint8_t %s : 1;\n' % ext.name[3:].lower()
+            union += '    uint8_t %s;\n' % ext.name[3:].lower()
 
-        union += '    };\n'
-        union += '    uint64_t padding[4];\n'
         union += '};\n\n'
         return union
 

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -44,6 +44,11 @@ if (UNIX)
     endif()
 endif()
 
+if (MSVC)
+# silence hidden class member warnings in test framework
+    target_compile_options(testing_framework_util PUBLIC /wd4458)
+endif()
+
 include(CMakeParseArguments)
 function(AddSharedLibrary LIBRARY_NAME)
     set(singleValueArgs DEF_FILE)

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -1474,7 +1474,6 @@ FRAMEWORK_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_icdGetInstanceProcA
     if (icd.called_vk_icd_gipa == CalledICDGIPA::not_called) icd.called_vk_icd_gipa = CalledICDGIPA::vk_icd_gipa;
 
     return base_get_instance_proc_addr(instance, pName);
-    return nullptr;
 }
 #else   // !TEST_ICD_EXPORT_ICD_GIPA
 FRAMEWORK_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* pName) {

--- a/tests/framework/layer/wrap_objects.cpp
+++ b/tests/framework/layer/wrap_objects.cpp
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include <string>
 #include <algorithm>
 #include <assert.h>
@@ -173,7 +174,8 @@ VKAPI_ATTR VkResult VKAPI_CALL wrap_vkCreateInstance(const VkInstanceCreateInfo 
     bool found = false;
     for (uint32_t layer = 0; layer < pCreateInfo->enabledLayerCount; ++layer) {
         std::string layer_name = pCreateInfo->ppEnabledLayerNames[layer];
-        std::transform(layer_name.begin(), layer_name.end(), layer_name.begin(), ::tolower);
+        std::transform(layer_name.begin(), layer_name.end(), layer_name.begin(),
+                       [](char c) { return static_cast<char>(::tolower(static_cast<char>(c))); });
         if (layer_name.find("wrap") != std::string::npos && layer_name.find("obj") != std::string::npos) {
             found = true;
             break;

--- a/tests/framework/shim/windows_shim.cpp
+++ b/tests/framework/shim/windows_shim.cpp
@@ -73,8 +73,8 @@ NTSTATUS APIENTRY ShimQueryAdapterInfo(const LoaderQueryAdapterInfo *query_info)
         return STATUS_INVALID_PARAMETER;
     }
     auto handle = query_info->handle;
-    auto &it = std::find_if(platform_shim.d3dkmt_adapters.begin(), platform_shim.d3dkmt_adapters.end(),
-                            [handle](const D3DKMT_Adapter &adapter) { return handle == adapter.hAdapter; });
+    auto it = std::find_if(platform_shim.d3dkmt_adapters.begin(), platform_shim.d3dkmt_adapters.end(),
+                           [handle](D3DKMT_Adapter const &adapter) { return handle == adapter.hAdapter; });
     if (it == platform_shim.d3dkmt_adapters.end()) {
         return STATUS_INVALID_PARAMETER;
     }
@@ -404,23 +404,23 @@ void WINAPI DetourFunctions() {
 
     DetourTransactionBegin();
     DetourUpdateThread(GetCurrentThread());
-    DetourAttach(&(PVOID &)fpGetSidSubAuthority, ShimGetSidSubAuthority);
-    DetourAttach(&(PVOID &)fpEnumAdapters2, ShimEnumAdapters2);
-    DetourAttach(&(PVOID &)fpQueryAdapterInfo, ShimQueryAdapterInfo);
-    DetourAttach(&(PVOID &)REAL_CM_Get_Device_ID_List_SizeW, SHIM_CM_Get_Device_ID_List_SizeW);
-    DetourAttach(&(PVOID &)REAL_CM_Get_Device_ID_ListW, SHIM_CM_Get_Device_ID_ListW);
-    DetourAttach(&(PVOID &)REAL_CM_Get_Device_ID_ListW, SHIM_CM_Get_Device_ID_ListW);
-    DetourAttach(&(PVOID &)REAL_CM_Locate_DevNodeW, SHIM_CM_Locate_DevNodeW);
-    DetourAttach(&(PVOID &)REAL_CM_Get_DevNode_Status, SHIM_CM_Get_DevNode_Status);
-    DetourAttach(&(PVOID &)REAL_CM_Get_Device_IDW, SHIM_CM_Get_Device_IDW);
-    DetourAttach(&(PVOID &)REAL_CM_Get_Child, SHIM_CM_Get_Child);
-    DetourAttach(&(PVOID &)REAL_CM_Get_DevNode_Registry_PropertyW, SHIM_CM_Get_DevNode_Registry_PropertyW);
-    DetourAttach(&(PVOID &)REAL_CM_Get_Sibling, SHIM_CM_Get_Sibling);
-    DetourAttach(&(PVOID &)RealCreateDXGIFactory1, ShimCreateDXGIFactory1);
-    DetourAttach(&(PVOID &)fpRegOpenKeyExA, ShimRegOpenKeyExA);
-    DetourAttach(&(PVOID &)fpRegQueryValueExA, ShimRegQueryValueExA);
-    DetourAttach(&(PVOID &)fpRegEnumValueA, ShimRegEnumValueA);
-    DetourAttach(&(PVOID &)fpRegCloseKey, ShimRegCloseKey);
+    DetourAttach(&(PVOID &)fpGetSidSubAuthority, (PVOID)ShimGetSidSubAuthority);
+    DetourAttach(&(PVOID &)fpEnumAdapters2, (PVOID)ShimEnumAdapters2);
+    DetourAttach(&(PVOID &)fpQueryAdapterInfo, (PVOID)ShimQueryAdapterInfo);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Device_ID_List_SizeW, (PVOID)SHIM_CM_Get_Device_ID_List_SizeW);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Device_ID_ListW, (PVOID)SHIM_CM_Get_Device_ID_ListW);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Device_ID_ListW, (PVOID)SHIM_CM_Get_Device_ID_ListW);
+    DetourAttach(&(PVOID &)REAL_CM_Locate_DevNodeW, (PVOID)SHIM_CM_Locate_DevNodeW);
+    DetourAttach(&(PVOID &)REAL_CM_Get_DevNode_Status, (PVOID)SHIM_CM_Get_DevNode_Status);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Device_IDW, (PVOID)SHIM_CM_Get_Device_IDW);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Child, (PVOID)SHIM_CM_Get_Child);
+    DetourAttach(&(PVOID &)REAL_CM_Get_DevNode_Registry_PropertyW, (PVOID)SHIM_CM_Get_DevNode_Registry_PropertyW);
+    DetourAttach(&(PVOID &)REAL_CM_Get_Sibling, (PVOID)SHIM_CM_Get_Sibling);
+    DetourAttach(&(PVOID &)RealCreateDXGIFactory1, (PVOID)ShimCreateDXGIFactory1);
+    DetourAttach(&(PVOID &)fpRegOpenKeyExA, (PVOID)ShimRegOpenKeyExA);
+    DetourAttach(&(PVOID &)fpRegQueryValueExA, (PVOID)ShimRegQueryValueExA);
+    DetourAttach(&(PVOID &)fpRegEnumValueA, (PVOID)ShimRegEnumValueA);
+    DetourAttach(&(PVOID &)fpRegCloseKey, (PVOID)ShimRegCloseKey);
     LONG error = DetourTransactionCommit();
 
     if (error != NO_ERROR) {
@@ -432,22 +432,22 @@ void WINAPI DetourFunctions() {
 void DetachFunctions() {
     DetourTransactionBegin();
     DetourUpdateThread(GetCurrentThread());
-    DetourDetach(&(PVOID &)fpGetSidSubAuthority, ShimGetSidSubAuthority);
-    DetourDetach(&(PVOID &)fpEnumAdapters2, ShimEnumAdapters2);
-    DetourDetach(&(PVOID &)fpQueryAdapterInfo, ShimQueryAdapterInfo);
-    DetourDetach(&(PVOID &)REAL_CM_Get_Device_ID_List_SizeW, SHIM_CM_Get_Device_ID_List_SizeW);
-    DetourDetach(&(PVOID &)REAL_CM_Get_Device_ID_ListW, SHIM_CM_Get_Device_ID_ListW);
-    DetourDetach(&(PVOID &)REAL_CM_Locate_DevNodeW, SHIM_CM_Locate_DevNodeW);
-    DetourDetach(&(PVOID &)REAL_CM_Get_DevNode_Status, SHIM_CM_Get_DevNode_Status);
-    DetourDetach(&(PVOID &)REAL_CM_Get_Device_IDW, SHIM_CM_Get_Device_IDW);
-    DetourDetach(&(PVOID &)REAL_CM_Get_Child, SHIM_CM_Get_Child);
-    DetourDetach(&(PVOID &)REAL_CM_Get_DevNode_Registry_PropertyW, SHIM_CM_Get_DevNode_Registry_PropertyW);
-    DetourDetach(&(PVOID &)REAL_CM_Get_Sibling, SHIM_CM_Get_Sibling);
-    DetourDetach(&(PVOID &)RealCreateDXGIFactory1, ShimCreateDXGIFactory1);
-    DetourDetach(&(PVOID &)fpRegOpenKeyExA, ShimRegOpenKeyExA);
-    DetourDetach(&(PVOID &)fpRegQueryValueExA, ShimRegQueryValueExA);
-    DetourDetach(&(PVOID &)fpRegEnumValueA, ShimRegEnumValueA);
-    DetourDetach(&(PVOID &)fpRegCloseKey, ShimRegCloseKey);
+    DetourDetach(&(PVOID &)fpGetSidSubAuthority, (PVOID)ShimGetSidSubAuthority);
+    DetourDetach(&(PVOID &)fpEnumAdapters2, (PVOID)ShimEnumAdapters2);
+    DetourDetach(&(PVOID &)fpQueryAdapterInfo, (PVOID)ShimQueryAdapterInfo);
+    DetourDetach(&(PVOID &)REAL_CM_Get_Device_ID_List_SizeW, (PVOID)SHIM_CM_Get_Device_ID_List_SizeW);
+    DetourDetach(&(PVOID &)REAL_CM_Get_Device_ID_ListW, (PVOID)SHIM_CM_Get_Device_ID_ListW);
+    DetourDetach(&(PVOID &)REAL_CM_Locate_DevNodeW, (PVOID)SHIM_CM_Locate_DevNodeW);
+    DetourDetach(&(PVOID &)REAL_CM_Get_DevNode_Status, (PVOID)SHIM_CM_Get_DevNode_Status);
+    DetourDetach(&(PVOID &)REAL_CM_Get_Device_IDW, (PVOID)SHIM_CM_Get_Device_IDW);
+    DetourDetach(&(PVOID &)REAL_CM_Get_Child, (PVOID)SHIM_CM_Get_Child);
+    DetourDetach(&(PVOID &)REAL_CM_Get_DevNode_Registry_PropertyW, (PVOID)SHIM_CM_Get_DevNode_Registry_PropertyW);
+    DetourDetach(&(PVOID &)REAL_CM_Get_Sibling, (PVOID)SHIM_CM_Get_Sibling);
+    DetourDetach(&(PVOID &)RealCreateDXGIFactory1, (PVOID)ShimCreateDXGIFactory1);
+    DetourDetach(&(PVOID &)fpRegOpenKeyExA, (PVOID)ShimRegOpenKeyExA);
+    DetourDetach(&(PVOID &)fpRegQueryValueExA, (PVOID)ShimRegQueryValueExA);
+    DetourDetach(&(PVOID &)fpRegEnumValueA, (PVOID)ShimRegEnumValueA);
+    DetourDetach(&(PVOID &)fpRegCloseKey, (PVOID)ShimRegCloseKey);
     DetourTransactionCommit();
 }
 

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -299,12 +299,12 @@ void FrameworkEnvironment::add_layer_impl(TestLayerDetails layer_details, fs::Fo
     }
 }
 
-TestICD& FrameworkEnvironment::get_test_icd(int index) noexcept { return icds[index].get_test_icd(); }
-TestICD& FrameworkEnvironment::reset_icd(int index) noexcept { return icds[index].reset_icd(); }
-fs::path FrameworkEnvironment::get_test_icd_path(int index) noexcept { return icds[index].get_icd_full_path(); }
-fs::path FrameworkEnvironment::get_icd_manifest_path(int index) noexcept { return icds[index].get_icd_manifest_path(); }
+TestICD& FrameworkEnvironment::get_test_icd(size_t index) noexcept { return icds[index].get_test_icd(); }
+TestICD& FrameworkEnvironment::reset_icd(size_t index) noexcept { return icds[index].reset_icd(); }
+fs::path FrameworkEnvironment::get_test_icd_path(size_t index) noexcept { return icds[index].get_icd_full_path(); }
+fs::path FrameworkEnvironment::get_icd_manifest_path(size_t index) noexcept { return icds[index].get_icd_manifest_path(); }
 
-TestLayer& FrameworkEnvironment::get_test_layer(int index) noexcept { return layers[index].get_test_layer(); }
-TestLayer& FrameworkEnvironment::reset_layer(int index) noexcept { return layers[index].reset_layer(); }
-fs::path FrameworkEnvironment::get_test_layer_path(int index) noexcept { return layers[index].get_layer_full_path(); }
-fs::path FrameworkEnvironment::get_layer_manifest_path(int index) noexcept { return layers[index].get_layer_manifest_path(); }
+TestLayer& FrameworkEnvironment::get_test_layer(size_t index) noexcept { return layers[index].get_test_layer(); }
+TestLayer& FrameworkEnvironment::reset_layer(size_t index) noexcept { return layers[index].reset_layer(); }
+fs::path FrameworkEnvironment::get_test_layer_path(size_t index) noexcept { return layers[index].get_layer_full_path(); }
+fs::path FrameworkEnvironment::get_layer_manifest_path(size_t index) noexcept { return layers[index].get_layer_manifest_path(); }

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -335,15 +335,15 @@ struct FrameworkEnvironment {
     void add_fake_implicit_layer(ManifestLayer layer_manifest, const std::string& json_name) noexcept;
     void add_fake_explicit_layer(ManifestLayer layer_manifest, const std::string& json_name) noexcept;
 
-    TestICD& get_test_icd(int index = 0) noexcept;
-    TestICD& reset_icd(int index = 0) noexcept;
-    fs::path get_test_icd_path(int index = 0) noexcept;
-    fs::path get_icd_manifest_path(int index = 0) noexcept;
+    TestICD& get_test_icd(size_t index = 0) noexcept;
+    TestICD& reset_icd(size_t index = 0) noexcept;
+    fs::path get_test_icd_path(size_t index = 0) noexcept;
+    fs::path get_icd_manifest_path(size_t index = 0) noexcept;
 
-    TestLayer& get_test_layer(int index = 0) noexcept;
-    TestLayer& reset_layer(int index = 0) noexcept;
-    fs::path get_test_layer_path(int index = 0) noexcept;
-    fs::path get_layer_manifest_path(int index = 0) noexcept;
+    TestLayer& get_test_layer(size_t index = 0) noexcept;
+    TestLayer& reset_layer(size_t index = 0) noexcept;
+    fs::path get_test_layer_path(size_t index = 0) noexcept;
+    fs::path get_layer_manifest_path(size_t index = 0) noexcept;
 
     PlatformShimWrapper platform_shim;
     fs::FolderManager null_folder;

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -45,11 +45,11 @@ void print_error_message(LSTATUS status, const char* function_name, std::string 
     LPVOID lpMsgBuf;
     DWORD dw = GetLastError();
 
-    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, dw,
-                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
+    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, dw,
+                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<LPTSTR>(&lpMsgBuf), 0, nullptr);
 
     std::cerr << function_name << " failed with " << win_api_error_str(status) << ": "
-              << std::string(static_cast<LPTSTR>(lpMsgBuf));
+              << std::string(reinterpret_cast<LPTSTR>(lpMsgBuf));
     if (optional_message != "") {
         std::cerr << " | " << optional_message;
     }
@@ -68,7 +68,7 @@ void remove_env_var(std::string const& name) { SetEnvironmentVariableA(name.c_st
 std::string get_env_var(std::string const& name, bool report_failure) {
     std::string value;
     value.resize(ENV_VAR_BUFFER_SIZE);
-    DWORD ret = GetEnvironmentVariable(name.c_str(), (LPSTR)value.c_str(), ENV_VAR_BUFFER_SIZE);
+    DWORD ret = GetEnvironmentVariable(name.c_str(), &value[0], ENV_VAR_BUFFER_SIZE);
     if (0 == ret) {
         if (report_failure) print_error_message(ERROR_ENVVAR_NOT_FOUND, "GetEnvironmentVariable");
         return std::string();

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -43,10 +43,6 @@
  */
 #pragma once
 
-// Following items are needed for C++ to work with PRIxLEAST64
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
-
 #include <algorithm>
 #include <array>
 #include <iostream>
@@ -62,6 +58,7 @@
 #include <cassert>
 #include <cstring>
 #include <ctime>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdint.h>
 
@@ -196,7 +193,7 @@ struct path {
     // get C++ style string
     std::string const& str() const { return contents; }
     std::string& str() { return contents; }
-    size_t size() const { return contents.size(); };
+    size_t size() const { return contents.size(); }
 
     // equality
     bool operator==(path const& other) const noexcept { return contents == other.contents; }
@@ -258,9 +255,9 @@ typedef HMODULE loader_platform_dl_handle;
 static loader_platform_dl_handle loader_platform_open_library(const char* lib_path) {
     // Try loading the library the original way first.
     loader_platform_dl_handle lib_handle = LoadLibrary(lib_path);
-    if (lib_handle == NULL && GetLastError() == ERROR_MOD_NOT_FOUND) {
+    if (lib_handle == nullptr && GetLastError() == ERROR_MOD_NOT_FOUND) {
         // If that failed, then try loading it with broader search folders.
-        lib_handle = LoadLibraryEx(lib_path, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+        lib_handle = LoadLibraryEx(lib_path, nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
     }
     return lib_handle;
 }
@@ -273,7 +270,7 @@ inline void loader_platform_close_library(loader_platform_dl_handle library) { F
 inline void* loader_platform_get_proc_address(loader_platform_dl_handle library, const char* name) {
     assert(library);
     assert(name);
-    return (void*)GetProcAddress(library, name);
+    return reinterpret_cast<void*>(GetProcAddress(library, name));
 }
 inline char* loader_platform_get_proc_address_error(const char* name) {
     static char errorMsg[120];
@@ -315,14 +312,14 @@ struct LibraryWrapper {
     explicit LibraryWrapper() noexcept {}
     explicit LibraryWrapper(fs::path const& lib_path) noexcept : lib_path(lib_path) {
         lib_handle = loader_platform_open_library(lib_path.c_str());
-        if (lib_handle == NULL) {
+        if (lib_handle == nullptr) {
             fprintf(stderr, "Unable to open library %s: %s\n", lib_path.c_str(),
                     loader_platform_open_library_error(lib_path.c_str()));
-            assert(lib_handle != NULL && "Must be able to open library");
+            assert(lib_handle != nullptr && "Must be able to open library");
         }
     }
     ~LibraryWrapper() noexcept {
-        if (lib_handle != NULL) {
+        if (lib_handle != nullptr) {
             loader_platform_close_library(lib_handle);
             lib_handle = nullptr;
         }
@@ -502,7 +499,7 @@ inline std::string version_to_string(uint32_t version) {
 // class_name = class the member variable is apart of
 // type = type of the variable
 // name = name of the variable
-// singular_name = used for the `add_singluar_name` member function
+// singular_name = used for the `add_singular_name` member function
 #define BUILDER_VECTOR(class_name, type, name, singular_name)                    \
     std::vector<type> name;                                                      \
     class_name& add_##singular_name(type const& singular_name) {                 \

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -104,7 +104,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyDriverEnvVar) {
     std::array<VkPhysicalDevice, 5> phys_devs_array;
     uint32_t phys_dev_count = 1;
     ASSERT_EQ(inst1->vkEnumeratePhysicalDevices(inst1.inst, &phys_dev_count, phys_devs_array.data()), VK_SUCCESS);
-    ASSERT_EQ(phys_dev_count, 1);
+    ASSERT_EQ(phys_dev_count, 1U);
 
     for (uint32_t add = 0; add < 2; ++add) {
         env.add_icd(TestICDDetails(TEST_ICD_PATH_EXPORT_NONE).set_use_env_var_icd_filenames(true));
@@ -120,7 +120,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyDriverEnvVar) {
 
     phys_dev_count = 5;
     ASSERT_EQ(inst2->vkEnumeratePhysicalDevices(inst2.inst, &phys_dev_count, phys_devs_array.data()), VK_SUCCESS);
-    ASSERT_EQ(phys_dev_count, 5);
+    ASSERT_EQ(phys_dev_count, 5U);
 
     env.debug_log.clear();
 
@@ -201,7 +201,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyAddDriverEnvVar) {
     std::array<VkPhysicalDevice, 1> phys_devs_array;
     uint32_t phys_dev_count = 1;
     ASSERT_EQ(inst1->vkEnumeratePhysicalDevices(inst1.inst, &phys_dev_count, phys_devs_array.data()), VK_SUCCESS);
-    ASSERT_EQ(phys_dev_count, 1);
+    ASSERT_EQ(phys_dev_count, 1U);
 
     env.platform_shim->set_elevated_privilege(true);
 
@@ -235,7 +235,7 @@ TEST(EnvVarICDOverrideSetup, TestBothDriverEnvVars) {
     std::array<VkPhysicalDevice, 3> phys_devs_array;
     uint32_t phys_dev_count = 3;
     ASSERT_EQ(inst->vkEnumeratePhysicalDevices(inst.inst, &phys_dev_count, phys_devs_array.data()), VK_SUCCESS);
-    ASSERT_EQ(phys_dev_count, 3);
+    ASSERT_EQ(phys_dev_count, 3U);
 
     remove_env_var("VK_DRIVER_FILES");
     remove_env_var("VK_ADD_DRIVER_FILES");

--- a/tests/loader_handle_validation_tests.cpp
+++ b/tests/loader_handle_validation_tests.cpp
@@ -28,23 +28,15 @@
 
 #include "test_environment.h"
 
-class LoaderHandleValidTests : public ::testing::Test {
-   protected:
-    virtual void SetUp() {
-        env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
-        env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
-    }
-    virtual void TearDown() { env.reset(); }
-    std::unique_ptr<FrameworkEnvironment> env;
-};
-
 // ---- Invalid Instance tests
 
-TEST_F(LoaderHandleValidTests, BadInstEnumPhysDevices) {
-    auto& driver = env->get_test_icd();
+TEST(LoaderHandleValidTests, BadInstEnumPhysDevices) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
 
     struct BadData {
@@ -53,15 +45,17 @@ TEST_F(LoaderHandleValidTests, BadInstEnumPhysDevices) {
     VkInstance bad_instance = (VkInstance)(&my_bad_data);
     uint32_t returned_physical_count = 0;
 
-    ASSERT_DEATH(env->vulkan_functions.vkEnumeratePhysicalDevices(bad_instance, &returned_physical_count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkEnumeratePhysicalDevices(bad_instance, &returned_physical_count, nullptr),
                  "vkEnumeratePhysicalDevices: Invalid instance \\[VUID-vkEnumeratePhysicalDevices-instance-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadInstGetInstProcAddr) {
-    auto& driver = env->get_test_icd();
+TEST(LoaderHandleValidTests, BadInstGetInstProcAddr) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
 
     struct BadData {
@@ -69,15 +63,17 @@ TEST_F(LoaderHandleValidTests, BadInstGetInstProcAddr) {
     } my_bad_data;
     VkInstance bad_instance = (VkInstance)(&my_bad_data);
 
-    ASSERT_DEATH(env->vulkan_functions.vkGetInstanceProcAddr(bad_instance, "vkGetBufferDeviceAddress"),
+    ASSERT_DEATH(env.vulkan_functions.vkGetInstanceProcAddr(bad_instance, "vkGetBufferDeviceAddress"),
                  "vkGetInstanceProcAddr: Invalid instance \\[VUID-vkGetInstanceProcAddr-instance-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadInstDestroyInstance) {
-    auto& driver = env->get_test_icd();
+TEST(LoaderHandleValidTests, BadInstDestroyInstance) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
 
     struct BadData {
@@ -85,18 +81,20 @@ TEST_F(LoaderHandleValidTests, BadInstDestroyInstance) {
     } my_bad_data;
     VkInstance bad_instance = (VkInstance)(&my_bad_data);
 
-    ASSERT_DEATH(env->vulkan_functions.vkDestroyInstance(bad_instance, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkDestroyInstance(bad_instance, nullptr),
                  "vkDestroyInstance: Invalid instance \\[VUID-vkDestroyInstance-instance-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadInstDestroySurface) {
+TEST(LoaderHandleValidTests, BadInstDestroySurface) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.CheckCreate();
 
@@ -105,18 +103,20 @@ TEST_F(LoaderHandleValidTests, BadInstDestroySurface) {
     } my_bad_data;
     VkInstance bad_instance = (VkInstance)(&my_bad_data);
 
-    ASSERT_DEATH(env->vulkan_functions.vkDestroySurfaceKHR(bad_instance, VK_NULL_HANDLE, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkDestroySurfaceKHR(bad_instance, VK_NULL_HANDLE, nullptr),
                  "vkDestroySurfaceKHR: Invalid instance \\[VUID-vkDestroySurfaceKHR-instance-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadInstCreateHeadlessSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateHeadlessSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_EXT_headless_surface");
     instance.CheckCreate();
@@ -130,18 +130,20 @@ TEST_F(LoaderHandleValidTests, BadInstCreateHeadlessSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateHeadlessSurfaceEXT(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateHeadlessSurfaceEXT(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateHeadlessSurfaceEXT: Invalid instance \\[VUID-vkCreateHeadlessSurfaceEXT-instance-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadInstCreateDisplayPlaneSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateDisplayPlaneSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_display");
     instance.CheckCreate();
@@ -155,19 +157,21 @@ TEST_F(LoaderHandleValidTests, BadInstCreateDisplayPlaneSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateDisplayPlaneSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateDisplayPlaneSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateDisplayPlaneSurfaceKHR: Invalid instance \\[VUID-vkCreateDisplayPlaneSurfaceKHR-instance-parameter\\]");
 }
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-TEST_F(LoaderHandleValidTests, BadInstCreateAndroidSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateAndroidSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_android_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_android_surface");
     instance.CheckCreate();
@@ -181,20 +185,22 @@ TEST_F(LoaderHandleValidTests, BadInstCreateAndroidSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateAndroidSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateAndroidSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateAndroidSurfaceKHR: Invalid instance \\[VUID-vkCreateAndroidSurfaceKHR-instance-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 
 #ifdef VK_USE_PLATFORM_DIRECTFB_EXT
-TEST_F(LoaderHandleValidTests, BadInstCreateDirectFBSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateDirectFBSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_directfb_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_EXT_directfb_surface");
     instance.CheckCreate();
@@ -208,20 +214,22 @@ TEST_F(LoaderHandleValidTests, BadInstCreateDirectFBSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_DIRECTFB_SURFACE_CREATE_INFO_EXT;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateDirectFBSurfaceEXT(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateDirectFBSurfaceEXT(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateDirectFBSurfaceEXT: Invalid instance \\[VUID-vkCreateDirectFBSurfaceEXT-instance-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_DIRECTFB_EXT
 
 #ifdef VK_USE_PLATFORM_FUCHSIA
-TEST_F(LoaderHandleValidTests, BadInstCreateFuchsiaSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateFuchsiaSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_FUCHSIA_imagepipe_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_FUCHSIA_imagepipe_surface");
     instance.CheckCreate();
@@ -235,20 +243,22 @@ TEST_F(LoaderHandleValidTests, BadInstCreateFuchsiaSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateImagePipeSurfaceFUCHSIA(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateImagePipeSurfaceFUCHSIA(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateImagePipeSurfaceFUCHSIA: Invalid instance \\[VUID-vkCreateImagePipeSurfaceFUCHSIA-instance-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_FUCHSIA
 
 #ifdef VK_USE_PLATFORM_GGP
-TEST_F(LoaderHandleValidTests, BadInstCreateGGPSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateGGPSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_GGP_stream_descriptor_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_GGP_stream_descriptor_surface");
     instance.CheckCreate();
@@ -263,20 +273,22 @@ TEST_F(LoaderHandleValidTests, BadInstCreateGGPSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     ASSERT_DEATH(
-        env->vulkan_functions.vkCreateStreamDescriptorSurfaceGGP(bad_instance, &surf_create_info, nullptr, &created_surface),
+        env.vulkan_functions.vkCreateStreamDescriptorSurfaceGGP(bad_instance, &surf_create_info, nullptr, &created_surface),
         "vkCreateStreamDescriptorSurfaceGGP: Invalid instance \\[VUID-vkCreateStreamDescriptorSurfaceGGP-instance-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_GGP
 
 #ifdef VK_USE_PLATFORM_IOS_MVK
-TEST_F(LoaderHandleValidTests, BadInstCreateIOSSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateIOSSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_MVK_ios_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_MVK_ios_surface");
     instance.CheckCreate();
@@ -290,20 +302,22 @@ TEST_F(LoaderHandleValidTests, BadInstCreateIOSSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateIOSSurfaceMVK(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateIOSSurfaceMVK(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateIOSSurfaceMVK: Invalid instance \\[VUID-vkCreateIOSSurfaceMVK-instance-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_IOS_MVK
 
 #ifdef VK_USE_PLATFORM_MACOS_MVK
-TEST_F(LoaderHandleValidTests, BadInstCreateMacOSSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateMacOSSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_MVK_macos_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_MVK_macos_surface");
     instance.CheckCreate();
@@ -317,20 +331,22 @@ TEST_F(LoaderHandleValidTests, BadInstCreateMacOSSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateMacOSSurfaceMVK(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateMacOSSurfaceMVK(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateMacOSSurfaceMVK: Invalid instance \\[VUID-vkCreateMacOSSurfaceMVK-instance-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_MACOS_MVK
 
 #if defined(VK_USE_PLATFORM_METAL_EXT)
-TEST_F(LoaderHandleValidTests, BadInstCreateMetalSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateMetalSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_metal_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_EXT_metal_surface");
     instance.CheckCreate();
@@ -344,20 +360,22 @@ TEST_F(LoaderHandleValidTests, BadInstCreateMetalSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateMetalSurfaceEXT(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateMetalSurfaceEXT(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateMetalSurfaceEXT: Invalid instance \\[VUID-vkCreateMetalSurfaceEXT-instance-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
-TEST_F(LoaderHandleValidTests, BadInstCreateQNXSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateQNXSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_QNX_screen_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_QNX_screen_surface");
     instance.CheckCreate();
@@ -371,21 +389,25 @@ TEST_F(LoaderHandleValidTests, BadInstCreateQNXSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_SCREEN_SURFACE_CREATE_INFO_QNX;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateScreenSurfaceQNX(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateScreenSurfaceQNX(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateScreenSurfaceQNX: Invalid instance \\[VUID-vkCreateScreenSurfaceQNX-instance-parameter\\]");
     // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
 }
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
 
 #ifdef VK_USE_PLATFORM_VI_NN
-TEST_F(LoaderHandleValidTests, BadInstCreateViNNSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateViNNSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_NN_vi_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_NN_vi_surface");
     instance.CheckCreate();
@@ -399,21 +421,23 @@ TEST_F(LoaderHandleValidTests, BadInstCreateViNNSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateViSurfaceNN(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateViSurfaceNN(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateViSurfaceNN: Invalid instance \\[VUID-vkCreateViSurfaceNN-instance-parameter\\]");
     // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
 }
 #endif  // VK_USE_PLATFORM_VI_NN
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-TEST_F(LoaderHandleValidTests, BadInstCreateWaylandSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateWaylandSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_wayland_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_wayland_surface");
     instance.CheckCreate();
@@ -427,21 +451,23 @@ TEST_F(LoaderHandleValidTests, BadInstCreateWaylandSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateWaylandSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateWaylandSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateWaylandSurfaceKHR: Invalid instance \\[VUID-vkCreateWaylandSurfaceKHR-instance-parameter\\]");
     // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
 }
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-TEST_F(LoaderHandleValidTests, BadInstCreateWin32Surf) {
+TEST(LoaderHandleValidTests, BadInstCreateWin32Surf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_win32_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_win32_surface");
     instance.CheckCreate();
@@ -455,21 +481,23 @@ TEST_F(LoaderHandleValidTests, BadInstCreateWin32Surf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateWin32SurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateWin32SurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateWin32SurfaceKHR: Invalid instance \\[VUID-vkCreateWin32SurfaceKHR-instance-parameter\\]");
     // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 #ifdef VK_USE_PLATFORM_XCB_KHR
-TEST_F(LoaderHandleValidTests, BadInstCreateXCBSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateXCBSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xcb_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_xcb_surface");
     instance.CheckCreate();
@@ -483,21 +511,23 @@ TEST_F(LoaderHandleValidTests, BadInstCreateXCBSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateXcbSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateXcbSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateXcbSurfaceKHR: Invalid instance \\[VUID-vkCreateXcbSurfaceKHR-instance-parameter\\]");
     // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
 }
 #endif  // VK_USE_PLATFORM_XCB_KHR
 
 #ifdef VK_USE_PLATFORM_XLIB_KHR
-TEST_F(LoaderHandleValidTests, BadInstCreateXlibSurf) {
+TEST(LoaderHandleValidTests, BadInstCreateXlibSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xlib_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_xlib_surface");
     instance.CheckCreate();
@@ -511,7 +541,7 @@ TEST_F(LoaderHandleValidTests, BadInstCreateXlibSurf) {
     surf_create_info.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateXlibSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateXlibSurfaceKHR(bad_instance, &surf_create_info, nullptr, &created_surface),
                  "vkCreateXlibSurfaceKHR: Invalid instance \\[VUID-vkCreateXlibSurfaceKHR-instance-parameter\\]");
     // TODO: Look for "invalid instance" in stderr log to make sure correct error is thrown
 }
@@ -519,11 +549,13 @@ TEST_F(LoaderHandleValidTests, BadInstCreateXlibSurf) {
 
 // ---- Invalid Physical Device tests
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFeature) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevFeature) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -534,15 +566,17 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFeature) {
 
     VkPhysicalDeviceFeatures features = {};
     ASSERT_DEATH(
-        env->vulkan_functions.vkGetPhysicalDeviceFeatures(bad_physical_dev, &features),
+        env.vulkan_functions.vkGetPhysicalDeviceFeatures(bad_physical_dev, &features),
         "vkGetPhysicalDeviceFeatures: Invalid physicalDevice \\[VUID-vkGetPhysicalDeviceFeatures-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFormatProps) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevFormatProps) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -552,17 +586,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFormatProps) {
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
 
     VkFormatProperties format_info = {};
-    ASSERT_DEATH(
-        env->vulkan_functions.vkGetPhysicalDeviceFormatProperties(bad_physical_dev, VK_FORMAT_R8G8B8A8_UNORM, &format_info),
-        "vkGetPhysicalDeviceFormatProperties: Invalid physicalDevice "
-        "\\[VUID-vkGetPhysicalDeviceFormatProperties-physicalDevice-parameter\\]");
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceFormatProperties(bad_physical_dev, VK_FORMAT_R8G8B8A8_UNORM, &format_info),
+                 "vkGetPhysicalDeviceFormatProperties: Invalid physicalDevice "
+                 "\\[VUID-vkGetPhysicalDeviceFormatProperties-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevImgFormatProps) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevImgFormatProps) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -572,18 +607,20 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevImgFormatProps) {
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
 
     VkImageFormatProperties format_info = {};
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceImageFormatProperties(bad_physical_dev, VK_FORMAT_R8G8B8A8_UNORM,
-                                                                                VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_LINEAR,
-                                                                                VK_IMAGE_USAGE_STORAGE_BIT, 0, &format_info),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceImageFormatProperties(bad_physical_dev, VK_FORMAT_R8G8B8A8_UNORM,
+                                                                               VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_LINEAR,
+                                                                               VK_IMAGE_USAGE_STORAGE_BIT, 0, &format_info),
                  "vkGetPhysicalDeviceImageFormatProperties: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceImageFormatProperties-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevProps) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevProps) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -594,15 +631,17 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevProps) {
 
     VkPhysicalDeviceProperties properties = {};
     ASSERT_DEATH(
-        env->vulkan_functions.vkGetPhysicalDeviceProperties(bad_physical_dev, &properties),
+        env.vulkan_functions.vkGetPhysicalDeviceProperties(bad_physical_dev, &properties),
         "vkGetPhysicalDeviceProperties: Invalid physicalDevice \\[VUID-vkGetPhysicalDeviceProperties-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamProps) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamProps) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -611,16 +650,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamProps) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceQueueFamilyProperties(bad_physical_dev, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceQueueFamilyProperties(bad_physical_dev, &count, nullptr),
                  "vkGetPhysicalDeviceQueueFamilyProperties: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceQueueFamilyProperties-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDevMemProps) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevDevMemProps) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -630,16 +671,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDevMemProps) {
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
 
     VkPhysicalDeviceMemoryProperties properties = {};
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceMemoryProperties(bad_physical_dev, &properties),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceMemoryProperties(bad_physical_dev, &properties),
                  "vkGetPhysicalDeviceMemoryProperties: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceMemoryProperties-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevCreateDevice) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevCreateDevice) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -668,15 +711,17 @@ TEST_F(LoaderHandleValidTests, BadPhysDevCreateDevice) {
     dev_create_info.ppEnabledExtensionNames = nullptr;
     dev_create_info.pEnabledFeatures = nullptr;
     VkDevice created_dev = VK_NULL_HANDLE;
-    ASSERT_DEATH(env->vulkan_functions.vkCreateDevice(bad_physical_dev, &dev_create_info, nullptr, &created_dev),
+    ASSERT_DEATH(env.vulkan_functions.vkCreateDevice(bad_physical_dev, &dev_create_info, nullptr, &created_dev),
                  "vkCreateDevice: Invalid physicalDevice \\[VUID-vkCreateDevice-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevEnumDevExtProps) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevEnumDevExtProps) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -685,16 +730,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevEnumDevExtProps) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkEnumerateDeviceExtensionProperties(bad_physical_dev, nullptr, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkEnumerateDeviceExtensionProperties(bad_physical_dev, nullptr, &count, nullptr),
                  "vkEnumerateDeviceExtensionProperties: Invalid physicalDevice "
                  "\\[VUID-vkEnumerateDeviceExtensionProperties-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevEnumDevLayerProps) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevEnumDevLayerProps) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -703,16 +750,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevEnumDevLayerProps) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkEnumerateDeviceLayerProperties(bad_physical_dev, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkEnumerateDeviceLayerProperties(bad_physical_dev, &count, nullptr),
                  "vkEnumerateDeviceLayerProperties: Invalid physicalDevice "
                  "\\[VUID-vkEnumerateDeviceLayerProperties-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSparseImgFormatProps) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevSparseImgFormatProps) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -722,18 +771,20 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSparseImgFormatProps) {
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
 
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSparseImageFormatProperties(
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceSparseImageFormatProperties(
                      bad_physical_dev, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D, VK_SAMPLE_COUNT_1_BIT,
                      VK_IMAGE_USAGE_STORAGE_BIT, VK_IMAGE_TILING_LINEAR, &count, nullptr),
                  "vkGetPhysicalDeviceSparseImageFormatProperties: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceSparseImageFormatProperties-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFeature2) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevFeature2) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -746,15 +797,17 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFeature2) {
     features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
     features.pNext = nullptr;
     ASSERT_DEATH(
-        env->vulkan_functions.vkGetPhysicalDeviceFeatures2(bad_physical_dev, &features),
+        env.vulkan_functions.vkGetPhysicalDeviceFeatures2(bad_physical_dev, &features),
         "vkGetPhysicalDeviceFeatures2: Invalid physicalDevice \\[VUID-vkGetPhysicalDeviceFeatures2-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFormatProps2) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevFormatProps2) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -766,17 +819,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFormatProps2) {
     VkFormatProperties2 properties = {};
     properties.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
     properties.pNext = nullptr;
-    ASSERT_DEATH(
-        env->vulkan_functions.vkGetPhysicalDeviceFormatProperties2(bad_physical_dev, VK_FORMAT_R8G8B8A8_UNORM, &properties),
-        "vkGetPhysicalDeviceFormatProperties2: Invalid physicalDevice "
-        "\\[VUID-vkGetPhysicalDeviceFormatProperties2-physicalDevice-parameter\\]");
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceFormatProperties2(bad_physical_dev, VK_FORMAT_R8G8B8A8_UNORM, &properties),
+                 "vkGetPhysicalDeviceFormatProperties2: Invalid physicalDevice "
+                 "\\[VUID-vkGetPhysicalDeviceFormatProperties2-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevImgFormatProps2) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevImgFormatProps2) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -791,16 +845,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevImgFormatProps2) {
     VkImageFormatProperties2 properties = {};
     properties.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
     properties.pNext = nullptr;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceImageFormatProperties2(bad_physical_dev, &format_info, &properties),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceImageFormatProperties2(bad_physical_dev, &format_info, &properties),
                  "vkGetPhysicalDeviceImageFormatProperties2: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceImageFormatProperties2-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevProps2) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevProps2) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -812,16 +868,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevProps2) {
     VkPhysicalDeviceProperties2 properties = {};
     properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
     properties.pNext = nullptr;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceProperties2(bad_physical_dev, &properties),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceProperties2(bad_physical_dev, &properties),
                  "vkGetPhysicalDeviceProperties2: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceProperties2-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamProps2) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamProps2) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -830,16 +888,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamProps2) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceQueueFamilyProperties2(bad_physical_dev, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceQueueFamilyProperties2(bad_physical_dev, &count, nullptr),
                  "vkGetPhysicalDeviceQueueFamilyProperties2: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceQueueFamilyProperties2-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDevMemProps2) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevDevMemProps2) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -851,16 +911,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDevMemProps2) {
     VkPhysicalDeviceMemoryProperties2 properties = {};
     properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
     properties.pNext = nullptr;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceMemoryProperties2(bad_physical_dev, &properties),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceMemoryProperties2(bad_physical_dev, &properties),
                  "vkGetPhysicalDeviceMemoryProperties2: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceMemoryProperties2-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSparseImgFormatProps2) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevSparseImgFormatProps2) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -873,16 +935,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSparseImgFormatProps2) {
     info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2;
     info.pNext = nullptr;
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSparseImageFormatProperties2(bad_physical_dev, &info, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceSparseImageFormatProperties2(bad_physical_dev, &info, &count, nullptr),
                  "vkGetPhysicalDeviceSparseImageFormatProperties2: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceSparseImageFormatProperties2-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevExternFenceProps) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevExternFenceProps) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -895,16 +959,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevExternFenceProps) {
     info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO;
     info.pNext = nullptr;
     VkExternalFenceProperties props = {};
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceExternalFenceProperties(bad_physical_dev, &info, &props),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceExternalFenceProperties(bad_physical_dev, &info, &props),
                  "vkGetPhysicalDeviceExternalFenceProperties: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceExternalFenceProperties-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevExternBufferProps) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevExternBufferProps) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -917,16 +983,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevExternBufferProps) {
     info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO;
     info.pNext = nullptr;
     VkExternalBufferProperties props = {};
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceExternalBufferProperties(bad_physical_dev, &info, &props),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceExternalBufferProperties(bad_physical_dev, &info, &props),
                  "vkGetPhysicalDeviceExternalBufferProperties: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceExternalBufferProperties-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevExternSemaphoreProps) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevExternSemaphoreProps) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(1, 1, 0);
     instance.CheckCreate();
 
@@ -939,19 +1007,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevExternSemaphoreProps) {
     info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO;
     info.pNext = nullptr;
     VkExternalSemaphoreProperties props = {};
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceExternalSemaphoreProperties(bad_physical_dev, &info, &props),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceExternalSemaphoreProperties(bad_physical_dev, &info, &props),
                  "vkGetPhysicalDeviceExternalSemaphoreProperties: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceExternalSemaphoreProperties-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceSupportKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceSupportKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.CheckCreate();
 
@@ -961,19 +1031,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceSupportKHR) {
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     VkBool32 supported = VK_FALSE;
 
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSurfaceSupportKHR(bad_physical_dev, 0, VK_NULL_HANDLE, &supported),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceSurfaceSupportKHR(bad_physical_dev, 0, VK_NULL_HANDLE, &supported),
                  "vkGetPhysicalDeviceSurfaceSupportKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceSurfaceSupportKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceCapsKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceCapsKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.CheckCreate();
 
@@ -982,19 +1054,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceCapsKHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     VkSurfaceCapabilitiesKHR caps = {};
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(bad_physical_dev, VK_NULL_HANDLE, &caps),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(bad_physical_dev, VK_NULL_HANDLE, &caps),
                  "vkGetPhysicalDeviceSurfaceCapabilitiesKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceSurfaceCapabilitiesKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceFormatsKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceFormatsKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.CheckCreate();
 
@@ -1003,19 +1077,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceFormatsKHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSurfaceFormatsKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceSurfaceFormatsKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
                  "vkGetPhysicalDeviceSurfaceFormatsKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceSurfaceFormatsKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfacePresentModesKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfacePresentModesKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_headless_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.CheckCreate();
 
@@ -1024,20 +1100,22 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfacePresentModesKHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSurfacePresentModesKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceSurfacePresentModesKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
                  "vkGetPhysicalDeviceSurfacePresentModesKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceSurfacePresentModesKHR-physicalDevice-parameter\\]");
 }
 
 #ifdef VK_USE_PLATFORM_DIRECTFB_EXT
-TEST_F(LoaderHandleValidTests, BadPhysDevGetDirectFBPresentSupportKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetDirectFBPresentSupportKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_directfb_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_EXT_directfb_surface");
     instance.CheckCreate();
@@ -1047,21 +1125,23 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDirectFBPresentSupportKHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     IDirectFB directfb;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceDirectFBPresentationSupportEXT(bad_physical_dev, 0, &directfb),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceDirectFBPresentationSupportEXT(bad_physical_dev, 0, &directfb),
                  "vkGetPhysicalDeviceDirectFBPresentationSupportEXT: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceDirectFBPresentationSupportEXT-physicalDevice-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_DIRECTFB_EXT
 
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
-TEST_F(LoaderHandleValidTests, BadPhysDevGetQNXPresentSupportKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetQNXPresentSupportKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_QNX_screen_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_QNX_screen_surface");
     instance.CheckCreate();
@@ -1070,21 +1150,23 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetQNXPresentSupportKHR) {
         uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
-    ASSERT_DEATH(env->vulkan_functions.PFN_vkGetPhysicalDeviceScreenPresentationSupportQNX(bad_physical_dev, 0, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.PFN_vkGetPhysicalDeviceScreenPresentationSupportQNX(bad_physical_dev, 0, nullptr),
                  "vkGetPhysicalDeviceScreenPresentationSupportQNX: Invalid instance "
                  "\\[VUID-vkGetPhysicalDeviceScreenPresentationSupportQNX-instance-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevWaylandPresentSupportKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevWaylandPresentSupportKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_wayland_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_wayland_surface");
     instance.CheckCreate();
@@ -1093,21 +1175,23 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevWaylandPresentSupportKHR) {
         uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceWaylandPresentationSupportKHR(bad_physical_dev, 0, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceWaylandPresentationSupportKHR(bad_physical_dev, 0, nullptr),
                  "vkGetPhysicalDeviceWaylandPresentationSupportKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceWaylandPresentationSupportKHR-physicalDevice-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevWin32PresentSupportKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevWin32PresentSupportKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_win32_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_win32_surface");
     instance.CheckCreate();
@@ -1116,21 +1200,23 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevWin32PresentSupportKHR) {
         uint64_t bad_array[3] = {0x123456789AB, 0x23456789AB1, 0x9876543210AB};
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceWin32PresentationSupportKHR(bad_physical_dev, 0),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceWin32PresentationSupportKHR(bad_physical_dev, 0),
                  "vkGetPhysicalDeviceWin32PresentationSupportKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceWin32PresentationSupportKHR-physicalDevice-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 #ifdef VK_USE_PLATFORM_XCB_KHR
-TEST_F(LoaderHandleValidTests, BadPhysDevGetXCBPresentSupportKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetXCBPresentSupportKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xcb_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_xcb_surface");
     instance.CheckCreate();
@@ -1141,21 +1227,23 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetXCBPresentSupportKHR) {
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
 
     xcb_visualid_t visual = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceXcbPresentationSupportKHR(bad_physical_dev, 0, nullptr, visual),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceXcbPresentationSupportKHR(bad_physical_dev, 0, nullptr, visual),
                  "vkGetPhysicalDeviceXcbPresentationSupportKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceXcbPresentationSupportKHR-physicalDevice-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_XCB_KHR
 
 #ifdef VK_USE_PLATFORM_XLIB_KHR
-TEST_F(LoaderHandleValidTests, BadPhysDevGetXlibPresentSupportKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetXlibPresentSupportKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xlib_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_xlib_surface");
     instance.CheckCreate();
@@ -1166,20 +1254,22 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetXlibPresentSupportKHR) {
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
 
     VisualID visual = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceXlibPresentationSupportKHR(bad_physical_dev, 0, nullptr, visual),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceXlibPresentationSupportKHR(bad_physical_dev, 0, nullptr, visual),
                  "vkGetPhysicalDeviceXlibPresentationSupportKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceXlibPresentationSupportKHR-physicalDevice-parameter\\]");
 }
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPropsKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPropsKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_display");
     instance.CheckCreate();
@@ -1189,19 +1279,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPropsKHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceDisplayPropertiesKHR(bad_physical_dev, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceDisplayPropertiesKHR(bad_physical_dev, &count, nullptr),
                  "vkGetPhysicalDeviceDisplayPropertiesKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceDisplayPropertiesKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPlanePropsKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPlanePropsKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_display");
     instance.CheckCreate();
@@ -1211,19 +1303,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPlanePropsKHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceDisplayPlanePropertiesKHR(bad_physical_dev, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceDisplayPlanePropertiesKHR(bad_physical_dev, &count, nullptr),
                  "vkGetPhysicalDeviceDisplayPlanePropertiesKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceDisplayPlanePropertiesKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneSupportedDisplaysKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneSupportedDisplaysKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_display");
     instance.CheckCreate();
@@ -1233,19 +1327,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneSupportedDisplaysKHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetDisplayPlaneSupportedDisplaysKHR(bad_physical_dev, 0, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetDisplayPlaneSupportedDisplaysKHR(bad_physical_dev, 0, &count, nullptr),
                  "vkGetDisplayPlaneSupportedDisplaysKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetDisplayPlaneSupportedDisplaysKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayModePropsKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetDisplayModePropsKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_display");
     instance.CheckCreate();
@@ -1256,18 +1352,20 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayModePropsKHR) {
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
     ASSERT_DEATH(
-        env->vulkan_functions.vkGetDisplayModePropertiesKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
+        env.vulkan_functions.vkGetDisplayModePropertiesKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
         "vkGetDisplayModePropertiesKHR: Invalid physicalDevice \\[VUID-vkGetDisplayModePropertiesKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevCreateDisplayModeKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevCreateDisplayModeKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_display");
     instance.CheckCreate();
@@ -1281,18 +1379,20 @@ TEST_F(LoaderHandleValidTests, BadPhysDevCreateDisplayModeKHR) {
     create_info.pNext = nullptr;
     VkDisplayModeKHR display_mode;
     ASSERT_DEATH(
-        env->vulkan_functions.vkCreateDisplayModeKHR(bad_physical_dev, VK_NULL_HANDLE, &create_info, nullptr, &display_mode),
+        env.vulkan_functions.vkCreateDisplayModeKHR(bad_physical_dev, VK_NULL_HANDLE, &create_info, nullptr, &display_mode),
         "vkCreateDisplayModeKHR: Invalid physicalDevice \\[VUID-vkCreateDisplayModeKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneCapsKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneCapsKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_display");
     instance.CheckCreate();
@@ -1302,19 +1402,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneCapsKHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     VkDisplayPlaneCapabilitiesKHR caps = {};
-    ASSERT_DEATH(env->vulkan_functions.vkGetDisplayPlaneCapabilitiesKHR(bad_physical_dev, VK_NULL_HANDLE, 0, &caps),
+    ASSERT_DEATH(env.vulkan_functions.vkGetDisplayPlaneCapabilitiesKHR(bad_physical_dev, VK_NULL_HANDLE, 0, &caps),
                  "vkGetDisplayPlaneCapabilitiesKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetDisplayPlaneCapabilitiesKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevPresentRectsKHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevPresentRectsKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_display");
     instance.CheckCreate();
@@ -1324,19 +1426,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevPresentRectsKHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDevicePresentRectanglesKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDevicePresentRectanglesKHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
                  "vkGetPhysicalDevicePresentRectanglesKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDevicePresentRectanglesKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayProps2KHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayProps2KHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_display_properties2"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_get_display_properties2");
     instance.CheckCreate();
@@ -1346,19 +1450,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayProps2KHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceDisplayProperties2KHR(bad_physical_dev, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceDisplayProperties2KHR(bad_physical_dev, &count, nullptr),
                  "vkGetPhysicalDeviceDisplayProperties2KHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceDisplayProperties2KHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPlaneProps2KHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPlaneProps2KHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_display_properties2"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_get_display_properties2");
     instance.CheckCreate();
@@ -1368,19 +1474,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevDisplayPlaneProps2KHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceDisplayPlaneProperties2KHR(bad_physical_dev, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceDisplayPlaneProperties2KHR(bad_physical_dev, &count, nullptr),
                  "vkGetPhysicalDeviceDisplayPlaneProperties2KHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceDisplayPlaneProperties2KHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayModeProps2KHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetDisplayModeProps2KHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_display_properties2"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_get_display_properties2");
     instance.CheckCreate();
@@ -1390,19 +1498,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayModeProps2KHR) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
-    ASSERT_DEATH(env->vulkan_functions.vkGetDisplayModeProperties2KHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
+    ASSERT_DEATH(env.vulkan_functions.vkGetDisplayModeProperties2KHR(bad_physical_dev, VK_NULL_HANDLE, &count, nullptr),
                  "vkGetDisplayModeProperties2KHR: Invalid physicalDevice "
                  "\\[VUID-vkGetDisplayModeProperties2KHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneCaps2KHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneCaps2KHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_display_properties2"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_get_display_properties2");
     instance.CheckCreate();
@@ -1415,19 +1525,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDisplayPlaneCaps2KHR) {
     disp_plane_info.sType = VK_STRUCTURE_TYPE_DISPLAY_PLANE_INFO_2_KHR;
     disp_plane_info.pNext = nullptr;
     VkDisplayPlaneCapabilities2KHR caps = {};
-    ASSERT_DEATH(env->vulkan_functions.vkGetDisplayPlaneCapabilities2KHR(bad_physical_dev, &disp_plane_info, &caps),
+    ASSERT_DEATH(env.vulkan_functions.vkGetDisplayPlaneCapabilities2KHR(bad_physical_dev, &disp_plane_info, &caps),
                  "vkGetDisplayPlaneCapabilities2KHR: Invalid physicalDevice "
                  "\\[VUID-vkGetDisplayPlaneCapabilities2KHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceCaps2KHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceCaps2KHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_surface_capabilities2"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_get_surface_capabilities2");
     instance.CheckCreate();
@@ -1440,19 +1552,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceCaps2KHR) {
     phys_dev_surf_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
     phys_dev_surf_info.pNext = nullptr;
     VkSurfaceCapabilities2KHR caps = {};
-    ASSERT_DEATH(env->vulkan_functions.vkGetPhysicalDeviceSurfaceCapabilities2KHR(bad_physical_dev, &phys_dev_surf_info, &caps),
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceSurfaceCapabilities2KHR(bad_physical_dev, &phys_dev_surf_info, &caps),
                  "vkGetPhysicalDeviceSurfaceCapabilities2KHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceFormats2KHR) {
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceFormats2KHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_get_surface_capabilities2"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_get_surface_capabilities2");
     instance.CheckCreate();
 
@@ -1464,17 +1578,18 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfaceFormats2KHR) {
     phys_dev_surf_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
     phys_dev_surf_info.pNext = nullptr;
     uint32_t count = 0;
-    ASSERT_DEATH(
-        env->vulkan_functions.vkGetPhysicalDeviceSurfaceFormats2KHR(bad_physical_dev, &phys_dev_surf_info, &count, nullptr),
-        "vkGetPhysicalDeviceSurfaceFormats2KHR: Invalid physicalDevice "
-        "\\[VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-physicalDevice-parameter\\]");
+    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceSurfaceFormats2KHR(bad_physical_dev, &phys_dev_surf_info, &count, nullptr),
+                 "vkGetPhysicalDeviceSurfaceFormats2KHR: Invalid physicalDevice "
+                 "\\[VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevEnumPhysDevQueueFamilyPerfQueryCountersKHR) {
-    auto& driver = env->get_test_icd();
+TEST(LoaderHandleValidTests, BadPhysDevEnumPhysDevQueueFamilyPerfQueryCountersKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
 
     struct BadData {
@@ -1484,19 +1599,21 @@ TEST_F(LoaderHandleValidTests, BadPhysDevEnumPhysDevQueueFamilyPerfQueryCounters
     uint32_t count = 0;
     PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR pfn =
         reinterpret_cast<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
-            env->vulkan_functions.vkGetInstanceProcAddr(instance,
-                                                        "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR"));
+            env.vulkan_functions.vkGetInstanceProcAddr(instance,
+                                                       "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR"));
     ASSERT_NE(pfn, nullptr);
     ASSERT_DEATH(pfn(bad_physical_dev, 0, &count, nullptr, nullptr),
                  "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR: Invalid physicalDevice "
                  "\\[VUID-vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamilyPerfQueryPassesKHR) {
-    auto& driver = env->get_test_icd();
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamilyPerfQueryPassesKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
 
     struct BadData {
@@ -1509,18 +1626,20 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevQueueFamilyPerfQueryPassesKHR
     uint32_t count = 0;
     PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR pfn =
         reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR>(
-            env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR"));
+            env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR"));
     ASSERT_NE(pfn, nullptr);
     ASSERT_DEATH(pfn(bad_physical_dev, &create_info, &count),
                  "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFragmentShadingRatesKHR) {
-    auto& driver = env->get_test_icd();
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevFragmentShadingRatesKHR) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
 
     struct BadData {
@@ -1529,18 +1648,20 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevFragmentShadingRatesKHR) {
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     uint32_t count = 0;
     PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR pfn = reinterpret_cast<PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFragmentShadingRatesKHR"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFragmentShadingRatesKHR"));
     ASSERT_NE(pfn, nullptr);
     ASSERT_DEATH(pfn(bad_physical_dev, &count, nullptr),
                  "vkGetPhysicalDeviceFragmentShadingRatesKHR: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceFragmentShadingRatesKHR-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevMSPropsEXT) {
-    auto& driver = env->get_test_icd();
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevMSPropsEXT) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
 
     struct BadData {
@@ -1549,21 +1670,23 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevMSPropsEXT) {
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     VkMultisamplePropertiesEXT props = {};
     PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT pfn = reinterpret_cast<PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceMultisamplePropertiesEXT"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceMultisamplePropertiesEXT"));
     ASSERT_NE(pfn, nullptr);
     ASSERT_DEATH(pfn(bad_physical_dev, VK_SAMPLE_COUNT_1_BIT, &props),
                  "vkGetPhysicalDeviceMultisamplePropertiesEXT: Invalid physicalDevice "
                  "\\[VUID-vkGetPhysicalDeviceMultisamplePropertiesEXT-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevAcquireDrmDisplayEXT) {
+TEST(LoaderHandleValidTests, BadPhysDevAcquireDrmDisplayEXT) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_acquire_drm_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_EXT_acquire_drm_display");
     instance.CheckCreate();
 
@@ -1572,20 +1695,22 @@ TEST_F(LoaderHandleValidTests, BadPhysDevAcquireDrmDisplayEXT) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     PFN_vkAcquireDrmDisplayEXT pfn = reinterpret_cast<PFN_vkAcquireDrmDisplayEXT>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkAcquireDrmDisplayEXT"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkAcquireDrmDisplayEXT"));
     ASSERT_NE(pfn, nullptr);
     ASSERT_DEATH(pfn(bad_physical_dev, 0, VK_NULL_HANDLE),
                  "vkAcquireDrmDisplayEXT: Invalid physicalDevice \\[VUID-vkAcquireDrmDisplayEXT-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetDrmDisplayEXT) {
+TEST(LoaderHandleValidTests, BadPhysDevGetDrmDisplayEXT) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_acquire_drm_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_EXT_acquire_drm_display");
     instance.CheckCreate();
 
@@ -1594,21 +1719,23 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetDrmDisplayEXT) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     PFN_vkGetDrmDisplayEXT pfn =
-        reinterpret_cast<PFN_vkGetDrmDisplayEXT>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetDrmDisplayEXT"));
+        reinterpret_cast<PFN_vkGetDrmDisplayEXT>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetDrmDisplayEXT"));
     ASSERT_NE(pfn, nullptr);
     ASSERT_DEATH(pfn(bad_physical_dev, 0, 0, VK_NULL_HANDLE),
                  "vkGetDrmDisplayEXT: Invalid physicalDevice "
                  "\\[VUID-vkGetDrmDisplayEXT-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevReleaseDisplayEXT) {
+TEST(LoaderHandleValidTests, BadPhysDevReleaseDisplayEXT) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_direct_mode_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_EXT_direct_mode_display");
     instance.CheckCreate();
 
@@ -1617,21 +1744,23 @@ TEST_F(LoaderHandleValidTests, BadPhysDevReleaseDisplayEXT) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     PFN_vkReleaseDisplayEXT pfn =
-        reinterpret_cast<PFN_vkReleaseDisplayEXT>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkReleaseDisplayEXT"));
+        reinterpret_cast<PFN_vkReleaseDisplayEXT>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkReleaseDisplayEXT"));
     ASSERT_NE(pfn, nullptr);
     ASSERT_DEATH(pfn(bad_physical_dev, VK_NULL_HANDLE),
                  "vkReleaseDisplayEXT: Invalid physicalDevice \\[VUID-vkReleaseDisplayEXT-physicalDevice-parameter\\]");
 }
 
 #ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
-TEST_F(LoaderHandleValidTests, BadPhysDevAcquireXlibDisplayEXT) {
+TEST(LoaderHandleValidTests, BadPhysDevAcquireXlibDisplayEXT) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_acquire_xlib_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_EXT_acquire_xlib_display");
     instance.CheckCreate();
 
@@ -1640,20 +1769,22 @@ TEST_F(LoaderHandleValidTests, BadPhysDevAcquireXlibDisplayEXT) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     PFN_vkAcquireXlibDisplayEXT pfn = reinterpret_cast<PFN_vkAcquireXlibDisplayEXT>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkAcquireXlibDisplayEXT"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkAcquireXlibDisplayEXT"));
     ASSERT_NE(pfn, nullptr);
     ASSERT_DEATH(pfn(bad_physical_dev, nullptr, VK_NULL_HANDLE),
                  "vkAcquireXlibDisplayEXT: Invalid physicalDevice \\[VUID-vkAcquireXlibDisplayEXT-physicalDevice-parameter\\]");
 }
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetRandROutputDisplayEXT) {
+TEST(LoaderHandleValidTests, BadPhysDevGetRandROutputDisplayEXT) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_acquire_xlib_display"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_EXT_acquire_xlib_display");
     instance.CheckCreate();
 
@@ -1664,7 +1795,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetRandROutputDisplayEXT) {
     RROutput rrout = {};
     VkDisplayKHR disp;
     PFN_vkGetRandROutputDisplayEXT pfn = reinterpret_cast<PFN_vkGetRandROutputDisplayEXT>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetRandROutputDisplayEXT"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetRandROutputDisplayEXT"));
     ASSERT_NE(pfn, nullptr);
     ASSERT_DEATH(
         pfn(bad_physical_dev, nullptr, rrout, &disp),
@@ -1673,11 +1804,13 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetRandROutputDisplayEXT) {
 #endif  // VK_USE_PLATFORM_XLIB_XRANDR_EXT
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfacePresentModes2EXT) {
-    auto& driver = env->get_test_icd();
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfacePresentModes2EXT) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
 
     struct BadData {
@@ -1689,7 +1822,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfacePresentModes2EXT) {
     phys_dev_surf_info.pNext = nullptr;
     uint32_t count = 0;
     PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT pfn = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfacePresentModes2EXT"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfacePresentModes2EXT"));
     ASSERT_NE(pfn, nullptr);
     ASSERT_DEATH(pfn(bad_physical_dev, &phys_dev_surf_info, &count, nullptr),
                  "vkGetPhysicalDeviceSurfacePresentModes2EXT: Invalid physicalDevice "
@@ -1697,11 +1830,13 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevSurfacePresentModes2EXT) {
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
-TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevToolPropertiesEXT) {
-    auto& driver = env->get_test_icd();
+TEST(LoaderHandleValidTests, BadPhysDevGetPhysDevToolPropertiesEXT) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
 
     struct BadData {
@@ -1709,7 +1844,7 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevToolPropertiesEXT) {
     } my_bad_data;
     VkPhysicalDevice bad_physical_dev = (VkPhysicalDevice)(&my_bad_data);
     PFN_vkGetPhysicalDeviceToolPropertiesEXT pfn = reinterpret_cast<PFN_vkGetPhysicalDeviceToolPropertiesEXT>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceToolPropertiesEXT"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceToolPropertiesEXT"));
     ASSERT_NE(pfn, nullptr);
     uint32_t count = 0;
     ASSERT_DEATH(pfn(bad_physical_dev, &count, nullptr),
@@ -1718,23 +1853,24 @@ TEST_F(LoaderHandleValidTests, BadPhysDevGetPhysDevToolPropertiesEXT) {
 }
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingAndroidSurface) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingAndroidSurface) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_android_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_android_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -1745,10 +1881,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingAndroidSurface) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateAndroidSurfaceKHR pfn_CreateSurface = reinterpret_cast<PFN_vkCreateAndroidSurfaceKHR>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateAndroidSurfaceKHR"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateAndroidSurfaceKHR"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -1756,23 +1892,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingAndroidSurface) {
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 
 #ifdef VK_USE_PLATFORM_DIRECTFB_EXT
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingDirectFBSurf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingDirectFBSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_directfb_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_EXT_directfb_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -1783,10 +1920,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingDirectFBSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateDirectFBSurfaceEXT pfn_CreateSurface = reinterpret_cast<PFN_vkCreateDirectFBSurfaceEXT>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateDirectFBSurfaceEXT"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateDirectFBSurfaceEXT"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -1794,23 +1931,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingDirectFBSurf) {
 #endif  // VK_USE_PLATFORM_DIRECTFB_EXT
 
 #ifdef VK_USE_PLATFORM_FUCHSIA
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingFuchsiaSurf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingFuchsiaSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_FUCHSIA_imagepipe_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_FUCHSIA_imagepipe_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -1821,10 +1959,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingFuchsiaSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateImagePipeSurfaceFUCHSIA pfn_CreateSurface = reinterpret_cast<PFN_vkCreateImagePipeSurfaceFUCHSIA>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateImagePipeSurfaceFUCHSIA"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateImagePipeSurfaceFUCHSIA"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -1832,23 +1970,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingFuchsiaSurf) {
 #endif  // VK_USE_PLATFORM_FUCHSIA
 
 #ifdef VK_USE_PLATFORM_GGP
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingGGPSurf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingGGPSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_GGP_stream_descriptor_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_GGP_stream_descriptor_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -1859,10 +1998,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingGGPSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateStreamDescriptorSurfaceGGP pfn_CreateSurface = reinterpret_cast<PFN_vkCreateStreamDescriptorSurfaceGGP>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateStreamDescriptorSurfaceGGP"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateStreamDescriptorSurfaceGGP"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -1870,23 +2009,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingGGPSurf) {
 #endif  // VK_USE_PLATFORM_GGP
 
 #ifdef VK_USE_PLATFORM_IOS_MVK
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingIOSSurf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingIOSSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_MVK_ios_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_MVK_ios_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -1897,10 +2037,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingIOSSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateIOSSurfaceMVK pfn_CreateSurface =
-        reinterpret_cast<PFN_vkCreateIOSSurfaceMVK>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateIOSSurfaceMVK"));
+        reinterpret_cast<PFN_vkCreateIOSSurfaceMVK>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateIOSSurfaceMVK"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -1908,23 +2048,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingIOSSurf) {
 #endif  // VK_USE_PLATFORM_IOS_MVK
 
 #ifdef VK_USE_PLATFORM_MACOS_MVK
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingMacOSSurf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingMacOSSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_MVK_macos_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_MVK_macos_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -1935,10 +2076,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingMacOSSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateMacOSSurfaceMVK pfn_CreateSurface = reinterpret_cast<PFN_vkCreateMacOSSurfaceMVK>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateMacOSSurfaceMVK"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateMacOSSurfaceMVK"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -1946,23 +2087,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingMacOSSurf) {
 #endif  // VK_USE_PLATFORM_MACOS_MVK
 
 #if defined(VK_USE_PLATFORM_METAL_EXT)
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingMetalSurf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingMetalSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_EXT_metal_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_EXT_metal_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -1973,10 +2115,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingMetalSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateMetalSurfaceEXT pfn_CreateSurface = reinterpret_cast<PFN_vkCreateMetalSurfaceEXT>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateMetalSurfaceEXT"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateMetalSurfaceEXT"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -1984,23 +2126,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingMetalSurf) {
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingQNXSurf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingQNXSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_QNX_screen_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_QNX_screen_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -2011,10 +2154,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingQNXSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateScreenSurfaceQNX pfn_CreateSurface = reinterpret_cast<PFN_vkCreateScreenSurfaceQNX>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateScreenSurfaceQNX"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateScreenSurfaceQNX"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -2022,23 +2165,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingQNXSurf) {
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
 
 #ifdef VK_USE_PLATFORM_VI_NN
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingViNNSurf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingViNNSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_NN_vi_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_NN_vi_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -2049,10 +2193,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingViNNSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateViSurfaceNN pfn_CreateSurface =
-        reinterpret_cast<PFN_vkCreateViSurfaceNN>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateViSurfaceNN"));
+        reinterpret_cast<PFN_vkCreateViSurfaceNN>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateViSurfaceNN"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -2060,23 +2204,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingViNNSurf) {
 #endif  // VK_USE_PLATFORM_VI_NN
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingWaylandSurf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingWaylandSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_wayland_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_wayland_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -2087,10 +2232,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingWaylandSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateWaylandSurfaceKHR pfn_CreateSurface = reinterpret_cast<PFN_vkCreateWaylandSurfaceKHR>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateWaylandSurfaceKHR"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateWaylandSurfaceKHR"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -2098,23 +2243,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingWaylandSurf) {
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingWin32Surf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingWin32Surf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_win32_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_win32_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -2125,10 +2271,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingWin32Surf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateWin32SurfaceKHR pfn_CreateSurface = reinterpret_cast<PFN_vkCreateWin32SurfaceKHR>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateWin32SurfaceKHR"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateWin32SurfaceKHR"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -2136,23 +2282,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingWin32Surf) {
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 #ifdef VK_USE_PLATFORM_XCB_KHR
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingXCBSurf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingXCBSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xcb_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_xcb_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -2163,10 +2310,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingXCBSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateXcbSurfaceKHR pfn_CreateSurface =
-        reinterpret_cast<PFN_vkCreateXcbSurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateXcbSurfaceKHR"));
+        reinterpret_cast<PFN_vkCreateXcbSurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateXcbSurfaceKHR"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -2174,23 +2321,24 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingXCBSurf) {
 #endif  // VK_USE_PLATFORM_XCB_KHR
 
 #ifdef VK_USE_PLATFORM_XLIB_KHR
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingXlibSurf) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingXlibSurf) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension first_ext{"VK_KHR_surface"};
     Extension second_ext{"VK_KHR_xlib_surface"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({first_ext, second_ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_KHR_surface");
     instance.create_info.add_extension("VK_KHR_xlib_surface");
     instance.create_info.add_layer(wrap_objects_name);
@@ -2201,10 +2349,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingXlibSurf) {
     surf_create_info.pNext = nullptr;
     VkSurfaceKHR created_surface = VK_NULL_HANDLE;
     PFN_vkCreateXlibSurfaceKHR pfn_CreateSurface = reinterpret_cast<PFN_vkCreateXlibSurfaceKHR>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateXlibSurfaceKHR"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateXlibSurfaceKHR"));
     ASSERT_NE(pfn_CreateSurface, nullptr);
     PFN_vkDestroySurfaceKHR pfn_DestroySurface =
-        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+        reinterpret_cast<PFN_vkDestroySurfaceKHR>(env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
     ASSERT_NE(pfn_DestroySurface, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateSurface(instance, &surf_create_info, nullptr, &created_surface));
     pfn_DestroySurface(instance, created_surface, nullptr);
@@ -2222,22 +2370,23 @@ static VkBool32 JunkDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT me
     return VK_FALSE;
 }
 
-TEST_F(LoaderHandleValidTests, VerifyHandleWrappingDebugUtilsMessenger) {
+TEST(LoaderHandleValidTests, VerifyHandleWrappingDebugUtilsMessenger) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     Extension ext{"VK_EXT_debug_utils"};
-    auto& driver = env->get_test_icd();
+    auto& driver = env.get_test_icd();
     driver.add_instance_extensions({ext});
 
     const char* wrap_objects_name = "WrapObjectsLayer";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     driver.physical_devices.emplace_back("physical_device_0");
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
-    InstWrapper instance(env->vulkan_functions);
+    InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension("VK_EXT_debug_utils");
     instance.create_info.add_layer(wrap_objects_name);
     instance.CheckCreate();
@@ -2251,10 +2400,10 @@ TEST_F(LoaderHandleValidTests, VerifyHandleWrappingDebugUtilsMessenger) {
     debug_messenger_create_info.pfnUserCallback = reinterpret_cast<PFN_vkDebugUtilsMessengerCallbackEXT>(JunkDebugUtilsCallback);
     VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
     PFN_vkCreateDebugUtilsMessengerEXT pfn_CreateMessenger = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT"));
     ASSERT_NE(pfn_CreateMessenger, nullptr);
     PFN_vkDestroyDebugUtilsMessengerEXT pfn_DestroyMessenger = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(
-        env->vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT"));
+        env.vulkan_functions.vkGetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT"));
     ASSERT_NE(pfn_DestroyMessenger, nullptr);
     ASSERT_EQ(VK_SUCCESS, pfn_CreateMessenger(instance, &debug_messenger_create_info, nullptr, &messenger));
     pfn_DestroyMessenger(instance, messenger, nullptr);

--- a/tests/loader_handle_validation_tests.cpp
+++ b/tests/loader_handle_validation_tests.cpp
@@ -2359,9 +2359,10 @@ TEST(LoaderHandleValidTests, VerifyHandleWrappingXlibSurf) {
 }
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
-static VkBool32 JunkDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
-                                       VkDebugUtilsMessageTypeFlagsEXT messageTypes,
-                                       const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData) {
+static VKAPI_ATTR VkBool32 VKAPI_CALL JunkDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+                                                             VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+                                                             const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData,
+                                                             void* pUserData) {
     // This is just a stub callback in case the loader or any other layer triggers it.
     (void)messageSeverity;
     (void)messageTypes;

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -27,26 +27,6 @@
 
 #include "test_environment.h"
 
-class LayerTests : public ::testing::Test {
-   protected:
-    virtual void SetUp() {
-        env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
-        env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
-    }
-
-    virtual void TearDown() { env.reset(); }
-    std::unique_ptr<FrameworkEnvironment> env;
-};
-
-// Subtyping for organization
-class ExplicitLayers : public LayerTests {};
-class ImplicitLayers : public LayerTests {};
-class LayerExtensions : public LayerTests {};
-class MetaLayers : public LayerTests {};
-class OverrideMetaLayer : public LayerTests {};
-class LayerCreateInstance : public LayerTests {};
-class LayerPhysDeviceMod : public LayerTests {};
-
 void CheckLogForLayerString(FrameworkEnvironment& env, const char* implicit_layer_name, bool check_for_enable) {
     {
         InstWrapper inst{env.vulkan_functions};
@@ -63,92 +43,98 @@ void CheckLogForLayerString(FrameworkEnvironment& env, const char* implicit_laye
 
 const char* lunarg_meta_layer_name = "VK_LAYER_LUNARG_override";
 
-TEST_F(ImplicitLayers, WithEnableAndDisableEnvVar) {
+TEST(ImplicitLayers, WithEnableAndDisableEnvVar) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
     const char* enable_env_var = "ENABLE_ME";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(implicit_layer_name)
-                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                                          .set_disable_environment(disable_env_var)
-                                                          .set_enable_environment(enable_env_var)),
-                            "implicit_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(implicit_layer_name)
+                                                         .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                         .set_disable_environment(disable_env_var)
+                                                         .set_enable_environment(enable_env_var)),
+                           "implicit_test_layer.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     // didn't set enable env-var, layer should not load
-    CheckLogForLayerString(*env, implicit_layer_name, false);
+    CheckLogForLayerString(env, implicit_layer_name, false);
 
     // set enable env-var to 0, no layer should be found
     set_env_var(enable_env_var, "0");
-    CheckLogForLayerString(*env, implicit_layer_name, false);
+    CheckLogForLayerString(env, implicit_layer_name, false);
 
     // // set enable env-var, layer should load
     set_env_var(enable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, true);
+    CheckLogForLayerString(env, implicit_layer_name, true);
 
     remove_env_var(enable_env_var);
 
     // set disable env-var to 0, layer should not load
     set_env_var(disable_env_var, "0");
-    CheckLogForLayerString(*env, implicit_layer_name, false);
+    CheckLogForLayerString(env, implicit_layer_name, false);
 
     // set disable env-var to 1, layer should not load
     set_env_var(disable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, false);
+    CheckLogForLayerString(env, implicit_layer_name, false);
 
     // set both enable and disable env-var, layer should not load
     set_env_var(enable_env_var, "1");
     set_env_var(disable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, false);
+    CheckLogForLayerString(env, implicit_layer_name, false);
 
     remove_env_var(enable_env_var);
     remove_env_var(disable_env_var);
 }
 
-TEST_F(ImplicitLayers, OnlyDisableEnvVar) {
+TEST(ImplicitLayers, OnlyDisableEnvVar) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     const char* implicit_layer_name = "ImplicitTestLayer";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(implicit_layer_name)
-                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                                          .set_disable_environment(disable_env_var)),
-                            "implicit_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(implicit_layer_name)
+                                                         .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                         .set_disable_environment(disable_env_var)),
+                           "implicit_test_layer.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     // don't set disable env-var, layer should load
-    CheckLogForLayerString(*env, implicit_layer_name, true);
+    CheckLogForLayerString(env, implicit_layer_name, true);
 
     // set disable env-var to 0, layer should load
     set_env_var(disable_env_var, "0");
-    CheckLogForLayerString(*env, implicit_layer_name, false);
+    CheckLogForLayerString(env, implicit_layer_name, false);
 
     // set disable env-var to 1, layer should not load
     set_env_var(disable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, false);
+    CheckLogForLayerString(env, implicit_layer_name, false);
 
     {
-        InstWrapper inst{env->vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.create_info.add_layer(implicit_layer_name);
         inst.CheckCreate(VK_SUCCESS);
-        ASSERT_TRUE(env->debug_log.find(std::string("Insert instance layer ") + implicit_layer_name));
+        ASSERT_TRUE(env.debug_log.find(std::string("Insert instance layer ") + implicit_layer_name));
     }
     remove_env_var(disable_env_var);
 }
 
-TEST_F(ImplicitLayers, PreInstanceEnumInstLayerProps) {
+TEST(ImplicitLayers, PreInstanceEnumInstLayerProps) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     const char* implicit_layer_name = "ImplicitTestLayer";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(
+    env.add_implicit_layer(
         ManifestLayer{}
             .set_file_format_version(ManifestVersion(1, 1, 2))
             .add_layer(ManifestLayer::LayerDescription{}
@@ -161,67 +147,71 @@ TEST_F(ImplicitLayers, PreInstanceEnumInstLayerProps) {
         "implicit_test_layer.json");
 
     uint32_t layer_props = 43;
-    auto& layer = env->get_test_layer(0);
+    auto& layer = env.get_test_layer(0);
     layer.set_reported_layer_props(layer_props);
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
     ASSERT_EQ(count, layer_props);
 
     // set disable env-var to 1, layer should not load
     set_env_var(disable_env_var, "1");
 
     count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_NE(count, 0);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_NE(count, 0U);
     ASSERT_NE(count, layer_props);
 
     remove_env_var(disable_env_var);
 }
 
-TEST_F(ImplicitLayers, PreInstanceEnumInstExtProps) {
+TEST(ImplicitLayers, PreInstanceEnumInstExtProps) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     const char* implicit_layer_name = "ImplicitTestLayer";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 1, 2))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(implicit_layer_name)
-                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                               .set_disable_environment(disable_env_var)
-                                               .add_pre_instance_function(
-                                                   ManifestLayer::LayerDescription::FunctionOverride{}
-                                                       .set_vk_func("vkEnumerateInstanceExtensionProperties")
-                                                       .set_override_name("test_preinst_vkEnumerateInstanceExtensionProperties"))),
-                            "implicit_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 1, 2))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(implicit_layer_name)
+                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                              .set_disable_environment(disable_env_var)
+                                              .add_pre_instance_function(
+                                                  ManifestLayer::LayerDescription::FunctionOverride{}
+                                                      .set_vk_func("vkEnumerateInstanceExtensionProperties")
+                                                      .set_override_name("test_preinst_vkEnumerateInstanceExtensionProperties"))),
+                           "implicit_test_layer.json");
 
     uint32_t ext_props = 52;
-    auto& layer = env->get_test_layer(0);
+    auto& layer = env.get_test_layer(0);
     layer.set_reported_extension_props(ext_props);
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr));
     ASSERT_EQ(count, ext_props);
 
     // set disable env-var to 1, layer should not load
     set_env_var(disable_env_var, "1");
 
     count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr));
-    ASSERT_NE(count, 0);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr));
+    ASSERT_NE(count, 0U);
     ASSERT_NE(count, ext_props);
 
     remove_env_var(disable_env_var);
 }
 
-TEST_F(ImplicitLayers, PreInstanceVersion) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 2, 3);
+TEST(ImplicitLayers, PreInstanceVersion) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 2, 3);
 
     const char* implicit_layer_name = "ImplicitTestLayer";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(
+    env.add_implicit_layer(
         ManifestLayer{}
             .set_file_format_version(ManifestVersion(1, 1, 2))
             .add_layer(ManifestLayer::LayerDescription{}
@@ -235,19 +225,19 @@ TEST_F(ImplicitLayers, PreInstanceVersion) {
         "implicit_test_layer.json");
 
     uint32_t layer_version = VK_MAKE_API_VERSION(1, 2, 3, 4);
-    auto& layer = env->get_test_layer(0);
+    auto& layer = env.get_test_layer(0);
     layer.set_reported_instance_version(layer_version);
 
     uint32_t version = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceVersion(&version));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceVersion(&version));
     ASSERT_EQ(version, layer_version);
 
     // set disable env-var to 1, layer should not load
     set_env_var(disable_env_var, "1");
 
     version = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceVersion(&version));
-    ASSERT_NE(version, 0);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceVersion(&version));
+    ASSERT_NE(version, 0U);
     ASSERT_NE(version, layer_version);
 
     remove_env_var(disable_env_var);
@@ -257,32 +247,34 @@ TEST_F(ImplicitLayers, PreInstanceVersion) {
 // renamed vkGetInstanceProcAddr function which returns one that intentionally fails.  Then disable the
 // layer and verify it works.  The non-override version of vkCreateInstance in the layer also works (and is
 // tested through behavior above).
-TEST_F(ImplicitLayers, OverrideGetInstanceProcAddr) {
-    env->get_test_icd().physical_devices.push_back({});
+TEST(ImplicitLayers, OverrideGetInstanceProcAddr) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().physical_devices.push_back({});
 
     const char* implicit_layer_name = "ImplicitTestLayer";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 0, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(implicit_layer_name)
-                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_1)
-                                               .set_disable_environment(disable_env_var)
-                                               .add_function(ManifestLayer::LayerDescription::FunctionOverride{}
-                                                                 .set_vk_func("vkGetInstanceProcAddr")
-                                                                 .set_override_name("test_override_vkGetInstanceProcAddr"))),
-                            "implicit_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 0, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(implicit_layer_name)
+                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_1)
+                                              .set_disable_environment(disable_env_var)
+                                              .add_function(ManifestLayer::LayerDescription::FunctionOverride{}
+                                                                .set_vk_func("vkGetInstanceProcAddr")
+                                                                .set_override_name("test_override_vkGetInstanceProcAddr"))),
+                           "implicit_test_layer.json");
 
     {
-        InstWrapper inst1{env->vulkan_functions};
+        InstWrapper inst1{env.vulkan_functions};
         inst1.CheckCreate(VK_ERROR_INVALID_SHADER_NV);
     }
 
     {
         // set disable env-var to 1, layer should not load
         set_env_var(disable_env_var, "1");
-        InstWrapper inst2{env->vulkan_functions};
+        InstWrapper inst2{env.vulkan_functions};
         inst2.CheckCreate();
     }
 
@@ -290,215 +282,225 @@ TEST_F(ImplicitLayers, OverrideGetInstanceProcAddr) {
 }
 
 // Meta layer which contains component layers that do not exist.
-TEST_F(MetaLayers, InvalidComponentLayer) {
+TEST(MetaLayers, InvalidComponentLayer) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* invalid_layer_name_1 = "VK_LAYER_InvalidLayer1";
     const char* invalid_layer_name_2 = "VK_LAYER_InvalidLayer2";
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 1, 2))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(meta_layer_name)
-                                               .add_component_layers({invalid_layer_name_1, invalid_layer_name_2})
-                                               .set_disable_environment("NotGonnaWork")
-                                               .add_instance_extension({"NeverGonnaGiveYouUp"})
-                                               .add_device_extension({"NeverGonnaLetYouDown"})),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 1, 2))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(meta_layer_name)
+                                              .add_component_layers({invalid_layer_name_1, invalid_layer_name_2})
+                                              .set_disable_environment("NotGonnaWork")
+                                              .add_instance_extension({"NeverGonnaGiveYouUp"})
+                                              .add_device_extension({"NeverGonnaLetYouDown"})),
+                           "meta_test_layer.json");
 
     const char* regular_layer_name = "TestLayer";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(regular_layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
         "regular_test_layer.json");
 
     // should find 1, the 'regular' layer
     uint32_t layer_count = 1;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
-    EXPECT_EQ(layer_count, 1);
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+    EXPECT_EQ(layer_count, 1U);
 
     VkLayerProperties layer_props;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, &layer_props));
-    EXPECT_EQ(layer_count, 1);
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, &layer_props));
+    EXPECT_EQ(layer_count, 1U);
     EXPECT_TRUE(string_eq(layer_props.layerName, regular_layer_name));
 
     uint32_t extension_count = 0;
     std::array<VkExtensionProperties, 2> extensions;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-    EXPECT_EQ(extension_count, 2);  // return debug report & debug utils
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+    EXPECT_EQ(extension_count, 2U);  // return debug report & debug utils
 
     EXPECT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data()));
-    EXPECT_EQ(extension_count, 2);
+              env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data()));
+    EXPECT_EQ(extension_count, 2U);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_layer(meta_layer_name);
-    FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+    FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate(VK_ERROR_LAYER_NOT_PRESENT);
-    ASSERT_TRUE(env->debug_log.find(std::string("verify_meta_layer_component_layers: Meta-layer ") + meta_layer_name +
-                                    " can't find component layer " + invalid_layer_name_1 + " at index 0.  Skipping this layer."));
+    ASSERT_TRUE(env.debug_log.find(std::string("verify_meta_layer_component_layers: Meta-layer ") + meta_layer_name +
+                                   " can't find component layer " + invalid_layer_name_1 + " at index 0.  Skipping this layer."));
 }
 
 // Meta layer that is an explicit layer
-TEST_F(MetaLayers, ExplicitMetaLayer) {
-    env->get_test_icd().add_physical_device({});
+TEST(MetaLayers, ExplicitMetaLayer) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* regular_layer_name = "VK_LAYER_TestLayer";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}
             .set_file_format_version(ManifestVersion(1, 1, 2))
             .add_layer(ManifestLayer::LayerDescription{}.set_name(meta_layer_name).add_component_layers({regular_layer_name})),
         "meta_test_layer.json");
 
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(regular_layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
         "regular_test_layer.json");
     {  // global functions
         // should find 1, the 'regular' layer
         uint32_t layer_count = 0;
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
-        EXPECT_EQ(layer_count, 2);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+        EXPECT_EQ(layer_count, 2U);
 
         std::array<VkLayerProperties, 2> layer_props;
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
-        EXPECT_EQ(layer_count, 2);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
+        EXPECT_EQ(layer_count, 2U);
         EXPECT_TRUE(check_permutation({regular_layer_name, meta_layer_name}, layer_props));
 
         uint32_t extension_count = 0;
         std::array<VkExtensionProperties, 2> extensions;
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-        EXPECT_EQ(extension_count, 2);  // return debug report & debug utils
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+        EXPECT_EQ(extension_count, 2U);  // return debug report & debug utils
 
         EXPECT_EQ(VK_SUCCESS,
-                  env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data()));
-        EXPECT_EQ(extension_count, 2);
+                  env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data()));
+        EXPECT_EQ(extension_count, 2U);
     }
     {  // don't enable the layer, shouldn't find any layers when calling vkEnumerateDeviceLayerProperties
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate(VK_SUCCESS);
         auto phys_dev = inst.GetPhysDev();
         uint32_t count = 0;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(count, 0);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        ASSERT_EQ(count, 0U);
     }
     {
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.create_info.add_layer(meta_layer_name);
         inst.CheckCreate(VK_SUCCESS);
         auto phys_dev = inst.GetPhysDev();
         uint32_t count = 0;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(count, 2);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        ASSERT_EQ(count, 2U);
         std::array<VkLayerProperties, 2> layer_props;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
-        ASSERT_EQ(count, 2);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
+        ASSERT_EQ(count, 2U);
         EXPECT_TRUE(check_permutation({regular_layer_name, meta_layer_name}, layer_props));
     }
 }
 
 // Meta layer which adds itself in its list of component layers
-TEST_F(MetaLayers, MetaLayerNameInComponentLayers) {
+TEST(MetaLayers, MetaLayerNameInComponentLayers) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* regular_layer_name = "VK_LAYER_TestLayer";
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 1, 2))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(meta_layer_name)
-                                               .add_component_layers({meta_layer_name, regular_layer_name})
-                                               .set_disable_environment("NotGonnaWork")
-                                               .add_instance_extension({"NeverGonnaGiveYouUp"})
-                                               .add_device_extension({"NeverGonnaLetYouDown"})),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 1, 2))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(meta_layer_name)
+                                              .add_component_layers({meta_layer_name, regular_layer_name})
+                                              .set_disable_environment("NotGonnaWork")
+                                              .add_instance_extension({"NeverGonnaGiveYouUp"})
+                                              .add_device_extension({"NeverGonnaLetYouDown"})),
+                           "meta_test_layer.json");
 
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(regular_layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
         "regular_test_layer.json");
 
     // should find 1, the 'regular' layer
     uint32_t layer_count = 1;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
-    EXPECT_EQ(layer_count, 1);
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+    EXPECT_EQ(layer_count, 1U);
 
     VkLayerProperties layer_props;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, &layer_props));
-    EXPECT_EQ(layer_count, 1);
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, &layer_props));
+    EXPECT_EQ(layer_count, 1U);
     EXPECT_TRUE(string_eq(layer_props.layerName, regular_layer_name));
 
     uint32_t extension_count = 0;
     std::array<VkExtensionProperties, 2> extensions;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-    EXPECT_EQ(extension_count, 2);  // return debug report & debug utils
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+    EXPECT_EQ(extension_count, 2U);  // return debug report & debug utils
 
     EXPECT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data()));
-    EXPECT_EQ(extension_count, 2);
+              env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data()));
+    EXPECT_EQ(extension_count, 2U);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_layer(meta_layer_name);
-    FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+    FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate(VK_ERROR_LAYER_NOT_PRESENT);
-    ASSERT_TRUE(env->debug_log.find(std::string("verify_meta_layer_component_layers: Meta-layer ") + meta_layer_name +
-                                    " lists itself in its component layer " + "list at index 0.  Skipping this layer."));
+    ASSERT_TRUE(env.debug_log.find(std::string("verify_meta_layer_component_layers: Meta-layer ") + meta_layer_name +
+                                   " lists itself in its component layer " + "list at index 0.  Skipping this layer."));
 }
 
 // Meta layer which adds another meta layer as a component layer
-TEST_F(MetaLayers, MetaLayerWhichAddsMetaLayer) {
+TEST(MetaLayers, MetaLayerWhichAddsMetaLayer) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* meta_meta_layer_name = "VK_LAYER_MetaMetaTestLayer";
     const char* regular_layer_name = "VK_LAYER_TestLayer";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(regular_layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
         "regular_test_layer.json");
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}
             .set_file_format_version(ManifestVersion(1, 1, 2))
             .add_layer(ManifestLayer::LayerDescription{}.set_name(meta_layer_name).add_component_layers({regular_layer_name})),
         "meta_test_layer.json");
-    env->add_explicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 1, 2))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(meta_meta_layer_name)
-                                               .add_component_layers({meta_layer_name, regular_layer_name})),
-                            "meta_meta_test_layer.json");
+    env.add_explicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 1, 2))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(meta_meta_layer_name)
+                                              .add_component_layers({meta_layer_name, regular_layer_name})),
+                           "meta_meta_test_layer.json");
 
     uint32_t layer_count = 3;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
-    EXPECT_EQ(layer_count, 3);
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+    EXPECT_EQ(layer_count, 3U);
 
     std::array<VkLayerProperties, 3> layer_props;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
-    EXPECT_EQ(layer_count, 3);
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
+    EXPECT_EQ(layer_count, 3U);
     EXPECT_TRUE(check_permutation({regular_layer_name, meta_layer_name, meta_meta_layer_name}, layer_props));
 
     uint32_t extension_count = 0;
     std::array<VkExtensionProperties, 2> extensions;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-    EXPECT_EQ(extension_count, 2);  // return debug report & debug utils
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+    EXPECT_EQ(extension_count, 2U);  // return debug report & debug utils
 
     EXPECT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data()));
-    EXPECT_EQ(extension_count, 2);
+              env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data()));
+    EXPECT_EQ(extension_count, 2U);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_layer(meta_layer_name);
-    FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+    FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate();
-    ASSERT_TRUE(env->debug_log.find(std::string("verify_meta_layer_component_layers: Adding meta-layer ") + meta_meta_layer_name +
-                                    " which also contains meta-layer " + meta_layer_name));
+    ASSERT_TRUE(env.debug_log.find(std::string("verify_meta_layer_component_layers: Adding meta-layer ") + meta_meta_layer_name +
+                                   " which also contains meta-layer " + meta_layer_name));
 }
 
-TEST_F(MetaLayers, InstanceExtensionInComponentLayer) {
-    env->get_test_icd().add_physical_device({});
+TEST(MetaLayers, InstanceExtensionInComponentLayer) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* regular_layer_name = "VK_LAYER_TestLayer";
     const char* instance_ext_name = "VK_EXT_headless_surface";
-    env->add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(regular_layer_name)
-                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                                          .add_instance_extension({instance_ext_name})),
-                            "regular_test_layer.json");
-    env->add_explicit_layer(
+    env.add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(regular_layer_name)
+                                                         .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                         .add_instance_extension({instance_ext_name})),
+                           "regular_test_layer.json");
+    env.add_explicit_layer(
         ManifestLayer{}
             .set_file_format_version(ManifestVersion(1, 1, 2))
             .add_layer(ManifestLayer::LayerDescription{}.set_name(meta_layer_name).add_component_layers({regular_layer_name})),
@@ -506,26 +508,28 @@ TEST_F(MetaLayers, InstanceExtensionInComponentLayer) {
 
     uint32_t extension_count = 0;
     std::array<VkExtensionProperties, 1> extensions;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(meta_layer_name, &extension_count, nullptr));
-    EXPECT_EQ(extension_count, 1);  // return instance_ext_name
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(meta_layer_name, &extension_count, nullptr));
+    EXPECT_EQ(extension_count, 1U);  // return instance_ext_name
 
     EXPECT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateInstanceExtensionProperties(meta_layer_name, &extension_count, extensions.data()));
-    EXPECT_EQ(extension_count, 1);
+              env.vulkan_functions.vkEnumerateInstanceExtensionProperties(meta_layer_name, &extension_count, extensions.data()));
+    EXPECT_EQ(extension_count, 1U);
     EXPECT_TRUE(string_eq(extensions[0].extensionName, instance_ext_name));
 }
 
-TEST_F(MetaLayers, DeviceExtensionInComponentLayer) {
-    env->get_test_icd().add_physical_device({});
+TEST(MetaLayers, DeviceExtensionInComponentLayer) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* regular_layer_name = "VK_LAYER_TestLayer";
     const char* device_ext_name = "VK_EXT_fake_dev_ext";
-    env->add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(regular_layer_name)
-                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                                          .add_device_extension({device_ext_name})),
-                            "regular_test_layer.json");
-    env->add_explicit_layer(
+    env.add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(regular_layer_name)
+                                                         .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                         .add_device_extension({device_ext_name})),
+                           "regular_test_layer.json");
+    env.add_explicit_layer(
         ManifestLayer{}
             .set_file_format_version(ManifestVersion(1, 1, 2))
             .add_layer(ManifestLayer::LayerDescription{}.set_name(meta_layer_name).add_component_layers({regular_layer_name})),
@@ -533,402 +537,416 @@ TEST_F(MetaLayers, DeviceExtensionInComponentLayer) {
     {
         uint32_t extension_count = 0;
         EXPECT_EQ(VK_SUCCESS,
-                  env->vulkan_functions.vkEnumerateInstanceExtensionProperties(meta_layer_name, &extension_count, nullptr));
-        EXPECT_EQ(extension_count, 0);
+                  env.vulkan_functions.vkEnumerateInstanceExtensionProperties(meta_layer_name, &extension_count, nullptr));
+        EXPECT_EQ(extension_count, 0U);
     }
     {  // layer is not enabled
-        InstWrapper inst{env->vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
-        ASSERT_TRUE(env->debug_log.find(std::string("Meta-layer ") + meta_layer_name + " component layer " + regular_layer_name +
-                                        " adding device extension " + device_ext_name));
+        ASSERT_TRUE(env.debug_log.find(std::string("Meta-layer ") + meta_layer_name + " component layer " + regular_layer_name +
+                                       " adding device extension " + device_ext_name));
 
         auto phys_dev = inst.GetPhysDev();
         uint32_t extension_count = 0;
         std::array<VkExtensionProperties, 1> extensions;
         EXPECT_EQ(VK_SUCCESS,
-                  env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, meta_layer_name, &extension_count, nullptr));
-        EXPECT_EQ(extension_count, 1);  // return device_ext_name
+                  env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, meta_layer_name, &extension_count, nullptr));
+        EXPECT_EQ(extension_count, 1U);  // return device_ext_name
 
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, meta_layer_name,
-                                                                                         &extension_count, extensions.data()));
-        EXPECT_EQ(extension_count, 1);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, meta_layer_name, &extension_count,
+                                                                                        extensions.data()));
+        EXPECT_EQ(extension_count, 1U);
         EXPECT_TRUE(string_eq(extensions[0].extensionName, device_ext_name));
     }
     {  // layer is enabled
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.create_info.add_layer(meta_layer_name);
-        FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
-        ASSERT_TRUE(env->debug_log.find(std::string("Meta-layer ") + meta_layer_name + " component layer " + regular_layer_name +
-                                        " adding device extension " + device_ext_name));
+        ASSERT_TRUE(env.debug_log.find(std::string("Meta-layer ") + meta_layer_name + " component layer " + regular_layer_name +
+                                       " adding device extension " + device_ext_name));
         auto phys_dev = inst.GetPhysDev();
 
         uint32_t extension_count = 0;
         std::array<VkExtensionProperties, 1> extensions;
         EXPECT_EQ(VK_SUCCESS,
-                  env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, meta_layer_name, &extension_count, nullptr));
-        EXPECT_EQ(extension_count, 1);  // return device_ext_name
+                  env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, meta_layer_name, &extension_count, nullptr));
+        EXPECT_EQ(extension_count, 1U);  // return device_ext_name
 
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, meta_layer_name,
-                                                                                         &extension_count, extensions.data()));
-        EXPECT_EQ(extension_count, 1);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, meta_layer_name, &extension_count,
+                                                                                        extensions.data()));
+        EXPECT_EQ(extension_count, 1U);
         EXPECT_TRUE(string_eq(extensions[0].extensionName, device_ext_name));
     }
 }
 // Override meta layer missing disable environment variable still enables the layer
-TEST_F(OverrideMetaLayer, InvalidDisableEnvironment) {
-    env->get_test_icd().add_physical_device({});
+TEST(OverrideMetaLayer, InvalidDisableEnvironment) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
     const char* regular_layer_name = "VK_LAYER_TestLayer";
-    env->add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(regular_layer_name)
-                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                                          .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                                          .add_device_extension({"NeverGonnaLetYouDown"})),
-                            "regular_test_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(regular_layer_name)
+                                                         .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                                         .add_device_extension({"NeverGonnaLetYouDown"})),
+                           "regular_test_layer.json");
 
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 1, 2))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(lunarg_meta_layer_name)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                               .add_component_layers({regular_layer_name})),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 1, 2))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(lunarg_meta_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                              .add_component_layers({regular_layer_name})),
+                           "meta_test_layer.json");
 
     uint32_t layer_count = 0;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
-    EXPECT_EQ(layer_count, 1);
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+    EXPECT_EQ(layer_count, 1U);
 
     std::array<VkLayerProperties, 1> layer_props;
-    EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
-    EXPECT_EQ(layer_count, 1);
+    EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
+    EXPECT_EQ(layer_count, 1U);
     EXPECT_TRUE(string_eq(layer_props[0].layerName, regular_layer_name));
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
 }
 
 // Override meta layer whose version is less than the api version of the instance
-TEST_F(OverrideMetaLayer, OlderVersionThanInstance) {
-    env->get_test_icd().add_physical_device({});
+TEST(OverrideMetaLayer, OlderVersionThanInstance) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
     const char* regular_layer_name = "VK_LAYER_TestLayer";
-    env->add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(regular_layer_name)
-                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                                          .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                                          .add_device_extension({"NeverGonnaLetYouDown"})),
-                            "regular_test_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(regular_layer_name)
+                                                         .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                                         .add_device_extension({"NeverGonnaLetYouDown"})),
+                           "regular_test_layer.json");
 
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 1, 2))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(lunarg_meta_layer_name)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                               .set_disable_environment("DisableMeIfYouCan")
-                                               .add_component_layers({regular_layer_name})),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 1, 2))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(lunarg_meta_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                              .set_disable_environment("DisableMeIfYouCan")
+                                              .add_component_layers({regular_layer_name})),
+                           "meta_test_layer.json");
     {  // global functions
         uint32_t layer_count = 0;
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
-        EXPECT_EQ(layer_count, 2);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+        EXPECT_EQ(layer_count, 2U);
 
         std::array<VkLayerProperties, 2> layer_props;
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
-        EXPECT_EQ(layer_count, 2);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
+        EXPECT_EQ(layer_count, 2U);
         EXPECT_TRUE(check_permutation({regular_layer_name, lunarg_meta_layer_name}, layer_props));
     }
     {  // 1.1 instance
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.create_info.api_version = VK_API_VERSION_1_1;
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
 
         uint32_t count = 0;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(2, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        ASSERT_EQ(2U, count);
         std::array<VkLayerProperties, 2> layer_props;
 
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
-        ASSERT_EQ(2, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
+        ASSERT_EQ(2U, count);
         ASSERT_TRUE(string_eq(layer_props[0].layerName, regular_layer_name));
         ASSERT_TRUE(string_eq(layer_props[1].layerName, lunarg_meta_layer_name));
     }
     {  // 1.2 instance
 
-        InstWrapper inst{env->vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
 
         inst.create_info.api_version = VK_API_VERSION_1_2;
         inst.CheckCreate();
-        ASSERT_TRUE(env->debug_log.find(std::string("loader_add_implicit_layer: Disabling implicit layer ") +
-                                        lunarg_meta_layer_name +
-                                        " for using an old API version 1.1 versus application requested 1.2"));
+        ASSERT_TRUE(env.debug_log.find(std::string("loader_add_implicit_layer: Disabling implicit layer ") +
+                                       lunarg_meta_layer_name +
+                                       " for using an old API version 1.1 versus application requested 1.2"));
     }
 }
 
-TEST_F(OverrideMetaLayer, OlderMetaLayerWithNewerInstanceVersion) {
-    env->get_test_icd().add_physical_device({});
+TEST(OverrideMetaLayer, OlderMetaLayerWithNewerInstanceVersion) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
 
     const char* regular_layer_name = "VK_LAYER_TestLayer";
-    env->add_explicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(regular_layer_name)
-                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))),
-                            "regular_test_layer.json");
+    env.add_explicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(regular_layer_name)
+                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))),
+                           "regular_test_layer.json");
 
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(lunarg_meta_layer_name)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                               .add_component_layers({regular_layer_name})
-                                               .set_disable_environment("DisableMeIfYouCan")),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(lunarg_meta_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                              .add_component_layers({regular_layer_name})
+                                              .set_disable_environment("DisableMeIfYouCan")),
+                           "meta_test_layer.json");
     {  // global functions
         uint32_t layer_count = 2;
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
-        EXPECT_EQ(layer_count, 2);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+        EXPECT_EQ(layer_count, 2U);
 
         std::array<VkLayerProperties, 2> layer_props;
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
-        EXPECT_EQ(layer_count, 2);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
+        EXPECT_EQ(layer_count, 2U);
         EXPECT_TRUE(check_permutation({regular_layer_name, lunarg_meta_layer_name}, layer_props));
     }
     {
         // 1.1 instance
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.create_info.set_api_version(1, 1, 0);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
 
         uint32_t count = 0;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(2, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        ASSERT_EQ(2U, count);
         std::array<VkLayerProperties, 2> layer_props;
 
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
-        ASSERT_EQ(2, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
+        ASSERT_EQ(2U, count);
         ASSERT_TRUE(string_eq(layer_props[0].layerName, regular_layer_name));
         ASSERT_TRUE(string_eq(layer_props[1].layerName, lunarg_meta_layer_name));
     }
 
     {
         // 1.2 instance
-        InstWrapper inst{env->vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.create_info.set_api_version(1, 2, 0);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
         ASSERT_TRUE(
-            env->debug_log.find("loader_add_implicit_layer: Disabling implicit layer VK_LAYER_LUNARG_override for using an old API "
-                                "version 1.1 versus application requested 1.2"));
+            env.debug_log.find("loader_add_implicit_layer: Disabling implicit layer VK_LAYER_LUNARG_override for using an old API "
+                               "version 1.1 versus application requested 1.2"));
         uint32_t count = 0;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(0, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        ASSERT_EQ(0U, count);
         std::array<VkLayerProperties, 2> layer_props;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
-        ASSERT_EQ(0, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
+        ASSERT_EQ(0U, count);
     }
 }
 
-TEST_F(OverrideMetaLayer, NewerComponentLayerInMetaLayer) {
-    env->get_test_icd().add_physical_device({});
+TEST(OverrideMetaLayer, NewerComponentLayerInMetaLayer) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
 
     const char* regular_layer_name = "VK_LAYER_TestLayer";
-    env->add_explicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(regular_layer_name)
-                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 2, 0))),
-                            "regular_test_layer.json");
+    env.add_explicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(regular_layer_name)
+                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 2, 0))),
+                           "regular_test_layer.json");
 
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(lunarg_meta_layer_name)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                               .add_component_layers({regular_layer_name})
-                                               .set_disable_environment("DisableMeIfYouCan")),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(lunarg_meta_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                              .add_component_layers({regular_layer_name})
+                                              .set_disable_environment("DisableMeIfYouCan")),
+                           "meta_test_layer.json");
     {  // global functions
         uint32_t layer_count = 1;
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
-        EXPECT_EQ(layer_count, 1);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+        EXPECT_EQ(layer_count, 1U);
 
         std::array<VkLayerProperties, 1> layer_props;
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
-        EXPECT_EQ(layer_count, 1);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
+        EXPECT_EQ(layer_count, 1U);
         // Expect the explicit layer to still be found
         EXPECT_TRUE(string_eq(layer_props[0].layerName, regular_layer_name));
     }
     {
         // 1.1 instance
-        InstWrapper inst{env->vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.create_info.set_api_version(1, 1, 0);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
         ASSERT_TRUE(
-            env->debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 uses "
-                                "API version 1.2.  Skipping this layer."));
-        env->debug_log.clear();
+            env.debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 uses "
+                               "API version 1.2.  Skipping this layer."));
+        env.debug_log.clear();
         uint32_t count = 0;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(0, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        ASSERT_EQ(0U, count);
         std::array<VkLayerProperties, 1> layer_props;
 
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
-        ASSERT_EQ(0, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
+        ASSERT_EQ(0U, count);
     }
 
     {
         // 1.2 instance
-        InstWrapper inst{env->vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.create_info.set_api_version(1, 2, 0);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
         ASSERT_TRUE(
-            env->debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 uses "
-                                "API version 1.2.  Skipping this layer."));
-        env->debug_log.clear();
+            env.debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 uses "
+                               "API version 1.2.  Skipping this layer."));
+        env.debug_log.clear();
         uint32_t count = 0;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(0, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        ASSERT_EQ(0U, count);
         std::array<VkLayerProperties, 2> layer_props;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
-        ASSERT_EQ(0, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
+        ASSERT_EQ(0U, count);
     }
 }
 
-TEST_F(OverrideMetaLayer, OlderComponentLayerInMetaLayer) {
-    env->get_test_icd().add_physical_device({});
+TEST(OverrideMetaLayer, OlderComponentLayerInMetaLayer) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
 
     const char* regular_layer_name = "VK_LAYER_TestLayer";
-    env->add_explicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(regular_layer_name)
-                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0))),
-                            "regular_test_layer.json");
+    env.add_explicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(regular_layer_name)
+                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0))),
+                           "regular_test_layer.json");
 
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(lunarg_meta_layer_name)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                               .add_component_layers({regular_layer_name})
-                                               .set_disable_environment("DisableMeIfYouCan")),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(lunarg_meta_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                              .add_component_layers({regular_layer_name})
+                                              .set_disable_environment("DisableMeIfYouCan")),
+                           "meta_test_layer.json");
     {  // global functions
         uint32_t layer_count = 0;
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
-        EXPECT_EQ(layer_count, 1);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
+        EXPECT_EQ(layer_count, 1U);
 
         std::array<VkLayerProperties, 1> layer_props;
-        EXPECT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
-        EXPECT_EQ(layer_count, 1);
+        EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
+        EXPECT_EQ(layer_count, 1U);
         EXPECT_TRUE(string_eq(layer_props[0].layerName, regular_layer_name));
     }
     {
         // 1.1 instance
-        InstWrapper inst{env->vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.create_info.set_api_version(1, 1, 0);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
         ASSERT_TRUE(
-            env->debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 uses "
-                                "API version 1.0.  Skipping this layer."));
-        env->debug_log.clear();
+            env.debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 uses "
+                               "API version 1.0.  Skipping this layer."));
+        env.debug_log.clear();
         uint32_t count = 0;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(0, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        ASSERT_EQ(0U, count);
         std::array<VkLayerProperties, 2> layer_props;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
-        ASSERT_EQ(0, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
+        ASSERT_EQ(0U, count);
     }
 
     {
         // 1.2 instance
-        InstWrapper inst{env->vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.create_info.set_api_version(1, 2, 0);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
         ASSERT_TRUE(
-            env->debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 uses "
-                                "API version 1.0.  Skipping this layer."));
-        env->debug_log.clear();
+            env.debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 uses "
+                               "API version 1.0.  Skipping this layer."));
+        env.debug_log.clear();
         uint32_t count = 0;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(0, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        ASSERT_EQ(0U, count);
         std::array<VkLayerProperties, 2> layer_props;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
-        ASSERT_EQ(0, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
+        ASSERT_EQ(0U, count);
     }
 }
 
-TEST_F(OverrideMetaLayer, ApplicationEnabledLayerInBlacklist) {
-    env->get_test_icd().add_physical_device({});
+TEST(OverrideMetaLayer, ApplicationEnabledLayerInBlacklist) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
 
     const char* automatic_regular_layer_name = "VK_LAYER_TestLayer_1";
     const char* manual_regular_layer_name = "VK_LAYER_TestLayer_2";
-    env->add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(automatic_regular_layer_name)
-                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                                          .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))),
-                            "regular_test_layer_1.json");
-    env->add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(manual_regular_layer_name)
-                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                                          .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))),
-                            "regular_test_layer_2.json");
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(lunarg_meta_layer_name)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                               .add_component_layer(automatic_regular_layer_name)
-                                               .add_blacklisted_layer(manual_regular_layer_name)
-                                               .set_disable_environment("DisableMeIfYouCan")),
-                            "meta_test_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(automatic_regular_layer_name)
+                                                         .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))),
+                           "regular_test_layer_1.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(manual_regular_layer_name)
+                                                         .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))),
+                           "regular_test_layer_2.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(lunarg_meta_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                              .add_component_layer(automatic_regular_layer_name)
+                                              .add_blacklisted_layer(manual_regular_layer_name)
+                                              .set_disable_environment("DisableMeIfYouCan")),
+                           "meta_test_layer.json");
 
     {  // enable the layer in the blacklist
-        InstWrapper inst{env->vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.create_info.add_layer(manual_regular_layer_name);
         inst.CheckCreate(VK_ERROR_LAYER_NOT_PRESENT);
-        ASSERT_TRUE(env->debug_log.find(std::string("loader_remove_layers_in_blacklist: Override layer is active and layer ") +
-                                        manual_regular_layer_name +
-                                        " is in the blacklist inside of it. Removing that layer from current layer list."));
-        env->debug_log.clear();
+        ASSERT_TRUE(env.debug_log.find(std::string("loader_remove_layers_in_blacklist: Override layer is active and layer ") +
+                                       manual_regular_layer_name +
+                                       " is in the blacklist inside of it. Removing that layer from current layer list."));
+        env.debug_log.clear();
     }
     {  // dont enable the layer in the blacklist
-        InstWrapper inst{env->vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
-        ASSERT_TRUE(env->debug_log.find(std::string("loader_remove_layers_in_blacklist: Override layer is active and layer ") +
-                                        manual_regular_layer_name +
-                                        " is in the blacklist inside of it. Removing that layer from current layer list."));
-        env->debug_log.clear();
+        ASSERT_TRUE(env.debug_log.find(std::string("loader_remove_layers_in_blacklist: Override layer is active and layer ") +
+                                       manual_regular_layer_name +
+                                       " is in the blacklist inside of it. Removing that layer from current layer list."));
+        env.debug_log.clear();
         uint32_t count = 0;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(2, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
+        ASSERT_EQ(2U, count);
         std::array<VkLayerProperties, 2> layer_props;
-        env->vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
-        ASSERT_EQ(2, count);
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
+        ASSERT_EQ(2U, count);
         ASSERT_TRUE(check_permutation({automatic_regular_layer_name, lunarg_meta_layer_name}, layer_props));
     }
 }
 
-TEST_F(OverrideMetaLayer, BasicOverridePaths) {
-    env->get_test_icd().add_physical_device({});
+TEST(OverrideMetaLayer, BasicOverridePaths) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
     fs::FolderManager override_layer_folder{FRAMEWORK_BUILD_DIRECTORY, "override_layer_folder"};
 
     const char* regular_layer_name = "VK_LAYER_TestLayer_1";
@@ -940,36 +958,38 @@ TEST_F(OverrideMetaLayer, BasicOverridePaths) {
                                                             .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0)))
                                              .get_manifest_str());
     auto override_folder_location = fs::make_native(override_layer_folder.location().str());
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(lunarg_meta_layer_name)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                               .add_component_layer(regular_layer_name)
-                                               .set_disable_environment("DisableMeIfYouCan")
-                                               .add_override_path(override_folder_location)),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(lunarg_meta_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                              .add_component_layer(regular_layer_name)
+                                              .set_disable_environment("DisableMeIfYouCan")
+                                              .add_override_path(override_folder_location)),
+                           "meta_test_layer.json");
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.set_api_version(1, 1, 0);
-    FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+    FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate();
-    ASSERT_TRUE(env->debug_log.find(std::string("Insert instance layer ") + regular_layer_name));
-    env->layers.clear();
+    ASSERT_TRUE(env.debug_log.find(std::string("Insert instance layer ") + regular_layer_name));
+    env.layers.clear();
 }
 
-TEST_F(OverrideMetaLayer, BasicOverridePathsIgnoreOtherLayers) {
-    env->get_test_icd().add_physical_device({});
+TEST(OverrideMetaLayer, BasicOverridePathsIgnoreOtherLayers) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
     fs::FolderManager override_layer_folder{FRAMEWORK_BUILD_DIRECTORY, "override_layer_folder"};
 
     const char* regular_layer_name = "VK_LAYER_TestLayer";
-    env->add_explicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(regular_layer_name)
-                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0))),
-                            "regular_test_layer.json");
+    env.add_explicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(regular_layer_name)
+                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0))),
+                           "regular_test_layer.json");
 
     const char* special_layer_name = "VK_LAYER_TestLayer_1";
     override_layer_folder.write_manifest("regular_test_layer.json",
@@ -980,27 +1000,29 @@ TEST_F(OverrideMetaLayer, BasicOverridePathsIgnoreOtherLayers) {
                                                             .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0)))
                                              .get_manifest_str());
     auto override_folder_location = fs::make_native(override_layer_folder.location().str());
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(lunarg_meta_layer_name)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                               .add_component_layer(special_layer_name)
-                                               .set_disable_environment("DisableMeIfYouCan")
-                                               .add_override_path(override_folder_location)),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(lunarg_meta_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                              .add_component_layer(special_layer_name)
+                                              .set_disable_environment("DisableMeIfYouCan")
+                                              .add_override_path(override_folder_location)),
+                           "meta_test_layer.json");
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.set_api_version(1, 1, 0);
     inst.create_info.add_layer(regular_layer_name);
-    FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+    FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate(VK_ERROR_LAYER_NOT_PRESENT);
-    ASSERT_FALSE(env->debug_log.find(std::string("Insert instance layer ") + regular_layer_name));
-    env->layers.clear();
+    ASSERT_FALSE(env.debug_log.find(std::string("Insert instance layer ") + regular_layer_name));
+    env.layers.clear();
 }
 
-TEST_F(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
-    env->get_test_icd().add_physical_device({});
+TEST(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
 
     fs::FolderManager vk_layer_path_folder{FRAMEWORK_BUILD_DIRECTORY, "vk_layer_folder"};
     set_env_var("VK_LAYER_PATH", vk_layer_path_folder.location().str());
@@ -1008,58 +1030,60 @@ TEST_F(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
 
     // add explicit layer to VK_LAYER_PATH folder
     const char* env_var_layer_name = "VK_LAYER_env_var_set_path";
-    env->add_explicit_layer(TestLayerDetails{ManifestLayer{}
-                                                 .set_file_format_version(ManifestVersion(1, 2, 0))
-                                                 .add_layer(ManifestLayer::LayerDescription{}
-                                                                .set_name(env_var_layer_name)
-                                                                .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                                                .set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0))),
-                                             "regular_test_layer.json"}
-                                .set_destination_folder(&vk_layer_path_folder));
+    env.add_explicit_layer(TestLayerDetails{ManifestLayer{}
+                                                .set_file_format_version(ManifestVersion(1, 2, 0))
+                                                .add_layer(ManifestLayer::LayerDescription{}
+                                                               .set_name(env_var_layer_name)
+                                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0))),
+                                            "regular_test_layer.json"}
+                               .set_destination_folder(&vk_layer_path_folder));
 
     // add layer to regular explicit layer folder
     const char* regular_layer_name = "VK_LAYER_regular_layer_path";
-    env->add_explicit_layer(TestLayerDetails{ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                                           .set_name(regular_layer_name)
-                                                                           .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                                                           .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))),
-                                             "regular_test_layer.json"}
-                                .set_destination_folder(&override_path_folder));
+    env.add_explicit_layer(TestLayerDetails{ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                                          .set_name(regular_layer_name)
+                                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                                          .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))),
+                                            "regular_test_layer.json"}
+                               .set_destination_folder(&override_path_folder));
 
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(lunarg_meta_layer_name)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                               .add_component_layer(regular_layer_name)
-                                               .set_disable_environment("DisableMeIfYouCan")
-                                               .add_override_path(override_path_folder.location().str())),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(lunarg_meta_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                              .add_component_layer(regular_layer_name)
+                                              .set_disable_environment("DisableMeIfYouCan")
+                                              .add_override_path(override_path_folder.location().str())),
+                           "meta_test_layer.json");
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.set_api_version(1, 1, 0);
     inst.create_info.add_layer(env_var_layer_name);
-    FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+    FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate(VK_ERROR_LAYER_NOT_PRESENT);
-    ASSERT_FALSE(env->debug_log.find(std::string("Insert instance layer ") + env_var_layer_name));
+    ASSERT_FALSE(env.debug_log.find(std::string("Insert instance layer ") + env_var_layer_name));
 
-    env->layers.clear();
+    env.layers.clear();
     remove_env_var("VK_LAYER_PATH");
 }
 
 // Make sure that implicit layers not in the override paths aren't found by mistake
-TEST_F(OverrideMetaLayer, OverridePathsEnableImplicitLayerInDefaultPaths) {
-    env->get_test_icd().add_physical_device({});
+TEST(OverrideMetaLayer, OverridePathsEnableImplicitLayerInDefaultPaths) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
     fs::FolderManager override_layer_folder{FRAMEWORK_BUILD_DIRECTORY, "override_layer_folder"};
 
     const char* implicit_layer_name = "VK_LAYER_ImplicitLayer";
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(implicit_layer_name)
-                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0))),
-                            "implicit_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(implicit_layer_name)
+                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0))),
+                           "implicit_test_layer.json");
 
     const char* regular_layer_name = "VK_LAYER_TestLayer_1";
     override_layer_folder.write_manifest("regular_test_layer.json",
@@ -1070,28 +1094,30 @@ TEST_F(OverrideMetaLayer, OverridePathsEnableImplicitLayerInDefaultPaths) {
                                                             .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0)))
                                              .get_manifest_str());
     auto override_folder_location = fs::make_native(override_layer_folder.location().str());
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 2, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(lunarg_meta_layer_name)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                               .add_component_layers({regular_layer_name, implicit_layer_name})
-                                               .set_disable_environment("DisableMeIfYouCan")
-                                               .add_override_path(override_folder_location)),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 2, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(lunarg_meta_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                              .add_component_layers({regular_layer_name, implicit_layer_name})
+                                              .set_disable_environment("DisableMeIfYouCan")
+                                              .add_override_path(override_folder_location)),
+                           "meta_test_layer.json");
 
-    InstWrapper inst{env->vulkan_functions};
-    FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+    InstWrapper inst{env.vulkan_functions};
+    FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.create_info.set_api_version(1, 1, 0);
     inst.CheckCreate();
-    ASSERT_FALSE(env->debug_log.find(std::string("Insert instance layer ") + implicit_layer_name));
+    ASSERT_FALSE(env.debug_log.find(std::string("Insert instance layer ") + implicit_layer_name));
     ASSERT_TRUE(
-        env->debug_log.find("Removing meta-layer VK_LAYER_LUNARG_override from instance layer list since it appears invalid."));
-    env->layers.clear();
+        env.debug_log.find("Removing meta-layer VK_LAYER_LUNARG_override from instance layer list since it appears invalid."));
+    env.layers.clear();
 }
 
-TEST_F(OverrideMetaLayer, ManifestFileFormatVersionTooOld) {
-    env->get_test_icd().add_physical_device({});
+TEST(OverrideMetaLayer, ManifestFileFormatVersionTooOld) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().add_physical_device({});
     fs::FolderManager override_layer_folder{FRAMEWORK_BUILD_DIRECTORY, "override_layer_folder"};
 
     const char* regular_layer_name = "VK_LAYER_TestLayer_1";
@@ -1103,40 +1129,42 @@ TEST_F(OverrideMetaLayer, ManifestFileFormatVersionTooOld) {
                                                             .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0)))
                                              .get_manifest_str());
     auto override_folder_location = fs::make_native(override_layer_folder.location().str());
-    env->add_implicit_layer(ManifestLayer{}
-                                .set_file_format_version(ManifestVersion(1, 0, 0))
-                                .add_layer(ManifestLayer::LayerDescription{}
-                                               .set_name(lunarg_meta_layer_name)
-                                               .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                               .add_component_layer(regular_layer_name)
-                                               .set_disable_environment("DisableMeIfYouCan")
-                                               .add_override_path(override_folder_location)),
-                            "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}
+                               .set_file_format_version(ManifestVersion(1, 0, 0))
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(lunarg_meta_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                              .add_component_layer(regular_layer_name)
+                                              .set_disable_environment("DisableMeIfYouCan")
+                                              .add_override_path(override_folder_location)),
+                           "meta_test_layer.json");
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.set_api_version(1, 1, 0);
-    FillDebugUtilsCreateDetails(inst.create_info, env->debug_log);
+    FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate();
-    ASSERT_TRUE(env->debug_log.find(std::string("Insert instance layer ") + regular_layer_name));
-    ASSERT_TRUE(env->debug_log.find("Indicating meta-layer-specific override paths, but using older JSON file version."));
-    env->layers.clear();
+    ASSERT_TRUE(env.debug_log.find(std::string("Insert instance layer ") + regular_layer_name));
+    ASSERT_TRUE(env.debug_log.find("Indicating meta-layer-specific override paths, but using older JSON file version."));
+    env.layers.clear();
 }
 
 // This test makes sure that any layer calling GetPhysicalDeviceProperties2 inside of CreateInstance
 // succeeds and doesn't crash.
-TEST_F(LayerCreateInstance, GetPhysicalDeviceProperties2) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
+TEST(LayerCreateInstance, GetPhysicalDeviceProperties2) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
     const char* regular_layer_name = "TestLayer";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}
             .set_file_format_version(ManifestVersion(1, 1, 2))
             .add_layer(
                 ManifestLayer::LayerDescription{}.set_name(regular_layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
         "regular_test_layer.json");
 
-    auto& layer = env->get_test_layer(0);
+    auto& layer = env.get_test_layer(0);
     layer.set_create_instance_callback([](TestLayer& layer) -> VkResult {
         uint32_t phys_dev_count = 0;
         VkResult res = layer.instance_dispatch_table.EnumeratePhysicalDevices(layer.instance_handle, &phys_dev_count, nullptr);
@@ -1158,22 +1186,24 @@ TEST_F(LayerCreateInstance, GetPhysicalDeviceProperties2) {
         return VK_SUCCESS;
     });
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_layer(regular_layer_name).set_api_version(1, 1, 0);
     inst.CheckCreate();
 }
 
-TEST_F(LayerCreateInstance, GetPhysicalDeviceProperties2KHR) {
-    env->get_test_icd().physical_devices.push_back({});
-    env->get_test_icd().add_instance_extension({"VK_KHR_get_physical_device_properties2", 0});
+TEST(LayerCreateInstance, GetPhysicalDeviceProperties2KHR) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().physical_devices.push_back({});
+    env.get_test_icd().add_instance_extension({"VK_KHR_get_physical_device_properties2", 0});
 
     const char* regular_layer_name = "VK_LAYER_TestLayer";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(regular_layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
         "regular_test_layer.json");
 
-    auto& layer = env->get_test_layer(0);
+    auto& layer = env.get_test_layer(0);
     layer.set_create_instance_callback([](TestLayer& layer) -> VkResult {
         uint32_t phys_dev_count = 1;
         VkPhysicalDevice phys_dev{};
@@ -1189,28 +1219,29 @@ TEST_F(LayerCreateInstance, GetPhysicalDeviceProperties2KHR) {
         return VK_SUCCESS;
     });
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_layer(regular_layer_name).add_extension("VK_KHR_get_physical_device_properties2");
     inst.CheckCreate();
 }
 
-TEST_F(ExplicitLayers, WrapObjects) {
-    auto& driver = env->get_test_icd();
+TEST(ExplicitLayers, WrapObjects) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
 
     const char* wrap_objects_name = "VK_LAYER_LUNARG_wrap_objects";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
-        "wrap_objects_layer.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(
+                               ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
+                           "wrap_objects_layer.json");
 
     const char* regular_layer_name_1 = "RegularLayer1";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(regular_layer_name_1).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
         "regular_layer_1.json");
 
     const char* regular_layer_name_2 = "RegularLayer2";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(regular_layer_name_2).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
         "regular_layer_2.json");
@@ -1220,7 +1251,7 @@ TEST_F(ExplicitLayers, WrapObjects) {
     driver.physical_devices.emplace_back("physical_device_0");
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
     {  // just the wrap layer
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.create_info.add_layer(wrap_objects_name);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
@@ -1230,7 +1261,7 @@ TEST_F(ExplicitLayers, WrapObjects) {
         dev.CheckCreate(phys_dev);
     }
     {  // wrap layer first
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.create_info.add_layer(wrap_objects_name).add_layer(regular_layer_name_1);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
@@ -1240,7 +1271,7 @@ TEST_F(ExplicitLayers, WrapObjects) {
         dev.CheckCreate(phys_dev);
     }
     {  // wrap layer last
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.create_info.add_layer(regular_layer_name_1).add_layer(wrap_objects_name);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
@@ -1250,7 +1281,7 @@ TEST_F(ExplicitLayers, WrapObjects) {
         dev.CheckCreate(phys_dev);
     }
     {  // wrap layer last
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.create_info.add_layer(regular_layer_name_1).add_layer(wrap_objects_name).add_layer(regular_layer_name_2);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
@@ -1261,8 +1292,10 @@ TEST_F(ExplicitLayers, WrapObjects) {
     }
 }
 
-TEST_F(LayerExtensions, ImplicitNoAdditionalInstanceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ImplicitNoAdditionalInstanceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
@@ -1272,28 +1305,28 @@ TEST_F(LayerExtensions, ImplicitNoAdditionalInstanceExtension) {
     const char* enable_env_var = "ENABLE_ME";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(implicit_layer_name)
-                                                          .set_lib_path(TEST_LAYER_WRAP_OBJECTS)
-                                                          .set_disable_environment(disable_env_var)
-                                                          .set_enable_environment(enable_env_var)),
-                            "implicit_wrap_layer_no_ext.json");
+    env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(implicit_layer_name)
+                                                         .set_lib_path(TEST_LAYER_WRAP_OBJECTS)
+                                                         .set_disable_environment(disable_env_var)
+                                                         .set_enable_environment(enable_env_var)),
+                           "implicit_wrap_layer_no_ext.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     // // set enable env-var, layer should load
     set_env_var(enable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, true);
+    CheckLogForLayerString(env, implicit_layer_name, true);
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
         ASSERT_EQ(VK_SUCCESS,
-                  env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
+                  env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
 
         // Make sure the extensions that are implemented only in the test layers is not present.
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -1302,18 +1335,20 @@ TEST_F(LayerExtensions, ImplicitNoAdditionalInstanceExtension) {
         }
     }
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
 
     // Make sure all the function pointers are NULL as well
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkReleaseDisplayEXT"));
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkReleaseDisplayEXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
 
     remove_env_var(enable_env_var);
 }
 
-TEST_F(LayerExtensions, ImplicitDirDispModeInstanceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ImplicitDirDispModeInstanceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
@@ -1323,7 +1358,7 @@ TEST_F(LayerExtensions, ImplicitDirDispModeInstanceExtension) {
     const char* enable_env_var = "ENABLE_ME";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(
+    env.add_implicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}
                 .set_name(implicit_layer_name)
@@ -1334,20 +1369,20 @@ TEST_F(LayerExtensions, ImplicitDirDispModeInstanceExtension) {
         "implicit_wrap_layer_dir_disp_mode.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     // // set enable env-var, layer should load
     set_env_var(enable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, true);
+    CheckLogForLayerString(env, implicit_layer_name, true);
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 3);  // the instance extension, debug_utils, and debug_report
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 3U);  // the instance extension, debug_utils, and debug_report
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
+              env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
 
     // Make sure the extensions that are implemented only in the test layers is not present.
     bool found = false;
@@ -1359,19 +1394,21 @@ TEST_F(LayerExtensions, ImplicitDirDispModeInstanceExtension) {
     }
     ASSERT_EQ(true, found);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extension(VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME);
     inst.CheckCreate();
 
     // Make sure only the appropriate function pointers are NULL as well
-    handle_assert_has_value(env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkReleaseDisplayEXT"));
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+    handle_assert_has_value(env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkReleaseDisplayEXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
 
     remove_env_var(enable_env_var);
 }
 
-TEST_F(LayerExtensions, ImplicitDispSurfCountInstanceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ImplicitDispSurfCountInstanceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
@@ -1381,32 +1418,31 @@ TEST_F(LayerExtensions, ImplicitDispSurfCountInstanceExtension) {
     const char* enable_env_var = "ENABLE_ME";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}
-                .set_name(implicit_layer_name)
-                .set_lib_path(TEST_LAYER_WRAP_OBJECTS_2)
-                .set_disable_environment(disable_env_var)
-                .set_enable_environment(enable_env_var)
-                .add_instance_extension(
-                    {VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME, 1, {"vkGetPhysicalDeviceSurfaceCapabilities2EXT"}})),
-        "implicit_wrap_layer_disp_surf_count.json");
+    env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(implicit_layer_name)
+                                                         .set_lib_path(TEST_LAYER_WRAP_OBJECTS_2)
+                                                         .set_disable_environment(disable_env_var)
+                                                         .set_enable_environment(enable_env_var)
+                                                         .add_instance_extension({VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME,
+                                                                                  1,
+                                                                                  {"vkGetPhysicalDeviceSurfaceCapabilities2EXT"}})),
+                           "implicit_wrap_layer_disp_surf_count.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     // // set enable env-var, layer should load
     set_env_var(enable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, true);
+    CheckLogForLayerString(env, implicit_layer_name, true);
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 3);  // the instance extension, debug_utils, and debug_report
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 3U);  // the instance extension, debug_utils, and debug_report
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
+              env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
 
     // Make sure the extensions that are implemented only in the test layers is not present.
     bool found = false;
@@ -1418,19 +1454,21 @@ TEST_F(LayerExtensions, ImplicitDispSurfCountInstanceExtension) {
     }
     ASSERT_EQ(true, found);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extension(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME);
     inst.CheckCreate();
 
     // Make sure only the appropriate function pointers are NULL as well
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkReleaseDisplayEXT"));
-    handle_assert_has_value(env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkReleaseDisplayEXT"));
+    handle_assert_has_value(env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
 
     remove_env_var(enable_env_var);
 }
 
-TEST_F(LayerExtensions, ImplicitBothInstanceExtensions) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ImplicitBothInstanceExtensions) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
@@ -1440,7 +1478,7 @@ TEST_F(LayerExtensions, ImplicitBothInstanceExtensions) {
     const char* enable_env_var = "ENABLE_ME";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(
+    env.add_implicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}
                 .set_name(implicit_layer_name)
@@ -1453,20 +1491,20 @@ TEST_F(LayerExtensions, ImplicitBothInstanceExtensions) {
         "implicit_wrap_layer_both_inst.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     // // set enable env-var, layer should load
     set_env_var(enable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, true);
+    CheckLogForLayerString(env, implicit_layer_name, true);
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 4);  // the two instance extension plus debug_utils and debug_report
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 4U);  // the two instance extension plus debug_utils and debug_report
     extension_props.resize(extension_count);
     ASSERT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
+              env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
 
     // Make sure the extensions that are implemented only in the test layers is not present.
     bool found[2] = {false, false};
@@ -1482,42 +1520,44 @@ TEST_F(LayerExtensions, ImplicitBothInstanceExtensions) {
         ASSERT_EQ(true, found[ext]);
     }
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extension(VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME)
         .add_extension(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME);
     inst.CheckCreate();
 
     // Make sure only the appropriate function pointers are NULL as well
-    handle_assert_has_value(env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkReleaseDisplayEXT"));
-    handle_assert_has_value(env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+    handle_assert_has_value(env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkReleaseDisplayEXT"));
+    handle_assert_has_value(env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
 
     remove_env_var(enable_env_var);
 }
 
-TEST_F(LayerExtensions, ExplicitNoAdditionalInstanceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ExplicitNoAdditionalInstanceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(explicit_layer_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
         "explicit_wrap_layer_no_ext.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
         ASSERT_EQ(VK_SUCCESS,
-                  env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
+                  env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
 
         // Make sure the extensions are not present
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -1530,11 +1570,11 @@ TEST_F(LayerExtensions, ExplicitNoAdditionalInstanceExtension) {
     extension_count = 0;
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count, nullptr));
+              env.vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
-        ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count,
-                                                                                           extension_props.data()));
+        ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count,
+                                                                                          extension_props.data()));
 
         // Make sure the extensions still aren't present in this layer
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -1543,23 +1583,25 @@ TEST_F(LayerExtensions, ExplicitNoAdditionalInstanceExtension) {
         }
     }
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
 
     // Make sure all the function pointers are NULL as well
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkReleaseDisplayEXT"));
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkReleaseDisplayEXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
 }
 
-TEST_F(LayerExtensions, ExplicitDirDispModeInstanceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ExplicitDirDispModeInstanceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}
                 .set_name(explicit_layer_name)
@@ -1568,16 +1610,16 @@ TEST_F(LayerExtensions, ExplicitDirDispModeInstanceExtension) {
         "explicit_wrap_layer_dir_disp_mode.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
         ASSERT_EQ(VK_SUCCESS,
-                  env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
+                  env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
 
         // Make sure the extensions are not present
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -1590,11 +1632,11 @@ TEST_F(LayerExtensions, ExplicitDirDispModeInstanceExtension) {
     extension_count = 0;
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 1);
+              env.vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 1U);
     extension_props.resize(extension_count);
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count,
-                                                                                       extension_props.data()));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count,
+                                                                                      extension_props.data()));
 
     // Make sure the extensions still aren't present in this layer
     bool found = false;
@@ -1606,51 +1648,52 @@ TEST_F(LayerExtensions, ExplicitDirDispModeInstanceExtension) {
     }
     ASSERT_EQ(true, found);
 
-    InstWrapper inst1{env->vulkan_functions};
+    InstWrapper inst1{env.vulkan_functions};
     inst1.create_info.add_extension(VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME);
     inst1.CheckCreate(VK_ERROR_EXTENSION_NOT_PRESENT);
 
     // Make sure only the appropriate function pointers are NULL as well
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkReleaseDisplayEXT"));
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkReleaseDisplayEXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
 
-    InstWrapper inst2{env->vulkan_functions};
+    InstWrapper inst2{env.vulkan_functions};
     inst2.create_info.add_layer(explicit_layer_name).add_extension(VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME);
     inst2.CheckCreate();
 
     // Make sure only the appropriate function pointers are NULL as well
-    handle_assert_has_value(env->vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkReleaseDisplayEXT"));
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+    handle_assert_has_value(env.vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkReleaseDisplayEXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
 }
 
-TEST_F(LayerExtensions, ExplicitDispSurfCountInstanceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ExplicitDispSurfCountInstanceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
-    env->add_explicit_layer(
-        ManifestLayer{}.add_layer(
-            ManifestLayer::LayerDescription{}
-                .set_name(explicit_layer_name)
-                .set_lib_path(TEST_LAYER_WRAP_OBJECTS_2)
-                .add_instance_extension(
-                    {VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME, 1, {"vkGetPhysicalDeviceSurfaceCapabilities2EXT"}})),
-        "explicit_wrap_layer_disp_surf_count.json");
+    env.add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(explicit_layer_name)
+                                                         .set_lib_path(TEST_LAYER_WRAP_OBJECTS_2)
+                                                         .add_instance_extension({VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME,
+                                                                                  1,
+                                                                                  {"vkGetPhysicalDeviceSurfaceCapabilities2EXT"}})),
+                           "explicit_wrap_layer_disp_surf_count.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
         ASSERT_EQ(VK_SUCCESS,
-                  env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
+                  env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
 
         // Make sure the extensions are not present
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -1663,11 +1706,11 @@ TEST_F(LayerExtensions, ExplicitDispSurfCountInstanceExtension) {
     extension_count = 0;
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 1);
+              env.vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 1U);
     extension_props.resize(extension_count);
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count,
-                                                                                       extension_props.data()));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count,
+                                                                                      extension_props.data()));
 
     // Make sure the extensions still aren't present in this layer
     bool found = false;
@@ -1679,32 +1722,34 @@ TEST_F(LayerExtensions, ExplicitDispSurfCountInstanceExtension) {
     }
     ASSERT_EQ(true, found);
 
-    InstWrapper inst1{env->vulkan_functions};
+    InstWrapper inst1{env.vulkan_functions};
     inst1.create_info.add_extension(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME);
     inst1.CheckCreate(VK_ERROR_EXTENSION_NOT_PRESENT);
 
     // Make sure only the appropriate function pointers are NULL as well
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkReleaseDisplayEXT"));
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkReleaseDisplayEXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
 
-    InstWrapper inst2{env->vulkan_functions};
+    InstWrapper inst2{env.vulkan_functions};
     inst2.create_info.add_layer(explicit_layer_name).add_extension(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME);
     inst2.CheckCreate();
 
     // Make sure only the appropriate function pointers are NULL as well
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkReleaseDisplayEXT"));
-    handle_assert_has_value(env->vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkReleaseDisplayEXT"));
+    handle_assert_has_value(env.vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
 }
 
-TEST_F(LayerExtensions, ExplicitBothInstanceExtensions) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ExplicitBothInstanceExtensions) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}
                 .set_name(explicit_layer_name)
@@ -1715,16 +1760,16 @@ TEST_F(LayerExtensions, ExplicitBothInstanceExtensions) {
         "explicit_wrap_layer_both_inst.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
         ASSERT_EQ(VK_SUCCESS,
-                  env->vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
+                  env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extension_props.data()));
 
         // Make sure the extensions are not present
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -1737,11 +1782,11 @@ TEST_F(LayerExtensions, ExplicitBothInstanceExtensions) {
     extension_count = 0;
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 2);
+              env.vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 2U);
     extension_props.resize(extension_count);
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count,
-                                                                                       extension_props.data()));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(explicit_layer_name, &extension_count,
+                                                                                      extension_props.data()));
 
     // Make sure the extensions still aren't present in this layer
     bool found[2] = {false, false};
@@ -1757,16 +1802,16 @@ TEST_F(LayerExtensions, ExplicitBothInstanceExtensions) {
         ASSERT_EQ(true, found[ext]);
     }
 
-    InstWrapper inst1{env->vulkan_functions};
+    InstWrapper inst1{env.vulkan_functions};
     inst1.create_info.add_extension(VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME)
         .add_extension(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME);
     inst1.CheckCreate(VK_ERROR_EXTENSION_NOT_PRESENT);
 
     // Make sure only the appropriate function pointers are NULL as well
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkReleaseDisplayEXT"));
-    handle_assert_null(env->vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkReleaseDisplayEXT"));
+    handle_assert_null(env.vulkan_functions.vkGetInstanceProcAddr(inst1.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
 
-    InstWrapper inst2{env->vulkan_functions};
+    InstWrapper inst2{env.vulkan_functions};
     inst2.create_info.add_layer(explicit_layer_name)
         .add_extension(VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME)
         .add_extension(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME);
@@ -1774,23 +1819,25 @@ TEST_F(LayerExtensions, ExplicitBothInstanceExtensions) {
     VkPhysicalDevice phys_dev = inst2.GetPhysDev();
 
     // Make sure only the appropriate function pointers are NULL as well
-    handle_assert_has_value(env->vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkReleaseDisplayEXT"));
+    handle_assert_has_value(env.vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkReleaseDisplayEXT"));
     PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT pfnGetPhysicalDeviceSurfaceCapabilities2EXT =
         reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT>(
-            env->vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+            env.vulkan_functions.vkGetInstanceProcAddr(inst2.inst, "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
     handle_assert_has_value(pfnGetPhysicalDeviceSurfaceCapabilities2EXT);
 
     VkSurfaceCapabilities2EXT surf_caps{VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT};
 
     // Call and then check a few things
     ASSERT_EQ(VK_SUCCESS, pfnGetPhysicalDeviceSurfaceCapabilities2EXT(phys_dev, VK_NULL_HANDLE, &surf_caps));
-    ASSERT_EQ(7, surf_caps.minImageCount);
-    ASSERT_EQ(12, surf_caps.maxImageCount);
-    ASSERT_EQ(365, surf_caps.maxImageArrayLayers);
+    ASSERT_EQ(7U, surf_caps.minImageCount);
+    ASSERT_EQ(12U, surf_caps.maxImageCount);
+    ASSERT_EQ(365U, surf_caps.maxImageArrayLayers);
 }
 
-TEST_F(LayerExtensions, ImplicitNoAdditionalDeviceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ImplicitNoAdditionalDeviceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
@@ -1800,32 +1847,32 @@ TEST_F(LayerExtensions, ImplicitNoAdditionalDeviceExtension) {
     const char* enable_env_var = "ENABLE_ME";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(implicit_layer_name)
-                                                          .set_lib_path(TEST_LAYER_WRAP_OBJECTS)
-                                                          .set_disable_environment(disable_env_var)
-                                                          .set_enable_environment(enable_env_var)),
-                            "implicit_wrap_layer_no_ext.json");
+    env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(implicit_layer_name)
+                                                         .set_lib_path(TEST_LAYER_WRAP_OBJECTS)
+                                                         .set_disable_environment(disable_env_var)
+                                                         .set_enable_environment(enable_env_var)),
+                           "implicit_wrap_layer_no_ext.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     // // set enable env-var, layer should load
     set_env_var(enable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, true);
+    CheckLogForLayerString(env, implicit_layer_name, true);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
     VkPhysicalDevice phys_dev = inst.GetPhysDev();
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
-        ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
-                                                                                         extension_props.data()));
+        ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
+                                                                                        extension_props.data()));
 
         // Make sure the extensions that are implemented only in the test layers is not present.
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -1874,8 +1921,10 @@ TEST_F(LayerExtensions, ImplicitNoAdditionalDeviceExtension) {
     remove_env_var(enable_env_var);
 }
 
-TEST_F(LayerExtensions, ImplicitMaintenanceDeviceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ImplicitMaintenanceDeviceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
@@ -1885,32 +1934,32 @@ TEST_F(LayerExtensions, ImplicitMaintenanceDeviceExtension) {
     const char* enable_env_var = "ENABLE_ME";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(implicit_layer_name)
-                                                          .set_lib_path(TEST_LAYER_WRAP_OBJECTS_1)
-                                                          .set_disable_environment(disable_env_var)
-                                                          .set_enable_environment(enable_env_var)),
-                            "implicit_wrap_layer_maint.json");
+    env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(implicit_layer_name)
+                                                         .set_lib_path(TEST_LAYER_WRAP_OBJECTS_1)
+                                                         .set_disable_environment(disable_env_var)
+                                                         .set_enable_environment(enable_env_var)),
+                           "implicit_wrap_layer_maint.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     // // set enable env-var, layer should load
     set_env_var(enable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, true);
+    CheckLogForLayerString(env, implicit_layer_name, true);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
     VkPhysicalDevice phys_dev = inst.GetPhysDev();
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 1U);
     extension_props.resize(extension_count);
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
-                                                                                     extension_props.data()));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
+                                                                                    extension_props.data()));
 
     // Make sure only the one extension implemented by the enabled implicit layer is present.
     bool found = false;
@@ -1933,8 +1982,10 @@ TEST_F(LayerExtensions, ImplicitMaintenanceDeviceExtension) {
     remove_env_var(enable_env_var);
 }
 
-TEST_F(LayerExtensions, ImplicitPresentImageDeviceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ImplicitPresentImageDeviceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
@@ -1944,32 +1995,32 @@ TEST_F(LayerExtensions, ImplicitPresentImageDeviceExtension) {
     const char* enable_env_var = "ENABLE_ME";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(implicit_layer_name)
-                                                          .set_lib_path(TEST_LAYER_WRAP_OBJECTS_2)
-                                                          .set_disable_environment(disable_env_var)
-                                                          .set_enable_environment(enable_env_var)),
-                            "implicit_wrap_layer_pres.json");
+    env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(implicit_layer_name)
+                                                         .set_lib_path(TEST_LAYER_WRAP_OBJECTS_2)
+                                                         .set_disable_environment(disable_env_var)
+                                                         .set_enable_environment(enable_env_var)),
+                           "implicit_wrap_layer_pres.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     // // set enable env-var, layer should load
     set_env_var(enable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, true);
+    CheckLogForLayerString(env, implicit_layer_name, true);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
     VkPhysicalDevice phys_dev = inst.GetPhysDev();
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 1U);
     extension_props.resize(extension_count);
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
-                                                                                     extension_props.data()));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
+                                                                                    extension_props.data()));
 
     // Make sure only the one extension implemented by the enabled implicit layer is present.
     bool found = false;
@@ -1993,8 +2044,10 @@ TEST_F(LayerExtensions, ImplicitPresentImageDeviceExtension) {
     remove_env_var(enable_env_var);
 }
 
-TEST_F(LayerExtensions, ImplicitBothDeviceExtensions) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ImplicitBothDeviceExtensions) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
@@ -2004,32 +2057,32 @@ TEST_F(LayerExtensions, ImplicitBothDeviceExtensions) {
     const char* enable_env_var = "ENABLE_ME";
     const char* disable_env_var = "DISABLE_ME";
 
-    env->add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                          .set_name(implicit_layer_name)
-                                                          .set_lib_path(TEST_LAYER_WRAP_OBJECTS_3)
-                                                          .set_disable_environment(disable_env_var)
-                                                          .set_enable_environment(enable_env_var)),
-                            "implicit_wrap_layer_both_dev.json");
+    env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(implicit_layer_name)
+                                                         .set_lib_path(TEST_LAYER_WRAP_OBJECTS_3)
+                                                         .set_disable_environment(disable_env_var)
+                                                         .set_enable_environment(enable_env_var)),
+                           "implicit_wrap_layer_both_dev.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
     // // set enable env-var, layer should load
     set_env_var(enable_env_var, "1");
-    CheckLogForLayerString(*env, implicit_layer_name, true);
+    CheckLogForLayerString(env, implicit_layer_name, true);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
     VkPhysicalDevice phys_dev = inst.GetPhysDev();
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 2);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 2U);
     extension_props.resize(extension_count);
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
-                                                                                     extension_props.data()));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
+                                                                                    extension_props.data()));
 
     // Make sure only the one extension implemented by the enabled implicit layer is present.
     bool found[2] = {false, false};
@@ -2058,35 +2111,37 @@ TEST_F(LayerExtensions, ImplicitBothDeviceExtensions) {
     remove_env_var(enable_env_var);
 }
 
-TEST_F(LayerExtensions, ExplicitNoAdditionalDeviceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ExplicitNoAdditionalDeviceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(explicit_layer_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
         "explicit_wrap_layer_no_ext.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_layer(explicit_layer_name);
     inst.CheckCreate();
     VkPhysicalDevice phys_dev = inst.GetPhysDev();
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
-        ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
-                                                                                         extension_props.data()));
+        ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
+                                                                                        extension_props.data()));
 
         // Make sure the extensions are not present
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -2099,11 +2154,11 @@ TEST_F(LayerExtensions, ExplicitNoAdditionalDeviceExtension) {
     extension_count = 0;
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count, nullptr));
+              env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
-        ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name,
-                                                                                         &extension_count, extension_props.data()));
+        ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name,
+                                                                                        &extension_count, extension_props.data()));
 
         // Make sure the extensions still aren't present in this layer
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -2122,15 +2177,17 @@ TEST_F(LayerExtensions, ExplicitNoAdditionalDeviceExtension) {
     handle_assert_null(dev->vkGetDeviceProcAddr(dev.dev, "vkSetDeviceMemoryPriorityEXT"));
 }
 
-TEST_F(LayerExtensions, ExplicitMaintenanceDeviceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ExplicitMaintenanceDeviceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                       .set_name(explicit_layer_name)
                                       .set_lib_path(TEST_LAYER_WRAP_OBJECTS_1)
@@ -2139,21 +2196,21 @@ TEST_F(LayerExtensions, ExplicitMaintenanceDeviceExtension) {
         "explicit_wrap_layer_maint.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_layer(explicit_layer_name);
     inst.CheckCreate();
     VkPhysicalDevice phys_dev = inst.GetPhysDev();
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
-        ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
-                                                                                         extension_props.data()));
+        ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
+                                                                                        extension_props.data()));
 
         // Make sure the extensions are not present
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -2166,11 +2223,11 @@ TEST_F(LayerExtensions, ExplicitMaintenanceDeviceExtension) {
     extension_count = 0;
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 1);
+              env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 1U);
     extension_props.resize(extension_count);
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name,
-                                                                                     &extension_count, extension_props.data()));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count,
+                                                                                    extension_props.data()));
 
     // Make sure only the one extension implemented by the enabled implicit layer is present.
     bool found = true;
@@ -2191,15 +2248,17 @@ TEST_F(LayerExtensions, ExplicitMaintenanceDeviceExtension) {
     handle_assert_null(dev->vkGetDeviceProcAddr(dev.dev, "vkGetSwapchainStatusKHR"));
 }
 
-TEST_F(LayerExtensions, ExplicitPresentImageDeviceExtension) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ExplicitPresentImageDeviceExtension) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}
                 .set_name(explicit_layer_name)
@@ -2209,21 +2268,21 @@ TEST_F(LayerExtensions, ExplicitPresentImageDeviceExtension) {
         "explicit_wrap_layer_pres.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_layer(explicit_layer_name);
     inst.CheckCreate();
     VkPhysicalDevice phys_dev = inst.GetPhysDev();
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
-        ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
-                                                                                         extension_props.data()));
+        ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
+                                                                                        extension_props.data()));
 
         // Make sure the extensions are not present
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -2236,11 +2295,11 @@ TEST_F(LayerExtensions, ExplicitPresentImageDeviceExtension) {
     extension_count = 0;
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 1);
+              env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 1U);
     extension_props.resize(extension_count);
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name,
-                                                                                     &extension_count, extension_props.data()));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count,
+                                                                                    extension_props.data()));
 
     // Make sure only the one extension implemented by the enabled implicit layer is present.
     bool found = false;
@@ -2262,15 +2321,17 @@ TEST_F(LayerExtensions, ExplicitPresentImageDeviceExtension) {
     handle_assert_has_value(dev->vkGetDeviceProcAddr(dev.dev, "vkGetSwapchainStatusKHR"));
 }
 
-TEST_F(LayerExtensions, ExplicitBothDeviceExtensions) {
-    auto& driver = env->get_test_icd();
+TEST(LayerExtensions, ExplicitBothDeviceExtensions) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
     driver.physical_devices.emplace_back("physical_device_0");
     driver.physical_devices.back().queue_family_properties.push_back(family_props);
 
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
-    env->add_explicit_layer(
+    env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}
                 .set_name(explicit_layer_name)
@@ -2281,10 +2342,10 @@ TEST_F(LayerExtensions, ExplicitBothDeviceExtensions) {
         "explicit_wrap_layer_both_dev.json");
 
     uint32_t count = 0;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
-    ASSERT_EQ(count, 1);
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_layer(explicit_layer_name);
     inst.CheckCreate();
     VkPhysicalDevice phys_dev = inst.GetPhysDev();
@@ -2292,11 +2353,11 @@ TEST_F(LayerExtensions, ExplicitBothDeviceExtensions) {
 
     uint32_t extension_count = 0;
     std::vector<VkExtensionProperties> extension_props;
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count, nullptr));
     if (extension_count > 0) {
         extension_props.resize(extension_count);
-        ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
-                                                                                         extension_props.data()));
+        ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, nullptr, &extension_count,
+                                                                                        extension_props.data()));
 
         // Make sure the extensions are not present
         for (uint32_t ext = 0; ext < extension_count; ++ext) {
@@ -2309,11 +2370,11 @@ TEST_F(LayerExtensions, ExplicitBothDeviceExtensions) {
     extension_count = 0;
     extension_props.clear();
     ASSERT_EQ(VK_SUCCESS,
-              env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count, nullptr));
-    ASSERT_EQ(extension_count, 2);  // debug_utils, and debug_report
+              env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count, nullptr));
+    ASSERT_EQ(extension_count, 2U);  // debug_utils, and debug_report
     extension_props.resize(extension_count);
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name,
-                                                                                     &extension_count, extension_props.data()));
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateDeviceExtensionProperties(phys_dev, explicit_layer_name, &extension_count,
+                                                                                    extension_props.data()));
 
     // Make sure only the one extension implemented by the enabled implicit layer is present.
     bool found[2] = {false, false};
@@ -2375,10 +2436,10 @@ TEST(TestLayers, ExplicitlyEnableImplicitLayer) {
 
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        EXPECT_EQ(1, count);
+        EXPECT_EQ(1U, count);
         VkLayerProperties layer_props{};
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
-        EXPECT_EQ(1, count);
+        EXPECT_EQ(1U, count);
         ASSERT_TRUE(string_eq(regular_layer_name, layer_props.layerName));
     }
     {  // 1.2 instance
@@ -2390,10 +2451,10 @@ TEST(TestLayers, ExplicitlyEnableImplicitLayer) {
 
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(1, count);
+        ASSERT_EQ(1U, count);
         VkLayerProperties layer_props{};
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
-        ASSERT_EQ(1, count);
+        ASSERT_EQ(1U, count);
     }
 }
 
@@ -2416,11 +2477,11 @@ TEST(TestLayers, NewerInstanceVersionThanImplicitLayer) {
     {  // global functions
         uint32_t layer_count = 0;
         EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
-        EXPECT_EQ(layer_count, 1);
+        EXPECT_EQ(layer_count, 1U);
 
         std::array<VkLayerProperties, 1> layer_props;
         EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
-        EXPECT_EQ(layer_count, 1);
+        EXPECT_EQ(layer_count, 1U);
         EXPECT_TRUE(string_eq(layer_props[0].layerName, regular_layer_name));
     }
     {  // 1.1 instance - should find the implicit layer
@@ -2431,10 +2492,10 @@ TEST(TestLayers, NewerInstanceVersionThanImplicitLayer) {
 
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        EXPECT_EQ(1, count);
+        EXPECT_EQ(1U, count);
         VkLayerProperties layer_props{};
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
-        EXPECT_EQ(1, count);
+        EXPECT_EQ(1U, count);
         ASSERT_TRUE(string_eq(regular_layer_name, layer_props.layerName));
     }
     {  // 1.2 instance -- instance layer shouldn't be found
@@ -2450,10 +2511,10 @@ TEST(TestLayers, NewerInstanceVersionThanImplicitLayer) {
 
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(0, count);
+        ASSERT_EQ(0U, count);
         VkLayerProperties layer_props{};
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
-        ASSERT_EQ(0, count);
+        ASSERT_EQ(0U, count);
     }
 }
 
@@ -2477,11 +2538,11 @@ TEST(TestLayers, ImplicitLayerPre10APIVersion) {
 
         uint32_t layer_count = 0;
         EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
-        EXPECT_EQ(layer_count, 1);
+        EXPECT_EQ(layer_count, 1U);
 
         std::array<VkLayerProperties, 1> layer_props;
         EXPECT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&layer_count, layer_props.data()));
-        EXPECT_EQ(layer_count, 1);
+        EXPECT_EQ(layer_count, 1U);
         EXPECT_TRUE(string_eq(layer_props[0].layerName, regular_layer_name));
     }
     {  // 1.0 instance -- instance layer should be found
@@ -2496,10 +2557,10 @@ TEST(TestLayers, ImplicitLayerPre10APIVersion) {
 
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(0, count);
+        ASSERT_EQ(0U, count);
         VkLayerProperties layer_props{};
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
-        ASSERT_EQ(0, count);
+        ASSERT_EQ(0U, count);
     }
     {  // 1.1 instance -- instance layer should be found
         DebugUtilsLogger log;
@@ -2512,10 +2573,10 @@ TEST(TestLayers, ImplicitLayerPre10APIVersion) {
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(0, count);
+        ASSERT_EQ(0U, count);
         VkLayerProperties layer_props{};
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
-        ASSERT_EQ(0, count);
+        ASSERT_EQ(0U, count);
     }
     {  // 1.2 instance -- instance layer shouldn't be found
         DebugUtilsLogger log;
@@ -2529,10 +2590,10 @@ TEST(TestLayers, ImplicitLayerPre10APIVersion) {
 
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(0, count);
+        ASSERT_EQ(0U, count);
         VkLayerProperties layer_props{};
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
-        ASSERT_EQ(0, count);
+        ASSERT_EQ(0U, count);
     }
     {  // application doesn't state its API version
         DebugUtilsLogger log;
@@ -2546,10 +2607,10 @@ TEST(TestLayers, ImplicitLayerPre10APIVersion) {
 
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
-        ASSERT_EQ(0, count);
+        ASSERT_EQ(0U, count);
         VkLayerProperties layer_props{};
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
-        ASSERT_EQ(0, count);
+        ASSERT_EQ(0U, count);
     }
 }
 
@@ -2788,8 +2849,9 @@ TEST(TestLayers, DeviceLayerNotPresent) {
     dev.CheckCreate(phys_dev);
 }
 
-TEST_F(LayerPhysDeviceMod, AddPhysicalDevices) {
+TEST(LayerPhysDeviceMod, AddPhysicalDevices) {
     FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_add_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -2807,15 +2869,10 @@ TEST_F(LayerPhysDeviceMod, AddPhysicalDevices) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
-        char vendor_char = 'a' + icd;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-            char dev_char = '0' + dev;
-            std::string dev_name = "physdev_";
-            dev_name += vendor_char;
-            dev_name += "_";
-            dev_name += dev_char;
+            auto dev_name = std::string("physdev_") + std::to_string(icd) + "_" + std::to_string(dev);
 #if defined(_WIN32)
             strncpy_s(properties.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE, dev_name.c_str(), dev_name.length() + 1);
 #else
@@ -2871,8 +2928,9 @@ TEST_F(LayerPhysDeviceMod, AddPhysicalDevices) {
     ASSERT_EQ(found_incomplete, icd_devices);
 }
 
-TEST_F(LayerPhysDeviceMod, RemovePhysicalDevices) {
+TEST(LayerPhysDeviceMod, RemovePhysicalDevices) {
     FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_remove_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -2890,15 +2948,10 @@ TEST_F(LayerPhysDeviceMod, RemovePhysicalDevices) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
-        char vendor_char = 'a' + icd;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-            char dev_char = '0' + dev;
-            std::string dev_name = "physdev_";
-            dev_name += vendor_char;
-            dev_name += "_";
-            dev_name += dev_char;
+            auto dev_name = std::string("physdev_") + std::to_string(icd) + "_" + std::to_string(dev);
 #if defined(_WIN32)
             strncpy_s(properties.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE, dev_name.c_str(), dev_name.length() + 1);
 #else
@@ -2927,8 +2980,9 @@ TEST_F(LayerPhysDeviceMod, RemovePhysicalDevices) {
     ASSERT_EQ(dev_count, returned_phys_dev_count);
 }
 
-TEST_F(LayerPhysDeviceMod, ReorderPhysicalDevices) {
+TEST(LayerPhysDeviceMod, ReorderPhysicalDevices) {
     FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_reorder_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -2946,15 +3000,10 @@ TEST_F(LayerPhysDeviceMod, ReorderPhysicalDevices) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
-        char vendor_char = 'a' + icd;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-            char dev_char = '0' + dev;
-            std::string dev_name = "physdev_";
-            dev_name += vendor_char;
-            dev_name += "_";
-            dev_name += dev_char;
+            auto dev_name = std::string("physdev_") + std::to_string(icd) + "_" + std::to_string(dev);
 #if defined(_WIN32)
             strncpy_s(properties.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE, dev_name.c_str(), dev_name.length() + 1);
 #else
@@ -2983,8 +3032,9 @@ TEST_F(LayerPhysDeviceMod, ReorderPhysicalDevices) {
     ASSERT_EQ(dev_count, returned_phys_dev_count);
 }
 
-TEST_F(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
+TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
     FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_all_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -3002,15 +3052,10 @@ TEST_F(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
-        char vendor_char = 'a' + icd;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-            char dev_char = '0' + dev;
-            std::string dev_name = "physdev_";
-            dev_name += vendor_char;
-            dev_name += "_";
-            dev_name += dev_char;
+            auto dev_name = std::string("physdev_") + std::to_string(icd) + "_" + std::to_string(dev);
 #if defined(_WIN32)
             strncpy_s(properties.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE, dev_name.c_str(), dev_name.length() + 1);
 #else
@@ -3049,8 +3094,8 @@ TEST_F(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
 
     // Should see 2 removed, but 3 added so a diff count of 1
     uint32_t diff_count = dev_count - icd_devices;
-    ASSERT_EQ(1, diff_count);
-    ASSERT_EQ(found_added_count, 3);
+    ASSERT_EQ(1U, diff_count);
+    ASSERT_EQ(found_added_count, 3U);
 }
 
 static bool GroupsAreTheSame(VkPhysicalDeviceGroupProperties a, VkPhysicalDeviceGroupProperties b) {
@@ -3065,8 +3110,9 @@ static bool GroupsAreTheSame(VkPhysicalDeviceGroupProperties a, VkPhysicalDevice
     return true;
 }
 
-TEST_F(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
+TEST(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
     FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_add_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -3084,15 +3130,10 @@ TEST_F(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
-        char vendor_char = 'a' + icd;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-            char dev_char = '0' + dev;
-            std::string dev_name = "physdev_";
-            dev_name += vendor_char;
-            dev_name += "_";
-            dev_name += dev_char;
+            auto dev_name = std::string("physdev_") + std::to_string(icd) + "_" + std::to_string(dev);
 #if defined(_WIN32)
             strncpy_s(properties.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE, dev_name.c_str(), dev_name.length() + 1);
 #else
@@ -3159,8 +3200,9 @@ TEST_F(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
     ASSERT_EQ(found_incomplete, icd_groups);
 }
 
-TEST_F(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
+TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
     FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_remove_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -3178,15 +3220,10 @@ TEST_F(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
-        char vendor_char = 'a' + icd;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-            char dev_char = '0' + dev;
-            std::string dev_name = "physdev_";
-            dev_name += vendor_char;
-            dev_name += "_";
-            dev_name += dev_char;
+            auto dev_name = std::string("physdev_") + std::to_string(icd) + "_" + std::to_string(dev);
 #if defined(_WIN32)
             strncpy_s(properties.deviceName, dev_name.c_str(), VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 #else
@@ -3218,8 +3255,9 @@ TEST_F(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
     ASSERT_EQ(grp_count, returned_group_count);
 }
 
-TEST_F(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
+TEST(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
     FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_reorder_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -3237,15 +3275,10 @@ TEST_F(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
-        char vendor_char = 'a' + icd;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-            char dev_char = '0' + dev;
-            std::string dev_name = "physdev_";
-            dev_name += vendor_char;
-            dev_name += "_";
-            dev_name += dev_char;
+            auto dev_name = std::string("physdev_") + std::to_string(icd) + "_" + std::to_string(dev);
 #if defined(_WIN32)
             strncpy_s(properties.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE, dev_name.c_str(), dev_name.length() + 1);
 #else
@@ -3277,8 +3310,9 @@ TEST_F(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
     ASSERT_EQ(grp_count, returned_group_count);
 }
 
-TEST_F(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
+TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
     FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_all_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -3296,15 +3330,10 @@ TEST_F(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
-        char vendor_char = 'a' + icd;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-            char dev_char = '0' + dev;
-            std::string dev_name = "physdev_";
-            dev_name += vendor_char;
-            dev_name += "_";
-            dev_name += dev_char;
+            auto dev_name = std::string("physdev_") + std::to_string(icd) + "_" + std::to_string(dev);
 #if defined(_WIN32)
             strncpy_s(properties.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE, dev_name.c_str(), dev_name.length() + 1);
 #else
@@ -3353,6 +3382,6 @@ TEST_F(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
     // Should see 2 devices removed which should result in 1 group removed and since 3
     // devices were added we should have 3 new groups.  So we should have a diff of 2
     // groups and 3 new groups
-    ASSERT_EQ(2, diff_count);
-    ASSERT_EQ(found_added_count, 3);
+    ASSERT_EQ(2U, diff_count);
+    ASSERT_EQ(found_added_count, 3U);
 }

--- a/tests/loader_phys_dev_inst_ext_tests.cpp
+++ b/tests/loader_phys_dev_inst_ext_tests.cpp
@@ -104,7 +104,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceProperties props{};
     instance->vkGetPhysicalDeviceProperties(physical_device, &props);
@@ -142,7 +142,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2Simple) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceProperties props{};
     instance->vkGetPhysicalDeviceProperties(physical_device, &props);
@@ -187,7 +187,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2KHRInstanceSupports11) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceProperties props{};
     instance->vkGetPhysicalDeviceProperties(physical_device, &props);
@@ -452,7 +452,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceFeatures feats{};
     instance->vkGetPhysicalDeviceFeatures(physical_device, &feats);
@@ -483,7 +483,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2Simple) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceFeatures feats{};
     instance->vkGetPhysicalDeviceFeatures(physical_device, &feats);
@@ -521,7 +521,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRInstanceSupports11) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceFeatures feats{};
     instance->vkGetPhysicalDeviceFeatures(physical_device, &feats);
@@ -672,7 +672,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkFormatProperties props{};
     instance->vkGetPhysicalDeviceFormatProperties(physical_device, VK_FORMAT_R4G4_UNORM_PACK8, &props);
@@ -706,7 +706,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatProps2Simple) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkFormatProperties props{};
     instance->vkGetPhysicalDeviceFormatProperties(physical_device, VK_FORMAT_R4G4_UNORM_PACK8, &props);
@@ -747,7 +747,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRInstanceSupports11) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkFormatProperties props{};
     instance->vkGetPhysicalDeviceFormatProperties(physical_device, VK_FORMAT_R4G4_UNORM_PACK8, &props);
@@ -904,7 +904,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkImageFormatProperties props{};
     ASSERT_EQ(VK_SUCCESS,
@@ -954,7 +954,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2Simple) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkImageFormatProperties props{};
     ASSERT_EQ(VK_SUCCESS,
@@ -1012,7 +1012,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2KHRInstanceSupports11) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkImageFormatProperties props{};
     ASSERT_EQ(VK_SUCCESS,
@@ -1225,7 +1225,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceMemoryProperties props{};
     instance->vkGetPhysicalDeviceMemoryProperties(physical_device, &props);
@@ -1257,7 +1257,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2Simple) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceMemoryProperties props{};
     instance->vkGetPhysicalDeviceMemoryProperties(physical_device, &props);
@@ -1296,7 +1296,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRInstanceSupports11) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceMemoryProperties props{};
     instance->vkGetPhysicalDeviceMemoryProperties(physical_device, &props);
@@ -1468,7 +1468,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     uint32_t ret_fam_1 = 0;
     std::vector<VkQueueFamilyProperties> props{};
@@ -1509,7 +1509,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2Simple) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     uint32_t ret_fam_1 = 0;
     std::vector<VkQueueFamilyProperties> props{};
@@ -1557,7 +1557,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRInstanceSupports11) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     uint32_t ret_fam_1 = 0;
     std::vector<VkQueueFamilyProperties> props{};
@@ -1742,19 +1742,19 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRInstanceAndICDSuppo
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     std::vector<VkSparseImageFormatProperties> props{};
     uint32_t sparse_count_1 = 0;
     instance->vkGetPhysicalDeviceSparseImageFormatProperties(physical_device, VK_FORMAT_R4G4_UNORM_PACK8, VK_IMAGE_TYPE_2D,
                                                              VK_SAMPLE_COUNT_4_BIT, VK_IMAGE_USAGE_STORAGE_BIT,
                                                              VK_IMAGE_TILING_OPTIMAL, &sparse_count_1, nullptr);
-    ASSERT_NE(sparse_count_1, 0);
+    ASSERT_NE(sparse_count_1, 0U);
     props.resize(sparse_count_1);
     instance->vkGetPhysicalDeviceSparseImageFormatProperties(physical_device, VK_FORMAT_R4G4_UNORM_PACK8, VK_IMAGE_TYPE_2D,
                                                              VK_SAMPLE_COUNT_4_BIT, VK_IMAGE_USAGE_STORAGE_BIT,
                                                              VK_IMAGE_TILING_OPTIMAL, &sparse_count_1, props.data());
-    ASSERT_NE(sparse_count_1, 0);
+    ASSERT_NE(sparse_count_1, 0U);
 
     VkPhysicalDeviceSparseImageFormatInfo2 info2{
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2,  // sType
@@ -1797,19 +1797,19 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2Simple) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     std::vector<VkSparseImageFormatProperties> props{};
     uint32_t sparse_count_1 = 0;
     instance->vkGetPhysicalDeviceSparseImageFormatProperties(physical_device, VK_FORMAT_R4G4_UNORM_PACK8, VK_IMAGE_TYPE_2D,
                                                              VK_SAMPLE_COUNT_4_BIT, VK_IMAGE_USAGE_STORAGE_BIT,
                                                              VK_IMAGE_TILING_OPTIMAL, &sparse_count_1, nullptr);
-    ASSERT_NE(sparse_count_1, 0);
+    ASSERT_NE(sparse_count_1, 0U);
     props.resize(sparse_count_1);
     instance->vkGetPhysicalDeviceSparseImageFormatProperties(physical_device, VK_FORMAT_R4G4_UNORM_PACK8, VK_IMAGE_TYPE_2D,
                                                              VK_SAMPLE_COUNT_4_BIT, VK_IMAGE_USAGE_STORAGE_BIT,
                                                              VK_IMAGE_TILING_OPTIMAL, &sparse_count_1, props.data());
-    ASSERT_NE(sparse_count_1, 0);
+    ASSERT_NE(sparse_count_1, 0U);
 
     VkPhysicalDeviceSparseImageFormatInfo2 info2{
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2,  // sType
@@ -1859,19 +1859,19 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRInstanceSupports11)
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     std::vector<VkSparseImageFormatProperties> props{};
     uint32_t sparse_count_1 = 0;
     instance->vkGetPhysicalDeviceSparseImageFormatProperties(physical_device, VK_FORMAT_R4G4_UNORM_PACK8, VK_IMAGE_TYPE_2D,
                                                              VK_SAMPLE_COUNT_4_BIT, VK_IMAGE_USAGE_STORAGE_BIT,
                                                              VK_IMAGE_TILING_OPTIMAL, &sparse_count_1, nullptr);
-    ASSERT_NE(sparse_count_1, 0);
+    ASSERT_NE(sparse_count_1, 0U);
     props.resize(sparse_count_1);
     instance->vkGetPhysicalDeviceSparseImageFormatProperties(physical_device, VK_FORMAT_R4G4_UNORM_PACK8, VK_IMAGE_TYPE_2D,
                                                              VK_SAMPLE_COUNT_4_BIT, VK_IMAGE_USAGE_STORAGE_BIT,
                                                              VK_IMAGE_TILING_OPTIMAL, &sparse_count_1, props.data());
-    ASSERT_NE(sparse_count_1, 0);
+    ASSERT_NE(sparse_count_1, 0U);
 
     VkPhysicalDeviceSparseImageFormatInfo2 info2{
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2,  // sType
@@ -1974,12 +1974,12 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatPropsMixed) {
         instance->vkGetPhysicalDeviceSparseImageFormatProperties(
             physical_devices[dev], VK_FORMAT_R4G4_UNORM_PACK8, VK_IMAGE_TYPE_2D, VK_SAMPLE_COUNT_4_BIT, VK_IMAGE_USAGE_STORAGE_BIT,
             VK_IMAGE_TILING_OPTIMAL, &sparse_count_1, nullptr);
-        ASSERT_NE(sparse_count_1, 0);
+        ASSERT_NE(sparse_count_1, 0U);
         props.resize(sparse_count_1);
         instance->vkGetPhysicalDeviceSparseImageFormatProperties(
             physical_devices[dev], VK_FORMAT_R4G4_UNORM_PACK8, VK_IMAGE_TYPE_2D, VK_SAMPLE_COUNT_4_BIT, VK_IMAGE_USAGE_STORAGE_BIT,
             VK_IMAGE_TILING_OPTIMAL, &sparse_count_1, props.data());
-        ASSERT_NE(sparse_count_1, 0);
+        ASSERT_NE(sparse_count_1, 0U);
 
         VkPhysicalDeviceSparseImageFormatInfo2 info2{
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2,  // sType
@@ -2076,7 +2076,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceExternalBufferInfoKHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO_KHR};
     VkExternalBufferPropertiesKHR props{VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR};
@@ -2107,7 +2107,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2Simple) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceExternalBufferInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO};
     VkExternalBufferProperties props{VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES};
@@ -2289,7 +2289,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceExternalSemaphoreInfoKHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO_KHR};
     VkExternalSemaphorePropertiesKHR props{VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES_KHR};
@@ -2319,7 +2319,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2Simple) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceExternalSemaphoreInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO};
     VkExternalSemaphoreProperties props{VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES};
@@ -2500,7 +2500,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceExternalFenceInfoKHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO_KHR};
     VkExternalFencePropertiesKHR props{VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES_KHR};
@@ -2530,7 +2530,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2Simple) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkPhysicalDeviceExternalFenceInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO};
     VkExternalFenceProperties props{VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES};
@@ -2755,7 +2755,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkSurfaceKHR surface;
     VkHeadlessSurfaceCreateInfoEXT create_info{VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT};
@@ -2961,7 +2961,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkSurfaceKHR surface;
     VkHeadlessSurfaceCreateInfoEXT create_info{VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT};
@@ -3077,10 +3077,10 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRMixed) {
         std::vector<VkSurfaceFormatKHR> props{};
         uint32_t count_1 = 0;
         ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormats(physical_devices[dev], surface, &count_1, nullptr));
-        ASSERT_NE(0, count_1);
+        ASSERT_NE(0U, count_1);
         props.resize(count_1);
         ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormats(physical_devices[dev], surface, &count_1, props.data()));
-        ASSERT_NE(0, count_1);
+        ASSERT_NE(0U, count_1);
 
         VkPhysicalDeviceSurfaceInfo2KHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, nullptr, surface};
         std::vector<VkSurfaceFormat2KHR> props2{};
@@ -3187,7 +3187,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     std::vector<VkDisplayPropertiesKHR> props{};
     uint32_t prop_count = 0;
@@ -3285,7 +3285,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRMixed) {
                     if (icd == 1) {
                         // For this extension, if no support exists (like for ICD 1), the value of 0 should be returned by the
                         // loader.
-                        ASSERT_EQ(0, prop_count);
+                        ASSERT_EQ(0U, prop_count);
                     } else {
                         ASSERT_EQ(cur_dev.display_properties.size(), prop_count);
                         props.resize(prop_count);
@@ -3374,7 +3374,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     std::vector<VkDisplayPlanePropertiesKHR> props{};
     uint32_t prop_count = 0;
@@ -3472,7 +3472,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRMixed) {
                     if (icd == 1) {
                         // For this extension, if no support exists (like for ICD 1), the value of 0 should be returned by the
                         // loader.
-                        ASSERT_EQ(0, prop_count);
+                        ASSERT_EQ(0U, prop_count);
                     } else {
                         ASSERT_EQ(cur_dev.display_plane_properties.size(), prop_count);
                         props.resize(prop_count);
@@ -3559,7 +3559,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     std::vector<VkDisplayKHR> disps{};
     uint32_t disp_count = 0;
@@ -3657,7 +3657,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRMixed) {
                     if (icd == 1) {
                         // For this extension, if no support exists (like for ICD 1), the value of 0 should be returned by the
                         // loader.
-                        ASSERT_EQ(0, disp_count);
+                        ASSERT_EQ(0U, disp_count);
                     } else {
                         ASSERT_EQ(cur_dev.displays.size(), disp_count);
                         disps.resize(disp_count);
@@ -3751,7 +3751,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     std::vector<VkDisplayModePropertiesKHR> props{};
     uint32_t props_count = 0;
@@ -3848,7 +3848,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRMixed) {
                     if (icd == 1) {
                         // For this extension, if no support exists (like for ICD 1), the value of 0 should be returned by the
                         // loader.
-                        ASSERT_EQ(0, props_count);
+                        ASSERT_EQ(0U, props_count);
                     } else {
                         std::vector<VkDisplayModePropertiesKHR> props{};
                         ASSERT_EQ(cur_dev.display_mode_properties.size(), props_count);
@@ -3921,7 +3921,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkDisplayModeKHR mode{};
     VkDisplayModeCreateInfoKHR create_info{VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR};
@@ -4143,7 +4143,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkDisplayPlaneCapabilitiesKHR caps{};
     ASSERT_EQ(VK_SUCCESS, GetDisplayPlaneCapabilities(physical_device, 0, 0, &caps));
@@ -4318,12 +4318,12 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     std::vector<VkDisplayPropertiesKHR> props{};
     uint32_t prop_count = 0;
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayProperties(physical_device, &prop_count, nullptr));
-    ASSERT_NE(0, prop_count);
+    ASSERT_NE(0U, prop_count);
     props.resize(prop_count);
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayProperties(physical_device, &prop_count, props.data()));
 
@@ -4411,7 +4411,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRMixed) {
         std::vector<VkDisplayPropertiesKHR> props{};
         uint32_t prop_count = 0;
         ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayProperties(physical_devices[dev], &prop_count, nullptr));
-        ASSERT_NE(0, prop_count);
+        ASSERT_NE(0U, prop_count);
         props.resize(prop_count);
         ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayProperties(physical_devices[dev], &prop_count, props.data()));
 
@@ -4492,12 +4492,12 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     std::vector<VkDisplayPlanePropertiesKHR> props{};
     uint32_t prop_count = 0;
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPlaneProperties(physical_device, &prop_count, nullptr));
-    ASSERT_NE(0, prop_count);
+    ASSERT_NE(0U, prop_count);
     props.resize(prop_count);
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPlaneProperties(physical_device, &prop_count, props.data()));
 
@@ -4584,7 +4584,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRMixed) {
         std::vector<VkDisplayPlanePropertiesKHR> props{};
         uint32_t prop_count = 0;
         ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPlaneProperties(physical_devices[dev], &prop_count, nullptr));
-        ASSERT_NE(0, prop_count);
+        ASSERT_NE(0U, prop_count);
         props.resize(prop_count);
         ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPlaneProperties(physical_devices[dev], &prop_count, props.data()));
 
@@ -4668,12 +4668,12 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     std::vector<VkDisplayModePropertiesKHR> props{};
     uint32_t props_count1 = 0;
     ASSERT_EQ(VK_SUCCESS, GetDisplayModeProperties(physical_device, VK_NULL_HANDLE, &props_count1, nullptr));
-    ASSERT_NE(0, props_count1);
+    ASSERT_NE(0U, props_count1);
     props.resize(props_count1);
     ASSERT_EQ(VK_SUCCESS, GetDisplayModeProperties(physical_device, VK_NULL_HANDLE, &props_count1, props.data()));
 
@@ -4760,7 +4760,7 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRMixed) {
         std::vector<VkDisplayModePropertiesKHR> props{};
         uint32_t props_count1 = 0;
         ASSERT_EQ(VK_SUCCESS, GetDisplayModeProperties(physical_devices[dev], VK_NULL_HANDLE, &props_count1, nullptr));
-        ASSERT_NE(0, props_count1);
+        ASSERT_NE(0U, props_count1);
         props.resize(props_count1);
         ASSERT_EQ(VK_SUCCESS, GetDisplayModeProperties(physical_devices[dev], VK_NULL_HANDLE, &props_count1, props.data()));
 
@@ -4851,7 +4851,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkDisplayPlaneCapabilitiesKHR caps{};
     ASSERT_EQ(VK_SUCCESS, GetDisplayPlaneCapabilities(physical_device, 0, 0, &caps));
@@ -4994,7 +4994,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkDisplayKHR display = VK_NULL_HANDLE;
     ASSERT_EQ(VK_SUCCESS, AcquireDrmDisplay(physical_device, 0, display));
@@ -5150,7 +5150,7 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTInstanceAndICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     VkDisplayKHR display = VK_NULL_HANDLE;
     ASSERT_EQ(VK_SUCCESS, GetDrmDisplay(physical_device, 0, 0, &display));

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -27,36 +27,30 @@
 
 #include "test_environment.h"
 
-class ICDInterfaceVersion2Plus : public ::testing::Test {
-   protected:
-    virtual void SetUp() {
-        env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
-        env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
-    }
-    virtual void TearDown() { env.reset(); }
-    std::unique_ptr<FrameworkEnvironment> env;
-};
-
-TEST_F(ICDInterfaceVersion2Plus, vk_icdNegotiateLoaderICDInterfaceVersion) {
-    auto& driver = env->get_test_icd();
+TEST(ICDInterfaceVersion2Plus, vk_icdNegotiateLoaderICDInterfaceVersion) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
 
     for (uint32_t i = 0; i <= 6; i++) {
         for (uint32_t j = i; j <= 6; j++) {
             driver.min_icd_interface_version = i;
             driver.max_icd_interface_version = j;
-            InstWrapper inst{env->vulkan_functions};
+            InstWrapper inst{env.vulkan_functions};
             inst.CheckCreate();
         }
     }
 }
 
-TEST_F(ICDInterfaceVersion2Plus, version_3) {
-    auto& driver = env->get_test_icd();
+TEST(ICDInterfaceVersion2Plus, version_3) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
     {
         driver.min_icd_interface_version = 2;
         driver.enable_icd_wsi = true;
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
         ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
@@ -64,7 +58,7 @@ TEST_F(ICDInterfaceVersion2Plus, version_3) {
     {
         driver.min_icd_interface_version = 3;
         driver.enable_icd_wsi = false;
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
         ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::not_using);
@@ -72,34 +66,36 @@ TEST_F(ICDInterfaceVersion2Plus, version_3) {
     {
         driver.min_icd_interface_version = 3;
         driver.enable_icd_wsi = true;
-        InstWrapper inst{env->vulkan_functions};
+        InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
         ASSERT_EQ(driver.is_using_icd_wsi, UsingICDProvidedWSI::is_using);
     }
 }
 
-TEST_F(ICDInterfaceVersion2Plus, version_4) {
-    auto& driver = env->get_test_icd();
+TEST(ICDInterfaceVersion2Plus, version_4) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
 }
 
-TEST_F(ICDInterfaceVersion2Plus, l4_icd4) {
+TEST(ICDInterfaceVersion2Plus, l4_icd4) {
     // ICD must fail with VK_ERROR_INCOMPATIBLE_DRIVER for all vkCreateInstance calls with apiVersion set to > Vulkan 1.0
     // because both the loader and ICD support interface version <= 4. Otherwise, the ICD should behave as normal.
 }
-TEST_F(ICDInterfaceVersion2Plus, l4_icd5) {
+TEST(ICDInterfaceVersion2Plus, l4_icd5) {
     // ICD must fail with VK_ERROR_INCOMPATIBLE_DRIVER for all vkCreateInstance calls with apiVersion set to > Vulkan 1.0
     // because the loader is still at interface version <= 4. Otherwise, the ICD should behave as normal.
 }
-TEST_F(ICDInterfaceVersion2Plus, l5_icd4) {
+TEST(ICDInterfaceVersion2Plus, l5_icd4) {
     // Loader will fail with VK_ERROR_INCOMPATIBLE_DRIVER if it can't handle the apiVersion. ICD may pass for all apiVersions,
     // but since its interface is <= 4, it is best if it assumes it needs to do the work of rejecting anything > Vulkan 1.0 and
     // fail with VK_ERROR_INCOMPATIBLE_DRIVER. Otherwise, the ICD should behave as normal.
 }
-TEST_F(ICDInterfaceVersion2Plus, l5_icd5) {
+TEST(ICDInterfaceVersion2Plus, l5_icd5) {
     // Loader will fail with VK_ERROR_INCOMPATIBLE_DRIVER if it can't handle the apiVersion, and ICDs should fail with
     // VK_ERROR_INCOMPATIBLE_DRIVER only if they can not support the specified apiVersion. Otherwise, the ICD should behave as
     // normal.
@@ -110,8 +106,10 @@ TEST_F(ICDInterfaceVersion2Plus, l5_icd5) {
 // Version 6 provides a mechanism to allow the loader to sort physical devices.
 // The loader will only attempt to sort physical devices on an ICD if version 6 of the interface is supported.
 // This version provides the vk_icdEnumerateAdapterPhysicalDevices function.
-TEST_F(ICDInterfaceVersion2Plus, version_5) {
-    auto& driver = env->get_test_icd();
+TEST(ICDInterfaceVersion2Plus, version_5) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_1");
     driver.physical_devices.emplace_back("physical_device_0");
     uint32_t physical_count = static_cast<uint32_t>(driver.physical_devices.size());
@@ -120,11 +118,11 @@ TEST_F(ICDInterfaceVersion2Plus, version_5) {
 
     driver.min_icd_interface_version = 5;
 
-    InstWrapper inst{env->vulkan_functions};
+    InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
 
-    ASSERT_EQ(VK_SUCCESS, env->vulkan_functions.vkEnumeratePhysicalDevices(inst.inst, &returned_physical_count,
-                                                                           physical_device_handles.data()));
+    ASSERT_EQ(VK_SUCCESS,
+              env.vulkan_functions.vkEnumeratePhysicalDevices(inst.inst, &returned_physical_count, physical_device_handles.data()));
     ASSERT_EQ(physical_count, returned_physical_count);
     ASSERT_FALSE(driver.called_enumerate_adapter_physical_devices);
 }
@@ -174,7 +172,7 @@ TEST(ICDInterfaceVersion2PlusEnumerateAdapterPhysicalDevices, version_6) {
     returned_physical_count = 0;
     ASSERT_EQ(VK_INCOMPLETE,
               env.vulkan_functions.vkEnumeratePhysicalDevices(inst.inst, &returned_physical_count, physical_device_handles.data()));
-    ASSERT_EQ(0, returned_physical_count);
+    ASSERT_EQ(0U, returned_physical_count);
     for (auto& phys_dev : physical_device_handles) {
         ASSERT_EQ(phys_dev, reinterpret_cast<VkPhysicalDevice>(temp_ptr.get()));
     }
@@ -329,7 +327,7 @@ TEST(MultipleICDConfig, Basic) {
     std::array<VkPhysicalDevice, 3> phys_devs_array;
     uint32_t phys_dev_count = 3;
     ASSERT_EQ(env.vulkan_functions.vkEnumeratePhysicalDevices(inst, &phys_dev_count, phys_devs_array.data()), VK_SUCCESS);
-    ASSERT_EQ(phys_dev_count, 3);
+    ASSERT_EQ(phys_dev_count, 3U);
     ASSERT_EQ(env.get_test_icd(0).physical_devices.at(0).properties.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
     ASSERT_EQ(env.get_test_icd(1).physical_devices.at(0).properties.deviceType, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU);
     ASSERT_EQ(env.get_test_icd(2).physical_devices.at(0).properties.deviceType, VK_PHYSICAL_DEVICE_TYPE_CPU);
@@ -356,7 +354,7 @@ TEST(MultipleDriverConfig, DifferentICDInterfaceVersions) {
     std::array<VkPhysicalDevice, 2> phys_devs_array;
     uint32_t phys_dev_count = 2;
     ASSERT_EQ(env.vulkan_functions.vkEnumeratePhysicalDevices(inst, &phys_dev_count, phys_devs_array.data()), VK_SUCCESS);
-    ASSERT_EQ(phys_dev_count, 2);
+    ASSERT_EQ(phys_dev_count, 2U);
 }
 
 TEST(MultipleDriverConfig, DifferentICDsWithDevices) {
@@ -390,7 +388,7 @@ TEST(MultipleDriverConfig, DifferentICDsWithDevices) {
     std::array<VkPhysicalDevice, 4> phys_devs_array;
     uint32_t phys_dev_count = 4;
     ASSERT_EQ(env.vulkan_functions.vkEnumeratePhysicalDevices(inst, &phys_dev_count, phys_devs_array.data()), VK_SUCCESS);
-    ASSERT_EQ(phys_dev_count, 4);
+    ASSERT_EQ(phys_dev_count, 4U);
 }
 
 TEST(MultipleDriverConfig, DifferentICDsWithDevicesAndGroups) {
@@ -561,7 +559,7 @@ TEST(MinorVersionUpdate, Version1_3) {
         inst.functions->vkGetInstanceProcAddr(inst, "vkGetPhysicalDeviceToolProperties"));
     uint32_t tool_count = 0;
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceToolProperties(phys_dev, &tool_count, nullptr));
-    ASSERT_EQ(tool_count, 0);
+    ASSERT_EQ(tool_count, 0U);
     VkPhysicalDeviceToolProperties props;
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceToolProperties(phys_dev, &tool_count, &props));
 

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -144,7 +144,7 @@ TEST(WsiTests, GetPhysicalDeviceWin32PresentNoICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceWin32PresentationSupportKHR(physical_device, 0),
                  "ICD for selected physical device does not export vkGetPhysicalDeviceWin32PresentationSupportKHR!");
@@ -168,7 +168,7 @@ TEST(WsiTests, GetPhysicalDeviceWin32PresentICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     ASSERT_EQ(VK_TRUE, env.vulkan_functions.vkGetPhysicalDeviceWin32PresentationSupportKHR(physical_device, 0));
 }
@@ -184,7 +184,7 @@ TEST(WsiTests, Win32GetPhysicalDeviceSurfaceSupportKHR) {
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.set_min_icd_interface_version(5);
         cur_icd.add_instance_extensions({first_ext, second_ext});
-        std::string dev_name = "phys_dev_" + icd;
+        std::string dev_name = "phys_dev_" + std::to_string(icd);
         cur_icd.physical_devices.emplace_back(dev_name.c_str());
         cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
         cur_icd.enable_icd_wsi = true;
@@ -329,7 +329,7 @@ TEST(WsiTests, GetPhysicalDeviceXcbPresentNoICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceXcbPresentationSupportKHR(physical_device, 0, nullptr, 0),
                  "ICD for selected physical device does not export vkGetPhysicalDeviceXcbPresentationSupportKHR!");
@@ -353,7 +353,7 @@ TEST(WsiTests, GetPhysicalDeviceXcbPresentICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     ASSERT_EQ(VK_TRUE, env.vulkan_functions.vkGetPhysicalDeviceXcbPresentationSupportKHR(physical_device, 0, nullptr, 0));
 }
@@ -369,7 +369,7 @@ TEST(WsiTests, XcbGetPhysicalDeviceSurfaceSupportKHR) {
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.set_min_icd_interface_version(5);
         cur_icd.add_instance_extensions({first_ext, second_ext});
-        std::string dev_name = "phys_dev_" + icd;
+        std::string dev_name = "phys_dev_" + std::to_string(icd);
         cur_icd.physical_devices.emplace_back(dev_name.c_str());
         cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
         cur_icd.enable_icd_wsi = true;
@@ -514,7 +514,7 @@ TEST(WsiTests, GetPhysicalDeviceXlibPresentNoICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceXlibPresentationSupportKHR(physical_device, 0, nullptr, 0),
                  "ICD for selected physical device does not export vkGetPhysicalDeviceXlibPresentationSupportKHR!");
@@ -538,7 +538,7 @@ TEST(WsiTests, GetPhysicalDeviceXlibPresentICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     ASSERT_EQ(VK_TRUE, env.vulkan_functions.vkGetPhysicalDeviceXlibPresentationSupportKHR(physical_device, 0, nullptr, 0));
 }
@@ -554,7 +554,7 @@ TEST(WsiTests, XlibGetPhysicalDeviceSurfaceSupportKHR) {
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.set_min_icd_interface_version(5);
         cur_icd.add_instance_extensions({first_ext, second_ext});
-        std::string dev_name = "phys_dev_" + icd;
+        std::string dev_name = "phys_dev_" + std::to_string(icd);
         cur_icd.physical_devices.emplace_back(dev_name.c_str());
         cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
         cur_icd.enable_icd_wsi = true;
@@ -699,7 +699,7 @@ TEST(WsiTests, GetPhysicalDeviceWaylandPresentNoICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceWaylandPresentationSupportKHR(physical_device, 0, nullptr),
                  "ICD for selected physical device does not export vkGetPhysicalDeviceWaylandPresentationSupportKHR!");
@@ -723,7 +723,7 @@ TEST(WsiTests, GetPhysicalDeviceWaylandPresentICDSupport) {
     uint32_t driver_count = 1;
     VkPhysicalDevice physical_device;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
-    ASSERT_EQ(driver_count, 1);
+    ASSERT_EQ(driver_count, 1U);
 
     ASSERT_EQ(VK_TRUE, env.vulkan_functions.vkGetPhysicalDeviceWaylandPresentationSupportKHR(physical_device, 0, nullptr));
 }
@@ -739,7 +739,7 @@ TEST(WsiTests, WaylandGetPhysicalDeviceSurfaceSupportKHR) {
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.set_min_icd_interface_version(5);
         cur_icd.add_instance_extensions({first_ext, second_ext});
-        std::string dev_name = "phys_dev_" + icd;
+        std::string dev_name = "phys_dev_" + std::to_string(icd);
         cur_icd.physical_devices.emplace_back(dev_name.c_str());
         cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
         cur_icd.enable_icd_wsi = true;
@@ -768,4 +768,3 @@ TEST(WsiTests, WaylandGetPhysicalDeviceSurfaceSupportKHR) {
     env.vulkan_functions.vkDestroySurfaceKHR(instance.inst, surface, nullptr);
 }
 #endif
-


### PR DESCRIPTION
Test fixturing (TEST_F) is useful when there is a lot of common code that needs
to be run for a suite of tests. However, the FrameworkEnvironment encapsulates
almost all of the setup work all tests needs, and so doesn't need to be in a
fixture. Making the add_icd call inside the tests makes it clear which binary
is being used.

This PR also uses the corrent signed/unsigned constants in tests, as was
warned by compilers when enhanced warnings were enabled (/W4 in msvc).

Refactor the CMakeLists.txt to allow for compiling with clang-cl. This required
figuring out that -Wall -Wextra mangle the set of warnings used. The solution
is to use /W4 instead when compiling with clang-cl on Windows.

Fixes #896 