### PR TITLE
Make tests get files in a consistent order

### DIFF
--- a/tests/framework/shim/shim.h
+++ b/tests/framework/shim/shim.h
@@ -109,10 +109,28 @@ struct D3DKMT_Adapter {
     D3DKMT_Adapter& add_path(fs::path src, std::vector<std::wstring>& dest);
 };
 
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+
+struct DirEntry {
+    DIR* directory;
+    std::string folder_path;
+    std::vector<struct dirent*> contents;
+    size_t current_index;
+};
+
 #endif
+
+struct FrameworkEnvironment;  // forward declaration
+
 // Necessary to have inline definitions as shim is a dll and thus functions
 // defined in the .cpp wont be found by the rest of the application
 struct PlatformShim {
+    PlatformShim() = default;
+    PlatformShim(std::vector<fs::FolderManager>* folders) : folders(folders) {}
+
+    // Used to get info about which drivers & layers have been added to folders
+    std::vector<fs::FolderManager>* folders;
+
     // Test Framework interface
     void reset();
 
@@ -170,20 +188,24 @@ struct PlatformShim {
 
     void set_elevated_privilege(bool elev) { use_fake_elevation = elev; }
     bool use_fake_elevation = false;
+
+    std::vector<DirEntry> dir_entries;
 #endif
 };
 
 std::vector<std::string> parse_env_var_list(std::string const& var);
 std::string category_path_name(ManifestCategory category);
 
+std::vector<std::string> get_folder_contents(std::vector<fs::FolderManager>* folders, std::string folder_name) noexcept;
+
 extern "C" {
 // dynamically link on windows and macos
 #if defined(WIN32) || defined(__APPLE__)
-using PFN_get_platform_shim = PlatformShim* (*)();
+using PFN_get_platform_shim = PlatformShim* (*)(std::vector<fs::FolderManager>* folders);
 #define GET_PLATFORM_SHIM_STR "get_platform_shim"
 
 #elif defined(__linux__) || defined(__FreeBSD__)
 // statically link on linux
-PlatformShim* get_platform_shim();
+PlatformShim* get_platform_shim(std::vector<fs::FolderManager>* folders);
 #endif
 }

--- a/tests/framework/shim/shim_common.cpp
+++ b/tests/framework/shim/shim_common.cpp
@@ -60,6 +60,15 @@ std::vector<std::string> parse_env_var_list(std::string const& var) {
     return items;
 }
 
+std::vector<std::string> get_folder_contents(std::vector<fs::FolderManager>* folders, std::string folder_name) noexcept {
+    for (auto& folder : *folders) {
+        if (folder.location() == folder_name) {
+            return folder.get_files();
+        }
+    }
+    return {};
+}
+
 #if defined(WIN32)
 
 D3DKMT_Adapter& D3DKMT_Adapter::add_driver_manifest_path(fs::path const& src) { return add_path(src, driver_paths); }

--- a/tests/framework/shim/windows_shim.cpp
+++ b/tests/framework/shim/windows_shim.cpp
@@ -224,7 +224,7 @@ HRESULT __stdcall ShimEnumAdapters1_1(IDXGIFactory1 *This,
         return DXGI_ERROR_INVALID_CALL;
     }
     if (ppAdapter != nullptr) {
-        auto* pAdapter = create_IDXGIAdapter1();
+        auto *pAdapter = create_IDXGIAdapter1();
         *ppAdapter = pAdapter;
         platform_shim.dxgi_adapter_map[pAdapter] = Adapter;
     }
@@ -239,7 +239,7 @@ HRESULT __stdcall ShimEnumAdapters1_6(IDXGIFactory6 *This,
         return DXGI_ERROR_INVALID_CALL;
     }
     if (ppAdapter != nullptr) {
-        auto* pAdapter = create_IDXGIAdapter1();
+        auto *pAdapter = create_IDXGIAdapter1();
         *ppAdapter = pAdapter;
         platform_shim.dxgi_adapter_map[pAdapter] = Adapter;
     }
@@ -256,7 +256,7 @@ HRESULT __stdcall ShimEnumAdapterByGpuPreference(IDXGIFactory6 *This, _In_ UINT 
     assert(GpuPreference == DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_UNSPECIFIED &&
            "Test shim assumes the GpuPreference is unspecified.");
     if (ppvAdapter != nullptr) {
-        auto* pAdapter = create_IDXGIAdapter1();
+        auto *pAdapter = create_IDXGIAdapter1();
         *ppvAdapter = pAdapter;
         platform_shim.dxgi_adapter_map[pAdapter] = Adapter;
     }
@@ -351,10 +351,12 @@ LSTATUS __stdcall ShimRegEnumValueA(HKEY hKey, DWORD dwIndex, LPSTR lpValueName,
                                     LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData) {
     const std::string *path = get_path_of_created_key(hKey);
     if (path == nullptr) return ERROR_NO_MORE_ITEMS;
+
     const auto *location_ptr = get_registry_vector(*path);
     if (location_ptr == nullptr) return ERROR_NO_MORE_ITEMS;
     const auto &location = *location_ptr;
     if (dwIndex >= location.size()) return ERROR_NO_MORE_ITEMS;
+
     if (*lpcchValueName < location[dwIndex].name.size()) return ERROR_NO_MORE_ITEMS;
     for (size_t i = 0; i < location[dwIndex].name.size(); i++) {
         lpValueName[i] = location[dwIndex].name[i];
@@ -466,8 +468,8 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved) {
     }
     return TRUE;
 }
-FRAMEWORK_EXPORT PlatformShim *get_platform_shim() {
-    platform_shim = PlatformShim();
+FRAMEWORK_EXPORT PlatformShim *get_platform_shim(std::vector<fs::FolderManager> *folders) {
+    platform_shim = PlatformShim(folders);
     return &platform_shim;
 }
 }

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -258,8 +258,10 @@ VkResult CreateDebugUtilsMessenger(DebugUtilsWrapper& debug_utils);
 void FillDebugUtilsCreateDetails(InstanceCreateInfo& create_info, DebugUtilsLogger& logger);
 void FillDebugUtilsCreateDetails(InstanceCreateInfo& create_info, DebugUtilsWrapper& wrapper);
 
+struct FrameworkEnvironment;  // forward declaration
+
 struct PlatformShimWrapper {
-    PlatformShimWrapper() noexcept;
+    PlatformShimWrapper(std::vector<fs::FolderManager>* folders) noexcept;
     ~PlatformShimWrapper() noexcept;
     PlatformShimWrapper(PlatformShimWrapper const&) = delete;
     PlatformShimWrapper& operator=(PlatformShimWrapper const&) = delete;
@@ -328,6 +330,17 @@ struct TestLayerDetails {
     BUILDER_VALUE(TestLayerDetails, bool, is_fake, false);
 };
 
+enum class ManifestLocation {
+    null = 0,
+    driver = 1,
+    driver_env_var = 2,
+    explicit_layer = 3,
+    explicit_layer_env_var = 4,
+    explicit_layer_add_env_var = 5,
+    implicit_layer = 6,
+    override_layer = 7
+};
+
 struct FrameworkEnvironment {
     FrameworkEnvironment() noexcept;
 
@@ -349,15 +362,10 @@ struct FrameworkEnvironment {
     fs::path get_test_layer_path(size_t index = 0) noexcept;
     fs::path get_layer_manifest_path(size_t index = 0) noexcept;
 
+    fs::FolderManager& get_folder(ManifestLocation location) noexcept;
+
     PlatformShimWrapper platform_shim;
-    fs::FolderManager null_folder;
-    fs::FolderManager icd_folder;
-    fs::FolderManager icd_env_vars_folder;
-    fs::FolderManager explicit_layer_folder;
-    fs::FolderManager explicit_env_var_layer_folder;
-    fs::FolderManager explicit_add_env_var_layer_folder;
-    fs::FolderManager implicit_layer_folder;
-    fs::FolderManager override_layer_folder;
+    std::vector<fs::FolderManager> folders;
 
     DebugUtilsLogger debug_log;
     VulkanFunctions vulkan_functions;

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -203,10 +203,12 @@ int delete_folder(path const& folder);
 
 class FolderManager {
    public:
-    explicit FolderManager(path root_path, std::string name);
-    ~FolderManager();
+    explicit FolderManager(path root_path, std::string name) noexcept;
+    ~FolderManager() noexcept;
     FolderManager(FolderManager const&) = delete;
     FolderManager& operator=(FolderManager const&) = delete;
+    FolderManager(FolderManager&& other) noexcept;
+    FolderManager& operator=(FolderManager&& other) noexcept;
 
     path write_manifest(std::string const& name, std::string const& contents);
 
@@ -218,6 +220,8 @@ class FolderManager {
 
     // location of the managed folder
     path location() const { return folder; }
+
+    std::vector<std::string> get_files() const { return files; }
 
    private:
     path folder;

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -261,7 +261,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyLayerEnvVar) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.push_back({});
-    env.platform_shim->redirect_path("/tmp/carol", env.explicit_env_var_layer_folder.location());
+    env.platform_shim->redirect_path("/tmp/carol", env.get_folder(ManifestLocation::explicit_layer_env_var).location());
 
     const char* layer_name = "TestLayer";
     env.add_explicit_layer(
@@ -310,7 +310,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyAddLayerEnvVar) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().physical_devices.push_back({});
-    env.platform_shim->redirect_path("/tmp/carol", env.explicit_add_env_var_layer_folder.location());
+    env.platform_shim->redirect_path("/tmp/carol", env.get_folder(ManifestLocation::explicit_layer_add_env_var).location());
 
     const char* layer_name = "TestLayer";
     env.add_explicit_layer(

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -1046,15 +1046,16 @@ TEST(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
                                             "regular_test_layer.json"}
                                .set_discovery_type(ManifestDiscoveryType::override_folder));
 
-    env.add_implicit_layer(ManifestLayer{}
-                               .set_file_format_version(ManifestVersion(1, 2, 0))
-                               .add_layer(ManifestLayer::LayerDescription{}
-                                              .set_name(lunarg_meta_layer_name)
-                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                              .add_component_layer(regular_layer_name)
-                                              .set_disable_environment("DisableMeIfYouCan")
-                                              .add_override_path(env.override_layer_folder.location().str())),
-                           "meta_test_layer.json");
+    env.add_implicit_layer(
+        ManifestLayer{}
+            .set_file_format_version(ManifestVersion(1, 2, 0))
+            .add_layer(ManifestLayer::LayerDescription{}
+                           .set_name(lunarg_meta_layer_name)
+                           .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                           .add_component_layer(regular_layer_name)
+                           .set_disable_environment("DisableMeIfYouCan")
+                           .add_override_path(env.get_folder(ManifestLocation::override_layer).location().str())),
+        "meta_test_layer.json");
 
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.set_api_version(1, 1, 0);


### PR DESCRIPTION
Use the order defined the FolderManager's to define the order readdir
uses, rather than leaving it undetermined. This makes tests more consistent
by forcing layers and drivers to always be found in the same order on all
systems.

Note: MacOS doesn't currently have consistent ordering due to a crash with
ASAN. But even if ASAN isn't running, the dirent structure is being filled
out incorrectly, causing further test failures. While not ideal to disable
consistent ordering on MacOS, it is needed for linux and thus the issue
isn't high enough priority to resolve.