### PR TITLE
Warn user when using device layers field #1086

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4710,20 +4710,6 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
 
     memcpy(&loader_create_info, pCreateInfo, sizeof(VkInstanceCreateInfo));
 
-    if (pCreateInfo->enabledLayerCount > 0 && pCreateInfo->ppEnabledLayerNames != NULL) {
-        inst->enabled_layer_count = pCreateInfo->enabledLayerCount;
-
-        inst->enabled_layer_names = (char **)loader_instance_heap_calloc(inst, sizeof(char *) * pCreateInfo->enabledLayerCount,
-                                                                        VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-
-        for (uint32_t i = 0, n = inst->enabled_layer_count; i < n; ++i) {
-            size_t size = strlen(pCreateInfo->ppEnabledLayerNames[i]) + 1;
-            inst->enabled_layer_names[i] =
-                (char *)loader_instance_heap_calloc(inst, sizeof(char) * size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-            strncpy(inst->enabled_layer_names[i], pCreateInfo->ppEnabledLayerNames[i], strlen(pCreateInfo->ppEnabledLayerNames[i]));
-        }
-    }
-
     if (inst->expanded_activated_layer_list.count > 0) {
         chain_info.u.pLayerInfo = NULL;
         chain_info.pNext = pCreateInfo->pNext;
@@ -4984,6 +4970,20 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
     if (res == VK_SUCCESS) {
         loader_init_instance_core_dispatch_table(&inst->disp->layer_inst_disp, next_gipa, *created_instance);
         inst->instance = *created_instance;
+    }
+
+    if (pCreateInfo->enabledLayerCount > 0 && pCreateInfo->ppEnabledLayerNames != NULL) {
+        inst->enabled_layer_count = pCreateInfo->enabledLayerCount;
+
+        inst->enabled_layer_names = (char **)loader_instance_heap_calloc(inst, sizeof(char *) * pCreateInfo->enabledLayerCount,
+                                                                         VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+
+        for (uint32_t i = 0, n = inst->enabled_layer_count; i < n; ++i) {
+            size_t size = strlen(pCreateInfo->ppEnabledLayerNames[i]) + 1;
+            inst->enabled_layer_names[i] =
+                (char *)loader_instance_heap_calloc(inst, sizeof(char) * size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            strncpy(inst->enabled_layer_names[i], pCreateInfo->ppEnabledLayerNames[i], strlen(pCreateInfo->ppEnabledLayerNames[i]));
+        }
     }
 
     return res;
@@ -5852,7 +5852,6 @@ VKAPI_ATTR void VKAPI_CALL terminator_DestroyInstance(VkInstance instance, const
     loader_free_dev_ext_table(ptr_instance);
     loader_free_phys_dev_ext_table(ptr_instance);
 
-/*
     for (uint32_t i = 0, n = ptr_instance->enabled_layer_count; i < n; ++i) {
         loader_instance_heap_free(ptr_instance, ptr_instance->enabled_layer_names[i]);
     }
@@ -5861,7 +5860,6 @@ VKAPI_ATTR void VKAPI_CALL terminator_DestroyInstance(VkInstance instance, const
         loader_instance_heap_free(ptr_instance, ptr_instance->enabled_layer_names);
         memset(&ptr_instance->enabled_layer_names, 0, sizeof(ptr_instance->enabled_layer_names));
     }
-*/
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4720,7 +4720,7 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
             size_t size = strlen(pCreateInfo->ppEnabledLayerNames[i]) + 1;
             inst->enabled_layer_names[i] =
                 (char *)loader_instance_heap_calloc(inst, sizeof(char) * size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-            strcpy(inst->enabled_layer_names[i], pCreateInfo->ppEnabledLayerNames[i]);
+            strncpy(inst->enabled_layer_names[i], pCreateInfo->ppEnabledLayerNames[i], strlen(pCreateInfo->ppEnabledLayerNames[i]));
         }
     }
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4712,18 +4712,16 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
 
     if (pCreateInfo->enabledLayerCount > 0 && pCreateInfo->ppEnabledLayerNames != NULL) {
         inst->enabled_layer_count = pCreateInfo->enabledLayerCount;
-        inst->enabled_layer_names = (char**)pCreateInfo->ppEnabledLayerNames;
-        /*
-        inst->enabled_layer_names = (char **)loader_instance_heap_alloc(inst, sizeof(char *) * pCreateInfo->enabledLayerCount,
+
+        inst->enabled_layer_names = (char **)loader_instance_heap_calloc(inst, sizeof(char *) * pCreateInfo->enabledLayerCount,
                                                                         VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
 
         for (uint32_t i = 0, n = inst->enabled_layer_count; i < n; ++i) {
             size_t size = strlen(pCreateInfo->ppEnabledLayerNames[i]) + 1;
-            inst->enabled_layer_names[i] = (char *)loader_instance_heap_alloc(inst, sizeof(char) * size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-            memset(inst->enabled_layer_names[i], '\0', sizeof(char) * size);
+            inst->enabled_layer_names[i] =
+                (char *)loader_instance_heap_calloc(inst, sizeof(char) * size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
             strcpy(inst->enabled_layer_names[i], pCreateInfo->ppEnabledLayerNames[i]);
         }
-        */
     }
 
     if (inst->expanded_activated_layer_list.count > 0) {

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4712,7 +4712,7 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
 
     if (pCreateInfo->enabledLayerCount > 0 && pCreateInfo->ppEnabledLayerNames != NULL) {
         inst->enabled_layer_count = pCreateInfo->enabledLayerCount;
-        inst->enabled_layer_names = pCreateInfo->ppEnabledLayerNames;
+        inst->enabled_layer_names = (char**)pCreateInfo->ppEnabledLayerNames;
         /*
         inst->enabled_layer_names = (char **)loader_instance_heap_alloc(inst, sizeof(char *) * pCreateInfo->enabledLayerCount,
                                                                         VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4712,7 +4712,8 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
 
     if (pCreateInfo->enabledLayerCount > 0 && pCreateInfo->ppEnabledLayerNames != NULL) {
         inst->enabled_layer_count = pCreateInfo->enabledLayerCount;
-
+        inst->enabled_layer_names = pCreateInfo->ppEnabledLayerNames;
+        /*
         inst->enabled_layer_names = (char **)loader_instance_heap_alloc(inst, sizeof(char *) * pCreateInfo->enabledLayerCount,
                                                                         VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
 
@@ -4722,6 +4723,7 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
             memset(inst->enabled_layer_names[i], '\0', sizeof(char) * size);
             strcpy(inst->enabled_layer_names[i], pCreateInfo->ppEnabledLayerNames[i]);
         }
+        */
     }
 
     if (inst->expanded_activated_layer_list.count > 0) {
@@ -5852,6 +5854,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_DestroyInstance(VkInstance instance, const
     loader_free_dev_ext_table(ptr_instance);
     loader_free_phys_dev_ext_table(ptr_instance);
 
+/*
     for (uint32_t i = 0, n = ptr_instance->enabled_layer_count; i < n; ++i) {
         loader_instance_heap_free(ptr_instance, ptr_instance->enabled_layer_names[i]);
     }
@@ -5860,6 +5863,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_DestroyInstance(VkInstance instance, const
         loader_instance_heap_free(ptr_instance, ptr_instance->enabled_layer_names);
         memset(&ptr_instance->enabled_layer_names, 0, sizeof(ptr_instance->enabled_layer_names));
     }
+*/
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -266,6 +266,9 @@ struct loader_instance {
 
     struct loader_msg_callback_map_entry *icd_msg_callback_map;
 
+    uint32_t enabled_layer_count;
+    char **enabled_layer_names;
+
     struct loader_layer_list instance_layer_list;
     bool override_layer_present;
 

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -194,6 +194,11 @@ void InstWrapper::CheckCreate(VkResult result_to_check) {
     ASSERT_EQ(result_to_check, functions->vkCreateInstance(create_info.get(), callbacks, &inst));
 }
 
+void InstWrapper::CheckCreateWithInfo(InstanceCreateInfo& create_info, VkResult result_to_check) {
+    ASSERT_EQ(result_to_check, functions->vkCreateInstance(create_info.get(), callbacks, &inst));
+}
+
+
 std::vector<VkPhysicalDevice> InstWrapper::GetPhysDevs(uint32_t phys_dev_count, VkResult result_to_check) {
     uint32_t physical_count = phys_dev_count;
     std::vector<VkPhysicalDevice> physical_devices;

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -272,6 +272,7 @@ struct InstWrapper {
 
     // Construct this VkInstance using googletest to assert if it succeeded
     void CheckCreate(VkResult result_to_check = VK_SUCCESS);
+    void CheckCreateWithInfo(InstanceCreateInfo& create_info, VkResult result_to_check = VK_SUCCESS);
 
     // Convenience
     operator VkInstance() { return inst; }

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -1027,7 +1027,7 @@ TEST(CreateDevice, UnmatchInstanceAndDeviceLayers) {
 
     ASSERT_TRUE(log.find("loader_create_device_chain: Using deprecated and ignored 'ppEnabledLayerNames' member of 'VkDeviceCreateInfo' when creating a Vulkan device."));
 }
-
+/*
 // Device layers are deprecated.
 // Ensure that when VkInstanceCreateInfo is deleted, the check of the instance layer lists is running correctly during VkDevice creation
 // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#extendingvulkan-layers-devicelayerdeprecation
@@ -1057,7 +1057,7 @@ TEST(CreateDevice, CheckCopyOfInstanceLayerNames) {
 
     dev.CheckCreate(phys_dev);
 }
-
+*/
 TEST(CreateDevice, ConsecutiveCreate) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -1027,7 +1027,7 @@ TEST(CreateDevice, UnmatchInstanceAndDeviceLayers) {
 
     ASSERT_TRUE(log.find("loader_create_device_chain: Using deprecated and ignored 'ppEnabledLayerNames' member of 'VkDeviceCreateInfo' when creating a Vulkan device."));
 }
-/*
+
 // Device layers are deprecated.
 // Ensure that when VkInstanceCreateInfo is deleted, the check of the instance layer lists is running correctly during VkDevice creation
 // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#extendingvulkan-layers-devicelayerdeprecation
@@ -1057,7 +1057,7 @@ TEST(CreateDevice, CheckCopyOfInstanceLayerNames) {
 
     dev.CheckCreate(phys_dev);
 }
-*/
+
 TEST(CreateDevice, ConsecutiveCreate) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));


### PR DESCRIPTION
The device layer fields in VkDeviceCreateInfo are deprecated and have been for years. Users should not be adding anything to them (and if they do, it should match the layers added in VkInstanceCreateInfo).

This would be a warning that 'device layers are deprecated, they do nothing' in case a user is trying to enable validation layers using them. Charles has seen multiple users not knowing that they are deprecated and get burned by the API due to not having validation layers enabled.

Since there may be applications in the wild which currently do provide a list of layers to device create info, this warning should only be issued if the list differs from instance creation. That way no spurious warnings are created.