### PR TITLE
Use integrity_level >= HIGH for is_high_integrity

### DIFF
--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -100,7 +100,7 @@ bool is_high_integrity() {
             const DWORD integrity_level = *GetSidSubAuthority(mandatory_label->Label.Sid, sub_authority_count - 1);
 
             CloseHandle(process_token);
-            return integrity_level > SECURITY_MANDATORY_MEDIUM_RID;
+            return integrity_level >= SECURITY_MANDATORY_HIGH_RID;
         }
 
         CloseHandle(process_token);


### PR DESCRIPTION
Previously it used integrity_level > MEDIUM, which causes issues since occasionally windows elevates certain regular user mode processes to be MEDIUM + 0x100 or similar, causing the `is_high_integrity()` to return true even though it isn't an admin level process.

Fixes #814 