### PR TITLE
Dont emit warnings on unknown manifest file versions

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2593,8 +2593,8 @@ static VkResult loader_add_layer_properties(const struct loader_instance *inst, 
     json_version = loader_make_api_version(file_vers);
 
     if (!is_valid_layer_json_version(&json_version)) {
-        loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0,
-                   "loader_add_layer_properties: %s invalid layer manifest file version %d.%d.%d.  May cause errors.", filename,
+        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_LAYER_BIT, 0,
+                   "loader_add_layer_properties: %s has unknown layer manifest file version %d.%d.%d.  May cause errors.", filename,
                    json_version.major, json_version.minor, json_version.patch);
     }
     cJSON_Free(inst, file_vers);
@@ -3440,8 +3440,9 @@ VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_t
         json_file_version = loader_make_api_version(file_vers);
 
         if (json_file_version.major != 1 || json_file_version.minor != 0 || json_file_version.patch > 1) {
-            loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
-                       "loader_icd_scan: Unexpected manifest file version (expected 1.0.0 or 1.0.1), may cause errors");
+            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                       "loader_icd_scan: %s has unknown icd manifest file version %d.%d.%d. May cause errors.", file_str,
+                       json_file_version.major, json_file_version.minor, json_file_version.patch);
         }
         cJSON_Free(inst, file_vers);
 

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -209,22 +209,18 @@ FrameworkEnvironment::FrameworkEnvironment(DebugMode debug_mode, bool override_i
 void FrameworkEnvironment::add_icd(TestICDDetails icd_details) noexcept {
     size_t cur_icd_index = icds.size();
     if (!icd_details.is_fake) {
-        fs::path new_driver_name = fs::path(icd_details.icd_path).stem() + "_" + std::to_string(cur_icd_index) +
-                                   fs::path(icd_details.icd_path).extension();
+        fs::path new_driver_name = fs::path(icd_details.icd_manifest.lib_path).stem() + "_" + std::to_string(cur_icd_index) +
+                                   fs::path(icd_details.icd_manifest.lib_path).extension();
 
-        auto new_driver_location = icd_folder.copy_file(icd_details.icd_path, new_driver_name.str());
+        auto new_driver_location = icd_folder.copy_file(icd_details.icd_manifest.lib_path, new_driver_name.str());
 
         icds.push_back(TestICDHandle(new_driver_location));
         icds.back().reset_icd();
-        icd_details.icd_path = new_driver_location;
+        icd_details.icd_manifest.lib_path = new_driver_location.str();
     }
     std::string full_json_name = icd_details.json_name + "_" + std::to_string(cur_icd_index) + ".json";
 
-    auto driver_loc =
-        icd_folder.write_manifest(full_json_name, ManifestICD{}
-                                                      .set_lib_path(fs::fixup_backslashes_in_path(icd_details.icd_path).str())
-                                                      .set_api_version(icd_details.api_version)
-                                                      .get_manifest_str());
+    auto driver_loc = icd_folder.write_manifest(full_json_name, icd_details.icd_manifest.get_manifest_str());
     icds.back().manifest_path = driver_loc;
 
     if (icd_details.use_env_var_icd_filenames) {

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -302,10 +302,11 @@ struct TestLayerHandle {
 };
 
 struct TestICDDetails {
-    TestICDDetails(fs::path icd_path, uint32_t api_version = VK_API_VERSION_1_0) noexcept
-        : icd_path(icd_path), api_version(api_version) {}
-    BUILDER_VALUE(TestICDDetails, fs::path, icd_path, {});
-    BUILDER_VALUE(TestICDDetails, uint32_t, api_version, VK_API_VERSION_1_0);
+    TestICDDetails(ManifestICD icd_manifest) noexcept : icd_manifest(icd_manifest) {}
+    TestICDDetails(fs::path icd_path, uint32_t api_version = VK_API_VERSION_1_0) noexcept {
+        icd_manifest.set_lib_path(icd_path.str()).set_api_version(api_version);
+    }
+    BUILDER_VALUE(TestICDDetails, ManifestICD, icd_manifest, {});
     BUILDER_VALUE(TestICDDetails, std::string, json_name, "test_icd");
     BUILDER_VALUE(TestICDDetails, bool, use_env_var_icd_filenames, false);
     BUILDER_VALUE(TestICDDetails, bool, use_add_env_var_icd_filenames, false);

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -793,3 +793,43 @@ TEST(LayerManifest, ExplicitNonVulkanVariant) {
     ASSERT_TRUE(log.find(std::string("Layer ") + explicit_layer_name +
                          " has an \'api_version\' field which contains a non-zero variant value of 1.  Skipping Layer."));
 }
+
+TEST(DriverManifest, UnknownManifestVersion) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(ManifestICD{}.set_lib_path(TEST_ICD_PATH_VERSION_6).set_file_format_version({3, 2, 1})));
+    env.get_test_icd().physical_devices.push_back({});
+
+    DebugUtilsLogger log;
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0));
+    FillDebugUtilsCreateDetails(inst.create_info, log);
+    inst.CheckCreate();
+    ASSERT_TRUE(log.find("loader_icd_scan: "));
+    // log prints the path to the file, don't look for it since it is hard to determine inside the test what the path should be.
+    ASSERT_TRUE(log.find("has unknown icd manifest file version 3.2.1. May cause errors."));
+}
+
+TEST(LayerManifest, UnknownManifestVersion) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.get_test_icd().physical_devices.push_back({});
+
+    const char* implicit_layer_name = "ImplicitTestLayer";
+    env.add_implicit_layer(ManifestLayer{}
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(implicit_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(1, 1, 0, 0))
+                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                              .set_disable_environment("DISABLE_ME"))
+                               .set_file_format_version({3, 2, 1}),
+                           "implicit_test_layer.json");
+
+    DebugUtilsLogger log;
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0));
+    FillDebugUtilsCreateDetails(inst.create_info, log);
+    inst.CheckCreate();
+    ASSERT_TRUE(log.find("loader_add_layer_properties: "));
+    // log prints the path to the file, don't look for it since it is hard to determine inside the test what the path should be.
+    ASSERT_TRUE(log.find("has unknown layer manifest file version 3.2.1.  May cause errors."));
+}


### PR DESCRIPTION
Since the loader is meant to be forward compatible, it makes little sense to emit
a warning when an ICD or Layer manifest is found with a version that it doesn't
understand. Thus they now are INFO level.