### PR TITLE
Clarify JSON Manifest "api_version"

### DIFF
--- a/docs/LoaderDriverInterface.md
+++ b/docs/LoaderDriverInterface.md
@@ -549,8 +549,14 @@ Here is an example driver JSON Manifest file:
   </tr>
   <tr>
     <td>"api_version" </td>
-    <td>The major.minor.patch version number of the Vulkan API that the shared
-        library files for the driver was built against.<br/>
+    <td>The major.minor.patch version number of the maximum Vulkan API supported
+        by the driver.
+        However, just because the driver supports the specific Vulkan API version,
+        it does not guarantee that the hardware on a user's system can support
+        that version.
+        Information on what the underlying physical device can support must be
+        queried by the user using the <i>vkGetPhysicalDeviceProperties</i> API call.
+        <br/>
         For example: 1.0.33.</td>
   </tr>
   <tr>

--- a/docs/LoaderLayerInterface.md
+++ b/docs/LoaderLayerInterface.md
@@ -1510,8 +1510,11 @@ Here's an example of a meta-layer manifest file:
   </tr>
   <tr>
     <td>"api_version"</td>
-    <td>The major.minor.patch version number of the Vulkan API that the shared
-        library file for the library was built against. </br>
+    <td>The major.minor.patch version number of the Vulkan API that the layer
+        supports.
+        It does not require the application to make use of that API version.
+        It simply is an indication that the layer can support Vulkan API
+        instance and device functions up to and including that API version. </br>
         For example: 1.0.33.
     </td>
     <td>None</td>


### PR DESCRIPTION
Clarify what is indicated by the "api_version" field in both
layer and driver manifest files.

Fixes issue #336.