### PR TITLE
loader: Only use alloca.h if it exists otherwise fallback to stdlib.h

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -95,6 +95,10 @@ else()
     if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
         target_compile_definitions(loader_specific_options INTERFACE __BSD_VISIBLE=1)
     endif()
+    check_include_file("alloca.h" HAVE_ALLOCA_H)
+    if(HAVE_ALLOCA_H)
+        target_compile_definitions(loader_specific_options INTERFACE HAVE_ALLOCA_H)
+    endif()
 endif()
 
 set(NORMAL_LOADER_SRCS

--- a/loader/stack_allocation.h
+++ b/loader/stack_allocation.h
@@ -30,8 +30,10 @@
 
 #if defined(_WIN32)
 #include <malloc.h>
-#else
+#elif defined(HAVE_ALLOCA_H)
 #include <alloca.h>
+#else
+#include <stdlib.h>
 #endif
 
 #if defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNXNTO__) || defined(__FreeBSD__) || defined(__OpenBSD__)


### PR DESCRIPTION
Check for the existence of the alloca.h header and only use it it exists,
otherwise fallback to stdlib.h. Some OS's like macOS and QNX have both
headers and can use either (stdlib.h includes alloca.h), some OS's like
OpenBSD / FreeBSD / NetBSD do not have the alloca.h header and require
the stdlib.h header.