### PR TITLE
Fix missed Physical Devices in Windows + test improvements

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5844,37 +5844,81 @@ bool is_linux_sort_enabled(struct loader_instance *inst) {
 }
 #endif  // LOADER_ENABLE_LINUX_SORT
 
+// Check if this physical device is already in the old buffer
+void check_if_phys_dev_already_present(struct loader_instance *inst, VkPhysicalDevice physical_device, uint32_t idx,
+                                       struct loader_physical_device_term **new_phys_devs) {
+    if (NULL != inst->phys_devs_term) {
+        for (uint32_t old_idx = 0; old_idx < inst->phys_dev_count_term; old_idx++) {
+            if (physical_device == inst->phys_devs_term[old_idx]->phys_dev) {
+                new_phys_devs[idx] = inst->phys_devs_term[old_idx];
+                break;
+            }
+        }
+    }
+}
+
+VkResult allocate_new_phys_dev_at_idx(struct loader_instance *inst, VkPhysicalDevice physical_device,
+                                      struct loader_phys_dev_per_icd *dev_array, uint32_t idx,
+                                      struct loader_physical_device_term **new_phys_devs) {
+    if (NULL == new_phys_devs[idx]) {
+        new_phys_devs[idx] =
+            loader_instance_heap_alloc(inst, sizeof(struct loader_physical_device_term), VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (NULL == new_phys_devs[idx]) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+                       "allocate_new_phys_dev_at_idx:  Failed to allocate physical device terminator object %d", idx);
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        loader_set_dispatch((void *)new_phys_devs[idx], inst->disp);
+        new_phys_devs[idx]->this_icd_term = dev_array->icd_term;
+        new_phys_devs[idx]->icd_index = (uint8_t)(dev_array->icd_index);
+        new_phys_devs[idx]->phys_dev = physical_device;
+    }
+    return VK_SUCCESS;
+}
+
+/* Enumerate all physical devices from ICDs and add them to inst->phys_devs_term
+ *
+ * There are two methods to find VkPhysicalDevices - vkEnumeratePhysicalDevices and vkEnumerateAdapterPhysicalDevices
+ * The latter is supported on windows only and on devices supporting ICD Interface Version 6 and greater.
+ *
+ * Once all physical devices are acquired, they need to be pulled into a single list of `loader_physical_device_term`'s.
+ * They also need to be setup - the icd_term, icd_index, phys_dev, and disp (dispatch table) all need the correct data.
+ * Additionally, we need to keep using already setup physical devices as they may be in use, thus anything enumerated
+ * that is already in inst->phys_devs_term will be carried over.
+ */
+
 VkResult setup_loader_term_phys_devs(struct loader_instance *inst) {
     VkResult res = VK_SUCCESS;
     struct loader_icd_term *icd_term;
-    struct loader_phys_dev_per_icd *icd_phys_dev_array = NULL;
-    struct loader_physical_device_term **new_phys_devs = NULL;
-    struct loader_phys_dev_per_icd *sorted_phys_dev_array = NULL;
     uint32_t icd_idx = 0;
-    uint32_t sorted_count = 0;
-
-    inst->total_gpu_count = 0;
-
-    // Allocate something to store the physical device characteristics
-    // that we read from each ICD.
-    icd_phys_dev_array =
-        (struct loader_phys_dev_per_icd *)loader_stack_alloc(sizeof(struct loader_phys_dev_per_icd) * inst->total_icd_count);
-    if (NULL == icd_phys_dev_array) {
-        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "setup_loader_term_phys_devs:  Failed to allocate temporary ICD Physical device info array of size %d",
-                   inst->total_icd_count);
-        res = VK_ERROR_OUT_OF_HOST_MEMORY;
-        goto out;
-    }
-    memset(icd_phys_dev_array, 0, sizeof(struct loader_phys_dev_per_icd) * inst->total_icd_count);
+    uint32_t windows_sorted_devices_count = 0;
+    struct loader_phys_dev_per_icd *windows_sorted_devices_array = NULL;
+    uint32_t icd_count = 0;
+    struct loader_phys_dev_per_icd *icd_phys_dev_array = NULL;
+    uint32_t new_phys_devs_count = 0;
+    struct loader_physical_device_term **new_phys_devs = NULL;
 
 #if defined(_WIN32)
     // Get the physical devices supported by platform sorting mechanism into a separate list
-    res = windows_read_sorted_physical_devices(inst, &sorted_phys_dev_array, &sorted_count);
+    res = windows_read_sorted_physical_devices(inst, &windows_sorted_devices_count, &windows_sorted_devices_array);
     if (VK_SUCCESS != res) {
         goto out;
     }
 #endif
+
+    icd_count = inst->total_icd_count;
+
+    // Allocate something to store the physical device characteristics that we read from each ICD.
+    icd_phys_dev_array = (struct loader_phys_dev_per_icd *)loader_stack_alloc(sizeof(struct loader_phys_dev_per_icd) * icd_count);
+    if (NULL == icd_phys_dev_array) {
+        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+                   "setup_loader_term_phys_devs:  Failed to allocate temporary ICD Physical device info array of size %d",
+                   icd_count);
+        res = VK_ERROR_OUT_OF_HOST_MEMORY;
+        goto out;
+    }
+    memset(icd_phys_dev_array, 0, sizeof(struct loader_phys_dev_per_icd) * icd_count);
 
     // For each ICD, query the number of physical devices, and then get an
     // internal value for those physical devices.
@@ -5883,8 +5927,9 @@ VkResult setup_loader_term_phys_devs(struct loader_instance *inst) {
         // This is the legacy behavior which should be skipped if EnumerateAdapterPhysicalDevices is available
         // and we successfully enumerated sorted adapters using windows_read_sorted_physical_devices.
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-        if (sorted_count && icd_term->scanned_icd->EnumerateAdapterPhysicalDevices != NULL) {
+        if (icd_term->scanned_icd->EnumerateAdapterPhysicalDevices != NULL) {
             icd_term = icd_term->next;
+            ++icd_idx;
             continue;
         }
 #endif
@@ -5902,7 +5947,7 @@ VkResult setup_loader_term_phys_devs(struct loader_instance *inst) {
         if (NULL == icd_phys_dev_array[icd_idx].physical_devices) {
             loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
                        "setup_loader_term_phys_devs:  Failed to allocate temporary ICD Physical device array for ICD %d of size %d",
-                       icd_idx, inst->total_gpu_count);
+                       icd_idx, icd_phys_dev_array[icd_idx].device_count);
             res = VK_ERROR_OUT_OF_HOST_MEMORY;
             goto out;
         }
@@ -5912,52 +5957,84 @@ VkResult setup_loader_term_phys_devs(struct loader_instance *inst) {
         if (VK_SUCCESS != res) {
             goto out;
         }
-        inst->total_gpu_count += icd_phys_dev_array[icd_idx].device_count;
         icd_phys_dev_array[icd_idx].icd_term = icd_term;
         icd_phys_dev_array[icd_idx].icd_index = icd_idx;
         icd_term = icd_term->next;
         ++icd_idx;
     }
 
-    if (0 == inst->total_gpu_count) {
+    // Add up both the windows sorted and non windows found physical device counts
+    for (uint32_t i = 0; i < windows_sorted_devices_count; ++i) {
+        new_phys_devs_count += windows_sorted_devices_array[i].device_count;
+    }
+    for (uint32_t i = 0; i < icd_count; ++i) {
+        new_phys_devs_count += icd_phys_dev_array[i].device_count;
+    }
+
+    // Bail out if there are no physical devices reported
+    if (0 == new_phys_devs_count) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "setup_loader_term_phys_devs:  Failed to detect any valid GPUs in the current config");
         res = VK_ERROR_INITIALIZATION_FAILED;
         goto out;
     }
 
-    new_phys_devs = loader_instance_heap_alloc(inst, sizeof(struct loader_physical_device_term *) * inst->total_gpu_count,
+    // Create an allocation large enough to hold both the windows sorting enumeration and non-windows physical device enumeration
+    new_phys_devs = loader_instance_heap_alloc(inst, sizeof(struct loader_physical_device_term *) * new_phys_devs_count,
                                                VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
     if (NULL == new_phys_devs) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "setup_loader_term_phys_devs:  Failed to allocate new physical device array of size %d", inst->total_gpu_count);
+                   "setup_loader_term_phys_devs:  Failed to allocate new physical device array of size %d", new_phys_devs_count);
         res = VK_ERROR_OUT_OF_HOST_MEMORY;
         goto out;
     }
-    memset(new_phys_devs, 0, sizeof(struct loader_physical_device_term *) * inst->total_gpu_count);
+    memset(new_phys_devs, 0, sizeof(struct loader_physical_device_term *) * new_phys_devs_count);
 
+    // Current index into the new_phys_devs array - increment whenever we've written in.
+    uint32_t idx = 0;
+
+    // Copy over everything found through sorted enumeration
+    for (uint32_t i = 0; i < windows_sorted_devices_count; ++i) {
+        for (uint32_t j = 0; j < windows_sorted_devices_array[i].device_count; ++j) {
+            check_if_phys_dev_already_present(inst, windows_sorted_devices_array[i].physical_devices[j], idx, new_phys_devs);
+
+            res = allocate_new_phys_dev_at_idx(inst, windows_sorted_devices_array[i].physical_devices[j],
+                                               &windows_sorted_devices_array[i], idx, new_phys_devs);
+            if (res == VK_ERROR_OUT_OF_HOST_MEMORY) {
+                goto out;
+            }
+            // Increment the count of new physical devices
+            idx++;
+        }
+    }
+
+    // Now go through the rest of the physical devices and add them to new_phys_devs
 #ifdef LOADER_ENABLE_LINUX_SORT
     if (is_linux_sort_enabled(inst)) {
-        for (uint32_t dev = 0; dev < inst->total_gpu_count; ++dev) {
+        for (uint32_t dev = idx; dev < new_phys_devs_count; ++dev) {
             new_phys_devs[dev] =
                 loader_instance_heap_alloc(inst, sizeof(struct loader_physical_device_term), VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
             if (NULL == new_phys_devs[dev]) {
                 loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
                            "setup_loader_term_phys_devs:  Failed to allocate physical device terminator object %d", dev);
-                inst->total_gpu_count = dev;
                 res = VK_ERROR_OUT_OF_HOST_MEMORY;
                 goto out;
             }
         }
 
         // Get the physical devices supported by platform sorting mechanism into a separate list
-        res = linux_read_sorted_physical_devices(inst, icd_idx, icd_phys_dev_array, new_phys_devs);
-
+        // Pass in a sublist to the function so it only operates on the correct elements. This means passing in a pointer to the
+        // current next element in new_phys_devs and passing in a `count` of currently unwritten elements
+        res =
+            linux_read_sorted_physical_devices(inst, icd_count, icd_phys_dev_array, new_phys_devs_count - idx, &new_phys_devs[idx]);
+        if (res == VK_ERROR_OUT_OF_HOST_MEMORY) {
+            goto out;
+        }
         // Keep previously allocated physical device info since apps may already be using that!
-        for (uint32_t new_idx = 0; new_idx < inst->total_gpu_count; new_idx++) {
+        for (uint32_t new_idx = idx; new_idx < new_phys_devs_count; new_idx++) {
             for (uint32_t old_idx = 0; old_idx < inst->phys_dev_count_term; old_idx++) {
                 if (new_phys_devs[new_idx]->phys_dev == inst->phys_devs_term[old_idx]->phys_dev) {
-                    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                    loader_log(inst, VULKAN_LOADER_DEBUG_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                                "Copying old device %u into new device %u", old_idx, new_idx);
                     // Free the old new_phys_devs info since we're not using it before we assign the new info
                     loader_instance_heap_free(inst, new_phys_devs[new_idx]);
@@ -5966,63 +6043,34 @@ VkResult setup_loader_term_phys_devs(struct loader_instance *inst) {
                 }
             }
         }
-        goto out;
-    }
+        // We want the following code to run if either linux sorting is disabled at compile time or runtime
+    } else {
 #endif  // LOADER_ENABLE_LINUX_SORT
 
-    // Copy or create everything to fill the new array of physical devices
-    uint32_t idx = 0;
+        // Copy over everything found through the non-sorted means.
+        for (uint32_t i = 0; i < icd_count; ++i) {
+            for (uint32_t j = 0; j < icd_phys_dev_array[i].device_count; ++j) {
+                check_if_phys_dev_already_present(inst, icd_phys_dev_array[i].physical_devices[j], idx, new_phys_devs);
 
-    // Copy over everything found through sorted enumeration
-    struct loader_phys_dev_per_icd *phys_dev_array = icd_phys_dev_array;
-    uint32_t max_count = inst->total_icd_count;
-#if defined(_WIN32)
-    if (sorted_count > 0) {
-        phys_dev_array = sorted_phys_dev_array;
-        max_count = sorted_count;
-    }
-#endif
-    for (uint32_t i = 0; i < max_count; ++i) {
-        for (uint32_t j = 0; j < phys_dev_array[i].device_count; ++j) {
-            // Check if this physical device is already in the old buffer
-            if (NULL != inst->phys_devs_term) {
-                for (uint32_t old_idx = 0; old_idx < inst->phys_dev_count_term; old_idx++) {
-                    if (phys_dev_array[i].physical_devices[j] == inst->phys_devs_term[old_idx]->phys_dev) {
-                        new_phys_devs[idx] = inst->phys_devs_term[old_idx];
-                        break;
-                    }
-                }
-            }
-
-            // If this physical device isn't in the old buffer, then we need to create it.
-            if (NULL == new_phys_devs[idx]) {
-                new_phys_devs[idx] = loader_instance_heap_alloc(inst, sizeof(struct loader_physical_device_term),
-                                                                VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-                if (NULL == new_phys_devs[idx]) {
-                    loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                               "setup_loader_term_phys_devs:  Failed to allocate physical device terminator object %d", idx);
-                    inst->total_gpu_count = idx;
-                    res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                // If this physical device isn't in the old buffer, then we need to create it.
+                res = allocate_new_phys_dev_at_idx(inst, icd_phys_dev_array[i].physical_devices[j], &icd_phys_dev_array[i], idx,
+                                                   new_phys_devs);
+                if (res == VK_ERROR_OUT_OF_HOST_MEMORY) {
                     goto out;
                 }
-
-                loader_set_dispatch((void *)new_phys_devs[idx], inst->disp);
-                new_phys_devs[idx]->this_icd_term = phys_dev_array[i].icd_term;
-                new_phys_devs[idx]->icd_index = (uint8_t)(phys_dev_array[i].icd_index);
-                new_phys_devs[idx]->phys_dev = phys_dev_array[i].physical_devices[j];
+                // Increment the count of new physical devices
+                idx++;
             }
-
-            // Increment the count of new physical devices
-            idx++;
         }
+#ifdef LOADER_ENABLE_LINUX_SORT
     }
-
+#endif  // LOADER_ENABLE_LINUX_SORT
 out:
 
     if (VK_SUCCESS != res) {
         if (NULL != new_phys_devs) {
             // We've encountered an error, so we should free the new buffers.
-            for (uint32_t i = 0; i < inst->total_gpu_count; i++) {
+            for (uint32_t i = 0; i < new_phys_devs_count; i++) {
                 // If an OOM occurred inside the copying of the new physical devices into the existing array
                 // will leave some of the old physical devices in the array which may have been copied into
                 // the new array, leading to them being freed twice. To avoid this we just make sure to not
@@ -6051,7 +6099,7 @@ out:
             // in memory leaking.
             for (uint32_t i = 0; i < inst->phys_dev_count_term; i++) {
                 bool found = false;
-                for (uint32_t j = 0; j < inst->total_gpu_count; j++) {
+                for (uint32_t j = 0; j < new_phys_devs_count; j++) {
                     if (new_phys_devs != NULL && inst->phys_devs_term[i] == new_phys_devs[j]) {
                         found = true;
                         break;
@@ -6065,17 +6113,18 @@ out:
         }
 
         // Swap out old and new devices list
-        inst->phys_dev_count_term = inst->total_gpu_count;
+        inst->phys_dev_count_term = new_phys_devs_count;
         inst->phys_devs_term = new_phys_devs;
+        inst->total_gpu_count = new_phys_devs_count;
     }
 
-    if (sorted_phys_dev_array != NULL) {
-        for (uint32_t i = 0; i < sorted_count; ++i) {
-            if (sorted_phys_dev_array[i].device_count > 0 && sorted_phys_dev_array[i].physical_devices != NULL) {
-                loader_instance_heap_free(inst, sorted_phys_dev_array[i].physical_devices);
+    if (windows_sorted_devices_array != NULL) {
+        for (uint32_t i = 0; i < windows_sorted_devices_count; ++i) {
+            if (windows_sorted_devices_array[i].device_count > 0 && windows_sorted_devices_array[i].physical_devices != NULL) {
+                loader_instance_heap_free(inst, windows_sorted_devices_array[i].physical_devices);
             }
         }
-        loader_instance_heap_free(inst, sorted_phys_dev_array);
+        loader_instance_heap_free(inst, windows_sorted_devices_array);
     }
 
     return res;
@@ -6137,12 +6186,12 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumeratePhysicalDevices(VkInstance in
         goto out;
     }
 
-    uint32_t copy_count = inst->total_gpu_count;
+    uint32_t copy_count = inst->phys_dev_count_term;
     if (NULL != pPhysicalDevices) {
         if (copy_count > *pPhysicalDeviceCount) {
             copy_count = *pPhysicalDeviceCount;
             loader_log(inst, VULKAN_LOADER_INFO_BIT, 0,
-                       "terminator_EnumeratePhysicalDevices : Trimming device count from %d to %d.", inst->total_gpu_count,
+                       "terminator_EnumeratePhysicalDevices : Trimming device count from %d to %d.", inst->phys_dev_count_term,
                        copy_count);
             res = VK_INCOMPLETE;
         }
@@ -6567,7 +6616,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumeratePhysicalDeviceGroups(
 
 #if defined(_WIN32)
         // Get the physical devices supported by platform sorting mechanism into a separate list
-        res = windows_read_sorted_physical_devices(inst, &sorted_phys_dev_array, &sorted_count);
+        res = windows_read_sorted_physical_devices(inst, &sorted_count, &sorted_phys_dev_array);
         if (VK_SUCCESS != res) {
             goto out;
         }

--- a/loader/loader_linux.h
+++ b/loader/loader_linux.h
@@ -28,7 +28,7 @@
 
 // This function allocates an array in sorted_devices which must be freed by the caller if not null
 VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32_t icd_count,
-                                            struct loader_phys_dev_per_icd *icd_devices,
+                                            struct loader_phys_dev_per_icd *icd_devices, uint32_t phys_dev_count,
                                             struct loader_physical_device_term **sorted_device_term);
 
 // This function sorts an array in physical device groups

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -857,7 +857,7 @@ VkResult windows_read_sorted_physical_devices(struct loader_instance *inst, stru
                     continue;
                 }
 
-                uint32_t count;
+                uint32_t count = 0;
                 VkResult vkres = icd_term->scanned_icd->EnumerateAdapterPhysicalDevices(icd_term->instance, description.AdapterLuid,
                                                                                         &count, NULL);
                 if (vkres == VK_ERROR_INCOMPATIBLE_DRIVER) {

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -580,8 +580,7 @@ VkResult windows_read_manifest_from_d3d_adapters(const struct loader_instance *i
         goto out;
     }
 
-    PFN_LoaderEnumAdapters2 fpLoaderEnumAdapters2 =
-        (PFN_LoaderEnumAdapters2)GetProcAddress(gdi32_dll, "D3DKMTEnumAdapters2");
+    PFN_LoaderEnumAdapters2 fpLoaderEnumAdapters2 = (PFN_LoaderEnumAdapters2)GetProcAddress(gdi32_dll, "D3DKMTEnumAdapters2");
     PFN_LoaderQueryAdapterInfo fpLoaderQueryAdapterInfo =
         (PFN_LoaderQueryAdapterInfo)GetProcAddress(gdi32_dll, "D3DKMTQueryAdapterInfo");
     if (fpLoaderEnumAdapters2 == NULL || fpLoaderQueryAdapterInfo == NULL) {
@@ -792,8 +791,8 @@ out:
 }
 
 // This function allocates an array in sorted_devices which must be freed by the caller if not null
-VkResult windows_read_sorted_physical_devices(struct loader_instance *inst, struct loader_phys_dev_per_icd **sorted_devices,
-                                              uint32_t *sorted_count) {
+VkResult windows_read_sorted_physical_devices(struct loader_instance *inst, uint32_t *sorted_devices_count,
+                                              struct loader_phys_dev_per_icd **sorted_devices) {
     VkResult res = VK_SUCCESS;
 
     uint32_t sorted_alloc = 0;
@@ -802,121 +801,119 @@ VkResult windows_read_sorted_physical_devices(struct loader_instance *inst, stru
     HRESULT hres = fpCreateDXGIFactory1(&IID_IDXGIFactory6, (void **)&dxgi_factory);
     if (hres != S_OK) {
         loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "Failed to create DXGI factory 6. Physical devices will not be sorted");
-    } else {
-        sorted_alloc = 16;
-        *sorted_devices = loader_instance_heap_alloc(inst, sorted_alloc * sizeof(struct loader_phys_dev_per_icd),
-                                                     VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-        if (*sorted_devices == NULL) {
-            res = VK_ERROR_OUT_OF_HOST_MEMORY;
-            goto out;
+        goto out;
+    }
+    sorted_alloc = 16;
+    *sorted_devices =
+        loader_instance_heap_alloc(inst, sorted_alloc * sizeof(struct loader_phys_dev_per_icd), VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
+    if (*sorted_devices == NULL) {
+        res = VK_ERROR_OUT_OF_HOST_MEMORY;
+        goto out;
+    }
+
+    memset(*sorted_devices, 0, sorted_alloc * sizeof(struct loader_phys_dev_per_icd));
+
+    for (uint32_t i = 0;; ++i) {
+        IDXGIAdapter1 *adapter;
+        hres = dxgi_factory->lpVtbl->EnumAdapterByGpuPreference(dxgi_factory, i, DXGI_GPU_PREFERENCE_UNSPECIFIED,
+                                                                &IID_IDXGIAdapter1, (void **)&adapter);
+        if (hres == DXGI_ERROR_NOT_FOUND) {
+            break;  // No more adapters
+        } else if (hres != S_OK) {
+            loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
+                       "Failed to enumerate adapters by GPU preference at index %u. This adapter will not be sorted", i);
+            break;
         }
 
-        memset(*sorted_devices, 0, sorted_alloc * sizeof(struct loader_phys_dev_per_icd));
+        DXGI_ADAPTER_DESC1 description;
+        hres = adapter->lpVtbl->GetDesc1(adapter, &description);
+        if (hres != S_OK) {
+            loader_log(inst, VULKAN_LOADER_WARN_BIT, 0, "Failed to get adapter LUID index %u. This adapter will not be sorted", i);
+            continue;
+        }
 
-        *sorted_count = 0;
-        for (uint32_t i = 0;; ++i) {
-            IDXGIAdapter1 *adapter;
-            hres = dxgi_factory->lpVtbl->EnumAdapterByGpuPreference(dxgi_factory, i, DXGI_GPU_PREFERENCE_UNSPECIFIED,
-                                                                    &IID_IDXGIAdapter1, (void **)&adapter);
-            if (hres == DXGI_ERROR_NOT_FOUND) {
-                break;  // No more adapters
-            } else if (hres != S_OK) {
-                loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
-                           "Failed to enumerate adapters by GPU preference at index %u. This adapter will not be sorted", i);
-                break;
+        if (sorted_alloc <= i) {
+            uint32_t old_size = sorted_alloc * sizeof(struct loader_phys_dev_per_icd);
+            *sorted_devices =
+                loader_instance_heap_realloc(inst, *sorted_devices, old_size, 2 * old_size, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
+            if (*sorted_devices == NULL) {
+                adapter->lpVtbl->Release(adapter);
+                res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                goto out;
             }
+            sorted_alloc *= 2;
+        }
+        struct loader_phys_dev_per_icd *sorted_array = *sorted_devices;
+        sorted_array[*sorted_devices_count].device_count = 0;
+        sorted_array[*sorted_devices_count].physical_devices = NULL;
 
-            DXGI_ADAPTER_DESC1 description;
-            hres = adapter->lpVtbl->GetDesc1(adapter, &description);
-            if (hres != S_OK) {
-                loader_log(inst, VULKAN_LOADER_WARN_BIT, 0, "Failed to get adapter LUID index %u. This adapter will not be sorted",
-                           i);
+        icd_term = inst->icd_terms;
+        for (uint32_t icd_idx = 0; NULL != icd_term; icd_term = icd_term->next, icd_idx++) {
+            // This is the new behavior, which cannot be run unless the ICD provides EnumerateAdapterPhysicalDevices
+            if (icd_term->scanned_icd->EnumerateAdapterPhysicalDevices == NULL) {
                 continue;
             }
 
-            if (sorted_alloc <= i) {
-                uint32_t old_size = sorted_alloc * sizeof(struct loader_phys_dev_per_icd);
-                *sorted_devices =
-                    loader_instance_heap_realloc(inst, *sorted_devices, old_size, 2 * old_size, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-                if (*sorted_devices == NULL) {
-                    adapter->lpVtbl->Release(adapter);
-                    res = VK_ERROR_OUT_OF_HOST_MEMORY;
-                    goto out;
-                }
-                sorted_alloc *= 2;
+            uint32_t count = 0;
+            VkResult vkres =
+                icd_term->scanned_icd->EnumerateAdapterPhysicalDevices(icd_term->instance, description.AdapterLuid, &count, NULL);
+            if (vkres == VK_ERROR_INCOMPATIBLE_DRIVER) {
+                continue;  // This driver doesn't support the adapter
+            } else if (vkres == VK_ERROR_OUT_OF_HOST_MEMORY) {
+                res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                goto out;
+            } else if (vkres != VK_SUCCESS) {
+                loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
+                           "Failed to convert DXGI adapter into Vulkan physical device with unexpected error code");
+                continue;
             }
-            struct loader_phys_dev_per_icd *sorted_array = *sorted_devices;
-            sorted_array[*sorted_count].device_count = 0;
-            sorted_array[*sorted_count].physical_devices = NULL;
-            //*sorted_count = i;
 
-            icd_term = inst->icd_terms;
-            for (uint32_t icd_idx = 0; NULL != icd_term; icd_term = icd_term->next, icd_idx++) {
-                // This is the new behavior, which cannot be run unless the ICD provides EnumerateAdapterPhysicalDevices
-                if (icd_term->scanned_icd->EnumerateAdapterPhysicalDevices == NULL) {
-                    continue;
-                }
-
-                uint32_t count = 0;
-                VkResult vkres = icd_term->scanned_icd->EnumerateAdapterPhysicalDevices(icd_term->instance, description.AdapterLuid,
-                                                                                        &count, NULL);
-                if (vkres == VK_ERROR_INCOMPATIBLE_DRIVER) {
-                    continue;  // This driver doesn't support the adapter
-                } else if (vkres == VK_ERROR_OUT_OF_HOST_MEMORY) {
-                    res = VK_ERROR_OUT_OF_HOST_MEMORY;
-                    goto out;
-                } else if (vkres != VK_SUCCESS) {
-                    loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
-                               "Failed to convert DXGI adapter into Vulkan physical device with unexpected error code");
-                    continue;
-                }
-
-                // Get the actual physical devices
-                if (0 != count) {
-                    do {
-                        sorted_array[*sorted_count].physical_devices =
-                            loader_instance_heap_realloc(inst, sorted_array[*sorted_count].physical_devices,
-                                                         sorted_array[*sorted_count].device_count * sizeof(VkPhysicalDevice),
-                                                         count * sizeof(VkPhysicalDevice), VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-                        if (sorted_array[*sorted_count].physical_devices == NULL) {
-                            res = VK_ERROR_OUT_OF_HOST_MEMORY;
-                            break;
-                        }
-                        sorted_array[*sorted_count].device_count = count;
-                    } while ((vkres = icd_term->scanned_icd->EnumerateAdapterPhysicalDevices(
-                                  icd_term->instance, description.AdapterLuid, &count,
-                                  sorted_array[*sorted_count].physical_devices)) == VK_INCOMPLETE);
-                }
-
-                if (vkres != VK_SUCCESS) {
-                    loader_instance_heap_free(inst, sorted_array[*sorted_count].physical_devices);
-                    sorted_array[*sorted_count].physical_devices = NULL;
-                    if (vkres == VK_ERROR_OUT_OF_HOST_MEMORY) {
+            // Get the actual physical devices
+            if (0 != count) {
+                do {
+                    sorted_array[*sorted_devices_count].physical_devices =
+                        loader_instance_heap_realloc(inst, sorted_array[*sorted_devices_count].physical_devices,
+                                                     sorted_array[*sorted_devices_count].device_count * sizeof(VkPhysicalDevice),
+                                                     count * sizeof(VkPhysicalDevice), VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
+                    if (sorted_array[*sorted_devices_count].physical_devices == NULL) {
                         res = VK_ERROR_OUT_OF_HOST_MEMORY;
-                        goto out;
-                    } else {
-                        loader_log(inst, VULKAN_LOADER_WARN_BIT, 0, "Failed to convert DXGI adapter into Vulkan physical device");
-                        continue;
+                        break;
                     }
-                }
-                inst->total_gpu_count += (sorted_array[*sorted_count].device_count = count);
-                sorted_array[*sorted_count].icd_index = icd_idx;
-                sorted_array[*sorted_count].icd_term = icd_term;
-                ++(*sorted_count);
+                    sorted_array[*sorted_devices_count].device_count = count;
+                } while ((vkres = icd_term->scanned_icd->EnumerateAdapterPhysicalDevices(
+                              icd_term->instance, description.AdapterLuid, &count,
+                              sorted_array[*sorted_devices_count].physical_devices)) == VK_INCOMPLETE);
             }
 
-            adapter->lpVtbl->Release(adapter);
+            if (vkres != VK_SUCCESS) {
+                loader_instance_heap_free(inst, sorted_array[*sorted_devices_count].physical_devices);
+                sorted_array[*sorted_devices_count].physical_devices = NULL;
+                if (vkres == VK_ERROR_OUT_OF_HOST_MEMORY) {
+                    res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                    goto out;
+                } else {
+                    loader_log(inst, VULKAN_LOADER_WARN_BIT, 0, "Failed to convert DXGI adapter into Vulkan physical device");
+                    continue;
+                }
+            }
+            sorted_array[*sorted_devices_count].device_count = count;
+            sorted_array[*sorted_devices_count].icd_index = icd_idx;
+            sorted_array[*sorted_devices_count].icd_term = icd_term;
+            (*sorted_devices_count)++;
         }
 
-        dxgi_factory->lpVtbl->Release(dxgi_factory);
+        adapter->lpVtbl->Release(adapter);
     }
 
-out:
+    dxgi_factory->lpVtbl->Release(dxgi_factory);
 
-    if (*sorted_count == 0 && *sorted_devices != NULL) {
+out:
+    if (*sorted_devices_count == 0 && *sorted_devices != NULL) {
         loader_instance_heap_free(inst, *sorted_devices);
         *sorted_devices = NULL;
     }
+    *sorted_devices_count = *sorted_devices_count;
+    *sorted_devices = *sorted_devices;
     return res;
 }
 

--- a/loader/loader_windows.h
+++ b/loader/loader_windows.h
@@ -99,8 +99,8 @@ VkResult windows_read_data_files_in_registry(const struct loader_instance *inst,
                                              struct loader_data_files *out_files);
 
 // This function allocates an array in sorted_devices which must be freed by the caller if not null
-VkResult windows_read_sorted_physical_devices(struct loader_instance *inst, struct loader_phys_dev_per_icd **sorted_devices,
-                                              uint32_t *sorted_count);
+VkResult windows_read_sorted_physical_devices(struct loader_instance *inst, uint32_t *sorted_devices_count,
+                                              struct loader_phys_dev_per_icd **sorted_devices);
 
 // This function sorts an array in physical device groups based on the sorted physical device information
 VkResult windows_sort_physical_device_groups(struct loader_instance *inst, const uint32_t group_count,

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -406,20 +406,42 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceToolProperties(VkPhysical
     return generic_tool_props_function(physicalDevice, pToolCount, pToolProperties);
 }
 
-//// WSI ////
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
-                                                              const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
+template <typename T>
+T to_nondispatch_handle(uint64_t handle) {
 #if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
     defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
+    return reinterpret_cast<T>(handle);
 #else
-        *pSurface = fake_surf_handle;
+    return handle;
 #endif
+}
+
+template <typename T>
+uint64_t from_nondispatch_handle(T handle) {
+#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
+    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+    return reinterpret_cast<uint64_t>(handle);
+#else
+    return handle;
+#endif
+}
+
+//// WSI ////
+template <typename HandleType>
+void common_nondispatch_handle_creation(std::vector<uint64_t>& handles, HandleType* pHandle) {
+    if (nullptr != pHandle) {
+        if (handles.size() == 0)
+            handles.push_back(800851234);
+        else
+            handles.push_back(handles.back() + 102030);
+        *pHandle = to_nondispatch_handle<HandleType>(handles.back());
     }
+}
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
+                                                              const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 #endif
@@ -427,16 +449,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateAndroidSurfaceKHR(VkInstance instanc
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
                                                             const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
-#else
-        *pSurface = fake_surf_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 
@@ -449,16 +462,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceWin32PresentationSupportK
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWaylandSurfaceKHR(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
                                                               const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
-#else
-        *pSurface = fake_surf_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 
@@ -471,16 +475,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceWaylandPresentationSuppor
 #ifdef VK_USE_PLATFORM_XCB_KHR
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXcbSurfaceKHR(VkInstance instance, const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
-#else
-        *pSurface = fake_surf_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 
@@ -495,16 +490,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceXcbPresentationSupportKHR
 #ifdef VK_USE_PLATFORM_XLIB_KHR
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXlibSurfaceKHR(VkInstance instance, const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
                                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
-#else
-        *pSurface = fake_surf_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 
@@ -519,16 +505,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceXlibPresentationSupportKH
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDirectFBSurfaceEXT(VkInstance instance,
                                                                const VkDirectFBSurfaceCreateInfoEXT* pCreateInfo,
                                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
-#else
-        *pSurface = fake_surf_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 
@@ -542,16 +519,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceDirectFBPresentationSuppo
 #ifdef VK_USE_PLATFORM_MACOS_MVK
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMacOSSurfaceMVK(VkInstance instance, const VkMacOSSurfaceCreateInfoMVK* pCreateInfo,
                                                             const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
-#else
-        *pSurface = fake_surf_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 #endif  // VK_USE_PLATFORM_MACOS_MVK
@@ -559,16 +527,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMacOSSurfaceMVK(VkInstance instance,
 #ifdef VK_USE_PLATFORM_IOS_MVK
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateIOSSurfaceMVK(VkInstance instance, const VkIOSSurfaceCreateInfoMVK* pCreateInfo,
                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
-#else
-        *pSurface = fake_surf_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 #endif  // VK_USE_PLATFORM_IOS_MVK
@@ -578,16 +537,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateStreamDescriptorSurfaceGGP(VkInstanc
                                                                        const VkStreamDescriptorSurfaceCreateInfoGGP* pCreateInfo,
                                                                        const VkAllocationCallbacks* pAllocator,
                                                                        VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
-#else
-        *pSurface = fake_surf_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 #endif  // VK_USE_PLATFORM_GGP
@@ -595,16 +545,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateStreamDescriptorSurfaceGGP(VkInstanc
 #if defined(VK_USE_PLATFORM_METAL_EXT)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMetalSurfaceEXT(VkInstance instance, const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
                                                             const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
-#else
-        *pSurface = fake_surf_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 #endif  // VK_USE_PLATFORM_METAL_EXT
@@ -612,16 +553,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMetalSurfaceEXT(VkInstance instance,
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateScreenSurfaceQNX(VkInstance instance, const VkScreenSurfaceCreateInfoQNX* pCreateInfo,
                                                              const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
-#else
-        *pSurface = fake_surf_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 
@@ -635,29 +567,18 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceScreenPresentationSupport
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateHeadlessSurfaceEXT(VkInstance instance,
                                                                const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
                                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
-    if (nullptr != pSurface) {
-        uint64_t fake_surf_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.surface_handles.push_back(fake_surf_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSurface = reinterpret_cast<VkSurfaceKHR>(fake_surf_handle);
-#else
-        *pSurface = fake_surf_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 
 VKAPI_ATTR void VKAPI_CALL test_vkDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface,
                                                     const VkAllocationCallbacks* pAllocator) {
     if (surface != VK_NULL_HANDLE) {
-        uint64_t fake_surf_handle = (uint64_t)(surface);
+        uint64_t fake_surf_handle = from_nondispatch_handle(surface);
         auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), fake_surf_handle);
         if (found_iter != icd.surface_handles.end()) {
             // Remove it from the list
             icd.surface_handles.erase(found_iter);
-            // Delete the handle
-            delete (uint8_t*)fake_surf_handle;
         } else {
             assert(false && "Surface not found during destroy!");
         }
@@ -666,23 +587,14 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroySurfaceKHR(VkInstance instance, VkSurfa
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                          const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain) {
-    if (nullptr != pSwapchain) {
-        uint64_t fake_swapchain_handle = reinterpret_cast<uint64_t>(new uint8_t);
-        icd.swapchain_handles.push_back(fake_swapchain_handle);
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        *pSwapchain = reinterpret_cast<VkSwapchainKHR>(fake_swapchain_handle);
-#else
-        *pSwapchain = fake_swapchain_handle;
-#endif
-    }
+    common_nondispatch_handle_creation(icd.swapchain_handles, pSwapchain);
     return VK_SUCCESS;
 }
 
 VKAPI_ATTR void VKAPI_CALL test_vkDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain,
                                                       const VkAllocationCallbacks* pAllocator) {
     if (swapchain != VK_NULL_HANDLE) {
-        uint64_t fake_swapchain_handle = (uint64_t)(swapchain);
+        uint64_t fake_swapchain_handle = from_nondispatch_handle(swapchain);
         auto found_iter = icd.swapchain_handles.erase(
             std::remove(icd.swapchain_handles.begin(), icd.swapchain_handles.end(), fake_swapchain_handle),
             icd.swapchain_handles.end());

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -304,3 +304,168 @@ TestLayer& FrameworkEnvironment::get_test_layer(size_t index) noexcept { return 
 TestLayer& FrameworkEnvironment::reset_layer(size_t index) noexcept { return layers[index].reset_layer(); }
 fs::path FrameworkEnvironment::get_test_layer_path(size_t index) noexcept { return layers[index].get_layer_full_path(); }
 fs::path FrameworkEnvironment::get_layer_manifest_path(size_t index) noexcept { return layers[index].get_layer_manifest_path(); }
+
+void setup_WSI_in_ICD(TestICD& icd) {
+    icd.enable_icd_wsi = true;
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_KHR_android_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_DIRECTFB_EXT
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_EXT_directfb_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_FUCHSIA
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_FUCHSIA_imagepipe_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_GGP
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_GGP_stream_descriptor_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_IOS_MVK
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_MVK_ios_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_MVK_macos_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_METAL_EXT
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_EXT_metal_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_QNX_screen_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_VI_NN
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_NN_vi_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_XCB_KHR
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_KHR_xcb_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_KHR_xlib_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_KHR_wayland_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    icd.add_instance_extensions({"VK_KHR_surface", "VK_KHR_win32_surface"});
+#endif
+}
+void setup_WSI_in_create_instance(InstWrapper& inst) {
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_KHR_android_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_DIRECTFB_EXT
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_EXT_directfb_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_FUCHSIA
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_FUCHSIA_imagepipe_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_GGP
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_GGP_stream_descriptor_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_IOS_MVK
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_MVK_ios_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_MVK_macos_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_METAL_EXT
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_EXT_metal_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_QNX_screen_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_VI_NN
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_NN_vi_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_XCB_KHR
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_KHR_xcb_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_KHR_xlib_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_KHR_wayland_surface"});
+#endif
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    inst.create_info.add_extensions({"VK_KHR_surface", "VK_KHR_win32_surface"});
+#endif
+}
+VkSurfaceKHR create_surface(InstWrapper& inst, const char* api_selection) {
+    VkSurfaceKHR surface{};
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    PFN_vkCreateAndroidSurfaceKHR pfn_CreateSurface = inst.load("vkCreateAndroidSurfaceKHR");
+    VkAndroidSurfaceCreateInfoKHR surf_create_info{};
+    EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+#endif
+#ifdef VK_USE_PLATFORM_DIRECTFB_EXT
+    PFN_vkCreateDirectFBSurfaceEXT pfn_CreateSurface = inst.load("vkCreateDirectFBSurfaceEXT");
+    VkDirectFBSurfaceCreateInfoEXT surf_create_info{};
+    EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+#endif
+#ifdef VK_USE_PLATFORM_FUCHSIA
+    PFN_vkCreateImagePipeSurfaceFUCHSIA pfn_CreateSurface = inst.load("vkCreateImagePipeSurfaceFUCHSIA");
+    VkImagePipeSurfaceCreateInfoFUCHSIA surf_create_info{};
+    EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+#endif
+#ifdef VK_USE_PLATFORM_GGP
+    PFN__vkCreateStreamDescriptorSurfaceGGP pfn_CreateSurface = inst.load("vkCreateStreamDescriptorSurfaceGGP");
+    VkStreamDescriptorSurfaceCreateInfoGGP surf_create_info{};
+    EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+#endif
+#ifdef VK_USE_PLATFORM_IOS_MVK
+    PFN_vkCreateIOSSurfaceMVK pfn_CreateSurface = inst.load("vkCreateIOSSurfaceMVK");
+    VkIOSSurfaceCreateInfoMVK surf_create_info{};
+    EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+#endif
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+    if (string_eq(api_selection, "VK_USE_PLATFORM_MACOS_MVK")) {
+        PFN_vkCreateMacOSSurfaceMVK pfn_CreateSurface = inst.load("vkCreateMacOSSurfaceMVK");
+        VkMacOSSurfaceCreateInfoMVK surf_create_info{};
+        EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+    }
+#endif
+#ifdef VK_USE_PLATFORM_METAL_EXT
+    if (string_eq(api_selection, "VK_USE_PLATFORM_METAL_EXT")) {
+        PFN_vkCreateMetalSurfaceEXT pfn_CreateSurface = inst.load("vkCreateMetalSurfaceEXT");
+        VkMetalSurfaceCreateInfoEXT surf_create_info{};
+        EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+    }
+#endif
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+    PFN_vkCreateScreenSurfaceQNX pfn_CreateSurface = inst.load("vkCreateScreenSurfaceQNX");
+    VkScreenSurfaceCreateInfoQNX surf_create_info{};
+    EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+#endif
+#ifdef VK_USE_PLATFORM_VI_NN
+    PFN_vkCreateViSurfaceNN pfn_CreateSurface = inst.load("vkCreateViSurfaceNN");
+    VkViSurfaceCreateInfoNN surf_create_info{};
+    EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+#endif
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    PFN_vkCreateWin32SurfaceKHR pfn_CreateSurface = inst.load("vkCreateWin32SurfaceKHR");
+    VkWin32SurfaceCreateInfoKHR surf_create_info{};
+    EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+#endif
+
+#ifdef VK_USE_PLATFORM_XCB_KHR
+    if (string_eq(api_selection, "VK_USE_PLATFORM_XCB_KHR")) {
+        PFN_vkCreateXcbSurfaceKHR pfn_CreateSurface = inst.load("vkCreateXcbSurfaceKHR");
+        VkXcbSurfaceCreateInfoKHR surf_create_info{};
+        EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+    }
+#endif
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+    if (string_eq(api_selection, "VK_USE_PLATFORM_XLIB_KHR")) {
+        PFN_vkCreateXlibSurfaceKHR pfn_CreateSurface = inst.load("vkCreateXlibSurfaceKHR");
+        VkXlibSurfaceCreateInfoKHR surf_create_info{};
+        EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+    }
+#endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    if (string_eq(api_selection, "VK_USE_PLATFORM_WAYLAND_KHR")) {
+        PFN_vkCreateWaylandSurfaceKHR pfn_CreateSurface = inst.load("vkCreateWaylandSurfaceKHR");
+        VkWaylandSurfaceCreateInfoKHR surf_create_info{};
+        EXPECT_EQ(VK_SUCCESS, pfn_CreateSurface(inst, &surf_create_info, nullptr, &surface));
+    }
+#endif
+
+    return surface;
+}

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -363,3 +363,11 @@ struct FrameworkEnvironment {
    private:
     void add_layer_impl(TestLayerDetails layer_details, fs::FolderManager& folder_manager, ManifestCategory category);
 };
+
+// The following helpers setup an icd with the required extensions and setting to use with WSI
+// By default they use whatever the set VK_USE_PLATFORM_XXX macros define
+void setup_WSI_in_ICD(TestICD& icd);
+void setup_WSI_in_create_instance(InstWrapper& inst);
+// api_selection: optionally provide a VK_USE_PLATFORM_XXX string to select which API to create a surface with
+// Note: MUST provide api_selection on platforms with multiple viable API's, such as linux and MacOS
+VkSurfaceKHR create_surface(InstWrapper& inst, const char* api_selection = nullptr);

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -595,7 +595,9 @@ struct Extension {
     BUILDER_VALUE(Extension, std::string, extensionName, {})
     BUILDER_VALUE(Extension, uint32_t, specVersion, VK_API_VERSION_1_0)
 
-    Extension(std::string extensionName, uint32_t specVersion = VK_API_VERSION_1_0)
+    Extension(const char* name, uint32_t specVersion = VK_API_VERSION_1_0) noexcept
+        : extensionName(name), specVersion(specVersion) {}
+    Extension(std::string extensionName, uint32_t specVersion = VK_API_VERSION_1_0) noexcept
         : extensionName(extensionName), specVersion(specVersion) {}
 
     VkExtensionProperties get() const noexcept {

--- a/tests/loader_alloc_callback_tests.cpp
+++ b/tests/loader_alloc_callback_tests.cpp
@@ -196,17 +196,6 @@ class MemoryTracker {
     }
 };
 
-class Allocation : public ::testing::Test {
-   protected:
-    virtual void SetUp() {
-        FrameworkEnvironment env{};
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
-    }
-
-    virtual void TearDown() { env.reset(); }
-    std::unique_ptr<FrameworkEnvironment> env;
-};
-
 // Test making sure the allocation functions are called to allocate and cleanup everything during
 // a CreateInstance/DestroyInstance call pair.
 TEST(Allocation, Instance) {
@@ -656,3 +645,91 @@ TEST(Allocation, EnumeratePhysicalDevicesIntentionalAllocFail) {
         reached_the_end = true;
     }
 }
+#if defined(WIN32)
+// Test failure during vkCreateInstance and vkCreateDevice to make sure we don't
+// leak memory if one of the out-of-memory conditions trigger.
+TEST(Allocation, CreateInstanceDeviceWithDXGIDriverIntentionalAllocFail) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6).set_add_manifest_to_default_driver_location(false));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+
+    for (uint32_t i = 0; i < 2; i++) {
+        auto& driver = env.get_test_icd(i);
+        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
+        driver.physical_devices[0].add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false});
+    }
+
+    auto& known_driver = known_driver_list.at(2);  // which drive this test pretends to be
+    DXGI_ADAPTER_DESC1 desc1{};
+    desc1.VendorId = known_driver.vendor_id;
+    desc1.AdapterLuid = _LUID{10, 1000};
+    env.platform_shim->add_dxgi_adapter(GpuType::discrete, desc1);
+    env.get_test_icd().set_adapterLUID(desc1.AdapterLuid);
+
+    env.platform_shim->add_d3dkmt_adapter(D3DKMT_Adapter{0, _LUID{10, 1000}}.add_driver_manifest_path(env.get_icd_manifest_path()));
+
+    size_t fail_index = 0;
+    VkResult result = VK_ERROR_OUT_OF_HOST_MEMORY;
+    while (result == VK_ERROR_OUT_OF_HOST_MEMORY && fail_index <= 10000) {
+        MemoryTracker tracker(MemoryTrackerSettings{false, 0, true, fail_index});
+        fail_index++;  // applies to the next loop
+
+        VkInstance instance;
+        InstanceCreateInfo inst_create_info{};
+        result = env.vulkan_functions.vkCreateInstance(inst_create_info.get(), tracker.get(), &instance);
+        if (result == VK_ERROR_OUT_OF_HOST_MEMORY) {
+            ASSERT_TRUE(tracker.empty());
+            continue;
+        }
+
+        uint32_t physical_count = 2;
+        uint32_t returned_physical_count = 0;
+        result = env.vulkan_functions.vkEnumeratePhysicalDevices(instance, &returned_physical_count, nullptr);
+        if (result == VK_ERROR_OUT_OF_HOST_MEMORY || result == VK_INCOMPLETE) {
+            env.vulkan_functions.vkDestroyInstance(instance, tracker.get());
+            ASSERT_TRUE(tracker.empty());
+            continue;
+        }
+        ASSERT_EQ(physical_count, returned_physical_count);
+
+        std::array<VkPhysicalDevice, 2> physical_devices;
+        result = env.vulkan_functions.vkEnumeratePhysicalDevices(instance, &returned_physical_count, physical_devices.data());
+        if (result == VK_ERROR_OUT_OF_HOST_MEMORY || result == VK_INCOMPLETE) {
+            env.vulkan_functions.vkDestroyInstance(instance, tracker.get());
+            ASSERT_TRUE(tracker.empty());
+            continue;
+        }
+        ASSERT_EQ(physical_count, returned_physical_count);
+
+        std::array<VkDevice, 2> devices;
+        for (uint32_t i = 0; i < returned_physical_count; i++) {
+            uint32_t family_count = 1;
+            uint32_t returned_family_count = 0;
+            env.vulkan_functions.vkGetPhysicalDeviceQueueFamilyProperties(physical_devices[i], &returned_family_count, nullptr);
+            ASSERT_EQ(returned_family_count, family_count);
+
+            VkQueueFamilyProperties family;
+            env.vulkan_functions.vkGetPhysicalDeviceQueueFamilyProperties(physical_devices[i], &returned_family_count, &family);
+            ASSERT_EQ(returned_family_count, family_count);
+            ASSERT_EQ(family.queueFlags, static_cast<VkQueueFlags>(VK_QUEUE_GRAPHICS_BIT));
+            ASSERT_EQ(family.queueCount, family_count);
+            ASSERT_EQ(family.timestampValidBits, 0U);
+
+            DeviceCreateInfo dev_create_info;
+            DeviceQueueCreateInfo queue_info;
+            queue_info.add_priority(0.0f);
+            dev_create_info.add_device_queue(queue_info);
+
+            result = env.vulkan_functions.vkCreateDevice(physical_devices[i], dev_create_info.get(), tracker.get(), &devices[i]);
+        }
+        for (uint32_t i = 0; i < returned_physical_count; i++) {
+            if (result == VK_SUCCESS) {
+                env.vulkan_functions.vkDestroyDevice(devices[i], tracker.get());
+            }
+        }
+        env.vulkan_functions.vkDestroyInstance(instance, tracker.get());
+
+        ASSERT_TRUE(tracker.empty());
+    }
+}
+#endif

--- a/tests/loader_debug_ext_tests.cpp
+++ b/tests/loader_debug_ext_tests.cpp
@@ -52,7 +52,7 @@ class DebugReportTest : public ::testing::Test {
     virtual void SetUp() {
         env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
         for (uint32_t icd = 0; icd < 3; ++icd) {
-            env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_API_VERSION_1_0));
+            env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_0));
             env->get_test_icd(icd).physical_devices.push_back({});
             env->get_test_icd(icd).physical_devices.push_back({});
         }
@@ -413,7 +413,7 @@ class DebugUtilTest : public ::testing::Test {
     virtual void SetUp() {
         env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
         for (uint32_t icd = 0; icd < 3; ++icd) {
-            env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_API_VERSION_1_0));
+            env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_0));
             env->get_test_icd(icd).physical_devices.push_back({});
             env->get_test_icd(icd).physical_devices.push_back({});
         }

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -141,7 +141,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyDriverEnvVar) {
 // Make sure the loader reports the correct message based on if USE_UNSAFE_FILE_SEARCH is set or not
 TEST(EnvVarICDOverrideSetup, NonSecureEnvVarLookup) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.emplace_back("physical_device_0");
 
     DebugUtilsLogger log{VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT};
@@ -169,7 +169,7 @@ TEST(EnvVarICDOverrideSetup, XDG) {
     set_env_var("XDG_DATA_HOME", "::::/tmp/goober3:/tmp/goober4/with spaces:::");
 
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.push_back({});
 
     InstWrapper inst{env.vulkan_functions};
@@ -254,7 +254,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyLayerEnvVar) {
     set_env_var("VK_LAYER_PATH", vk_layer_path);
 
     FrameworkEnvironment env{DebugMode::none, false, true};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.push_back({});
     env.platform_shim->redirect_path("/tmp/carol", env.explicit_layer_folder.location());
 
@@ -302,7 +302,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyAddLayerEnvVar) {
     set_env_var("VK_ADD_LAYER_PATH", vk_layer_path);
 
     FrameworkEnvironment env{DebugMode::none, false, true};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.push_back({});
     env.platform_shim->redirect_path("/tmp/carol", env.explicit_layer_folder.location());
 

--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -30,7 +30,7 @@
 // Verify that the various ways to get vkGetInstanceProcAddr return the same value
 TEST(GetProcAddr, VerifyGetInstanceProcAddr) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.emplace_back("physical_device_0");
     {
         InstWrapper inst{env.vulkan_functions};
@@ -62,7 +62,7 @@ TEST(GetProcAddr, VerifyGetInstanceProcAddr) {
 // Verify that the various ways to get vkGetDeviceProcAddr return the same value
 TEST(GetProcAddr, VerifyGetDeviceProcAddr) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.emplace_back("physical_device_0");
 
     InstWrapper inst{env.vulkan_functions};
@@ -90,7 +90,7 @@ TEST(GetProcAddr, VerifyGetDeviceProcAddr) {
 // Call the function to make sure it is callable, don't care about what is returned.
 TEST(GetProcAddr, GlobalFunctions) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.emplace_back("physical_device_0");
 
     auto& gipa = env.vulkan_functions.vkGetInstanceProcAddr;

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -45,7 +45,7 @@ const char* lunarg_meta_layer_name = "VK_LAYER_LUNARG_override";
 
 TEST(ImplicitLayers, WithEnableAndDisableEnvVar) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
     const char* enable_env_var = "ENABLE_ME";
     const char* disable_env_var = "DISABLE_ME";
@@ -93,7 +93,7 @@ TEST(ImplicitLayers, WithEnableAndDisableEnvVar) {
 
 TEST(ImplicitLayers, OnlyDisableEnvVar) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     const char* implicit_layer_name = "ImplicitTestLayer";
     const char* disable_env_var = "DISABLE_ME";
 
@@ -130,7 +130,7 @@ TEST(ImplicitLayers, OnlyDisableEnvVar) {
 
 TEST(ImplicitLayers, PreInstanceEnumInstLayerProps) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     const char* implicit_layer_name = "ImplicitTestLayer";
     const char* disable_env_var = "DISABLE_ME";
 
@@ -167,7 +167,7 @@ TEST(ImplicitLayers, PreInstanceEnumInstLayerProps) {
 
 TEST(ImplicitLayers, PreInstanceEnumInstExtProps) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     const char* implicit_layer_name = "ImplicitTestLayer";
     const char* disable_env_var = "DISABLE_ME";
 
@@ -204,7 +204,7 @@ TEST(ImplicitLayers, PreInstanceEnumInstExtProps) {
 
 TEST(ImplicitLayers, PreInstanceVersion) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.push_back({});
     env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 2, 3);
 
@@ -249,7 +249,7 @@ TEST(ImplicitLayers, PreInstanceVersion) {
 // tested through behavior above).
 TEST(ImplicitLayers, OverrideGetInstanceProcAddr) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.push_back({});
 
     const char* implicit_layer_name = "ImplicitTestLayer";
@@ -284,7 +284,7 @@ TEST(ImplicitLayers, OverrideGetInstanceProcAddr) {
 // Meta layer which contains component layers that do not exist.
 TEST(MetaLayers, InvalidComponentLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* invalid_layer_name_1 = "VK_LAYER_InvalidLayer1";
     const char* invalid_layer_name_2 = "VK_LAYER_InvalidLayer2";
@@ -334,7 +334,7 @@ TEST(MetaLayers, InvalidComponentLayer) {
 // Meta layer that is an explicit layer
 TEST(MetaLayers, ExplicitMetaLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* regular_layer_name = "VK_LAYER_TestLayer";
@@ -394,7 +394,7 @@ TEST(MetaLayers, ExplicitMetaLayer) {
 // Meta layer which adds itself in its list of component layers
 TEST(MetaLayers, MetaLayerNameInComponentLayers) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* regular_layer_name = "VK_LAYER_TestLayer";
     env.add_implicit_layer(ManifestLayer{}
@@ -442,7 +442,7 @@ TEST(MetaLayers, MetaLayerNameInComponentLayers) {
 // Meta layer which adds another meta layer as a component layer
 TEST(MetaLayers, MetaLayerWhichAddsMetaLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* meta_meta_layer_name = "VK_LAYER_MetaMetaTestLayer";
     const char* regular_layer_name = "VK_LAYER_TestLayer";
@@ -490,7 +490,7 @@ TEST(MetaLayers, MetaLayerWhichAddsMetaLayer) {
 
 TEST(MetaLayers, InstanceExtensionInComponentLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* regular_layer_name = "VK_LAYER_TestLayer";
@@ -519,7 +519,7 @@ TEST(MetaLayers, InstanceExtensionInComponentLayer) {
 
 TEST(MetaLayers, DeviceExtensionInComponentLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
     const char* meta_layer_name = "VK_LAYER_MetaTestLayer";
     const char* regular_layer_name = "VK_LAYER_TestLayer";
@@ -583,7 +583,7 @@ TEST(MetaLayers, DeviceExtensionInComponentLayer) {
 // Override meta layer missing disable environment variable still enables the layer
 TEST(OverrideMetaLayer, InvalidDisableEnvironment) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
     const char* regular_layer_name = "VK_LAYER_TestLayer";
     env.add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -617,7 +617,7 @@ TEST(OverrideMetaLayer, InvalidDisableEnvironment) {
 // Override meta layer whose version is less than the api version of the instance
 TEST(OverrideMetaLayer, OlderVersionThanInstance) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
     const char* regular_layer_name = "VK_LAYER_TestLayer";
     env.add_explicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -676,7 +676,7 @@ TEST(OverrideMetaLayer, OlderVersionThanInstance) {
 
 TEST(OverrideMetaLayer, OlderMetaLayerWithNewerInstanceVersion) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
 
     const char* regular_layer_name = "VK_LAYER_TestLayer";
@@ -745,7 +745,7 @@ TEST(OverrideMetaLayer, OlderMetaLayerWithNewerInstanceVersion) {
 
 TEST(OverrideMetaLayer, NewerComponentLayerInMetaLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
 
     const char* regular_layer_name = "VK_LAYER_TestLayer";
@@ -818,7 +818,7 @@ TEST(OverrideMetaLayer, NewerComponentLayerInMetaLayer) {
 
 TEST(OverrideMetaLayer, OlderComponentLayerInMetaLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
 
     const char* regular_layer_name = "VK_LAYER_TestLayer";
@@ -889,7 +889,7 @@ TEST(OverrideMetaLayer, OlderComponentLayerInMetaLayer) {
 
 TEST(OverrideMetaLayer, ApplicationEnabledLayerInBlacklist) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
 
     const char* automatic_regular_layer_name = "VK_LAYER_TestLayer_1";
@@ -945,7 +945,7 @@ TEST(OverrideMetaLayer, ApplicationEnabledLayerInBlacklist) {
 
 TEST(OverrideMetaLayer, BasicOverridePaths) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
     fs::FolderManager override_layer_folder{FRAMEWORK_BUILD_DIRECTORY, "override_layer_folder"};
 
@@ -978,7 +978,7 @@ TEST(OverrideMetaLayer, BasicOverridePaths) {
 
 TEST(OverrideMetaLayer, BasicOverridePathsIgnoreOtherLayers) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
     fs::FolderManager override_layer_folder{FRAMEWORK_BUILD_DIRECTORY, "override_layer_folder"};
 
@@ -1021,7 +1021,7 @@ TEST(OverrideMetaLayer, BasicOverridePathsIgnoreOtherLayers) {
 
 TEST(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
 
     fs::FolderManager vk_layer_path_folder{FRAMEWORK_BUILD_DIRECTORY, "vk_layer_folder"};
@@ -1072,7 +1072,7 @@ TEST(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
 // Make sure that implicit layers not in the override paths aren't found by mistake
 TEST(OverrideMetaLayer, OverridePathsEnableImplicitLayerInDefaultPaths) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
     fs::FolderManager override_layer_folder{FRAMEWORK_BUILD_DIRECTORY, "override_layer_folder"};
 
@@ -1116,7 +1116,7 @@ TEST(OverrideMetaLayer, OverridePathsEnableImplicitLayerInDefaultPaths) {
 
 TEST(OverrideMetaLayer, ManifestFileFormatVersionTooOld) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
     fs::FolderManager override_layer_folder{FRAMEWORK_BUILD_DIRECTORY, "override_layer_folder"};
 
@@ -1152,7 +1152,7 @@ TEST(OverrideMetaLayer, ManifestFileFormatVersionTooOld) {
 // succeeds and doesn't crash.
 TEST(LayerCreateInstance, GetPhysicalDeviceProperties2) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.push_back({});
     env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 1, 0);
 
@@ -1193,7 +1193,7 @@ TEST(LayerCreateInstance, GetPhysicalDeviceProperties2) {
 
 TEST(LayerCreateInstance, GetPhysicalDeviceProperties2KHR) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.push_back({});
     env.get_test_icd().add_instance_extension({"VK_KHR_get_physical_device_properties2", 0});
 
@@ -1226,7 +1226,7 @@ TEST(LayerCreateInstance, GetPhysicalDeviceProperties2KHR) {
 
 TEST(ExplicitLayers, WrapObjects) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
 
     const char* wrap_objects_name = "VK_LAYER_LUNARG_wrap_objects";
@@ -1294,7 +1294,7 @@ TEST(ExplicitLayers, WrapObjects) {
 
 TEST(LayerExtensions, ImplicitNoAdditionalInstanceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -1347,7 +1347,7 @@ TEST(LayerExtensions, ImplicitNoAdditionalInstanceExtension) {
 
 TEST(LayerExtensions, ImplicitDirDispModeInstanceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -1407,7 +1407,7 @@ TEST(LayerExtensions, ImplicitDirDispModeInstanceExtension) {
 
 TEST(LayerExtensions, ImplicitDispSurfCountInstanceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -1467,7 +1467,7 @@ TEST(LayerExtensions, ImplicitDispSurfCountInstanceExtension) {
 
 TEST(LayerExtensions, ImplicitBothInstanceExtensions) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -1534,7 +1534,7 @@ TEST(LayerExtensions, ImplicitBothInstanceExtensions) {
 
 TEST(LayerExtensions, ExplicitNoAdditionalInstanceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -1593,7 +1593,7 @@ TEST(LayerExtensions, ExplicitNoAdditionalInstanceExtension) {
 
 TEST(LayerExtensions, ExplicitDirDispModeInstanceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -1667,7 +1667,7 @@ TEST(LayerExtensions, ExplicitDirDispModeInstanceExtension) {
 
 TEST(LayerExtensions, ExplicitDispSurfCountInstanceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -1741,7 +1741,7 @@ TEST(LayerExtensions, ExplicitDispSurfCountInstanceExtension) {
 
 TEST(LayerExtensions, ExplicitBothInstanceExtensions) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -1836,7 +1836,7 @@ TEST(LayerExtensions, ExplicitBothInstanceExtensions) {
 
 TEST(LayerExtensions, ImplicitNoAdditionalDeviceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -1923,7 +1923,7 @@ TEST(LayerExtensions, ImplicitNoAdditionalDeviceExtension) {
 
 TEST(LayerExtensions, ImplicitMaintenanceDeviceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -1984,7 +1984,7 @@ TEST(LayerExtensions, ImplicitMaintenanceDeviceExtension) {
 
 TEST(LayerExtensions, ImplicitPresentImageDeviceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -2046,7 +2046,7 @@ TEST(LayerExtensions, ImplicitPresentImageDeviceExtension) {
 
 TEST(LayerExtensions, ImplicitBothDeviceExtensions) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -2113,7 +2113,7 @@ TEST(LayerExtensions, ImplicitBothDeviceExtensions) {
 
 TEST(LayerExtensions, ExplicitNoAdditionalDeviceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -2179,7 +2179,7 @@ TEST(LayerExtensions, ExplicitNoAdditionalDeviceExtension) {
 
 TEST(LayerExtensions, ExplicitMaintenanceDeviceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -2250,7 +2250,7 @@ TEST(LayerExtensions, ExplicitMaintenanceDeviceExtension) {
 
 TEST(LayerExtensions, ExplicitPresentImageDeviceExtension) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -2323,7 +2323,7 @@ TEST(LayerExtensions, ExplicitPresentImageDeviceExtension) {
 
 TEST(LayerExtensions, ExplicitBothDeviceExtensions) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     MockQueueFamilyProperties family_props{{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true};
 
@@ -2413,7 +2413,7 @@ TEST(LayerExtensions, ExplicitBothDeviceExtensions) {
 
 TEST(TestLayers, ExplicitlyEnableImplicitLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_MAKE_API_VERSION(0, 1, 2, 0)));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_MAKE_API_VERSION(0, 1, 2, 0)));
     env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 2, 0);
     VkPhysicalDeviceProperties properties{};
     properties.apiVersion = VK_MAKE_API_VERSION(0, 1, 2, 0);
@@ -2460,7 +2460,7 @@ TEST(TestLayers, ExplicitlyEnableImplicitLayer) {
 
 TEST(TestLayers, NewerInstanceVersionThanImplicitLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_MAKE_API_VERSION(0, 1, 2, 0)));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_MAKE_API_VERSION(0, 1, 2, 0)));
     env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 2, 0);
     VkPhysicalDeviceProperties properties{};
     properties.apiVersion = VK_MAKE_API_VERSION(0, 1, 2, 0);
@@ -2520,7 +2520,7 @@ TEST(TestLayers, NewerInstanceVersionThanImplicitLayer) {
 
 TEST(TestLayers, ImplicitLayerPre10APIVersion) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_MAKE_API_VERSION(0, 1, 2, 0)));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_MAKE_API_VERSION(0, 1, 2, 0)));
     env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 2, 0);
     VkPhysicalDeviceProperties properties{};
     properties.apiVersion = VK_MAKE_API_VERSION(0, 1, 2, 0);
@@ -2618,7 +2618,7 @@ TEST(TestLayers, ImplicitLayerPre10APIVersion) {
 // it is set with VK_INSTANCE_LAYERS
 TEST(TestLayers, EnvironEnableExplicitLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_MAKE_API_VERSION(0, 1, 2, 0)));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_MAKE_API_VERSION(0, 1, 2, 0)));
     env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 2, 0);
     VkPhysicalDeviceProperties properties{};
     properties.apiVersion = VK_MAKE_API_VERSION(0, 1, 2, 0);
@@ -2708,7 +2708,7 @@ TEST(TestLayers, EnvironEnableExplicitLayer) {
 // Add a device layer, should not work
 TEST(TestLayers, DoNotUseDeviceLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_MAKE_API_VERSION(0, 1, 2, 0)));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_MAKE_API_VERSION(0, 1, 2, 0)));
     env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 2, 0);
     VkPhysicalDeviceProperties properties{};
     properties.apiVersion = VK_MAKE_API_VERSION(0, 1, 2, 0);
@@ -2790,7 +2790,7 @@ TEST(TestLayers, DoNotUseDeviceLayer) {
 // Make sure that a layer enabled as both an instance and device layer works properly.
 TEST(TestLayers, InstanceAndDeviceLayer) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_MAKE_API_VERSION(0, 1, 2, 0)));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_MAKE_API_VERSION(0, 1, 2, 0)));
     env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 2, 0);
     VkPhysicalDeviceProperties properties{};
     properties.apiVersion = VK_MAKE_API_VERSION(0, 1, 2, 0);
@@ -2831,7 +2831,7 @@ TEST(TestLayers, InstanceAndDeviceLayer) {
 // Make sure loader does not throw an error for a device layer  that is not present
 TEST(TestLayers, DeviceLayerNotPresent) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_MAKE_API_VERSION(0, 1, 2, 0)));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_MAKE_API_VERSION(0, 1, 2, 0)));
     env.get_test_icd().icd_api_version = VK_MAKE_API_VERSION(0, 1, 2, 0);
     VkPhysicalDeviceProperties properties{};
     properties.apiVersion = VK_MAKE_API_VERSION(0, 1, 2, 0);
@@ -2851,7 +2851,7 @@ TEST(TestLayers, DeviceLayerNotPresent) {
 
 TEST(LayerPhysDeviceMod, AddPhysicalDevices) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_add_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -2930,7 +2930,7 @@ TEST(LayerPhysDeviceMod, AddPhysicalDevices) {
 
 TEST(LayerPhysDeviceMod, RemovePhysicalDevices) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_remove_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -2982,7 +2982,7 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDevices) {
 
 TEST(LayerPhysDeviceMod, ReorderPhysicalDevices) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_reorder_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -3034,7 +3034,7 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDevices) {
 
 TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_all_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -3112,7 +3112,7 @@ static bool GroupsAreTheSame(VkPhysicalDeviceGroupProperties a, VkPhysicalDevice
 
 TEST(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_add_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -3202,7 +3202,7 @@ TEST(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
 
 TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_remove_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -3257,7 +3257,7 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
 
 TEST(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_reorder_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -3312,7 +3312,7 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
 
 TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VkLayer_LunarG_all_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)

--- a/tests/loader_phys_dev_inst_ext_tests.cpp
+++ b/tests/loader_phys_dev_inst_ext_tests.cpp
@@ -59,7 +59,7 @@ static void FillInRandomDeviceProps(VkPhysicalDeviceProperties& props, uint32_t 
 // Test vkGetPhysicalDeviceProperties2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevProps2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -73,7 +73,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2KHRNoSupport) {
 // Test vkGetPhysicalDeviceProperties2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevProps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -88,7 +88,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2KHRNoICDSupport) {
 // Test vkGetPhysicalDeviceProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_API_VERSION_1_0, 5, 123);
@@ -124,7 +124,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2KHRInstanceAndICDSupport) {
 // also support, so everything should work and return properly.
 TEST(LoaderInstPhysDevExts, PhysDevProps2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
@@ -162,7 +162,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2Simple) {
 // extension but the instance supports 1.1 and the extension
 TEST(LoaderInstPhysDevExts, PhysDevProps2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_API_VERSION_1_0));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_0));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
@@ -236,7 +236,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2Mixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -407,7 +407,7 @@ static bool CompareFeatures(const VkPhysicalDeviceFeatures& feats1, const VkPhys
 // Test vkGetPhysicalDeviceFeatures2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -421,7 +421,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRNoSupport) {
 // Test vkGetPhysicalDeviceFeatures2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevFeatsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -436,7 +436,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeatsKHRNoICDSupport) {
 // Test vkGetPhysicalDeviceFeatures2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     FillInRandomFeatures(env.get_test_icd(0).physical_devices.back().features);
@@ -465,7 +465,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRInstanceAndICDSupport) {
 // also support, so everything should work and return properly.
 TEST(LoaderInstPhysDevExts, PhysDevFeats2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
@@ -496,7 +496,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2Simple) {
 // extension but the instance supports 1.1 and the extension
 TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6, VK_API_VERSION_1_0));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_0));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
@@ -557,7 +557,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeatsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -624,7 +624,7 @@ static void FillInRandomFormatProperties(std::vector<VkFormatProperties>& props)
 // Test vkGetPhysicalDeviceFormatProperties2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -638,7 +638,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRNoSupport) {
 // Test vkGetPhysicalDeviceFormatProperties2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevFormatPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -653,7 +653,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatPropsKHRNoICDSupport) {
 // Test vkGetPhysicalDeviceFormatProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     FillInRandomFormatProperties(env.get_test_icd(0).physical_devices.back().format_properties);
@@ -688,7 +688,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRInstanceAndICDSupport) {
 // also support, so everything should work and return properly.
 TEST(LoaderInstPhysDevExts, PhysDevFormatProps2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
@@ -722,7 +722,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatProps2Simple) {
 // extension but the instance supports 1.1 and the extension
 TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
@@ -788,7 +788,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -859,7 +859,7 @@ static void FillInRandomImageFormatData(VkImageFormatProperties& props) {
 // Test vkGetPhysicalDeviceImageFormatProperties2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -873,7 +873,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2KHRNoSupport) {
 // Test vkGetPhysicalDeviceImageFormatProperties2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevImageFormatPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -888,7 +888,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatPropsKHRNoICDSupport) {
 // Test vkGetPhysicalDeviceImageFormatProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     FillInRandomImageFormatData(env.get_test_icd(0).physical_devices.back().image_format_properties);
@@ -936,7 +936,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2KHRInstanceAndICDSupport) {
 // also support, so everything should work and return properly.
 TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
@@ -987,7 +987,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2Simple) {
 // and a device under that ICD also support, so everything should work and return properly.
 TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
@@ -1074,7 +1074,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -1150,7 +1150,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatPropsMixed) {
 // Test vkGetPhysicalDeviceMemoryProperties2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -1164,7 +1164,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRNoSupport) {
 // Test vkGetPhysicalDeviceMemoryProperties2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevMemoryPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -1209,7 +1209,7 @@ static bool CompareMemoryData(const VkPhysicalDeviceMemoryProperties& props1, co
 // Test vkGetPhysicalDeviceMemoryProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     FillInRandomMemoryData(env.get_test_icd(0).physical_devices.back().memory_properties);
@@ -1239,7 +1239,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRInstanceAndICDSupport) {
 // also support, so everything should work and return properly.
 TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
@@ -1271,7 +1271,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2Simple) {
 // extension but the instance supports 1.1 and the extension
 TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
@@ -1331,7 +1331,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -1389,7 +1389,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryPropsMixed) {
 // Test vkGetPhysicalDeviceQueueFamilyProperties2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -1403,7 +1403,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRNoSupport) {
 // Test vkGetPhysicalDeviceQueueFamilyProperties2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -1452,7 +1452,7 @@ static bool CompareQueueFamilyData(const std::vector<VkQueueFamilyProperties>& p
 // Test vkGetPhysicalDeviceQueueFamilyProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     uint32_t num_fam = FillInRandomQueueFamilyData(env.get_test_icd(0).physical_devices.back().queue_family_properties);
@@ -1491,7 +1491,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRInstanceAndICDSupport) {
 // also support, so everything should work and return properly.
 TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
@@ -1532,7 +1532,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2Simple) {
 // extension but the instance supports 1.1 and the extension
 TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
@@ -1606,7 +1606,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -1671,7 +1671,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyPropsMixed) {
 // Test vkGetPhysicalDeviceSparseImageFormatProperties2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -1685,7 +1685,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRNoSupport) {
 // Test vkGetPhysicalDeviceSparseImageFormatProperties2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -1726,7 +1726,7 @@ static bool CompareSparseImageFormatData(const std::vector<VkSparseImageFormatPr
 // Test vkGetPhysicalDeviceSparseImageFormatProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     FillInRandomSparseImageFormatData(env.get_test_icd(0).physical_devices.back().sparse_image_format_properties);
@@ -1779,7 +1779,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRInstanceAndICDSuppo
 // also support, so everything should work and return properly.
 TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
@@ -1834,7 +1834,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2Simple) {
 // supports extension but the instance supports 1.1 and the extension
 TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
@@ -1923,7 +1923,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -2008,7 +2008,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatPropsMixed) {
 // Test vkGetPhysicalDeviceExternalBufferPropertiesKHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsKHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -2022,7 +2022,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsKHRNoSupport) {
 // Test vkGetPhysicalDeviceExternalBufferPropertiesKHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -2060,7 +2060,7 @@ static bool CompareExtMemoryData(const VkExternalMemoryProperties& props1, const
 // Test vkGetPhysicalDeviceExternalBufferPropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     FillInRandomExtMemoryData(env.get_test_icd(0).physical_devices.back().external_memory_properties);
@@ -2089,7 +2089,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2KHRInstanceAndICDSupport) {
 // also support, so everything should work and return properly.
 TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
@@ -2136,7 +2136,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -2219,7 +2219,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsMixed) {
 // Test vkGetPhysicalDeviceExternalSemaphorePropertiesKHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsKHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -2233,7 +2233,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsKHRNoSupport) {
 // Test vkGetPhysicalDeviceExternalSemaphorePropertiesKHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -2273,7 +2273,7 @@ static bool CompareExtSemaphoreData(const VkExternalSemaphoreProperties& props1,
 // Test vkGetPhysicalDeviceExternalSemaphorePropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     FillInRandomExtSemData(env.get_test_icd(0).physical_devices.back().external_semaphore_properties);
@@ -2301,7 +2301,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2KHRInstanceAndICDSupport) {
 // also support, so everything should work and return properly.
 TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
@@ -2347,7 +2347,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -2430,7 +2430,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsMixed) {
 // Test vkGetPhysicalDeviceExternalFencePropertiesKHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsKHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -2444,7 +2444,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsKHRNoSupport) {
 // Test vkGetPhysicalDeviceExternalFencePropertiesKHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -2484,7 +2484,7 @@ static bool CompareExtFenceData(const VkExternalFenceProperties& props1, const V
 // Test vkGetPhysicalDeviceExternalFencePropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     FillInRandomExtFenceData(env.get_test_icd(0).physical_devices.back().external_fence_properties);
@@ -2512,7 +2512,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2KHRInstanceAndICDSupport) {
 // also support, so everything should work and return properly.
 TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
@@ -2558,7 +2558,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -2641,7 +2641,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsMixed) {
 // Test vkGetPhysicalDeviceSurfaceCapabilities2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -2655,7 +2655,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRNoSupport) {
 // Test vkGetPhysicalDeviceSurfaceCapabilities2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -2723,7 +2723,7 @@ static bool CompareSurfaceCapsData(const VkSurfaceCapabilitiesKHR& props1, const
 // Test vkGetPhysicalDeviceSurfaceCapabilities2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME};
     Extension third_ext{VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME};
@@ -2795,7 +2795,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRMixed) {
     Extension third_ext{VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME};
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.min_icd_interface_version = 3;
@@ -2874,7 +2874,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRMixed) {
 // Test vkGetPhysicalDeviceSurfaceFormats2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -2888,7 +2888,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRNoSupport) {
 // Test vkGetPhysicalDeviceSurfaceFormats2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -2929,7 +2929,7 @@ static bool CompareSurfaceFormatsData(const std::vector<VkSurfaceFormatKHR>& pro
 // Test vkGetPhysicalDeviceSurfaceFormats2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     Extension first_ext{VK_KHR_SURFACE_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME};
     Extension third_ext{VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME};
@@ -3010,7 +3010,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRMixed) {
     Extension third_ext{VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME};
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.enable_icd_wsi = true;
@@ -3103,7 +3103,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRMixed) {
 // Test vkGetPhysicalDeviceDisplayPropertiesKHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -3117,7 +3117,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRNoSupport) {
 // Test vkGetPhysicalDeviceDisplayPropertiesKHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -3171,7 +3171,7 @@ static bool CompareDisplayPropData(const std::vector<VkDisplayPropertiesKHR>& pr
 // Test vGetPhysicalDeviceDisplayPropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     FillInRandomDisplayPropData(env.get_test_icd(0).physical_devices.back().display_properties);
@@ -3220,7 +3220,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -3308,7 +3308,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRMixed) {
 // Test vkGetPhysicalDeviceDisplayPlanePropertiesKHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -3322,7 +3322,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRNoSupport) {
 // Test vkGetPhysicalDeviceDisplayPlanePropertiesKHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -3358,7 +3358,7 @@ static bool CompareDisplayPlanePropData(const std::vector<VkDisplayPlaneProperti
 // Test vGetPhysicalDeviceDisplayPlanePropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     FillInRandomDisplayPlanePropData(env.get_test_icd(0).physical_devices.back().display_plane_properties);
@@ -3407,7 +3407,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -3496,7 +3496,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRMixed) {
 // Test vkGetDisplayPlaneSupportedDisplaysKHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -3510,7 +3510,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRNoSupport) {
 // Test vkGetDisplayPlaneSupportedDisplaysKHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -3543,7 +3543,7 @@ static bool CompareDisplays(const std::vector<VkDisplayKHR>& disps1, const std::
 // Test vGetDisplayPlaneSupportedDisplaysKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     GenerateRandomDisplays(env.get_test_icd(0).physical_devices.back().displays);
@@ -3592,7 +3592,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -3681,7 +3681,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRMixed) {
 // Test vkGetDisplayModePropertiesKHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, GetDispModePropsKHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -3695,7 +3695,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRNoSupport) {
 // Test vkGetDisplayModePropertiesKHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, GetDispModePropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -3735,7 +3735,7 @@ static bool CompareDisplayModeProps(const std::vector<VkDisplayModePropertiesKHR
 // Test vGetDisplayModePropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDispModePropsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     GenerateRandomDisplayModeProps(env.get_test_icd(0).physical_devices.back().display_mode_properties);
@@ -3784,7 +3784,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -3873,7 +3873,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRMixed) {
 // Test vkCreateDisplayModeKHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, GetDispModesKHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -3887,7 +3887,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRNoSupport) {
 // Test vkCreateDisplayModeKHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, GetDispModesKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -3905,7 +3905,7 @@ static bool CompareDisplayModes(const VkDisplayModeKHR& disps1, VkDisplayModeKHR
 // Test vkCreateDisplayModeKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDispModesKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     env.get_test_icd(0).physical_devices.back().display_mode = CreateRandomDisplayMode();
@@ -3949,7 +3949,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -4033,7 +4033,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRMixed) {
 // Test vkGetDisplayPlaneCapabilitiesKHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4047,7 +4047,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRNoSupport) {
 // Test vkGetDisplayPlaneCapabilitiesKHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4127,7 +4127,7 @@ static bool CompareDisplayPlaneCaps(const VkDisplayPlaneCapabilitiesKHR& caps1, 
 // Test vkGetDisplayPlaneCapabilitiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     GenerateRandomDisplayPlaneCaps(env.get_test_icd(0).physical_devices.back().display_plane_capabilities);
@@ -4170,7 +4170,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -4250,7 +4250,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRMixed) {
 // Test vkGetPhysicalDeviceDisplayProperties2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4264,7 +4264,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRNoSupport) {
 // Test vkGetPhysicalDeviceDisplayProperties2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4297,7 +4297,7 @@ static bool CompareDisplayPropData(const std::vector<VkDisplayPropertiesKHR>& pr
 // Test vGetPhysicalDeviceDisplayProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
@@ -4358,7 +4358,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -4430,7 +4430,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRMixed) {
 // Test vkGetPhysicalDeviceDisplayPlaneProperties2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4444,7 +4444,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRNoSupport) {
 // Test vkGetPhysicalDeviceDisplayPlaneProperties2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4471,7 +4471,7 @@ static bool CompareDisplayPlanePropData(const std::vector<VkDisplayPlaneProperti
 // Test vGetPhysicalDeviceDisplayPlaneProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
@@ -4531,7 +4531,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -4602,7 +4602,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRMixed) {
 // Test vkGetDisplayModeProperties2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4616,7 +4616,7 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRNoSupport) {
 // Test vkGetDisplayModeProperties2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4647,7 +4647,7 @@ static bool CompareDisplayModeProps(const std::vector<VkDisplayModePropertiesKHR
 // Test vGetDisplayModeProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
@@ -4707,7 +4707,7 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -4778,7 +4778,7 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRMixed) {
 // Test vkGetDisplayPlaneCapabilities2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4792,7 +4792,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRNoSupport) {
 // Test vkGetDisplayPlaneCapabilities2KHR where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4830,7 +4830,7 @@ static bool CompareDisplayPlaneCaps(const VkDisplayPlaneCapabilitiesKHR& caps1, 
 // Test vkGetDisplayPlaneCapabilities2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
@@ -4881,7 +4881,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -4947,7 +4947,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRMixed) {
 // Test vkAcquireDrmDisplayEXT where nothing supports it.
 TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4961,7 +4961,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTNoSupport) {
 // Test vkAcquireDrmDisplayEXT where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -4976,7 +4976,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTNoICDSupport) {
 // Test vkAcquireDrmDisplayEXT where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
@@ -5020,7 +5020,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -5103,7 +5103,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTMixed) {
 // Test vkGetDrmDisplayEXT where nothing supports it.
 TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTNoSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -5117,7 +5117,7 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTNoSupport) {
 // Test vkGetDrmDisplayEXT where instance supports it, but nothing else.
 TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTNoICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).physical_devices.push_back({});
 
     InstWrapper instance(env.vulkan_functions);
@@ -5132,7 +5132,7 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTNoICDSupport) {
 // Test vkGetDrmDisplayEXT where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTInstanceAndICDSupport) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
@@ -5177,7 +5177,7 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -2122,7 +2122,7 @@ TEST(EnumeratePhysicalDeviceGroups, FakePNext) {
     //   PhysDev 6: pd6, Discrete, Vulkan 1.1, Bus 2
     //   Group 0: PhysDev 5, PhysDev 6
     //   Group 1: PhysDev 4
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& cur_icd_0 = env.get_test_icd(0);
     cur_icd_0.set_icd_api_version(VK_API_VERSION_1_1);
     cur_icd_0.physical_devices.push_back({"pd0", 7});
@@ -2143,7 +2143,7 @@ TEST(EnumeratePhysicalDeviceGroups, FakePNext) {
         .use_physical_device(cur_icd_0.physical_devices[2]);
     cur_icd_0.physical_device_groups.push_back({cur_icd_0.physical_devices[1]});
 
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& cur_icd_1 = env.get_test_icd(1);
     cur_icd_1.set_icd_api_version(VK_API_VERSION_1_1);
     cur_icd_1.physical_devices.push_back({"pd4", 1});
@@ -2211,7 +2211,7 @@ TEST(ExtensionManual, ToolingProperties) {
                                                      "No-Layer"};
     {  // No support in driver
         FrameworkEnvironment env{};
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         env.get_test_icd().physical_devices.push_back({});
 
         InstWrapper inst{env.vulkan_functions};
@@ -2229,7 +2229,7 @@ TEST(ExtensionManual, ToolingProperties) {
     }
     {  // extension is supported in driver
         FrameworkEnvironment env{};
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         env.get_test_icd().physical_devices.push_back({});
         env.get_test_icd().supports_tooling_info_ext = true;
         env.get_test_icd().tooling_properties.push_back(icd_tool_props);
@@ -2253,7 +2253,7 @@ TEST(ExtensionManual, ToolingProperties) {
     }
     {  // core
         FrameworkEnvironment env{};
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
         env.get_test_icd().physical_devices.push_back({});
         env.get_test_icd().physical_devices.back().properties.apiVersion = VK_MAKE_API_VERSION(0, 1, 3, 0);
         env.get_test_icd().supports_tooling_info_core = true;

--- a/tests/loader_threading_tests.cpp
+++ b/tests/loader_threading_tests.cpp
@@ -69,7 +69,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkCmdDraw(VkCommandBuffer cmd_buf, uint32_t vert
                                           uint32_t firstVertex, uint32_t firstInstance) {}
 TEST(ThreadingTests, ConcurentGetDeviceProcAddr) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t num_threads = 100;
     uint32_t num_loops_create_destroy_device = 10;
     uint32_t num_loops_try_get_proc_addr = 100;

--- a/tests/loader_unknown_ext_tests.cpp
+++ b/tests/loader_unknown_ext_tests.cpp
@@ -103,7 +103,7 @@ TEST(UnknownFunction, PhysicalDeviceFunction) {
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
     auto& driver = env.get_test_icd();
     std::vector<std::string> fake_function_names;
@@ -124,8 +124,8 @@ TEST(UnknownFunction, PhysicalDeviceFunctionMultipleDriverSupport) {
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver_0 = env.get_test_icd(0);
     auto& driver_1 = env.get_test_icd(1);
     std::vector<std::string> fake_function_names;
@@ -170,8 +170,8 @@ TEST(UnknownFunctionDeathTests, PhysicalDeviceFunctionErrorPath) {
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver_0 = env.get_test_icd(0);
     auto& driver_1 = env.get_test_icd(1);
     std::vector<std::string> fake_function_names;
@@ -210,7 +210,7 @@ TEST(UnknownFunction, PhysicalDeviceFunctionWithImplicitLayer) {
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
     auto& driver = env.get_test_icd();
     std::vector<std::string> fake_function_names;
@@ -238,8 +238,8 @@ TEST(UnknownFunction, PhysicalDeviceFunctionMultipleDriverSupportWithImplicitLay
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver_0 = env.get_test_icd(0);
     auto& driver_1 = env.get_test_icd(1);
     std::vector<std::string> fake_function_names;
@@ -289,7 +289,7 @@ TEST(UnknownFunction, PhysicalDeviceFunctionWithImplicitLayerInterception) {
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
     auto& driver = env.get_test_icd();
     std::vector<std::string> fake_function_names;
@@ -318,7 +318,7 @@ TEST(UnknownFunction, PhysicalDeviceFunctionWithMultipleImplicitLayersIntercepti
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     auto& driver = env.get_test_icd();
     std::vector<std::string> fake_function_names;
 
@@ -356,7 +356,7 @@ TEST(UnknownFunction, DeviceFunctionFromGetInstanceProcAddr) {
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
@@ -379,7 +379,7 @@ TEST(UnknownFunction, DeviceFunctionFromGetInstanceProcAddrWithImplicitLayer) {
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
@@ -404,7 +404,7 @@ TEST(UnknownFunction, DeviceFunctionFromGetInstanceProcAddrWithImplicitLayer) {
 
 TEST(UnknownFunction, DeviceFunctionFromGetDeviceProcAddr) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = 1000;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
@@ -422,7 +422,7 @@ TEST(UnknownFunction, DeviceFunctionFromGetDeviceProcAddr) {
 
 TEST(UnknownFunction, DeviceFunctionFromGetDeviceProcAddrWithImplicitLayer) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = 1000;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
@@ -447,7 +447,7 @@ using custom_command_buffer_functions = custom_functions<VkCommandBuffer>;
 
 TEST(UnknownFunction, CommandBufferFunctionFromGetDeviceProcAddr) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = 1000;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
@@ -479,7 +479,7 @@ TEST(UnknownFunction, CommandBufferFunctionFromGetDeviceProcAddr) {
 
 TEST(UnknownFunction, CommandBufferFunctionFromGetDeviceProcAddrWithImplicitLayer) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = 1000;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
@@ -519,7 +519,7 @@ TEST(UnknownFunction, CommandBufferFunctionFromGetInstanceProcAddr) {
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
@@ -553,7 +553,7 @@ TEST(UnknownFunction, CommandBufferFunctionFromGetInstanceProcAddrWithImplicitLa
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
@@ -592,7 +592,7 @@ using custom_queue_functions = custom_functions<VkQueue>;
 
 TEST(UnknownFunction, QueueFunctionFromGetDeviceProcAddr) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = 1000;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
@@ -615,7 +615,7 @@ TEST(UnknownFunction, QueueFunctionFromGetDeviceProcAddr) {
 
 TEST(UnknownFunction, QueueFunctionFromGetDeviceProcAddrWithImplicitLayer) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = 1000;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
@@ -647,7 +647,7 @@ TEST(UnknownFunction, QueueFunctionFromGetInstanceProcAddr) {
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
@@ -673,7 +673,7 @@ TEST(UnknownFunction, QueueFunctionFromGetInstanceProcAddrWithImplicitLayer) {
     GTEST_SKIP() << "Skip this test as currently macOS doesn't fully support unknown functions.";
 #endif
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");


### PR DESCRIPTION
The previous logic would cause any non-sorted physical devices to be missed
when aggregating the final list. This caused crashes due to the phys_dev
value not being initialized. The fix is to make sure both sorted and non
sorted physical devices are included in the final output of
setup_loader_term_phys_devs().

This PR should replace #868 