### PR TITLE
fix: add dev pointer checking before using

### DIFF
--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -9538,6 +9538,11 @@ void extensions_create_instance(struct loader_instance *ptr_instance, const VkIn
 PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *dev, const char *pName) {
     PFN_vkVoidFunction addr = NULL;
 
+    if (dev == NULL)
+    {
+        return addr;
+    }
+    
     // ---- VK_KHR_swapchain extension commands
     if (dev->extensions.khr_swapchain_enabled) {
         if(!strcmp(pName, "vkCreateSwapchainKHR")) {

--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -9538,11 +9538,6 @@ void extensions_create_instance(struct loader_instance *ptr_instance, const VkIn
 PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *dev, const char *pName) {
     PFN_vkVoidFunction addr = NULL;
 
-    if (dev == NULL)
-    {
-        return addr;
-    }
-    
     // ---- VK_KHR_swapchain extension commands
     if (dev->extensions.khr_swapchain_enabled) {
         if(!strcmp(pName, "vkCreateSwapchainKHR")) {

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -192,7 +192,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkSetDeviceDispatch(VkDevice device, void *object
     struct loader_device *dev;
     struct loader_icd_term *icd_term = loader_get_icd_and_device(device, &dev, NULL);
 
-    if (NULL == icd_term) {
+    if (NULL == icd_term || NULL == dev) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
     loader_set_dispatch(object, &dev->loader_dispatch);
@@ -3951,9 +3951,11 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL loader_gpa_device_terminator(VkDevice d
     // object before passing the appropriate info along to the ICD.
     // This is why we also have to override the direct ICD call to
     // vkGetDeviceProcAddr to intercept those calls.
-    PFN_vkVoidFunction addr = get_extension_device_proc_terminator(dev, pName);
-    if (NULL != addr) {
-        return addr;
+    if(NULL != dev) {
+        PFN_vkVoidFunction addr = get_extension_device_proc_terminator(dev, pName);
+        if (NULL != addr) {
+            return addr;
+        }
     }
 
     return icd_term->dispatch.GetDeviceProcAddr(device, pName);

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4307,8 +4307,7 @@ VKAPI_ATTR void VKAPI_CALL loader_layer_destroy_device(VkDevice device, const Vk
     const struct loader_instance *inst = icd_term->this_instance;
 
     destroyFunction(device, pAllocator);
-    if (NULL != dev)
-    {
+    if (NULL != dev) {
         dev->chain_device = NULL;
         dev->icd_device = NULL;
         loader_remove_logical_device(inst, icd_term, dev, pAllocator);

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4307,9 +4307,12 @@ VKAPI_ATTR void VKAPI_CALL loader_layer_destroy_device(VkDevice device, const Vk
     const struct loader_instance *inst = icd_term->this_instance;
 
     destroyFunction(device, pAllocator);
-    dev->chain_device = NULL;
-    dev->icd_device = NULL;
-    loader_remove_logical_device(inst, icd_term, dev, pAllocator);
+    if (NULL != dev)
+    {
+        dev->chain_device = NULL;
+        dev->icd_device = NULL;
+        loader_remove_logical_device(inst, icd_term, dev, pAllocator);
+    }
 }
 
 // Given the list of layers to activate in the loader_instance


### PR DESCRIPTION
My electron app crashed on vulkan.dll, then I found the dev pointer may be null but still be read.
![image](https://user-images.githubusercontent.com/34939113/197125162-793f0a63-8c45-4dfb-8edf-8ce517eaa5b9.png)

From the call stack, we can see that it's calling `loader_get_icd_and_device`  to get `dev`, and the dev may be null

```
VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL loader_gpa_device_terminator(VkDevice device, const char *pName) {
struct loader_device *dev;
struct loader_icd_term *icd_term = loader_get_icd_and_device(device, &dev, NULL);
...
PFN_vkVoidFunction addr = get_extension_device_proc_terminator(dev, pName);
    if (NULL != addr) {
        return addr;
    }
return icd_term->dispatch.GetDeviceProcAddr(device, pName);
}

PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *dev, const char *pName) {
    PFN_vkVoidFunction addr = NULL;

    // ---- VK_KHR_swapchain extension commands
    if (dev->extensions.khr_swapchain_enabled) {
        if(!strcmp(pName, "vkCreateSwapchainKHR")) {
            addr = (PFN_vkVoidFunction)terminator_CreateSwapchainKHR;
        } else if(!strcmp(pName, "vkGetDeviceGroupSurfacePresentModesKHR")) {
            addr = (PFN_vkVoidFunction)terminator_GetDeviceGroupSurfacePresentModesKHR;
        }
    }

    // ---- VK_KHR_display_swapchain extension commands
    if (dev->extensions.khr_display_swapchain_enabled) {
        if(!strcmp(pName, "vkCreateSharedSwapchainsKHR")) {
            addr = (PFN_vkVoidFunction)terminator_CreateSharedSwapchainsKHR;
        }
    }
   ...
}

```

then the `dev` be used in `get_extension_device_proc_terminator`  and causes the app to crash.


**Solution:**

I think we may add the null pointer checking here.

```
PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *dev, const char *pName) {
    PFN_vkVoidFunction addr = NULL;

    if (dev == NULL)
    {
        return addr;
    }
    ...
```

