### PR TITLE
Disable VulkanOn12/Dozen in Windows 7

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2910,8 +2910,10 @@ static VkResult read_data_files_in_search_paths(const struct loader_instance *in
     bool xdg_data_dirs_secenv_alloc = true;
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
+#if WINVER >= _WIN32_WINNT_WINBLUE
     char *package_path = NULL;
+#endif
 #else
     // Determine how much space is needed to generate the full search path
     // for the current manifest files.
@@ -2999,7 +3001,7 @@ static VkResult read_data_files_in_search_paths(const struct loader_instance *in
             }
             additional_env = loader_secure_getenv(VK_ADDITIONAL_DRIVER_FILES_ENV_VAR, inst);
             relative_location = VK_DRIVERS_INFO_RELATIVE_DIR;
-#ifdef _WIN32
+#if defined(_WIN32) && WINVER >= _WIN32_WINNT_WINBLUE
             package_path = windows_get_app_package_manifest_path(inst);
 #endif
             break;
@@ -3033,8 +3035,8 @@ static VkResult read_data_files_in_search_paths(const struct loader_instance *in
         // Add the size of any additional search paths defined in the additive environment variable
         if (NULL != additional_env) {
             search_path_size += determine_data_file_path_size(additional_env, 0) + 2;
-#ifdef _WIN32
-        } 
+#if defined(_WIN32) && WINVER >= _WIN32_WINNT_WINBLUE
+        }
         if (NULL != package_path) {
             search_path_size += determine_data_file_path_size(package_path, 0) + 2;
         }
@@ -3090,7 +3092,7 @@ static VkResult read_data_files_in_search_paths(const struct loader_instance *in
             copy_data_file_info(additional_env, NULL, 0, &cur_path_ptr);
         }
 
-#ifdef _WIN32
+#if defined(_WIN32) && WINVER >= _WIN32_WINNT_WINBLUE
         if (NULL != package_path) {
             copy_data_file_info(package_path, NULL, 0, &cur_path_ptr);
         }
@@ -3229,7 +3231,7 @@ out:
     if (NULL != override_env) {
         loader_free_getenv(override_env, inst);
     }
-#ifdef _WIN32
+#if defined(_WIN32) && WINVER >= _WIN32_WINNT_WINBLUE
     if (NULL != package_path) {
         loader_instance_heap_free(inst, package_path);
     }

--- a/loader/loader_windows.h
+++ b/loader/loader_windows.h
@@ -35,6 +35,7 @@
 
 #include <minwindef.h>
 #include <cfgmgr32.h>
+#include <sdkddkver.h>
 
 // Windows specific initialization functionality
 void windows_initialization(void);
@@ -112,7 +113,9 @@ VkResult windows_sort_physical_device_groups(struct loader_instance *inst, const
 // Returns VkLoaderFeatureFlags containing VK_LOADER_FEATURE_PHYSICAL_DEVICE_SORTING if successful, otherwise 0
 VkLoaderFeatureFlags windows_initialize_dxgi(void);
 
+#if WINVER >= _WIN32_WINNT_WINBLUE  // Only Available on windows 8 and above
 // Retrieve a path to an installed app package that contains Vulkan manifests.
 // When done using the returned string, the caller should free the pointer.
 char *windows_get_app_package_manifest_path(const struct loader_instance *inst);
+#endif
 #endif  // WIN32


### PR DESCRIPTION
Chromium still supports building for Win7, as such the newly added support for
VulkanOn12/Dozen needs to be excluded from said build. This is achieved by using
the SDK version macros defined in <sdkddkver>