### PR TITLE
loader: Mark unknown_ext_chain symbols as hidden

### DIFF
--- a/loader/unknown_ext_chain_gas_aarch64.S
+++ b/loader/unknown_ext_chain_gas_aarch64.S
@@ -27,6 +27,7 @@
 
 .macro PhysDevExtTramp num
 .global vkPhysDevExtTramp\num
+.hidden vkPhysDevExtTramp\num
 vkPhysDevExtTramp\num:
     ldr     x9, [x0]                                                 // Load the loader_instance_dispatch_table* into x9
     ldr     x0, [x0, PHYS_DEV_OFFSET_PHYS_DEV_TRAMP]                 // Load the unwrapped VkPhysicalDevice into x0
@@ -37,6 +38,7 @@ vkPhysDevExtTramp\num:
 
 .macro PhysDevExtTermin num
 .global vkPhysDevExtTermin\num
+.hidden vkPhysDevExtTermin\num
 vkPhysDevExtTermin\num:
     ldr     x9, [x0, ICD_TERM_OFFSET_PHYS_DEV_TERM]             // Load the loader_icd_term* in x9
     mov     x11, (DISPATCH_OFFSET_ICD_TERM + (PTR_SIZE * \num)) // Put the offset into the dispatch table in x11
@@ -60,6 +62,7 @@ terminError\num:
 
 .macro DevExtTramp num
 .global vkdev_ext\num
+.hidden vkdev_ext\num
 vkdev_ext\num:
     ldr     x9, [x0]                                              // Load the loader_instance_dispatch_table* into x9
     mov     x10, (EXT_OFFSET_DEVICE_DISPATCH + (PTR_SIZE * \num)) // Offset of the desired function in the dispatch table

--- a/loader/unknown_ext_chain_gas_x86.S
+++ b/loader/unknown_ext_chain_gas_x86.S
@@ -37,6 +37,7 @@
 
 .macro PhysDevExtTramp num
 .global vkPhysDevExtTramp\num
+.hidden vkPhysDevExtTramp\num
 vkPhysDevExtTramp\num:
     _CET_ENDBR
     mov     rax, [rdi]
@@ -46,6 +47,7 @@ vkPhysDevExtTramp\num:
 
 .macro PhysDevExtTermin num
 .global vkPhysDevExtTermin\num
+.hidden vkPhysDevExtTermin\num
 vkPhysDevExtTermin\num:
     _CET_ENDBR
     mov     rax, [rdi + ICD_TERM_OFFSET_PHYS_DEV_TERM]                          # Store the loader_icd_term* in rax
@@ -68,6 +70,7 @@ terminError\num:
 
 .macro DevExtTramp num
 .global vkdev_ext\num
+.hidden vkdev_ext\num
 vkdev_ext\num:
     _CET_ENDBR
     mov     rax, [rdi]                                                          # Dereference the handle to get the dispatch table
@@ -78,6 +81,7 @@ vkdev_ext\num:
 
 .macro PhysDevExtTramp num
 .global vkPhysDevExtTramp\num
+.hidden vkPhysDevExtTramp\num
 vkPhysDevExtTramp\num:
     _CET_ENDBR
     mov     eax, [esp + 4]                              # Load the wrapped VkPhysicalDevice into eax
@@ -89,6 +93,7 @@ vkPhysDevExtTramp\num:
 
 .macro PhysDevExtTermin num
 .global vkPhysDevExtTermin\num
+.hidden vkPhysDevExtTermin\num
 vkPhysDevExtTermin\num:
     _CET_ENDBR
     mov     ecx, [esp + 4]                                                      # Move the wrapped VkPhysicalDevice into ecx
@@ -112,6 +117,7 @@ terminError\num:
 
 .macro DevExtTramp num
 .global vkdev_ext\num
+.hidden vkdev_ext\num
 vkdev_ext\num:
     _CET_ENDBR
     mov     eax, dword ptr [esp + 4]                                            # Dereference the handle to get the dispatch table


### PR DESCRIPTION
These don't need to be exported from the shared library, as they're just internal implementation details.

Closes #1079