### PR TITLE
Recheck API version in terminator_CreateInstance

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4981,6 +4981,16 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateInstance(const VkInstanceCreateI
                    ptr_instance->magic);
     }
 
+    // Save the application version if it has been modified - layers sometimes needs features in newer API versions than
+    // what the application requested, and thus will increase the instance version to a level that suites their needs.
+    if (pCreateInfo->pApplicationInfo && pCreateInfo->pApplicationInfo->apiVersion) {
+        loader_api_version altered_version = loader_make_version(pCreateInfo->pApplicationInfo->apiVersion);
+        if (altered_version.major != ptr_instance->app_api_version.major ||
+            altered_version.minor != ptr_instance->app_api_version.minor) {
+            ptr_instance->app_api_version = altered_version;
+        }
+    }
+
     memcpy(&icd_create_info, pCreateInfo, sizeof(icd_create_info));
 
     icd_create_info.enabledLayerCount = 0;

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -102,6 +102,9 @@ struct TestLayer {
     BUILDER_VALUE(TestLayer, uint32_t, min_implementation_version, 0)
     BUILDER_VALUE(TestLayer, std::string, description, {})
 
+    // Some layers may try to change the API version during instance creation - we should allow testing of such behavior
+    BUILDER_VALUE(TestLayer, uint32_t, alter_api_version, VK_API_VERSION_1_0)
+
     BUILDER_VECTOR(TestLayer, std::string, alternative_function_names, alternative_function_name)
 
     BUILDER_VECTOR(TestLayer, Extension, instance_extensions, instance_extension)


### PR DESCRIPTION
Layers are liable of changing the API version during the call down vkCreateInstance. Certain layers use the guarantees of 1.1 to allow using VK_KHR_get_physical_device_properties2 functionality. This commit checks and assignes a new API version if it was modified.

Add tests for when the application forgets to enable 1.1 and when a layer enabled 1.1 on behalf of the application.

Fixes #1055 