### PR TITLE
Layers: add tests to verify VK_LAYER_PATH supports both directories and files 

### DIFF
--- a/docs/LoaderApplicationInterface.md
+++ b/docs/LoaderApplicationInterface.md
@@ -471,7 +471,7 @@ This can be accomplished in one of two ways:
  1. Selecting specific layer paths using the
 [VkConfig](https://github.com/LunarG/VulkanTools/blob/master/vkconfig/README.md)
 tool shipped with the Vulkan SDK.
- 2. Directing the loader to look for layers in specific folders by using the
+ 2. Directing the loader to look for layers in specific files and/or folders by using the
 `VK_LAYER_PATH` environment variable.
 
 The `VK_LAYER_PATH` environment variable can contain multiple paths separated by
@@ -479,7 +479,7 @@ the operating-system specific path separator.
 On Windows, this is a semicolon (`;`), while on Linux and macOS it is a colon
 (`:`).
 
-If `VK_LAYER_PATH` exists, the folders listed in it will be scanned for explicit
+If `VK_LAYER_PATH` exists, the files and/or folders listed will be scanned for explicit
 layer manifest files.
 Implicit layer discovery is unaffected by this environment variable.
 Each directory listed should be the full pathname of a folder containing layer

--- a/docs/LoaderDebugging.md
+++ b/docs/LoaderDebugging.md
@@ -99,7 +99,7 @@ the following:
 
 ```
 LAYER: Searching for layer manifest files
-LAYER:  In following folders:
+LAYER:  In following locations:
 LAYER:   /home/${USER}/.config/vulkan/implicit_layer.d
 LAYER:   /etc/xdg/vulkan/implicit_layer.d
 LAYER:   /usr/local/etc/vulkan/implicit_layer.d

--- a/docs/LoaderInterfaceArchitecture.md
+++ b/docs/LoaderInterfaceArchitecture.md
@@ -659,7 +659,7 @@ discovery.
         <i>VK_LAYER_PATH</i></small></td>
     <td><small>
         Override the loader's standard Layer library search folders and use the
-        provided delimited folders to search for explicit layer manifest files.
+        provided delimited file and/or folders to locate explicit layer manifest files.
     </small></td>
     <td><small>
         <a href="#elevated-privilege-caveats">

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3103,7 +3103,7 @@ static VkResult read_data_files_in_search_paths(const struct loader_instance *in
                 log_flags = VULKAN_LOADER_LAYER_BIT;
                 loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "Searching for layer manifest files");
             }
-            loader_log(inst, log_flags, 0, "   In following folders:");
+            loader_log(inst, log_flags, 0, "   In following locations:");
             char *cur_file;
             char *next_file = tmp_search_path;
             while (NULL != next_file && *next_file != '\0') {

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -456,6 +456,11 @@ void FrameworkEnvironment::add_layer_impl(TestLayerDetails layer_details, Manife
             if (!env_var_vk_layer_paths.empty()) {
                 env_var_vk_layer_paths += OS_ENV_VAR_LIST_SEPARATOR;
             }
+            if(layer_details.is_dir) {
+                env_var_vk_layer_paths += fs_ptr->location().str();
+            } else {
+                env_var_vk_layer_paths += fs_ptr->location().str() + OS_ENV_VAR_LIST_SEPARATOR + layer_details.json_name;
+            }
             env_var_vk_layer_paths += fs_ptr->location().str();
             set_env_var("VK_LAYER_PATH", env_var_vk_layer_paths);
             break;

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -477,6 +477,7 @@ struct TestLayerDetails {
     BUILDER_VALUE(TestLayerDetails, std::string, json_name, "test_layer");
     BUILDER_VALUE(TestLayerDetails, ManifestDiscoveryType, discovery_type, ManifestDiscoveryType::generic);
     BUILDER_VALUE(TestLayerDetails, bool, is_fake, false);
+    BUILDER_VALUE(TestLayerDetails, bool, is_dir, true);
 };
 
 enum class ManifestLocation {

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -2112,6 +2112,10 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
         ASSERT_EQ(count, 1U);
+
+        VkLayerProperties layer_props;
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
+        EXPECT_TRUE(string_eq(layer_props.layerName, regular_layer_name_1));
     }
     { 
         // verify layers load successfully when setting VK_LAYER_PATH to multiple full filepaths
@@ -2137,6 +2141,10 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
         ASSERT_EQ(count, 2U);
+
+        std::array<VkLayerProperties, 2> layer_props;
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
+        EXPECT_TRUE(check_permutation({regular_layer_name_1, regular_layer_name_2}, layer_props));
     }
     { 
         // verify layers load successfully when setting VK_LAYER_PATH to a directory
@@ -2162,6 +2170,10 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
         uint32_t count = 0;
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, nullptr);
         ASSERT_EQ(count, 2U);
+
+        std::array<VkLayerProperties, 2> layer_props;
+        env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
+        EXPECT_TRUE(check_permutation({regular_layer_name_1, regular_layer_name_2}, layer_props));
     }
 }
 

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -2096,26 +2096,17 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
 
-    const char* regular_layer_name_1 = "RegularLayer1";
-    env.add_explicit_layer(
+    { 
+        // verify layer loads successfully when setting VK_LAYER_PATH to a full filepath
+        const char* regular_layer_name_1 = "RegularLayer1";
+        env.add_explicit_layer(
+        TestLayerDetails(
             ManifestLayer{}.add_layer(
                 ManifestLayer::LayerDescription{}.set_name(regular_layer_name_1).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
-            "regular_layer_1.json");
+            "regular_layer_1.json").set_discovery_type(ManifestDiscoveryType::env_var).set_is_dir(false));
 
-
-
-    { 
-        // when overriding the search path to a non-existent file, instance should fail to create
         InstWrapper inst(env.vulkan_functions);
         inst.create_info.add_layer(regular_layer_name_1);
-        set_env_var("VK_LAYER_PATH", "/home/phish3y/dev/Vulkan-Loader/build/install/etc/vulkan/explicit_layer.d/regular_layer_2.json");
-        inst.CheckCreate(VK_ERROR_LAYER_NOT_PRESENT);
-    }
-    { 
-        // when overriding the search path to an existing file, count should be 1
-        InstWrapper inst(env.vulkan_functions);
-        inst.create_info.add_layer(regular_layer_name_1);
-        set_env_var("VK_LAYER_PATH", "/home/phish3y/dev/Vulkan-Loader/build/install/etc/vulkan/explicit_layer.d/regular_layer_1.json");
         inst.CheckCreate(VK_SUCCESS);
         auto phys_dev = inst.GetPhysDev();
         uint32_t count = 0;
@@ -2123,16 +2114,24 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
         ASSERT_EQ(count, 1U);
     }
     { 
-        // when overriding the search path to two existing files, count should be 2
+        // verify layers load successfully when setting VK_LAYER_PATH to multiple full filepaths
+        const char* regular_layer_name_1 = "RegularLayer1";
+        env.add_explicit_layer(
+            TestLayerDetails(
+                ManifestLayer{}.add_layer(
+                    ManifestLayer::LayerDescription{}.set_name(regular_layer_name_1).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+                "regular_layer_1.json").set_discovery_type(ManifestDiscoveryType::env_var).set_is_dir(false));
+
         const char* regular_layer_name_2 = "RegularLayer2";
         env.add_explicit_layer(
-            ManifestLayer{}.add_layer(
-                ManifestLayer::LayerDescription{}.set_name(regular_layer_name_2).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
-            "regular_layer_2.json");
+            TestLayerDetails(
+                ManifestLayer{}.add_layer(
+                    ManifestLayer::LayerDescription{}.set_name(regular_layer_name_2).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+                "regular_layer_2.json").set_discovery_type(ManifestDiscoveryType::env_var).set_is_dir(false));
+
         InstWrapper inst(env.vulkan_functions);
         inst.create_info.add_layer(regular_layer_name_1);
         inst.create_info.add_layer(regular_layer_name_2);
-        set_env_var("VK_LAYER_PATH", "/home/phish3y/dev/Vulkan-Loader/build/install/etc/vulkan/explicit_layer.d/regular_layer_1.json:/home/phish3y/dev/Vulkan-Loader/build/install/etc/vulkan/explicit_layer.d/regular_layer_2.json");
         inst.CheckCreate(VK_SUCCESS);
         auto phys_dev = inst.GetPhysDev();
         uint32_t count = 0;
@@ -2140,16 +2139,24 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
         ASSERT_EQ(count, 2U);
     }
     { 
-        // when overriding the search path to an existing directory with two files, count should be 2
+        // verify layers load successfully when setting VK_LAYER_PATH to a directory
+        const char* regular_layer_name_1 = "RegularLayer1";
+        env.add_explicit_layer(
+            TestLayerDetails(
+                ManifestLayer{}.add_layer(
+                    ManifestLayer::LayerDescription{}.set_name(regular_layer_name_1).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+                "regular_layer_1.json").set_discovery_type(ManifestDiscoveryType::env_var));
+
         const char* regular_layer_name_2 = "RegularLayer2";
         env.add_explicit_layer(
-            ManifestLayer{}.add_layer(
-                ManifestLayer::LayerDescription{}.set_name(regular_layer_name_2).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
-            "regular_layer_2.json");
+            TestLayerDetails(
+                ManifestLayer{}.add_layer(
+                    ManifestLayer::LayerDescription{}.set_name(regular_layer_name_2).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+                "regular_layer_2.json").set_discovery_type(ManifestDiscoveryType::env_var));
+
         InstWrapper inst(env.vulkan_functions);
         inst.create_info.add_layer(regular_layer_name_1);
         inst.create_info.add_layer(regular_layer_name_2);
-        set_env_var("VK_LAYER_PATH", "/home/phish3y/dev/Vulkan-Loader/build/install/etc/vulkan/explicit_layer.d");
         inst.CheckCreate(VK_SUCCESS);
         auto phys_dev = inst.GetPhysDev();
         uint32_t count = 0;


### PR DESCRIPTION
Added a new field `is_dir` to the `TestLayerDetails` to allow for the test suite to set either directories or files on the VK_LAYER_PATH environment variable. Added tests to verify that the layers actually get loaded by calling `vkEnumerateDeviceLayerProperties`