### PR TITLE
Free file_vers after if-branch, fixing possible memory leak

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2574,7 +2574,6 @@ static VkResult loader_add_layer_properties(const struct loader_instance *inst, 
                    "loader_add_layer_properties: %s has unknown layer manifest file version %d.%d.%d.  May cause errors.", filename,
                    json_version.major, json_version.minor, json_version.patch);
     }
-    loader_instance_heap_free(inst, file_vers);
 
     // If "layers" is present, read in the array of layer objects
     layers_node = cJSON_GetObjectItem(json, "layers");
@@ -2631,6 +2630,8 @@ static VkResult loader_add_layer_properties(const struct loader_instance *inst, 
             } while (layer_node != NULL);
         }
     }
+    
+    loader_instance_heap_free(inst, file_vers);
 
 out:
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2631,10 +2631,12 @@ static VkResult loader_add_layer_properties(const struct loader_instance *inst, 
         }
     }
     
-    loader_instance_heap_free(inst, file_vers);
+    
 
 out:
-
+    if(NULL != file_vers) {
+        loader_instance_heap_free(inst, file_vers);
+    }
     return result;
 }
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2634,7 +2634,7 @@ static VkResult loader_add_layer_properties(const struct loader_instance *inst, 
     
 
 out:
-    if(NULL != file_vers) {
+    if (NULL != file_vers) {
         loader_instance_heap_free(inst, file_vers);
     }
     return result;


### PR DESCRIPTION
file_vers may be accessed in the following branch even though its memory has been freed
free() call happens in https://github.com/KhronosGroup/Vulkan-Loader/blob/master/loader/loader.c#L2577
but could still be accessed in https://github.com/KhronosGroup/Vulkan-Loader/blob/master/loader/loader.c#L2588
