### PR TITLE
cmake: Fix usage of Vulkan::Registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,16 +322,14 @@ endif()
 
 # Optional codegen target
 if(PYTHONINTERP_FOUND)
-    get_target_property(VulkanRegistry_DIR Vulkan::Registry INTERFACE_INCLUDE_DIRECTORIES)
     add_custom_target(VulkanLoader_generated_source
                       COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/generate_source.py
-                              ${VulkanRegistry_DIR}
+                              ${VULKAN_HEADERS_REGISTRY_DIRECTORY}
                               --generated-version ${VulkanHeaders_VERSION}
                               --incremental)
 else()
     message("WARNING: VulkanLoader_generated_source target requires python 3")
 endif()
-
 
 if(UNIX)
     target_compile_definitions(loader_common_options INTERFACE FALLBACK_CONFIG_DIRS="${FALLBACK_CONFIG_DIRS}" FALLBACK_DATA_DIRS="${FALLBACK_DATA_DIRS}")

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -6,7 +6,7 @@
             "sub_dir": "Vulkan-Headers",
             "build_dir": "Vulkan-Headers/build",
             "install_dir": "Vulkan-Headers/build/install",
-            "commit": "v1.3.238"
+            "commit": "5eeb2c4c570ce92f5f48bf667e39e9d4da2ef13a"
         },
         {
             "name": "googletest",


### PR DESCRIPTION
Vulkan::Registry was deprecated by Vulkan-Headers

Use 'VULKAN_HEADERS_REGISTRY_DIRECTORY' instead.