### PR TITLE
Use correct generated header version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM OFF)
 
 project(Vulkan-Loader)
 
+# Gets the header version used during code generation
+include(cmake/generated_header_version.cmake)
+
 if (UPDATE_DEPS)
     find_package(PythonInterp 3 REQUIRED)
 
@@ -322,8 +325,9 @@ if(PYTHONINTERP_FOUND)
     get_target_property(VulkanRegistry_DIR Vulkan::Registry INTERFACE_INCLUDE_DIRECTORIES)
     add_custom_target(VulkanLoader_generated_source
                       COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/generate_source.py
-                              ${VulkanRegistry_DIR} --incremental
-                      )
+                              ${VulkanRegistry_DIR}
+                              --generated-version ${VulkanHeaders_VERSION}
+                              --incremental)
 else()
     message("WARNING: VulkanLoader_generated_source target requires python 3")
 endif()

--- a/cmake/generated_header_version.cmake
+++ b/cmake/generated_header_version.cmake
@@ -1,0 +1,3 @@
+# *** THIS FILE IS GENERATED - DO NOT EDIT ***
+# See generate_source.py for modifications
+set(LOADER_GENERATED_HEADER_VERSION 1.3.238)

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -312,7 +312,7 @@ else()
     add_dependencies(vulkan loader_asm_gen_files)
     set_target_properties(vulkan
                           PROPERTIES SOVERSION "1"
-                          VERSION ${VulkanHeaders_VERSION})
+                          VERSION ${LOADER_GENERATED_HEADER_VERSION})
     target_link_libraries(vulkan PRIVATE ${CMAKE_DL_LIBS} m)
     if (NOT ANDROID)
         target_link_libraries(vulkan PRIVATE Threads::Threads)
@@ -351,7 +351,7 @@ else()
             OUTPUT_NAME vulkan
             FRAMEWORK TRUE
             FRAMEWORK_VERSION A
-            VERSION "${VulkanHeaders_VERSION}" # "current version"
+            VERSION "${LOADER_GENERATED_HEADER_VERSION}" # "current generated version"
             SOVERSION "1.0.0"                  # "compatibility version"
             MACOSX_FRAMEWORK_IDENTIFIER com.lunarg.vulkanFramework
             PUBLIC_HEADER "${FRAMEWORK_HEADERS}"
@@ -375,7 +375,7 @@ endif()
 # Generate pkg-config file.
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
-    set(VK_API_VERSION "${VulkanHeaders_VERSION}")
+    set(VK_API_VERSION "${LOADER_GENERATED_HEADER_VERSION}")
     set(PRIVATE_LIBS "")
     if (APPLE AND BUILD_STATIC_LOADER)
         # Libs.private should only be present when building a static loader

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -33,6 +33,7 @@ verify_exclude = ['.clang-format']
 def main(argv):
     parser = argparse.ArgumentParser(description='Generate source code for this repository')
     parser.add_argument('registry', metavar='REGISTRY_PATH', help='path to the Vulkan-Headers registry directory')
+    parser.add_argument('--generated-version', help='sets the header version used to generate the repo')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-i', '--incremental', action='store_true', help='only update repo files that change')
     group.add_argument('-v', '--verify', action='store_true', help='verify repo files match generator output')
@@ -105,6 +106,14 @@ def main(argv):
                not filecmp.cmp(temp_filename, repo_filename, shallow=False):
                 print('update', repo_filename)
                 shutil.copyfile(temp_filename, repo_filename)
+
+    # write out the header version used to generate the code to a checked in CMake FIle
+    if args.generated_version:
+        f = open(common_codegen.repo_relative('cmake/generated_header_version.cmake'), "w")
+        f.write('# *** THIS FILE IS GENERATED - DO NOT EDIT ***\n')
+        f.write('# See generate_source.py for modifications\n')
+        f.write(f'set(LOADER_GENERATED_HEADER_VERSION {args.generated_version})')
+        f.close()
 
     return 0
 

--- a/tests/loader_alloc_callback_tests.cpp
+++ b/tests/loader_alloc_callback_tests.cpp
@@ -440,7 +440,7 @@ TEST(Allocation, DriverEnvVarIntentionalAllocFail) {
     driver_files += (fs::path("totally_made_up") / "path_to_fake" / "jason_file.json").str();
     set_env_var("VK_DRIVER_FILES", driver_files);
     EnvVarCleaner cleaner("VK_DRIVER_FILES");
-    size_t fail_index = 66;  // 0
+    size_t fail_index = 0;
     VkResult result = VK_ERROR_OUT_OF_HOST_MEMORY;
     while (result == VK_ERROR_OUT_OF_HOST_MEMORY && fail_index <= 10000) {
         MemoryTracker tracker(MemoryTrackerSettings{false, 0, true, fail_index});


### PR DESCRIPTION
The version of the Vulkan-Headers used to generate the source code is what should be
used to set the version of the binary, rather than the version of the Vulkan-Headers
that is currently available. This commit checks that version into the repo so that
it is used, and adds the necessary python code to update it.

This behavior was previously in the repo but was broken by the update to use the
version parsing logic from the Vulkan-Headers.

Fixes #141

This also fixes an accidental error made to allocation callback test code.