### PR TITLE
loader: Add ability for layers to require instance extensions

### DIFF
--- a/docs/LoaderLayerInterface.md
+++ b/docs/LoaderLayerInterface.md
@@ -1721,6 +1721,16 @@ Here's an example of a meta-layer manifest file:
     <td><small>N/A</small></td>
   </tr>
   <tr>
+    <td>"required_instance_extensions"</td>
+    <td><b>OPTIONAL:</b> Contains the list of instance extension names required
+        by this layer. Extension names in this list will function as if they
+        were appended to VkInstanceCreateInfo::ppEnabledExtensionNames.
+    </td>
+    <td>None</td>
+    <td>"layer"/"layers"</td>
+    <td><small>N/A</small></td>
+  </tr>
+  <tr>
     <td>"enable_environment"</td>
     <td><b>OPTIONAL:</b> Indicates an environment variable used to enable the
         Implicit Layer (when defined to any non-empty string value).<br/>

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -149,6 +149,8 @@ struct loader_layer_properties {
     char (*blacklist_layer_names)[MAX_STRING_SIZE];
     uint32_t num_app_key_paths;
     char (*app_key_paths)[MAX_STRING_SIZE];
+    uint32_t num_required_instance_extensions;
+    char (*required_instance_extensions)[VK_MAX_EXTENSION_NAME_SIZE];
 };
 
 struct loader_layer_list {


### PR DESCRIPTION
This commit adds a new JSON entry called `required_instance_extensions` to the layer JSON.

It is an array of extension names that is required for the layer to function.

This is useful for layers requiring certain physical device/surface related extensions. For eg. wrapping one WSI to another or for getting surface/physical device properties only exposed by an instance extension that would be typically inaccessible if the primary application did not enable the layer at runtime.

Signed-off-by: Joshua Ashton <joshua@froggi.es>