### PR TITLE
WIP: Don't abort when drivers don't support WSI calls

### DIFF
--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -251,9 +251,11 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceSupportKHR(VkP
     *pSupported = false;
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfaceSupportKHR) {
+        // set pSupported to false as this driver doesn't support WSI functionality
+        *pSupported = false;
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceSurfaceSupportKHR!\n");
-        abort();
+        return VK_SUCCESS;
     }
 
     VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
@@ -303,9 +305,11 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilitiesKH
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfaceCapabilitiesKHR) {
+        // Zero out the capabilities as this driver doesn't support WSI functionality
+        memset(pSurfaceCapabilities, 0, sizeof(VkSurfaceCapabilitiesKHR));
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceSurfaceCapabilitiesKHR!\n");
-        abort();
+        return VK_SUCCESS;
     }
 
     VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
@@ -357,9 +361,11 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormatsKHR(VkP
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfaceFormatsKHR) {
+        // Zero out the format count as this driver doesn't support WSI functionality
+        *pSurfaceFormatCount = 0;
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceSurfaceCapabilitiesKHR!\n");
-        abort();
+        return VK_SUCCESS;
     }
 
     VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
@@ -413,9 +419,11 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfacePresentModesKH
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfacePresentModesKHR) {
+        // Zero out the present mode count as this driver doesn't support WSI functionality
+        *pPresentModeCount = 0;
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceSurfacePresentModesKHR!\n");
-        abort();
+        return VK_SUCCESS;
     }
 
     VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
@@ -646,13 +654,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceWin32PresentationSupp
     if (!loader_inst->wsi_win32_surface_enabled) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_win32_surface extension not enabled. vkGetPhysicalDeviceWin32PresentationSupportKHR not executed!\n");
-        return VK_SUCCESS;
+        return VK_FALSE;
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceWin32PresentationSupportKHR) {
+        // return VK_FALSE as this driver doesn't support WSI functionality
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceWin32PresentationSupportKHR!\n");
-        abort();
+        return VK_FALSE;
     }
 
     return icd_term->dispatch.GetPhysicalDeviceWin32PresentationSupportKHR(phys_dev_term->phys_dev, queueFamilyIndex);
@@ -767,13 +776,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceWaylandPresentationSu
         loader_log(
             loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
             "VK_KHR_wayland_surface extension not enabled. vkGetPhysicalDeviceWaylandPresentationSupportKHR not executed!\n");
-        return VK_SUCCESS;
+        return VK_FALSE;
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceWaylandPresentationSupportKHR) {
+        // return VK_FALSE as this driver doesn't support WSI functionality
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceWaylandPresentationSupportKHR!\n");
-        abort();
+        return VK_FALSE;
     }
 
     return icd_term->dispatch.GetPhysicalDeviceWaylandPresentationSupportKHR(phys_dev_term->phys_dev, queueFamilyIndex, display);
@@ -890,13 +900,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceXcbPresentationSuppor
     if (!loader_inst->wsi_xcb_surface_enabled) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_xcb_surface extension not enabled. vkGetPhysicalDeviceXcbPresentationSupportKHR not executed!\n");
-        return VK_SUCCESS;
+        return VK_FALSE;
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceXcbPresentationSupportKHR) {
+        // return VK_FALSE as this driver doesn't support WSI functionality
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceXcbPresentationSupportKHR!\n");
-        abort();
+        return VK_FALSE;
     }
 
     return icd_term->dispatch.GetPhysicalDeviceXcbPresentationSupportKHR(phys_dev_term->phys_dev, queueFamilyIndex, connection,
@@ -1012,13 +1023,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceXlibPresentationSuppo
     if (!loader_inst->wsi_xlib_surface_enabled) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_xlib_surface extension not enabled. vkGetPhysicalDeviceXlibPresentationSupportKHR not executed!\n");
-        return VK_SUCCESS;
+        return VK_FALSE;
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceXlibPresentationSupportKHR) {
+        // return VK_FALSE as this driver doesn't support WSI functionality
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceXlibPresentationSupportKHR!\n");
-        abort();
+        return VK_FALSE;
     }
 
     return icd_term->dispatch.GetPhysicalDeviceXlibPresentationSupportKHR(phys_dev_term->phys_dev, queueFamilyIndex, dpy, visualID);
@@ -1137,13 +1149,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceDirectFBPresentationS
         loader_log(
             loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
             "VK_EXT_directfb_surface extension not enabled. vkGetPhysicalDeviceDirectFBPresentationSupportKHR not executed!\n");
-        return VK_SUCCESS;
+        return VK_FALSE;
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceDirectFBPresentationSupportEXT) {
+        // return VK_FALSE as this driver doesn't support WSI functionality
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceDirectFBPresentationSupportEXT!\n");
-        abort();
+        return VK_FALSE;
     }
 
     return icd_term->dispatch.GetPhysicalDeviceDirectFBPresentationSupportEXT(phys_dev_term->phys_dev, queueFamilyIndex, dfb);
@@ -1656,13 +1669,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceScreenPresentationSup
     if (!loader_inst->wsi_screen_surface_enabled) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_QNX_screen_surface extension not enabled. vkGetPhysicalDeviceScreenPresentationSupportQNX not executed!\n");
-        return VK_SUCCESS;
+        return VK_FALSE;
     }
 
     if (NULL == icd_term->dispatch.GetPhysicalDeviceScreenPresentationSupportQNX) {
+        // return VK_FALSE as this driver doesn't support WSI functionality
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceScreenPresentationSupportQNX!\n");
-        abort();
+        return VK_FALSE;
     }
 
     return icd_term->dispatch.GetPhysicalDeviceScreenPresentationSupportQNX(phys_dev_term->phys_dev, queueFamilyIndex, window);
@@ -1780,7 +1794,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceDisplayPropertiesKHR(
     if (NULL == icd_term->dispatch.GetPhysicalDeviceDisplayPropertiesKHR) {
         loader_log(loader_inst, VULKAN_LOADER_WARN_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceDisplayPropertiesKHR!\n");
-        *pPropertyCount = 0;
+        // return 0 for property count as this driver doesn't support WSI functionality
+        if (pPropertyCount) {
+            *pPropertyCount = 0;
+        }
         return VK_SUCCESS;
     }
 
@@ -1818,7 +1835,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceDisplayPlanePropertie
     if (NULL == icd_term->dispatch.GetPhysicalDeviceDisplayPlanePropertiesKHR) {
         loader_log(loader_inst, VULKAN_LOADER_WARN_BIT, 0,
                    "ICD for selected physical device does not export vkGetPhysicalDeviceDisplayPlanePropertiesKHR!\n");
-        *pPropertyCount = 0;
+        // return 0 for property count as this driver doesn't support WSI functionality
+        if (pPropertyCount) {
+            *pPropertyCount = 0;
+        }
         return VK_SUCCESS;
     }
 
@@ -1856,7 +1876,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayPlaneSupportedDisplaysKHR(Vk
     if (NULL == icd_term->dispatch.GetDisplayPlaneSupportedDisplaysKHR) {
         loader_log(loader_inst, VULKAN_LOADER_WARN_BIT, 0,
                    "ICD for selected physical device does not export vkGetDisplayPlaneSupportedDisplaysKHR!\n");
-        *pDisplayCount = 0;
+        // return 0 for property count as this driver doesn't support WSI functionality
+        if (pDisplayCount) {
+            *pDisplayCount = 0;
+        }
         return VK_SUCCESS;
     }
 
@@ -1895,7 +1918,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayModePropertiesKHR(VkPhysical
     if (NULL == icd_term->dispatch.GetDisplayModePropertiesKHR) {
         loader_log(loader_inst, VULKAN_LOADER_WARN_BIT, 0,
                    "ICD for selected physical device does not export vkGetDisplayModePropertiesKHR!\n");
-        *pPropertyCount = 0;
+        // return 0 for property count as this driver doesn't support WSI functionality
+        if (pPropertyCount) {
+            *pPropertyCount = 0;
+        }
         return VK_SUCCESS;
     }
 
@@ -2172,7 +2198,11 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDevicePresentRectanglesKHR(
     if (NULL == icd_term->dispatch.GetPhysicalDevicePresentRectanglesKHR) {
         loader_log(icd_term->this_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD associated with VkPhysicalDevice does not support GetPhysicalDevicePresentRectanglesKHX");
-        abort();
+        // return as this driver doesn't support WSI functionality
+        if (pRectCount) {
+            *pRectCount = 0;
+        }
+        return VK_SUCCESS;
     }
     VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)(surface);
     uint8_t icd_index = phys_dev_term->icd_index;
@@ -2394,8 +2424,15 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayPlaneCapabilities2KHR(VkPhys
     loader_log(icd_term->this_instance, VULKAN_LOADER_INFO_BIT, 0,
                "vkGetDisplayPlaneCapabilities2KHR: Emulating call in ICD \"%s\"", icd_term->scanned_icd->lib_name);
 
+    // If the icd doesn't support VK_KHR_display, then there are no capabilities
+    if (NULL == icd_term->dispatch.GetDisplayPlaneCapabilitiesKHR) {
+        if (pCapabilities) {
+            memset(&pCapabilities->capabilities, 0, sizeof(VkDisplayPlaneCapabilitiesKHR));
+        }
+        return VK_SUCCESS;
+    }
+
     // Just call into the old version of the function.
-    // If the icd doesn't support VK_KHR_display, there are zero planes and this call is invalid (and will crash)
     return icd_term->dispatch.GetDisplayPlaneCapabilitiesKHR(phys_dev_term->phys_dev, pDisplayPlaneInfo->mode,
                                                              pDisplayPlaneInfo->planeIndex, &pCapabilities->capabilities);
 }
@@ -2554,6 +2591,14 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2K
         if (NULL != icd_surface->real_icd_surfaces && NULL != (void *)(uintptr_t)(icd_surface->real_icd_surfaces[icd_index])) {
             surface = icd_surface->real_icd_surfaces[icd_index];
         }
+
+        // If the icd doesn't support VK_KHR_surface, then there are no capabilities
+        if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfaceCapabilitiesKHR) {
+            if (pSurfaceCapabilities) {
+                memset(&pSurfaceCapabilities->surfaceCapabilities, 0, sizeof(VkSurfaceCapabilitiesKHR));
+            }
+            return VK_SUCCESS;
+        }
         VkResult res = icd_term->dispatch.GetPhysicalDeviceSurfaceCapabilitiesKHR(phys_dev_term->phys_dev, surface,
                                                                                   &pSurfaceCapabilities->surfaceCapabilities);
 
@@ -2624,6 +2669,14 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormats2KHR(Vk
         VkSurfaceKHR surface = pSurfaceInfo->surface;
         if (NULL != icd_surface->real_icd_surfaces && NULL != (void *)(uintptr_t)(icd_surface->real_icd_surfaces[icd_index])) {
             surface = icd_surface->real_icd_surfaces[icd_index];
+        }
+
+        // If the icd doesn't support VK_KHR_surface, then there are no formats
+        if (NULL == icd_term->dispatch.GetPhysicalDeviceSurfaceFormatsKHR) {
+            if (pSurfaceFormatCount) {
+                *pSurfaceFormatCount = 0;
+            }
+            return VK_SUCCESS;
         }
 
         if (*pSurfaceFormatCount == 0 || pSurfaceFormats == NULL) {

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -138,7 +138,8 @@ TEST(WsiTests, GetPhysicalDeviceWin32PresentNoICDSupport) {
     cur_icd.enable_icd_wsi = false;
 
     InstWrapper inst{env.vulkan_functions};
-    inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
+    inst.create_info.add_extensions(
+        {VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WIN32_SURFACE_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_EXTENSION_NAME});
     inst.CheckCreate();
 
     uint32_t driver_count = 1;
@@ -146,8 +147,11 @@ TEST(WsiTests, GetPhysicalDeviceWin32PresentNoICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1U);
 
-    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceWin32PresentationSupportKHR(physical_device, 0),
-                 "ICD for selected physical device does not export vkGetPhysicalDeviceWin32PresentationSupportKHR!");
+    DebugUtilsWrapper log{inst};
+    CreateDebugUtilsMessenger(log);
+    auto res = env.vulkan_functions.vkGetPhysicalDeviceWin32PresentationSupportKHR(physical_device, 0);
+    ASSERT_EQ(res, VK_SUCCESS);
+    ASSERT_TRUE(log.find("ICD for selected physical device does not export vkGetPhysicalDeviceWin32PresentationSupportKHR!"));
 }
 
 TEST(WsiTests, GetPhysicalDeviceWin32PresentICDSupport) {
@@ -323,7 +327,8 @@ TEST(WsiTests, GetPhysicalDeviceXcbPresentNoICDSupport) {
     cur_icd.enable_icd_wsi = false;
 
     InstWrapper inst{env.vulkan_functions};
-    inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XCB_SURFACE_EXTENSION_NAME});
+    inst.create_info.add_extensions(
+        {VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XCB_SURFACE_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_EXTENSION_NAME});
     inst.CheckCreate();
 
     uint32_t driver_count = 1;
@@ -331,8 +336,11 @@ TEST(WsiTests, GetPhysicalDeviceXcbPresentNoICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1U);
 
-    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceXcbPresentationSupportKHR(physical_device, 0, nullptr, 0),
-                 "ICD for selected physical device does not export vkGetPhysicalDeviceXcbPresentationSupportKHR!");
+    DebugUtilsWrapper log{inst};
+    CreateDebugUtilsMessenger(log);
+    auto res = env.vulkan_functions.vkGetPhysicalDeviceXcbPresentationSupportKHR(physical_device, 0, nullptr, 0);
+    ASSERT_EQ(res, VK_SUCCESS);
+    ASSERT_TRUE(log.find("ICD for selected physical device does not export vkGetPhysicalDeviceXcbPresentationSupportKHR!"));
 }
 
 TEST(WsiTests, GetPhysicalDeviceXcbPresentICDSupport) {
@@ -508,7 +516,8 @@ TEST(WsiTests, GetPhysicalDeviceXlibPresentNoICDSupport) {
     cur_icd.enable_icd_wsi = false;
 
     InstWrapper inst{env.vulkan_functions};
-    inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
+    inst.create_info.add_extensions(
+        {VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XLIB_SURFACE_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_EXTENSION_NAME});
     inst.CheckCreate();
 
     uint32_t driver_count = 1;
@@ -516,8 +525,11 @@ TEST(WsiTests, GetPhysicalDeviceXlibPresentNoICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1U);
 
-    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceXlibPresentationSupportKHR(physical_device, 0, nullptr, 0),
-                 "ICD for selected physical device does not export vkGetPhysicalDeviceXlibPresentationSupportKHR!");
+    DebugUtilsWrapper log{inst};
+    CreateDebugUtilsMessenger(log);
+    auto res = env.vulkan_functions.vkGetPhysicalDeviceXlibPresentationSupportKHR(physical_device, 0, nullptr, 0);
+    ASSERT_EQ(res, VK_SUCCESS);
+    ASSERT_TRUE(log.find("ICD for selected physical device does not export vkGetPhysicalDeviceXlibPresentationSupportKHR!"));
 }
 
 TEST(WsiTests, GetPhysicalDeviceXlibPresentICDSupport) {
@@ -693,7 +705,8 @@ TEST(WsiTests, GetPhysicalDeviceWaylandPresentNoICDSupport) {
     cur_icd.enable_icd_wsi = false;
 
     InstWrapper inst{env.vulkan_functions};
-    inst.create_info.add_extensions({VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
+    inst.create_info.add_extensions(
+        {VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_EXTENSION_NAME});
     inst.CheckCreate();
 
     uint32_t driver_count = 1;
@@ -701,8 +714,11 @@ TEST(WsiTests, GetPhysicalDeviceWaylandPresentNoICDSupport) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &driver_count, &physical_device));
     ASSERT_EQ(driver_count, 1U);
 
-    ASSERT_DEATH(env.vulkan_functions.vkGetPhysicalDeviceWaylandPresentationSupportKHR(physical_device, 0, nullptr),
-                 "ICD for selected physical device does not export vkGetPhysicalDeviceWaylandPresentationSupportKHR!");
+    DebugUtilsWrapper log{inst};
+    CreateDebugUtilsMessenger(log);
+    auto res = env.vulkan_functions.vkGetPhysicalDeviceWaylandPresentationSupportKHR(physical_device, 0, nullptr);
+    ASSERT_EQ(res, false);
+    ASSERT_TRUE(log.find("ICD for selected physical device does not export vkGetPhysicalDeviceWaylandPresentationSupportKHR!"));
 }
 
 TEST(WsiTests, GetPhysicalDeviceWaylandPresentICDSupport) {


### PR DESCRIPTION
Instance extensions are aggregated, therefore an application has no way of knowing whether an ICD supports a WSI function or not. This necessitates returning instead of aborting from WSI functions, as well as writing 0, NULL, or returning false as needed for each function. This also needs additional NULL checks before calling down into the driver.

Fixes #4 