### PR TITLE
Validate dispatch table before using pointer

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -49,7 +49,7 @@ static inline VkLayerDispatchTable *loader_get_dispatch(const void *obj) {
         return NULL;
     }
     VkLayerDispatchTable *disp = *((VkLayerDispatchTable **)obj);
-    if (VK_NULL_HANDLE == disp || DEVICE_DISP_TABLE_MAGIC_NUMBER != disp->magic) {
+    if (VK_NULL_HANDLE == disp || disp == (void *)ICD_LOADER_MAGIC || DEVICE_DISP_TABLE_MAGIC_NUMBER != disp->magic) {
         return NULL;
     }
     return disp;


### PR DESCRIPTION
It was previously not validating the internal magic value so the pointer was not used even if it was 0x1cdc0de.