### PR TITLE
Only deduplicate driver manifests

### DIFF
--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -525,8 +525,8 @@ VkResult windows_get_registry_files(const struct loader_instance *inst, char *lo
                                 foundDuplicate = true;
                             }
                         }
-
-                        if (foundDuplicate == false) {
+                        // Only skip if we are adding a driver and a duplicate was found
+                        if (!is_driver || (is_driver && foundDuplicate == false)) {
                             // Add the new entry to the list.
                             (void)snprintf(*reg_data + strlen(*reg_data), name_size + 2, "%c%s", PATH_SEPARATOR, name);
                             found = true;


### PR DESCRIPTION
Code which was originally meant to deduplicate drivers that moved from the old registry HKEY_LOCAL_MACHINE/SOFTWARE/Khronos/Vulkan/Drivers to PnP locations was incorrectly applied to layers as well. The issue is that multiple layers can share the same json file name but not actually contain the same manifest. Worse, the first layer found would be assumed to be correct, even the file had been deleted from the file system.

Fixes #750 