### PR TITLE
Fix typo in env var table

### DIFF
--- a/docs/LoaderInterfaceArchitecture.md
+++ b/docs/LoaderInterfaceArchitecture.md
@@ -669,8 +669,6 @@ discovery.
     </small></td>
     <td><small>
         <b>Use Wisely!</b> This may cause the loader or application to crash.
-        <br/> <br/>
-        <b>Linux Only</b>
     </small></td>
     <td><small>
         export<br/>


### PR DESCRIPTION
Introduced a typo in my last commit in the table regarding the
disabling of instance extensions.  This is not a Linux only env
var.