### PR TITLE
ci: Use MACOS_DEPLOYMENT_TARGET

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,10 @@ jobs:
 
             - name: Generate build files
               run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=${{matrix.config}} -DBUILD_TESTS=On -DUPDATE_DEPS=ON -DTEST_USE_ADDRESS_SANITIZER=ON
+              env:
+                # Specify the minimum version of macOS on which the target binaries are to be deployed.
+                # https://cmake.org/cmake/help/latest/envvar/MACOSX_DEPLOYMENT_TARGET.html
+                MACOSX_DEPLOYMENT_TARGET: 10.12
 
             - name: Build the loader
               run: make -C build

--- a/BUILD.md
+++ b/BUILD.md
@@ -228,7 +228,6 @@ The following is a table of all string options currently supported by this repos
 
 | Option                      | Platform    | Default                       | Description                                                                                                                                          |
 | --------------------------- | ----------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CMAKE_OSX_DEPLOYMENT_TARGET | MacOS       | `10.12`                       | The minimum version of MacOS for loader deployment.                                                                                                  |
 | FALLBACK_CONFIG_DIRS        | Linux/MacOS | `/etc/xdg`                    | Configuration path(s) to use instead of `XDG_CONFIG_DIRS` if that environment variable is unavailable. The default setting is freedesktop compliant. |
 | FALLBACK_DATA_DIRS          | Linux/MacOS | `/usr/local/share:/usr/share` | Configuration path(s) to use instead of `XDG_DATA_DIRS` if that environment variable is unavailable. The default setting is freedesktop compliant.   |
 | BUILD_DLL_VERSIONINFO       | Windows     | `""` (empty string)           | Allows setting the Windows specific version information for the Loader DLL. Format is "major.minor.patch.build".                                     |
@@ -634,7 +633,9 @@ Finally, rebuild the repository using `cmake` and `make`, as explained above.
 
 ### MacOS Development Environment Requirements
 
-Tested on OSX version 10.12.6
+Tested on OSX version 10.12
+
+NOTE: To force the OSX version set the environment variable [MACOSX_DEPLOYMENT_TARGET](https://cmake.org/cmake/help/latest/envvar/MACOSX_DEPLOYMENT_TARGET.html) when building VVL and it's dependencies.
 
 Setup Homebrew and components
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,6 @@
 
 cmake_minimum_required(VERSION 3.10.2)
 
-# Apple: Must be set before enable_language() or project() as it may influence configuration of the toolchain and flags.
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment version")
-
 # If we are building in Visual Studio 2015 and with a CMake version 3.19 or greater, we need to set this variable
 # so that CMake will choose a Windows SDK version higher than 10.0.14393.0, as dxgi1_6.h is only found in Windows SDK
 # 10.0.17763 and higher.


### PR DESCRIPTION
- This approach matches what our SDK release process expect
  - Since setting CMAKE_MACOS_DEPLOYMENT_TARGET ignores env variable which SDK release process uses, which could will cause issues in the future, if the version is changed
- CMAKE_MACOS_DEPLOYMENT_TARGET doesn't propogate to dependencies via update_deps.py