### PR TITLE
Add 32 & 64 bit field to json manifests

### DIFF
--- a/docs/LoaderDriverInterface.md
+++ b/docs/LoaderDriverInterface.md
@@ -516,6 +516,7 @@ Here is an example driver JSON Manifest file:
    "ICD": {
       "library_path": "path to driver library",
       "api_version": "1.2.205",
+      "library_arch" : "64",
       "is_portability_driver": false
    }
 }
@@ -551,6 +552,14 @@ Here is an example driver JSON Manifest file:
         Windows, ".so" on Linux and ".dylib" on macOS).</td>
   </tr>
   <tr>
+    <td>"library_arch"</td>
+    <td>Optional field which specifies the architecture of the binary associated
+        with "library_path". <br />
+        Allows the loader to quickly determine if the architecture of the driver
+        matches that of the running application. <br />
+        The only valid values are "32" and "64".</td>
+  </tr>
+  <tr>
     <td>"api_version" </td>
     <td>The major.minor.patch version number of the maximum Vulkan API supported
         by the driver.
@@ -574,7 +583,7 @@ Here is an example driver JSON Manifest file:
 versions of text manifest file format versions, it must have separate JSON files
 for each (all of which may point to the same shared library).
 
-#### Driver Manifest File Versions
+### Driver Manifest File Versions
 
 The current highest supported Layer Manifest file format supported is 1.0.1.
 Information about each version is detailed in the following sub-sections:
@@ -596,6 +605,9 @@ they contain VkPhysicalDevices which support the VK_KHR_portability_subset
 extension. This is an optional field. Omitting the field has the same effect as
 setting the field to `false`.
 
+Added the "library\_arch" field to the driver manifest to allow the loader to
+quickly determine if the driver matches the architecture of the current running
+application. This field is optional.
 
 ##  Driver Vulkan Entry Point Discovery
 

--- a/docs/LoaderLayerInterface.md
+++ b/docs/LoaderLayerInterface.md
@@ -1437,11 +1437,12 @@ Here is an example layer JSON Manifest file with a single layer:
 
 ```json
 {
-   "file_format_version" : "1.0.0",
+   "file_format_version" : "1.2.1",
    "layer": {
        "name": "VK_LAYER_LUNARG_overlay",
        "type": "INSTANCE",
        "library_path": "vkOverlayLayer.dll",
+       "library_arch" : "64",
        "api_version" : "1.0.5",
        "implementation_version" : "2",
        "description" : "LunarG HUD layer",
@@ -1708,6 +1709,15 @@ Here's an example of a meta-layer manifest file:
     <td>"layer"/"layers"</td>
     <td><small>N/A</small></td>
   </tr>
+  <td>"library_arch"</td>
+    <td>Optional field which specifies the architecture of the binary associated
+        with "library_path". <br />
+        Allows the loader to quickly determine if the architecture of the layer
+        matches that of the running application. <br />       
+        The only valid values are "32" and "64".</td>
+    <td><small>N/A</small></td>
+  </tr>
+  <tr>
   <tr>
     <td>"name"</td>
     <td>The string used to uniquely identify this layer to applications.</td>
@@ -1763,6 +1773,12 @@ Here's an example of a meta-layer manifest file:
 
 The current highest supported Layer Manifest file format supported is 1.2.0.
 Information about each version is detailed in the following sub-sections:
+
+### Layer Manifest File Version 1.2.1
+
+Added the "library\_arch" field to the layer manifest to allow the loader to
+quickly determine if the layer matches the architecture of the current running
+application.
 
 #### Layer Manifest File Version 1.2.0
 

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -137,7 +137,12 @@ std::string ManifestICD::get_manifest_str() const {
     out += "    \"ICD\": {\n";
     out += "        \"library_path\": \"" + fs::fixup_backslashes_in_path(lib_path) + "\",\n";
     out += "        \"api_version\": \"" + version_to_string(api_version) + "\",\n";
-    out += "        \"is_portability_driver\": " + to_text(is_portability_driver) + "\n";
+    out += "        \"is_portability_driver\": " + to_text(is_portability_driver);
+    if (!library_arch.empty()) {
+        out += ",\n       \"library_arch\": \"" + library_arch + "\"\n";
+    } else {
+        out += "\n";
+    }
     out += "    }\n";
     out += "}\n";
     return out;
@@ -176,7 +181,9 @@ std::string ManifestLayer::LayerDescription::get_manifest_str() const {
     print_vector_of_strings(out, "override_paths", override_paths);
     print_vector_of_strings(out, "app_keys", app_keys);
     print_list_of_t(out, "pre_instance_functions", pre_instance_functions);
-
+    if (!library_arch.empty()) {
+        out += ",\n\t\t\"library_arch\": \"" + library_arch + "\"";
+    }
     out += "\n\t}";
 
     return out;

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -543,6 +543,7 @@ struct ManifestICD {
     BUILDER_VALUE(ManifestICD, uint32_t, api_version, 0)
     BUILDER_VALUE(ManifestICD, std::string, lib_path, {})
     BUILDER_VALUE(ManifestICD, bool, is_portability_driver, false)
+    BUILDER_VALUE(ManifestICD, std::string, library_arch, "")
     std::string get_manifest_str() const;
 };
 
@@ -589,6 +590,7 @@ struct ManifestLayer {
         BUILDER_VECTOR(LayerDescription, std::string, override_paths, override_path)
         BUILDER_VECTOR(LayerDescription, FunctionOverride, pre_instance_functions, pre_instance_function)
         BUILDER_VECTOR(LayerDescription, std::string, app_keys, app_key)
+        BUILDER_VALUE(LayerDescription, std::string, library_arch, "")
 
         std::string get_manifest_str() const;
         VkLayerProperties get_layer_properties() const;


### PR DESCRIPTION
Allows drivers and layers to specify if they are 32 bit or 64 bit in the
manifest file. This makes the loader able to prune manifests without
loading the library and finding that it failed to load.