### PR TITLE
Layers: test to see if VK_LAYER_PATH already accepts explicit files

### DIFF
--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -285,6 +285,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyLayerEnvVar) {
     set_env_var("HOME", HOME.str());
     std::string vk_layer_path = ":/tmp/carol::::/:";
     vk_layer_path += (HOME / "/ with spaces/:::::/tandy:").str();
+    vk_layer_path += "/tmp/evan/1.json:/tmp/evan/2.json";
     set_env_var("VK_LAYER_PATH", vk_layer_path);
     EnvVarCleaner layer_path_cleaner("VK_LAYER_PATH");
     InstWrapper inst1{env.vulkan_functions};
@@ -296,6 +297,8 @@ TEST(EnvVarICDOverrideSetup, TestOnlyLayerEnvVar) {
     EXPECT_TRUE(env.debug_log.find("/tmp/carol"));
     EXPECT_TRUE(env.debug_log.find("/tandy"));
     EXPECT_TRUE(env.debug_log.find((HOME / "/ with spaces/").str()));
+    EXPECT_TRUE(env.debug_log.find("/tmp/evan/1.json"));
+    EXPECT_TRUE(env.debug_log.find("/tmp/evan/2.json"));
 
     env.debug_log.clear();
 


### PR DESCRIPTION
The test cases added passes. It seems like this provides the desired behavior mentioned in https://github.com/KhronosGroup/Vulkan-Loader/issues/154