### PR TITLE
Prevent loader config from overriding project config

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -228,7 +228,7 @@ if(WIN32)
                 ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-1.def
                 ${CMAKE_CURRENT_LIST_DIR}/loader.rc)
 
-    target_link_libraries(vulkan loader_specific_options loader-opt)
+    target_link_libraries(vulkan PRIVATE loader_specific_options loader-opt)
 
     if (UPDATE_DEPS)
         add_dependencies(vulkan vl_update_deps)
@@ -242,10 +242,10 @@ if(WIN32)
                           OUTPUT_NAME vulkan-1)
 
     if(MSVC AND ENABLE_WIN10_ONECORE)
-        target_link_libraries(vulkan OneCoreUAP.lib LIBCMT.LIB LIBCMTD.LIB LIBVCRUNTIME.LIB LIBUCRT.LIB)
+        target_link_libraries(vulkan PRIVATE OneCoreUAP.lib LIBCMT.LIB LIBCMTD.LIB LIBVCRUNTIME.LIB LIBUCRT.LIB)
         set_target_properties(vulkan PROPERTIES LINK_FLAGS "/NODEFAULTLIB")
     else()
-        target_link_libraries(vulkan cfgmgr32)
+       target_link_libraries(vulkan PRIVATE cfgmgr32)
     endif()
 
     add_dependencies(vulkan loader_asm_gen_files)
@@ -261,14 +261,14 @@ else()
     set_target_properties(vulkan
                           PROPERTIES SOVERSION "1"
                           VERSION ${LOADER_GENERATED_HEADER_VERSION})
-    target_link_libraries(vulkan ${CMAKE_DL_LIBS} m)
+    target_link_libraries(vulkan PRIVATE ${CMAKE_DL_LIBS} m)
     if (NOT ANDROID)
-        target_link_libraries(vulkan Threads::Threads)
+        target_link_libraries(vulkan PRIVATE Threads::Threads)
     endif()
 
     if(APPLE)
         find_library(COREFOUNDATION_LIBRARY NAMES CoreFoundation)
-        target_link_libraries(vulkan "-framework CoreFoundation")
+        target_link_libraries(vulkan PRIVATE "-framework CoreFoundation")
 
         # Build vulkan.framework
         # Use GLOB_RECURSE to find all the header files and populate the vulkan.framework headers with them
@@ -312,7 +312,7 @@ else()
 endif()
 
 # common attributes of the vulkan library
-target_link_libraries(vulkan loader_specific_options)
+target_link_libraries(vulkan PRIVATE loader_specific_options)
 
 set_target_properties(vulkan ${LOADER_STANDARD_C_PROPERTIES})
 if (TARGET asm_offset)
@@ -342,7 +342,7 @@ if(PKG_CONFIG_FOUND)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/vulkan.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif()
 
-target_link_libraries(vulkan Vulkan::Headers)
+target_link_libraries(vulkan PRIVATE Vulkan::Headers)
 add_library(Vulkan::Vulkan ALIAS vulkan)
 
 install(TARGETS vulkan


### PR DESCRIPTION
The loader options dummy targets were being linked into the public
interface of the loader, meaning that they were also set in projects the
include the loader as a sub-project. These override the containing
projects settings and can break things. There don't seem to be any
interface requirements in these settings, so include them as PRIVATE, so
that they stay local to the loader.

Fixes #961.