### PR TITLE
Revert asm_offset CMake code to work with 3.10

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -157,9 +157,7 @@ if(WIN32)
         target_link_libraries(asm_offset PRIVATE loader_specific_options)
         # If not cross compiling, run asm_offset to generage gen_defines.asm
         if (NOT CMAKE_CROSSCOMPILING)
-            add_custom_command(TARGET asm_offset POST_BUILD
-                COMMAND asm_offset MASM
-                BYPRODUCTS gen_defines.asm)
+            add_custom_command(OUTPUT gen_defines.asm DEPENDS asm_offset COMMAND asm_offset MASM)
         else()
             # Forces compiler to write the intermediate asm file, needed so that we can get sizeof/offset of info out of it.
             target_compile_options(asm_offset PRIVATE "/Fa$<TARGET_FILE_DIR:asm_offset>/asm_offset.asm" /FA)
@@ -233,9 +231,7 @@ else() # i.e.: Linux
         target_link_libraries(asm_offset loader_specific_options)
         # If not cross compiling, run asm_offset to generage gen_defines.asm
         if (NOT CMAKE_CROSSCOMPILING)
-            add_custom_command(TARGET asm_offset POST_BUILD
-                COMMAND asm_offset GAS
-                BYPRODUCTS gen_defines.asm)
+            add_custom_command(OUTPUT gen_defines.asm DEPENDS asm_offset COMMAND asm_offset GAS)
         else()
             # Forces compiler to write the intermediate asm file, needed so that we can get sizeof/offset of info out of it.
             target_compile_options(asm_offset PRIVATE -save-temps=obj)


### PR DESCRIPTION
The revertion of gen_defines.asm generation during cross compilation changed the form of add_custom_command used, which inadvertently relied on CMake 3.16 support.

Fixes #1095 

From the CMake Docs:
DEPENDS:
...
A target-level dependency is added if any dependency is a byproduct of a target or any of its build events in the same directory to ensure the byproducts will be available before this target is built.