### PR TITLE
loader: device array dealloc fix

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5438,6 +5438,13 @@ VKAPI_ATTR void VKAPI_CALL terminator_DestroyInstance(VkInstance instance, const
     loader_destroy_generic_list(ptr_instance, (struct loader_generic_list *)&ptr_instance->ext_list);
     if (NULL != ptr_instance->phys_devs_term) {
         for (uint32_t i = 0; i < ptr_instance->phys_dev_count_term; i++) {
+            for (uint32_t j = i+1; j < ptr_instance->phys_dev_count_term; j++) {
+                if (ptr_instance->phys_devs_term[i] == ptr_instance->phys_devs_term[j]) {
+                    ptr_instance->phys_devs_term[j] = NULL;
+                }
+            }
+        }
+        for (uint32_t i = 0; i < ptr_instance->phys_dev_count_term; i++) {
             loader_instance_heap_free(ptr_instance, ptr_instance->phys_devs_term[i]);
         }
         loader_instance_heap_free(ptr_instance, ptr_instance->phys_devs_term);


### PR DESCRIPTION
AMD driver has the ability to create both physical and virtual devices. Virtual devices have adapterID = 0.

Recent change in Loader 1.3.211.0 made EnumeratePhysicalDevices obsolete, in favour of EnumerateAdapterPhysicalDevices. Virtual devices are reported for each physical adapterID, which makes duplicates in ptr_instance->phys_devs_term array.

The function that deletes this array tries to delete each element one by one, but if there are duplicate pointers present, it crashes on trying to delete the same element twice.

The easiest fix is to remove the duplicates before deleting the array.  