### PR TITLE
Re-add asm offset execution & Update BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,33 +4,64 @@ Instructions for building this repository on Linux, Windows, and MacOS.
 
 ## Table Of Contents
 
-- [Contributing to the Repository](#contributing-to-the-repository)
-- [Repository Content](#repository-content)
-  - [Installed Files](#installed-files)
-- [Repository Set-Up](#repository-set-up)
-  - [Display Drivers](#display-drivers)
-  - [Download the Repository](#download-the-repository)
-  - [Repository Dependencies](#repository-dependencies)
-  - [Build and Install Directories](#build-and-install-directories)
-  - [Building Dependent Repositories with Known-Good Revisions](#building-dependent-repositories-with-known-good-revisions)
-  - [Generated source code](#generated-source-code)
-  - [Build Options](#build-options)
-- [Building On Windows](#building-on-windows)
-  - [Windows Development Environment Requirements](#windows-development-environment-requirements)
-  - [Windows Build - Microsoft Visual Studio](#windows-build---microsoft-visual-studio)
-  - [Windows Notes](#windows-notes)
-    - [CMake Visual Studio Generators](#cmake-visual-studio-generators)
-    - [Using The Vulkan Loader Library in this Repository on Windows](#using-the-vulkan-loader-library-in-this-repository-on-windows)
-- [Building On Linux](#building-on-linux)
-  - [Linux Development Environment Requirements](#linux-development-environment-requirements)
-  - [Linux Build](#linux-build)
-- [Building on MacOS](#building-on-macos)
-  - [MacOS Development Environment Requirements](#macos-development-environment-requirements)
-  - [Clone the Repository](#clone-the-repository)
-  - [MacOS build](#macos-build)
-- [Building on Fuchsia](#building-on-fuchsia)
-- [Building on QNX](#building-on-qnx)
-  - [SDK Symbols](#sdk-symbols)
+- [Build Instructions](#build-instructions)
+  - [Table Of Contents](#table-of-contents)
+  - [Contributing to the Repository](#contributing-to-the-repository)
+  - [Repository Content](#repository-content)
+    - [Installed Files](#installed-files)
+  - [Repository Set-Up](#repository-set-up)
+    - [Display Drivers](#display-drivers)
+    - [Download the Repository](#download-the-repository)
+    - [Repository Dependencies](#repository-dependencies)
+      - [Vulkan-Headers](#vulkan-headers)
+      - [Test Dependencies](#test-dependencies)
+    - [Build and Install Directories](#build-and-install-directories)
+    - [Building Dependent Repositories with Known-Good Revisions](#building-dependent-repositories-with-known-good-revisions)
+      - [Manually](#manually)
+        - [Notes About the Manual Option](#notes-about-the-manual-option)
+      - [Automatically](#automatically)
+        - [Notes About the Automatic Option](#notes-about-the-automatic-option)
+    - [Generated source code](#generated-source-code)
+    - [Build Options](#build-options)
+  - [Building On Windows](#building-on-windows)
+    - [Windows Development Environment Requirements](#windows-development-environment-requirements)
+    - [Windows Build - Microsoft Visual Studio](#windows-build---microsoft-visual-studio)
+      - [Windows Quick Start](#windows-quick-start)
+      - [Use `CMake` to Create the Visual Studio Project Files](#use-cmake-to-create-the-visual-studio-project-files)
+      - [Build the Solution From the Command Line](#build-the-solution-from-the-command-line)
+      - [Build the Solution With Visual Studio](#build-the-solution-with-visual-studio)
+      - [Windows Install Target](#windows-install-target)
+    - [Windows Notes](#windows-notes)
+      - [Using The Vulkan Loader Library in this Repository on Windows](#using-the-vulkan-loader-library-in-this-repository-on-windows)
+  - [Building On Linux](#building-on-linux)
+    - [Linux Development Environment Requirements](#linux-development-environment-requirements)
+      - [Required Package List](#required-package-list)
+    - [Linux Build](#linux-build)
+      - [Linux Quick Start](#linux-quick-start)
+      - [Use CMake to Create the Make Files](#use-cmake-to-create-the-make-files)
+      - [Build the Project](#build-the-project)
+    - [Linux Notes](#linux-notes)
+      - [Using The Vulkan Loader Library in this Repository on Linux](#using-the-vulkan-loader-library-in-this-repository-on-linux)
+      - [WSI Support Build Options](#wsi-support-build-options)
+      - [Linux Install to System Directories](#linux-install-to-system-directories)
+      - [Linux Uninstall](#linux-uninstall)
+      - [Linux 32-bit support](#linux-32-bit-support)
+  - [Building on MacOS](#building-on-macos)
+    - [MacOS Development Environment Requirements](#macos-development-environment-requirements)
+    - [Clone the Repository](#clone-the-repository)
+    - [MacOS build](#macos-build)
+      - [CMake Generators](#cmake-generators)
+      - [Building with the Unix Makefiles Generator](#building-with-the-unix-makefiles-generator)
+      - [Building with the Xcode Generator](#building-with-the-xcode-generator)
+    - [Using the new macOS loader](#using-the-new-macos-loader)
+  - [Building on Fuchsia](#building-on-fuchsia)
+  - [Building on QNX](#building-on-qnx)
+    - [SDK Symbols](#sdk-symbols)
+  - [Cross Compilation](#cross-compilation)
+    - [Unknown function handling which requires explicit assembly implementations](#unknown-function-handling-which-requires-explicit-assembly-implementations)
+      - [Platforms which fully support unknown function handling](#platforms-which-fully-support-unknown-function-handling)
+    - [Link Time Optimization](#link-time-optimization)
+  - [Tests](#tests)
 
 
 ## Contributing to the Repository
@@ -226,11 +257,11 @@ on/off options currently supported by this repository:
 | BUILD_STATIC_LOADER          | macOS    | `OFF`   | This allows the loader to be built as a static library on macOS. Not tested, use at your own risk.                                                                                |
 The following is a table of all string options currently supported by this repository:
 
-| Option                      | Platform    | Default                       | Description                                                                                                                                          |
-| --------------------------- | ----------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| FALLBACK_CONFIG_DIRS        | Linux/MacOS | `/etc/xdg`                    | Configuration path(s) to use instead of `XDG_CONFIG_DIRS` if that environment variable is unavailable. The default setting is freedesktop compliant. |
-| FALLBACK_DATA_DIRS          | Linux/MacOS | `/usr/local/share:/usr/share` | Configuration path(s) to use instead of `XDG_DATA_DIRS` if that environment variable is unavailable. The default setting is freedesktop compliant.   |
-| BUILD_DLL_VERSIONINFO       | Windows     | `""` (empty string)           | Allows setting the Windows specific version information for the Loader DLL. Format is "major.minor.patch.build".                                     |
+| Option                | Platform    | Default                       | Description                                                                                                                                          |
+| --------------------- | ----------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FALLBACK_CONFIG_DIRS  | Linux/MacOS | `/etc/xdg`                    | Configuration path(s) to use instead of `XDG_CONFIG_DIRS` if that environment variable is unavailable. The default setting is freedesktop compliant. |
+| FALLBACK_DATA_DIRS    | Linux/MacOS | `/usr/local/share:/usr/share` | Configuration path(s) to use instead of `XDG_DATA_DIRS` if that environment variable is unavailable. The default setting is freedesktop compliant.   |
+| BUILD_DLL_VERSIONINFO | Windows     | `""` (empty string)           | Allows setting the Windows specific version information for the Loader DLL. Format is "major.minor.patch.build".                                     |
 
 These variables should be set using the `-D` option when invoking CMake to generate the native platform files.
 
@@ -242,9 +273,8 @@ These variables should be set using the `-D` option when invoking CMake to gener
   - Any Personal Computer version supported by Microsoft
 - Microsoft [Visual Studio](https://www.visualstudio.com/)
   - Versions
-    - [2015](https://www.visualstudio.com/vs/older-downloads/)
-    - [2017](https://www.visualstudio.com/vs/older-downloads/)
-    - [2019](https://www.visualstudio.com/vs/downloads/)
+    - [2022](https://www.visualstudio.com/vs/downloads/)
+    - [2017 & 2019](https://www.visualstudio.com/vs/older-downloads/)
   - The Community Edition of each of the above versions is sufficient, as
     well as any more capable edition.
 - [CMake 3.10.2](https://cmake.org/files/v3.10/cmake-3.10.2-win64-x64.zip) is recommended.
@@ -270,17 +300,13 @@ Open a developer command prompt and enter:
     cd Vulkan-Loader
     mkdir build
     cd build
-    cmake -A x64 -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir ..
+    cmake -A x64 -DUPDATE_DEPS=ON ..
     cmake --build .
 
 The above commands instruct CMake to find and use the default Visual Studio
 installation to generate a Visual Studio solution and projects for the x64
 architecture. The second CMake command builds the Debug (default)
 configuration of the solution.
-
-Note that if you do not wish to use a developer command prompt, you may either
-run either `vcvars64.bat` or `vcvars32.bat` to set the required environment
-variables.
 
 #### Use `CMake` to Create the Visual Studio Project Files
 
@@ -290,26 +316,25 @@ create a build directory and generate the Visual Studio project files:
     cd Vulkan-Loader
     mkdir build
     cd build
-    cmake -A x64 -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir ..
+    cmake -DUPDATE_DEPS=ON -G "Visual Studio 16 2019" -A x64 ..
 
 > Note: The `..` parameter tells `cmake` the location of the top of the
 > repository. If you place your build directory someplace else, you'll need to
-> specify the location of the repository top differently.
+> specify the location of the repository differently.
 
-The `-A` option is used to select either the "Win32" or "x64" architecture.
+The `-G` option is used to select the generator
 
-If a generator for a specific version of Visual Studio is required, you can
-specify it for Visual Studio 2015, for example, with:
+Supported Visual Studio generators:
+* `Visual Studio 17 2022`
+* `Visual Studio 16 2019`
+* `Visual Studio 15 2017`
 
-    64-bit: -G "Visual Studio 14 2015 Win64"
-    32-bit: -G "Visual Studio 14 2015"
-
-See this [list](#cmake-visual-studio-generators) of other possible generators
-for Visual Studio.
+The `-A` option is used to select either the "Win32", "x64", or "ARM64 architecture.
 
 When generating the project files, the absolute path to a Vulkan-Headers
-install directory must be provided. This can be done by setting the
-`VULKAN_HEADERS_INSTALL_DIR` environment variable or by setting the
+install directory must be provided. This can be done automatically by the
+`-DUPDATE_DEPS=ON` option, by directly setting the
+`VULKAN_HEADERS_INSTALL_DIR` environment variable, or by setting the
 `VULKAN_HEADERS_INSTALL_DIR` CMake variable with the `-D` CMake option. In
 either case, the variable should point to the installation directory of a
 Vulkan-Headers repository built with the install target.
@@ -356,47 +381,8 @@ You can build the install target from the command line with:
 
 or build the `INSTALL` target from the Visual Studio solution explorer.
 
-### Windows Tests
-
-The Vulkan-Loader repository contains some simple unit tests for the loader
-but no other test clients.
-
-To run the loader test script, open a Powershell Console, change to the
-`build\tests` directory, and run:
-
-For Release builds:
-
-    .\run_all_tests.ps1
-
-For Debug builds:
-
-    .\run_all_tests.ps1 -Debug
-
-This script will run the following tests:
-
-- `vk_loader_validation_tests`:
-  Vulkan loader handle wrapping, allocation callback, and loader/layer interface tests
-
-You can also change to either `build\tests\Debug` or `build\tests\Release`
-(depending on which one you built) and run the executable tests (`*.exe`)
-files from there.
 
 ### Windows Notes
-
-#### CMake Visual Studio Generators
-
-The chosen generator should match one of the Visual Studio versions that you
-have installed. Generator strings that correspond to versions of Visual Studio
-include:
-
-| Build Platform               | 64-bit Generator              | 32-bit Generator        |
-| ---------------------------- | ----------------------------- | ----------------------- |
-| Microsoft Visual Studio 2015 | "Visual Studio 14 2015 Win64" | "Visual Studio 14 2015" |
-| Microsoft Visual Studio 2017 | "Visual Studio 15 2017 Win64" | "Visual Studio 15 2017" |
-| Microsoft Visual Studio 2019 | "Visual Studio 16 2019"       | "Visual Studio 16 2019" |
-
-Note that with Visual Studio 2019, the architecture will need to be specified with the `-A`
-flag for 64-bit builds.
 
 #### Using The Vulkan Loader Library in this Repository on Windows
 
@@ -407,14 +393,13 @@ directory as the program. The projects in this solution copy the Vulkan loader
 library and the "googletest" libraries to the `build\tests\Debug` or the
 `build\tests\Release` directory, which is where the
 `vk_loader_validation_test.exe` executable is found, depending on what
-configuration you built. (The loader validation tests use the "googletest"
-testing framework.)
+configuration you built.
 
 Other techniques include placing the library in a system folder
 (C:\Windows\System32) or in a directory that appears in the `PATH` environment
 variable.
 
-See the `LoaderAndLayerInterface` document in the `loader` folder in this
+See the documentation in the `docs` folder in this
 repository for more information on how the loader finds driver libraries and
 layer libraries. The document also describes both how ICDs and layers should
 be packaged, and how developers can point to ICDs and layers within their
@@ -425,7 +410,7 @@ builds.
 ### Linux Development Environment Requirements
 
 This repository has been built and tested on the two most recent Ubuntu LTS
-versions. Currently, the oldest supported version is Ubuntu 16.04, meaning
+versions. Currently, the oldest supported version is Ubuntu 18.04, meaning
 that the minimum officially supported C++11 compiler version is GCC 5.4.0,
 although earlier versions may work. It should be straightforward to adapt this
 repository to other Linux distributions.
@@ -447,7 +432,7 @@ CMake with the `--build` option or `make` to build from the command line.
     cd Vulkan-Loader
     mkdir build
     cd build
-    cmake -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir ..
+    cmake -DUPDATE_DEPS=ON ..
     make
 
 See below for the details.
@@ -471,8 +456,9 @@ create a build directory and generate the make files.
 Use `-DCMAKE_BUILD_TYPE` to specify a Debug or Release build.
 
 When generating the project files, the absolute path to a Vulkan-Headers
-install directory must be provided. This can be done by setting the
-`VULKAN_HEADERS_INSTALL_DIR` environment variable or by setting the
+install directory must be provided. This can be done automatically by the
+`-DUPDATE_DEPS=ON` option, by directly setting the
+`VULKAN_HEADERS_INSTALL_DIR` environment variable, or by setting the
 `VULKAN_HEADERS_INSTALL_DIR` CMake variable with the `-D` CMake option. In
 either case, the variable should point to the installation directory of a
 Vulkan-Headers repository built with the install target.
@@ -502,13 +488,7 @@ If your build system supports ccache, you can enable that via CMake option
 
 #### Using The Vulkan Loader Library in this Repository on Linux
 
-The `vk_loader_validation_tests` executable is linked with an RPATH setting to
-allow it to find the Vulkan loader library in the repository's build
-directory. This allows the test executable to run and find this Vulkan loader
-library without installing the loader library to a directory searched by the
-system loader or in the `LD_LIBRARY_PATH`.
-
-If you want to test a Vulkan application that is not built within this
+If you want to run a Vulkan application that is not built within this
 repository with the loader you just built from this repository, you can direct
 the application to load it from your build directory:
 
@@ -587,19 +567,6 @@ To uninstall the files from the system directories, you can execute:
 
     sudo make uninstall
 
-#### Linux Tests
-
-The Vulkan-Loader repository contains some simple unit tests for the loader
-but no other test clients.
-
-To run the loader test script, change to the `build/tests` directory, and run:
-
-    ./run_all_tests.sh
-
-This script will run the following tests:
-
-- `vk_loader_validation_tests`: Vulkan loader handle wrapping, allocation
-  callback, and loader/layer interface tests
 
 #### Linux 32-bit support
 
@@ -676,15 +643,16 @@ this repository are:
 This generator is the default generator.
 
 When generating the project files, the absolute path to a Vulkan-Headers
-install directory must be provided. This can be done by setting the
-`VULKAN_HEADERS_INSTALL_DIR` environment variable or by setting the
+install directory must be provided. This can be done automatically by the
+`-DUPDATE_DEPS=ON` option, by directly setting the
+`VULKAN_HEADERS_INSTALL_DIR` environment variable, or by setting the
 `VULKAN_HEADERS_INSTALL_DIR` CMake variable with the `-D` CMake option. In
 either case, the variable should point to the installation directory of a
 Vulkan-Headers repository built with the install target.
 
     mkdir build
     cd build
-    cmake -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir -DCMAKE_BUILD_TYPE=Debug ..
+    cmake -DUPDATE_DEPS=ON -DVULKAN_HEADERS_INSTALL_DIR=absolute_path_to_install_dir -DCMAKE_BUILD_TYPE=Debug ..
     make
 
 To speed up the build on a multi-core machine, use the `-j` option for `make`
@@ -711,23 +679,6 @@ can direct the application to load it from your build directory:
 
     export DYLD_LIBRARY_PATH=<path to your repository>/build/loader
 
-### MacOS Tests
-
-The Vulkan-Loader repository contains some simple unit tests for the loader
-but no other test clients.
-
-Before you run these tests, you will need to clone and build the
-[MoltenVK](https://github.com/KhronosGroup/MoltenVK) repository.
-
-You will also need to direct your new loader to the MoltenVK ICD:
-
-    export VK_DRIVER_FILES=<path to MoltenVK repository>/Package/Latest/MoltenVK/macOS/MoltenVK_icd.json
-
-To run the loader test script, change to the `build/tests` directory in your
-Vulkan-Loader repository, and run:
-
-    ./vk_loader_validation_tests
-
 ## Building on Fuchsia
 
 Fuchsia uses the project's GN build system to integrate with the Fuchsia platform build.
@@ -745,3 +696,40 @@ It will build the ICD loader for all CPU targets supported by QNX.
 
 The Vulkan Loader is a component of the Fuchsia SDK, so it must explicitly declare its exported symbols in
 the file vulkan.symbols.api; see [SDK](https://fuchsia.dev/fuchsia-src/development/sdk).
+
+## Cross Compilation
+
+While this repo is capable of cross compilation, there are a handful of caveats.
+
+### Unknown function handling which requires explicit assembly implementations
+
+Unknown function handling is only fully supported on select platforms due to the
+need for assembly in the implementation. Other platforms will need to disable
+assembly by setting `USE_GAS` or `USE_MASM` to `OFF`.
+#### Platforms which fully support unknown function handling
+
+* 64 bit Windows (x64)
+* 32 bit Windows (x86)
+* 64 bit Linux (x64)
+* 32 bit Linux (x86)
+* 64 bit Arm (aarch64)
+
+Platforms not listed will use a fallback C Code path that relies on tail-call optimization to work.
+No guarantees are made about the use of the fallback code paths.
+
+### Link Time Optimization
+
+When cross compiling, the use of Link Time Optimization (LTO) and unknown function handling
+is not supported. Either LTO needs to be turned off, or the assembly should be disabled.
+
+## Tests
+
+To build tests, make sure that the `BUILD_TESTS` option is set to true. Using
+the command line, this looks like `-DBUILD_TESTS=ON`.
+
+This project is configured to run with `ctest`, which makes it easy to run the
+tests. To run the tests, change the directory to that of the build direction, and
+execute `ctest`.
+
+More details can be found in the [README.md](./tests/README.md) for the tests
+directory of this project.

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -158,18 +158,25 @@ if(WIN32)
 
         add_executable(asm_offset asm_offset.c)
         target_link_libraries(asm_offset PRIVATE loader_specific_options)
-        # Forces compiler to write the intermediate asm file, needed so that we can get sizeof/offset of info out of it.
-        target_compile_options(asm_offset PRIVATE "/Fa$<TARGET_FILE_DIR:asm_offset>/asm_offset.asm" /FA)
-        # Force off optimization so that the output assembly includes all the necessary info - optimizer would get rid of it otherwise.
-        target_compile_options(asm_offset PRIVATE /Od)
+        # If not cross compiling, run asm_offset to generage gen_defines.asm
+        if (NOT CMAKE_CROSSCOMPILING)
+            add_custom_command(TARGET asm_offset POST_BUILD
+                COMMAND asm_offset MASM
+                BYPRODUCTS gen_defines.asm)
+        else()
+            # Forces compiler to write the intermediate asm file, needed so that we can get sizeof/offset of info out of it.
+            target_compile_options(asm_offset PRIVATE "/Fa$<TARGET_FILE_DIR:asm_offset>/asm_offset.asm" /FA)
+            # Force off optimization so that the output assembly includes all the necessary info - optimizer would get rid of it otherwise.
+            target_compile_options(asm_offset PRIVATE /Od)
 
-        find_package(PythonInterp REQUIRED)
-        # Run parse_asm_values.py on asm_offset's assembly file to generate the gen_defines.asm, which the asm code depends on
-        add_custom_command(TARGET asm_offset POST_BUILD
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/parse_asm_values.py "${CMAKE_CURRENT_BINARY_DIR}/gen_defines.asm"
-                "$<TARGET_FILE_DIR:asm_offset>/asm_offset.asm" "MASM" "${CMAKE_CXX_COMPILER_ID}" "${CMAKE_SYSTEM_PROCESSOR}"
-            BYPRODUCTS gen_defines.asm
-            )
+            find_package(PythonInterp REQUIRED)
+            # Run parse_asm_values.py on asm_offset's assembly file to generate the gen_defines.asm, which the asm code depends on
+            add_custom_command(TARGET asm_offset POST_BUILD
+                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/parse_asm_values.py "${CMAKE_CURRENT_BINARY_DIR}/gen_defines.asm"
+                    "$<TARGET_FILE_DIR:asm_offset>/asm_offset.asm" "MASM" "${CMAKE_CXX_COMPILER_ID}" "${CMAKE_SYSTEM_PROCESSOR}"
+                BYPRODUCTS gen_defines.asm
+                )
+        endif()
         add_custom_target(loader_asm_gen_files DEPENDS gen_defines.asm)
         set_target_properties(loader_asm_gen_files PROPERTIES FOLDER ${LOADER_HELPER_FOLDER})
 
@@ -216,23 +223,30 @@ else() # i.e.: Linux
     endif()
 
     if(ASSEMBLER_WORKS)
-        add_library(asm_offset STATIC asm_offset.c)
+        add_executable(asm_offset asm_offset.c)
         target_link_libraries(asm_offset loader_specific_options)
-        # Forces compiler to write the intermediate asm file, needed so that we can get sizeof/offset of info out of it.
-        target_compile_options(asm_offset PRIVATE -save-temps=obj)
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-            set(ASM_OFFSET_INTERMEDIATE_LOCATION "$<TARGET_FILE_DIR:asm_offset>/CMakeFiles/asm_offset.dir/asm_offset.c.s")
-        elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-            set(ASM_OFFSET_INTERMEDIATE_LOCATION "$<TARGET_FILE_DIR:asm_offset>/CMakeFiles/asm_offset.dir/asm_offset.s")
-        endif()
+        # If not cross compiling, run asm_offset to generage gen_defines.asm
+        if (NOT CMAKE_CROSSCOMPILING)
+            add_custom_command(TARGET asm_offset POST_BUILD
+                COMMAND asm_offset GAS
+                BYPRODUCTS gen_defines.asm)
+        else()
+            # Forces compiler to write the intermediate asm file, needed so that we can get sizeof/offset of info out of it.
+            target_compile_options(asm_offset PRIVATE -save-temps=obj)
+            if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+                set(ASM_OFFSET_INTERMEDIATE_LOCATION "$<TARGET_FILE_DIR:asm_offset>/CMakeFiles/asm_offset.dir/asm_offset.c.s")
+            elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+                set(ASM_OFFSET_INTERMEDIATE_LOCATION "$<TARGET_FILE_DIR:asm_offset>/CMakeFiles/asm_offset.dir/asm_offset.s")
+            endif()
 
-        find_package(PythonInterp REQUIRED)
-        # Run parse_asm_values.py on asm_offset's assembly file to generate the gen_defines.asm, which the asm code depends on
-        add_custom_command(TARGET asm_offset POST_BUILD
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/parse_asm_values.py "$<TARGET_FILE_DIR:asm_offset>/gen_defines.asm"
-                "${ASM_OFFSET_INTERMEDIATE_LOCATION}" "GAS" "${CMAKE_CXX_COMPILER_ID}" "${CMAKE_SYSTEM_PROCESSOR}"
-            BYPRODUCTS gen_defines.asm
-            )
+            find_package(PythonInterp REQUIRED)
+            # Run parse_asm_values.py on asm_offset's assembly file to generate the gen_defines.asm, which the asm code depends on
+            add_custom_command(TARGET asm_offset POST_BUILD
+                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/parse_asm_values.py "$<TARGET_FILE_DIR:asm_offset>/gen_defines.asm"
+                    "${ASM_OFFSET_INTERMEDIATE_LOCATION}" "GAS" "${CMAKE_CXX_COMPILER_ID}" "${CMAKE_SYSTEM_PROCESSOR}"
+                BYPRODUCTS gen_defines.asm
+                )
+        endif()
         add_custom_target(loader_asm_gen_files DEPENDS gen_defines.asm)
     else()
         if(USE_GAS)

--- a/loader/asm_offset.c
+++ b/loader/asm_offset.c
@@ -68,6 +68,71 @@ struct ValueInfo {
     const char *comment;
 };
 
-// This file is not intended to be executed, as the generated asm contains all the relevant data which
-// the parse_asm_values.py script needs to write gen_defines.asm
-int main(int argc, char **argv) { return 0; }
+// This file can both be executed to produce gen_defines.asm and contains all the relevant data which
+// the parse_asm_values.py script needs to write gen_defines.asm, necessary for cross compilation
+int main(int argc, char **argv) {
+    const char *assembler = NULL;
+    for (int i = 0; i < argc; ++i) {
+        if (!strcmp(argv[i], "MASM")) {
+            assembler = "MASM";
+        } else if (!strcmp(argv[i], "GAS")) {
+            assembler = "GAS";
+        }
+    }
+    if (assembler == NULL) {
+        return 1;
+    }
+
+    struct ValueInfo values[] = {
+        // clang-format off
+        { .name = "VULKAN_LOADER_ERROR_BIT", .value = (size_t) VULKAN_LOADER_ERROR_BIT,
+            .comment = "The numerical value of the enum value 'VULKAN_LOADER_ERROR_BIT'" },
+        { .name = "PTR_SIZE", .value = sizeof(void*),
+            .comment = "The size of a pointer" },
+        { .name = "CHAR_PTR_SIZE", .value = sizeof(char *),
+            .comment = "The size of a 'const char *' struct" },
+        { .name = "FUNCTION_OFFSET_INSTANCE", .value = offsetof(struct loader_instance, phys_dev_ext_disp_functions),
+            .comment = "The offset of 'phys_dev_ext_disp_functions' within a 'loader_instance' struct" },
+        { .name = "PHYS_DEV_OFFSET_INST_DISPATCH", .value = offsetof(struct loader_instance_dispatch_table, phys_dev_ext),
+            .comment = "The offset of 'phys_dev_ext' within in 'loader_instance_dispatch_table' struct" },
+        { .name = "PHYS_DEV_OFFSET_PHYS_DEV_TRAMP", .value = offsetof(struct loader_physical_device_tramp, phys_dev),
+            .comment = "The offset of 'phys_dev' within a 'loader_physical_device_tramp' struct" },
+        { .name = "ICD_TERM_OFFSET_PHYS_DEV_TERM", .value = offsetof(struct loader_physical_device_term, this_icd_term),
+            .comment = "The offset of 'this_icd_term' within a 'loader_physical_device_term' struct" },
+        { .name = "PHYS_DEV_OFFSET_PHYS_DEV_TERM", .value = offsetof(struct loader_physical_device_term, phys_dev),
+            .comment = "The offset of 'phys_dev' within a 'loader_physical_device_term' struct" },
+        { .name = "INSTANCE_OFFSET_ICD_TERM", .value = offsetof(struct loader_icd_term, this_instance),
+            .comment = "The offset of 'this_instance' within a 'loader_icd_term' struct" },
+        { .name = "DISPATCH_OFFSET_ICD_TERM", .value = offsetof(struct loader_icd_term, phys_dev_ext),
+            .comment = "The offset of 'phys_dev_ext' within a 'loader_icd_term' struct" },
+        { .name = "EXT_OFFSET_DEVICE_DISPATCH", .value = offsetof(struct loader_dev_dispatch_table, ext_dispatch),
+            .comment = "The offset of 'ext_dispatch' within a 'loader_dev_dispatch_table' struct" },
+        // clang-format on
+    };
+
+    FILE *file = fopen("gen_defines.asm", "w");
+    fprintf(file, "\n");
+    if (!strcmp(assembler, "MASM")) {
+        for (size_t i = 0; i < sizeof(values) / sizeof(values[0]); ++i) {
+            fprintf(file, "%-32s equ " SIZE_T_FMT "; %s\n", values[i].name, values[i].value, values[i].comment);
+        }
+    } else if (!strcmp(assembler, "GAS")) {
+#if defined(__x86_64__) || defined(__i386__)
+        const char *comment_delimiter = "#";
+#if defined(__x86_64__)
+        fprintf(file, ".set X86_64, 1\n");
+#endif  // defined(__x86_64__)
+#elif defined(__aarch64__)
+        const char *comment_delimiter = "//";
+        fprintf(file, ".set AARCH_64, 1\n");
+#else
+        // Default comment delimiter
+        const char *comment_delimiter = "#";
+#endif
+        for (size_t i = 0; i < sizeof(values) / sizeof(values[0]); ++i) {
+            fprintf(file, ".set %-32s, " SIZE_T_FMT "%s %s\n", values[i].name, values[i].value, comment_delimiter,
+                    values[i].comment);
+        }
+    }
+    return fclose(file);
+}


### PR DESCRIPTION
The cross compiling workaround for asm_offset requires python, but this meant
that all builds required python. This commit re-adds the removed asm_offset
logic and then only requires python during cross compilation.