### PR TITLE
Cleanup version checks and allow newer component layers in meta layers

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -111,9 +111,9 @@ loader_api_version loader_make_version(uint32_t version) {
 
 loader_api_version loader_combine_version(uint32_t major, uint32_t minor, uint32_t patch) {
     loader_api_version out_version;
-    out_version.major = major;
-    out_version.minor = minor;
-    out_version.patch = patch;
+    out_version.major = (uint16_t)major;
+    out_version.minor = (uint16_t)minor;
+    out_version.patch = (uint16_t)patch;
     return out_version;
 }
 
@@ -1739,12 +1739,12 @@ static bool verify_meta_layer_component_layers(const struct loader_instance *ins
             break;
         }
 
-        // Check the version of each layer, they need to be equal
+        // Check the version of each layer, they need to be at least MAJOR and MINOR
         loader_api_version comp_prop_version = loader_make_version(comp_prop->info.specVersion);
-        if (meta_layer_version.major != comp_prop_version.major || meta_layer_version.minor != comp_prop_version.minor) {
+        if (!loader_check_version_meets_required(meta_layer_version, comp_prop_version)) {
             loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
                        "verify_meta_layer_component_layers: Meta-layer uses API version %d.%d, but component "
-                       "layer %d uses API version %d.%d.  Skipping this layer.",
+                       "layer %d has API version %d.%d that is lower.  Skipping this layer.",
                        meta_layer_version.major, meta_layer_version.minor, comp_layer, comp_prop_version.major,
                        comp_prop_version.minor);
 

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -163,3 +163,18 @@ VkStringErrorFlags vk_string_validate(const int max_length, const char *char_arr
 char *loader_get_next_path(char *path);
 VkResult add_data_files(const struct loader_instance *inst, char *search_path, struct loader_data_files *out_files,
                         bool use_first_found_manifest);
+
+loader_api_version loader_make_version(uint32_t version);
+loader_api_version loader_combine_version(uint32_t major, uint32_t minor, uint32_t patch);
+
+// Helper macros for determining if a version is valid or not
+bool loader_check_version_meets_required(loader_api_version required, loader_api_version version);
+
+// Convenience macros for common versions
+#ifndef LOADER_VERSION_1_0_0
+#define LOADER_VERSION_1_0_0 loader_combine_version(1, 0, 0)
+#endif
+
+#ifndef LOADER_VERSION_1_1_0
+#define LOADER_VERSION_1_1_0 loader_combine_version(1, 1, 0)
+#endif

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -236,8 +236,7 @@ struct loader_instance {
     uint64_t magic;                               // Should be LOADER_MAGIC_NUMBER
 
     // Vulkan API version the app is intending to use.
-    uint16_t app_api_major_version;
-    uint16_t app_api_minor_version;
+    loader_api_version app_api_version;
 
     // We need to manually track physical devices over time.  If the user
     // re-queries the information, we don't want to delete old data or

--- a/loader/loader_linux.c
+++ b/loader/loader_linux.c
@@ -236,10 +236,7 @@ VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32
                                             struct loader_phys_dev_per_icd *icd_devices,
                                             struct loader_physical_device_term **sorted_device_term) {
     VkResult res = VK_SUCCESS;
-    bool app_is_vulkan_1_1 = false;
-    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
-        app_is_vulkan_1_1 = true;
-    }
+    bool app_is_vulkan_1_1 = loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version);
 
     struct LinuxSortedDeviceInfo *sorted_device_info = loader_instance_heap_alloc(
         inst, inst->total_gpu_count * sizeof(struct LinuxSortedDeviceInfo), VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
@@ -271,7 +268,7 @@ VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32
             sorted_device_info[index].device_id = dev_props.deviceID;
 
             bool device_is_1_1_capable =
-                VK_API_VERSION_MAJOR(dev_props.apiVersion) == 1 && VK_API_VERSION_MINOR(dev_props.apiVersion) >= 1;
+                loader_check_version_meets_required(LOADER_VERSION_1_1_0, loader_make_version(dev_props.apiVersion));
             if (!sorted_device_info[index].has_pci_bus_info) {
                 uint32_t ext_count;
                 icd_term->dispatch.EnumerateDeviceExtensionProperties(sorted_device_info[index].physical_device, NULL, &ext_count,
@@ -353,10 +350,7 @@ out:
 VkResult linux_sort_physical_device_groups(struct loader_instance *inst, uint32_t group_count,
                                            struct loader_physical_device_group_term *sorted_group_term) {
     VkResult res = VK_SUCCESS;
-    bool app_is_vulkan_1_1 = false;
-    if (inst->app_api_major_version >= 1 && inst->app_api_minor_version >= 1) {
-        app_is_vulkan_1_1 = true;
-    }
+    bool app_is_vulkan_1_1 = loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version);
 
     loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "linux_sort_physical_device_groups:  Original order:");
 
@@ -380,7 +374,7 @@ VkResult linux_sort_physical_device_groups(struct loader_instance *inst, uint32_
             sorted_group_term[group].internal_device_info[gpu].device_id = dev_props.deviceID;
 
             bool device_is_1_1_capable =
-                VK_API_VERSION_MAJOR(dev_props.apiVersion) == 1 && VK_API_VERSION_MINOR(dev_props.apiVersion) >= 1;
+                loader_check_version_meets_required(LOADER_VERSION_1_1_0, loader_make_version(dev_props.apiVersion));
             if (!sorted_group_term[group].internal_device_info[gpu].has_pci_bus_info) {
                 uint32_t ext_count;
                 icd_term->dispatch.EnumerateDeviceExtensionProperties(

--- a/loader/terminator.c
+++ b/loader/terminator.c
@@ -31,6 +31,7 @@
 
 #include "allocation.h"
 #include "loader_common.h"
+#include "loader.h"
 #include "log.h"
 
 // Terminators for 1.0 functions
@@ -132,7 +133,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceFeatures2(VkPhysicalDevic
 
     // Get the function pointer to use to call into the ICD. This could be the core or KHR version
     PFN_vkGetPhysicalDeviceFeatures2 fpGetPhysicalDeviceFeatures2 = NULL;
-    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
+    if (loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version)) {
         fpGetPhysicalDeviceFeatures2 = icd_term->dispatch.GetPhysicalDeviceFeatures2;
     }
     if (fpGetPhysicalDeviceFeatures2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
@@ -188,7 +189,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceProperties2(VkPhysicalDev
 
     // Get the function pointer to use to call into the ICD. This could be the core or KHR version
     PFN_vkGetPhysicalDeviceProperties2 fpGetPhysicalDeviceProperties2 = NULL;
-    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
+    if (loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version)) {
         fpGetPhysicalDeviceProperties2 = icd_term->dispatch.GetPhysicalDeviceProperties2;
     }
     if (fpGetPhysicalDeviceProperties2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
@@ -251,7 +252,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceFormatProperties2(VkPhysi
 
     // Get the function pointer to use to call into the ICD. This could be the core or KHR version
     PFN_vkGetPhysicalDeviceFormatProperties2 fpGetPhysicalDeviceFormatProperties2 = NULL;
-    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
+    if (loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version)) {
         fpGetPhysicalDeviceFormatProperties2 = icd_term->dispatch.GetPhysicalDeviceFormatProperties2;
     }
     if (fpGetPhysicalDeviceFormatProperties2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
@@ -289,7 +290,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceImageFormatProperties
 
     // Get the function pointer to use to call into the ICD. This could be the core or KHR version
     PFN_vkGetPhysicalDeviceImageFormatProperties2 fpGetPhysicalDeviceImageFormatProperties2 = NULL;
-    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
+    if (loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version)) {
         fpGetPhysicalDeviceImageFormatProperties2 = icd_term->dispatch.GetPhysicalDeviceImageFormatProperties2;
     }
     if (fpGetPhysicalDeviceImageFormatProperties2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
@@ -329,7 +330,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceQueueFamilyProperties2(Vk
 
     // Get the function pointer to use to call into the ICD. This could be the core or KHR version
     PFN_vkGetPhysicalDeviceQueueFamilyProperties2 fpGetPhysicalDeviceQueueFamilyProperties2 = NULL;
-    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
+    if (loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version)) {
         fpGetPhysicalDeviceQueueFamilyProperties2 = icd_term->dispatch.GetPhysicalDeviceQueueFamilyProperties2;
     }
     if (fpGetPhysicalDeviceQueueFamilyProperties2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
@@ -387,7 +388,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceMemoryProperties2(VkPhysi
 
     // Get the function pointer to use to call into the ICD. This could be the core or KHR version
     PFN_vkGetPhysicalDeviceMemoryProperties2 fpGetPhysicalDeviceMemoryProperties2 = NULL;
-    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
+    if (loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version)) {
         fpGetPhysicalDeviceMemoryProperties2 = icd_term->dispatch.GetPhysicalDeviceMemoryProperties2;
     }
     if (fpGetPhysicalDeviceMemoryProperties2 == NULL && inst->enabled_known_extensions.khr_get_physical_device_properties2) {
@@ -425,7 +426,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceSparseImageFormatProperti
 
     // Get the function pointer to use to call into the ICD. This could be the core or KHR version
     PFN_vkGetPhysicalDeviceSparseImageFormatProperties2 fpGetPhysicalDeviceSparseImageFormatProperties2 = NULL;
-    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
+    if (loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version)) {
         fpGetPhysicalDeviceSparseImageFormatProperties2 = icd_term->dispatch.GetPhysicalDeviceSparseImageFormatProperties2;
     }
     if (fpGetPhysicalDeviceSparseImageFormatProperties2 == NULL &&
@@ -495,7 +496,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceExternalBufferProperties(
 
     // Get the function pointer to use to call into the ICD. This could be the core or KHR version
     PFN_vkGetPhysicalDeviceExternalBufferProperties fpGetPhysicalDeviceExternalBufferProperties = NULL;
-    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
+    if (loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version)) {
         fpGetPhysicalDeviceExternalBufferProperties = icd_term->dispatch.GetPhysicalDeviceExternalBufferProperties;
     }
     if (fpGetPhysicalDeviceExternalBufferProperties == NULL && inst->enabled_known_extensions.khr_external_memory_capabilities) {
@@ -538,7 +539,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceExternalSemaphoreProperti
 
     // Get the function pointer to use to call into the ICD. This could be the core or KHR version
     PFN_vkGetPhysicalDeviceExternalSemaphoreProperties fpGetPhysicalDeviceExternalSemaphoreProperties = NULL;
-    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
+    if (loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version)) {
         fpGetPhysicalDeviceExternalSemaphoreProperties = icd_term->dispatch.GetPhysicalDeviceExternalSemaphoreProperties;
     }
     if (fpGetPhysicalDeviceExternalSemaphoreProperties == NULL &&
@@ -585,7 +586,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceExternalFenceProperties(
 
     // Get the function pointer to use to call into the ICD. This could be the core or KHR version
     PFN_vkGetPhysicalDeviceExternalFenceProperties fpGetPhysicalDeviceExternalFenceProperties = NULL;
-    if (inst->app_api_major_version > 1 || inst->app_api_minor_version >= 1) {
+    if (loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version)) {
         fpGetPhysicalDeviceExternalFenceProperties = icd_term->dispatch.GetPhysicalDeviceExternalFenceProperties;
     }
     if (fpGetPhysicalDeviceExternalFenceProperties == NULL && inst->enabled_known_extensions.khr_external_fence_capabilities) {

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -78,7 +78,8 @@ LOADER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkI
 
             // First check if instance is valid - loader_get_instance() returns NULL if it isn't.
             struct loader_instance *ptr_instance = loader_get_instance(instance);
-            if (ptr_instance != NULL && (ptr_instance->app_api_minor_version > 2)) {
+            if (ptr_instance != NULL &&
+                loader_check_version_meets_required(loader_combine_version(1, 3, 0), ptr_instance->app_api_version)) {
                 // New behavior
                 return NULL;
             } else {
@@ -474,11 +475,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
 
     // Save the application version
     if (NULL == pCreateInfo->pApplicationInfo || 0 == pCreateInfo->pApplicationInfo->apiVersion) {
-        ptr_instance->app_api_major_version = 1;
-        ptr_instance->app_api_minor_version = 0;
+        ptr_instance->app_api_version = LOADER_VERSION_1_0_0;
     } else {
-        ptr_instance->app_api_major_version = VK_API_VERSION_MAJOR(pCreateInfo->pApplicationInfo->apiVersion);
-        ptr_instance->app_api_minor_version = VK_API_VERSION_MINOR(pCreateInfo->pApplicationInfo->apiVersion);
+        ptr_instance->app_api_version = loader_make_version(pCreateInfo->pApplicationInfo->apiVersion);
+        // zero out the patch version since we don't actually want to compare with it
+        ptr_instance->app_api_version.patch = 0;
     }
 
     // Look for one or more VK_EXT_debug_report or VK_EXT_debug_utils create info structures

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -194,7 +194,9 @@ static inline char *loader_platform_executable_path(char *buffer, size_t size) {
         -1,
 #endif
     };
-    if (sysctl(mib, sizeof(mib) / sizeof(mib[0]), buffer, &size, NULL, 0) < 0) return NULL;
+    if (sysctl(mib, sizeof(mib) / sizeof(mib[0]), buffer, &size, NULL, 0) < 0) {
+        return NULL;
+    }
 
     return buffer;
 }

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -857,9 +857,9 @@ TEST(OverrideMetaLayer, OlderComponentLayerInMetaLayer) {
         inst.create_info.set_api_version(1, 1, 0);
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
-        ASSERT_TRUE(
-            env.debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 uses "
-                               "API version 1.0.  Skipping this layer."));
+        EXPECT_TRUE(
+            env.debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 has API "
+                               "version 1.0 that is lower.  Skipping this layer."));
         env.debug_log.clear();
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
@@ -877,8 +877,8 @@ TEST(OverrideMetaLayer, OlderComponentLayerInMetaLayer) {
         inst.CheckCreate();
         VkPhysicalDevice phys_dev = inst.GetPhysDev();
         ASSERT_TRUE(
-            env.debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 uses "
-                               "API version 1.0.  Skipping this layer."));
+            env.debug_log.find("verify_meta_layer_component_layers: Meta-layer uses API version 1.1, but component layer 0 has API "
+                               "version 1.0 that is lower.  Skipping this layer."));
         env.debug_log.clear();
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);


### PR DESCRIPTION
Refactor the version selection logic by utilizing `loader_api_version`.
Relaxes the requirement that all components layers have the exact same API version as the meta layer, to just requiring that their version is greater than or equal to the meta layer API version.

Fixes #796 