### PR TITLE
Only check first GPDPA in the layer chain.

### DIFF
--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -445,6 +445,12 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroyDevice(VkDevice device, const VkAllocat
         }
     }
 }
+// forward declarations needed for trampolines
+#if TEST_LAYER_EXPORT_GET_PHYSICAL_DEVICE_PROC_ADDR
+extern "C" {
+FRAMEWORK_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDeviceProcAddr(VkInstance instance, const char* pName);
+}
+#endif
 
 // trampolines
 
@@ -467,6 +473,10 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL get_physical_device_func(VkInstance ins
             return to_vkVoidFunction(func.function);
         }
     }
+
+#if TEST_LAYER_EXPORT_GET_PHYSICAL_DEVICE_PROC_ADDR
+    if (string_eq(pName, "vk_layerGetPhysicalDeviceProcAddr")) return to_vkVoidFunction(vk_layerGetPhysicalDeviceProcAddr);
+#endif
     return nullptr;
 }
 


### PR DESCRIPTION
When checking for unknown physical device functions, check the first layer that supports
vk_layerGetPhysicalDeviceProcAddr in the chain starting with the layer closest to the
application. This prevents unecessary work being done, and if any layer wraps VkInstance
will properly call through the wrapping layer first without calling into any other layer.