### PR TITLE
Remove override layer expiration

### DIFF
--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -99,14 +99,6 @@ struct loader_layer_functions {
     PFN_GetPhysicalDeviceProcAddr get_physical_device_proc_addr;
 };
 
-struct loader_override_expiration {
-    uint16_t year;
-    uint8_t month;
-    uint8_t day;
-    uint8_t hour;
-    uint8_t minute;
-};
-
 // This structure is used to store the json file version in a more manageable way.
 typedef struct {
     uint16_t major;
@@ -153,8 +145,6 @@ struct loader_layer_properties {
     uint32_t num_override_paths;
     char (*override_paths)[MAX_STRING_SIZE];
     bool is_override;
-    bool has_expiration;
-    struct loader_override_expiration expiration;
     bool keep;
     uint32_t num_blacklist_layers;
     char (*blacklist_layer_names)[MAX_STRING_SIZE];


### PR DESCRIPTION
This was an undocumented feature of the override manifest layer. Since vkconfig is the primary user of the override layer, and vkconfig makes no effort to include expiration support, this feature is not being used. Thus, it is best to remove it entirely.

@christophe-lunarg This is a feature that just isn't very useful. I would like to remove it from the loader, but would like your approval, as if you would like to see this feature stay I should know before removing it, not after. 

The gist of the feature is an automatic 'time out' where a layer with an expiration date that has elapsed will no longer be loaded. 