### PR TITLE
Don't load layer libraries in vkCreateDevice

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1187,12 +1187,8 @@ void loader_destroy_logical_device(const struct loader_instance *inst, struct lo
     if (pAllocator) {
         dev->alloc_callbacks = *pAllocator;
     }
-    if (NULL != dev->expanded_activated_layer_list.list) {
-        loader_deactivate_layers(inst, dev, &dev->expanded_activated_layer_list);
-    }
-    if (NULL != dev->app_activated_layer_list.list) {
-        loader_destroy_layer_list(inst, dev, &dev->app_activated_layer_list);
-    }
+    loader_destroy_layer_list(inst, dev, &dev->expanded_activated_layer_list);
+    loader_destroy_layer_list(inst, dev, &dev->app_activated_layer_list);
     loader_device_heap_free(dev, dev);
 }
 
@@ -3976,8 +3972,7 @@ struct loader_instance *loader_get_instance(const VkInstance instance) {
     return ptr_instance;
 }
 
-static loader_platform_dl_handle loader_open_layer_file(const struct loader_instance *inst, const char *chain_type,
-                                                        struct loader_layer_properties *prop) {
+static loader_platform_dl_handle loader_open_layer_file(const struct loader_instance *inst, struct loader_layer_properties *prop) {
     if ((prop->lib_handle = loader_platform_open_library(prop->lib_name)) == NULL) {
         loader_handle_load_library_error(inst, prop->lib_name, &prop->lib_status);
     } else {
@@ -4370,7 +4365,7 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
                 continue;
             }
 
-            lib_handle = loader_open_layer_file(inst, "instance", layer_prop);
+            lib_handle = loader_open_layer_file(inst, layer_prop);
             if (!lib_handle) {
                 continue;
             }
@@ -4684,20 +4679,12 @@ VkResult loader_create_device_chain(const VkPhysicalDevice pd, const VkDeviceCre
         chain_info.pNext = loader_create_info.pNext;
         loader_create_info.pNext = &chain_info;
 
-        bool done = false;
-
         // Create instance chain of enabled layers
         for (int32_t i = dev->expanded_activated_layer_list.count - 1; i >= 0; i--) {
             struct loader_layer_properties *layer_prop = &dev->expanded_activated_layer_list.list[i];
-            loader_platform_dl_handle lib_handle;
-
+            loader_platform_dl_handle lib_handle = layer_prop->lib_handle;
             // Skip it if a Layer with the same name has been already successfully activated
             if (loader_names_array_has_layer_property(&layer_prop->info, num_activated_layers, activated_layers)) {
-                continue;
-            }
-
-            lib_handle = loader_open_layer_file(inst, "device", layer_prop);
-            if (!lib_handle || done) {
                 continue;
             }
 
@@ -4722,7 +4709,6 @@ VkResult loader_create_device_chain(const VkPhysicalDevice pd, const VkDeviceCre
                 if (layerNextGDPA != NULL) {
                     *layerNextGDPA = nextGDPA;
                 }
-                done = true;
                 continue;
             }
 


### PR DESCRIPTION
These libraries will always be loaded in vkCreateInstance, so we don't need to load them again in vkCreateDevice. This has the added benefit of not printing 'unloading library X' twice in the log.