### PR TITLE
Fix CMake code for getting Git Version information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,15 +148,17 @@ if(APPLE)
     set(CMAKE_MACOSX_RPATH 1)
 endif()
 
+set(GIT_BRANCH_NAME "--unknown--")
+set(GIT_TAG_INFO "--unknown--")
 find_package (Git)
-if (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git/HEAD")
+if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git/HEAD")
     execute_process(
         COMMAND ${GIT_EXECUTABLE} describe --tags --always
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
         OUTPUT_VARIABLE GIT_TAG_INFO)
     string(REGEX REPLACE "\n$" "" GIT_TAG_INFO "${GIT_TAG_INFO}")
 
-    file(READ ".git/HEAD" GIT_HEAD_REF_INFO)
+    file(READ "${CMAKE_CURRENT_LIST_DIR}/.git/HEAD" GIT_HEAD_REF_INFO)
     if (GIT_HEAD_REF_INFO)
         string(REGEX MATCH "ref: refs/heads/(.*)" _ ${GIT_HEAD_REF_INFO})
         if (CMAKE_MATCH_1)
@@ -165,12 +167,7 @@ if (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git/HEAD")
             set(GIT_BRANCH_NAME ${GIT_HEAD_REF_INFO})
         endif()
         string(REGEX REPLACE "\n$" "" GIT_BRANCH_NAME "${GIT_BRANCH_NAME}")
-    else()
-        set(GIT_BRANCH_NAME "--unknown--")
     endif()
-else()
-    set(GIT_BRANCH_NAME "--unknown--")
-    set(GIT_TAG_INFO "--unknown--")
 endif()
 
 if(WIN32 AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -341,7 +338,7 @@ endif()
 
 # DEBUG enables runtime loader ICD verification
 # Add git branch and tag info in debug mode
-target_compile_definitions(loader_common_options INTERFACE $<$<CONFIG:DEBUG>:DEBUG;GIT_BRANCH_NAME=${GIT_BRANCH_NAME};GIT_TAG_INFO=${GIT_TAG_INFO}>)
+target_compile_definitions(loader_common_options INTERFACE $<$<CONFIG:DEBUG>:DEBUG;GIT_BRANCH_NAME="${GIT_BRANCH_NAME}";GIT_TAG_INFO="${GIT_TAG_INFO}">)
 
 # Check for the existance of the secure_getenv or __secure_getenv commands
 include(CheckFunctionExists)

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1544,11 +1544,7 @@ void loader_initialize(void) {
     loader_log(NULL, VULKAN_LOADER_INFO_BIT, 0, "Vulkan Loader Version %d.%d.%d", version.major, version.minor, version.patch);
 
 #if defined(GIT_BRANCH_NAME) && defined(GIT_TAG_INFO)
-#define LOADER_GIT_STRINGIFY(x) #x
-#define LOADER_GIT_TOSTRING(x) LOADER_GIT_STRINGIFY(x)
-    const char git_branch_name[] = LOADER_GIT_TOSTRING(GIT_BRANCH_NAME);
-    const char git_tag_info[] = LOADER_GIT_TOSTRING(GIT_TAG_INFO);
-    loader_log(NULL, VULKAN_LOADER_INFO_BIT, 0, "[Git - Tag: %s, Branch/Commit: %s]", git_tag_info, git_branch_name);
+    loader_log(NULL, VULKAN_LOADER_INFO_BIT, 0, "[Vulkan Loader Git - Tag: " GIT_BRANCH_NAME ", Branch/Commit: " GIT_TAG_INFO "]");
 #endif
 }
 


### PR DESCRIPTION
The ${CMAKE_SOURCE_DIR} uses the wrong directory when the loader is included as a
subproject. By using ${CMAKE_CURRENT_LIST_DIR}, the CMake code to find the git
commit and branch name will use the correct directory.

Additionally, the logic was ammended to curtail this issue in the future. Quotes are
included in the string to allow it to be used as a string literal, instead of
needing a const char[] variable and macros. Also, the CMake code was restructured
to always define GIT_BRANCH_NAME and GIT_TAG_INFO.

Fixes #919 