### PR TITLE
Added build as submodule option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,9 @@ if(BUILD_STATIC_LOADER)
         "or tested as part of the loader. Use it at your own risk.")
 endif()
 
-find_package(VulkanHeaders REQUIRED CONFIG QUIET)
+if (NOT TARGET Vulkan::Headers)
+    find_package(VulkanHeaders REQUIRED CONFIG QUIET)
+endif()
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
In CMakeLists.txt, I've added an option to enable or disable build vulkan loader as submodule, by default, is false, not changing the default behavior