### PR TITLE
Ensure VkPhysicalDevice unwrapping in Device functions

### DIFF
--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -1380,11 +1380,30 @@ void init_extension_device_proc_terminator_dispatch(struct loader_device *dev) {
 #endif // None
 }
 
+// These are prototypes for functions that need their trampoline called in all circumstances.
+// They are used in loader_lookup_device_dispatch_table but are defined afterwards.
+    // ---- VK_EXT_debug_marker extension commands
+VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
+    VkDevice                                    device,
+    const VkDebugMarkerObjectTagInfoEXT*        pTagInfo);
+VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(
+    VkDevice                                    device,
+    const VkDebugMarkerObjectNameInfoEXT*       pNameInfo);
+    // ---- VK_EXT_debug_utils extension commands
+VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
+    VkDevice                                    device,
+    const VkDebugUtilsObjectNameInfoEXT*        pNameInfo);
+VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectTagEXT(
+    VkDevice                                    device,
+    const VkDebugUtilsObjectTagInfoEXT*         pTagInfo);
+
 // Device command lookup function
 VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDispatchTable *table, const char *name) {
     if (!name || name[0] != 'v' || name[1] != 'k') return NULL;
 
     name += 2;
+    struct loader_device* dev = (struct loader_device *)table;
+
 
     // ---- Core 1_0 commands
     if (!strcmp(name, "GetDeviceProcAddr")) return (void *)table->GetDeviceProcAddr;
@@ -1758,8 +1777,8 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
     if (!strcmp(name, "GetDeviceImageSparseMemoryRequirementsKHR")) return (void *)table->GetDeviceImageSparseMemoryRequirementsKHR;
 
     // ---- VK_EXT_debug_marker extension commands
-    if (!strcmp(name, "DebugMarkerSetObjectTagEXT")) return (void *)table->DebugMarkerSetObjectTagEXT;
-    if (!strcmp(name, "DebugMarkerSetObjectNameEXT")) return (void *)table->DebugMarkerSetObjectNameEXT;
+    if (!strcmp(name, "DebugMarkerSetObjectTagEXT")) return dev->extensions.ext_debug_marker_enabled ? (void *)DebugMarkerSetObjectTagEXT : NULL;
+    if (!strcmp(name, "DebugMarkerSetObjectNameEXT")) return dev->extensions.ext_debug_marker_enabled ? (void *)DebugMarkerSetObjectNameEXT : NULL;
     if (!strcmp(name, "CmdDebugMarkerBeginEXT")) return (void *)table->CmdDebugMarkerBeginEXT;
     if (!strcmp(name, "CmdDebugMarkerEndEXT")) return (void *)table->CmdDebugMarkerEndEXT;
     if (!strcmp(name, "CmdDebugMarkerInsertEXT")) return (void *)table->CmdDebugMarkerInsertEXT;
@@ -1819,8 +1838,8 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
     if (!strcmp(name, "SetHdrMetadataEXT")) return (void *)table->SetHdrMetadataEXT;
 
     // ---- VK_EXT_debug_utils extension commands
-    if (!strcmp(name, "SetDebugUtilsObjectNameEXT")) return (void *)table->SetDebugUtilsObjectNameEXT;
-    if (!strcmp(name, "SetDebugUtilsObjectTagEXT")) return (void *)table->SetDebugUtilsObjectTagEXT;
+    if (!strcmp(name, "SetDebugUtilsObjectNameEXT")) return dev->extensions.ext_debug_utils_enabled ? (void *)SetDebugUtilsObjectNameEXT : NULL;
+    if (!strcmp(name, "SetDebugUtilsObjectTagEXT")) return dev->extensions.ext_debug_utils_enabled ? (void *)SetDebugUtilsObjectTagEXT : NULL;
     if (!strcmp(name, "QueueBeginDebugUtilsLabelEXT")) return (void *)table->QueueBeginDebugUtilsLabelEXT;
     if (!strcmp(name, "QueueEndDebugUtilsLabelEXT")) return (void *)table->QueueEndDebugUtilsLabelEXT;
     if (!strcmp(name, "QueueInsertDebugUtilsLabelEXT")) return (void *)table->QueueInsertDebugUtilsLabelEXT;
@@ -3934,6 +3953,9 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_DebugMarkerSetObjectTagEXT(
                 local_tag_info.object = (uint64_t)icd_surface->real_icd_surfaces[icd_index];
             }
         }
+    // If this is an instance we have to replace it with the proper one for the next call.
+    } else if (pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {
+        local_tag_info.object = (uint64_t)(uintptr_t)icd_term->instance;
     }
     // Exit early if the driver does not support the function - this can happen as a layer or the loader itself supports
     // debug utils but the driver does not.
@@ -3986,6 +4008,9 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_DebugMarkerSetObjectNameEXT(
                 local_name_info.object = (uint64_t)icd_surface->real_icd_surfaces[icd_index];
             }
         }
+    // If this is an instance we have to replace it with the proper one for the next call.
+    } else if (pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {
+        local_name_info.object = (uint64_t)(uintptr_t)icd_term->instance;
     }
     // Exit early if the driver does not support the function - this can happen as a layer or the loader itself supports
     // debug utils but the driver does not.
@@ -4544,6 +4569,9 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_SetDebugUtilsObjectNameEXT(
                 local_name_info.objectHandle = (uint64_t)icd_surface->real_icd_surfaces[icd_index];
             }
         }
+    // If this is an instance we have to replace it with the proper one for the next call.
+    } else if (pNameInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {
+        local_name_info.objectHandle = (uint64_t)(uintptr_t)icd_term->instance;
     }
     // Exit early if the driver does not support the function - this can happen as a layer or the loader itself supports
     // debug utils but the driver does not.
@@ -4600,6 +4628,9 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_SetDebugUtilsObjectTagEXT(
                 local_tag_info.objectHandle = (uint64_t)icd_surface->real_icd_surfaces[icd_index];
             }
         }
+    // If this is an instance we have to replace it with the proper one for the next call.
+    } else if (pTagInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {
+        local_tag_info.objectHandle = (uint64_t)(uintptr_t)icd_term->instance;
     }
     // Exit early if the driver does not support the function - this can happen as a layer or the loader itself supports
     // debug utils but the driver does not.

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -77,6 +77,11 @@ DEVICE_CMDS_NEED_TERM = ['vkGetDeviceProcAddr',
                          'vkCmdInsertDebugUtilsLabelEXT',
                          'vkGetDeviceGroupSurfacePresentModes2EXT']
 
+DEVICE_CMDS_MUST_USE_TRAMP = ['vkSetDebugUtilsObjectNameEXT',
+                              'vkSetDebugUtilsObjectTagEXT',
+                              'vkDebugMarkerSetObjectNameEXT',
+                              'vkDebugMarkerSetObjectTagEXT']
+
 # These are the aliased functions that use the same terminator for both extension and core versions
 # Generally, this is only applies to physical device level functions in instance extensions
 SHARED_ALIASES = {
@@ -248,6 +253,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
             file_data += self.OutputIcdDispatchTableInit()
             file_data += self.OutputLoaderDispatchTables()
             file_data += self.InitDeviceFunctionTerminatorDispatchTable()
+            file_data += self.OutputDeviceFunctionTrampolinePrototypes()
             file_data += self.OutputLoaderLookupFunc()
             file_data += self.CreateTrampTermFuncs()
             file_data += self.InstExtensionGPA()
@@ -870,6 +876,8 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 tables += '    if (!name || name[0] != \'v\' || name[1] != \'k\') return NULL;\n'
                 tables += '\n'
                 tables += '    name += 2;\n'
+                tables += '    struct loader_device* dev = (struct loader_device *)table;\n'
+                tables += '\n'
             else:
                 cur_type = 'instance'
 
@@ -913,7 +921,10 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                         if cur_cmd.protect is not None:
                             tables += '#ifdef %s\n' % cur_cmd.protect
 
-                        tables += '    if (!strcmp(name, "%s")) return (void *)table->%s;\n' % (base_name, base_name)
+                        if cur_cmd.name in DEVICE_CMDS_MUST_USE_TRAMP:
+                            tables += f'    if (!strcmp(name, "{base_name}")) return dev->extensions.{cur_cmd.ext_name[3:].lower()}_enabled ? (void *){base_name} : NULL;\n'
+                        else:
+                            tables += f'    if (!strcmp(name, "{base_name}")) return (void *)table->{base_name};\n'
 
                         if cur_cmd.protect is not None:
                             tables += '#endif // %s\n' % cur_cmd.protect
@@ -1221,6 +1232,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                         member_name = 'objectHandle' if is_debug_utils else 'object'
                         phys_dev_check = 'VK_OBJECT_TYPE_PHYSICAL_DEVICE' if is_debug_utils else 'VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT'
                         surf_check = 'VK_OBJECT_TYPE_SURFACE_KHR' if is_debug_utils else 'VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT'
+                        inst_check = 'VK_OBJECT_TYPE_INSTANCE' if is_debug_utils else 'VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT'
                         funcs += '    uint32_t icd_index = 0;\n'
                         funcs += '    struct loader_device *dev;\n'
                         funcs += f'    struct loader_icd_term *icd_term = loader_get_icd_and_device({ ext_cmd.params[0].name}, &dev, &icd_index);\n'
@@ -1242,6 +1254,9 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                         funcs += f'                {local_struct}.{member_name} = (uint64_t)icd_surface->real_icd_surfaces[icd_index];\n'
                         funcs += '            }\n'
                         funcs += '        }\n'
+                        funcs += '    // If this is an instance we have to replace it with the proper one for the next call.\n'
+                        funcs += f'    }} else if ({debug_struct_name}->objectType == {inst_check}) {{\n'
+                        funcs += f'        {local_struct}.{member_name} = (uint64_t)(uintptr_t)icd_term->instance;\n'
                         funcs += '    }\n'
                         funcs += '    // Exit early if the driver does not support the function - this can happen as a layer or the loader itself supports\n'
                         funcs += '    // debug utils but the driver does not.\n'
@@ -1494,6 +1509,31 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
         term_func += '}; \n\n'
 
         return term_func
+
+    def OutputDeviceFunctionTrampolinePrototypes(self):
+        tramp_protos = ''
+        tramp_protos += '// These are prototypes for functions that need their trampoline called in all circumstances.\n'
+        tramp_protos += '// They are used in loader_lookup_device_dispatch_table but are defined afterwards.\n'
+        last_protect = None
+        last_ext = None
+        for ext_cmd in self.ext_commands:
+            if ext_cmd.name in DEVICE_CMDS_MUST_USE_TRAMP:
+                if 'VK_VERSION_' in ext_cmd.ext_name:
+                    tramp_protos += f'    // ---- Core {ext_cmd.ext_name[11:]} commands\n'
+                else:
+                    last_protect = ext_cmd.protect
+                    if ext_cmd.protect is not None:
+                        tramp_protos += f'#ifdef {ext_cmd.protect}\n'
+                    if (last_ext != ext_cmd.ext_name):
+                        tramp_protos += f'    // ---- {ext_cmd.ext_name} extension commands\n'
+                        last_ext = ext_cmd.ext_name
+
+                tramp_protos += f'{ext_cmd.cdecl.replace("VKAPI_CALL vk", "VKAPI_CALL ")}\n'
+
+        if last_protect is not None:
+            tramp_protos += '#endif // %s\n' % ext_cmd.protect
+        tramp_protos += '\n'
+        return tramp_protos
 
     #
     # Create code to initialize a dispatch table from the appropriate list of

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -329,15 +329,59 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroyDebugUtilsMessengerEXT(VkInstance insta
 
 // Debug utils & debug marker ext stubs
 VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectTagEXT(VkDevice dev, const VkDebugMarkerObjectTagInfoEXT* pTagInfo) {
+    if (pTagInfo && pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {
+        VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pTagInfo->object);
+        if (pd != icd.physical_devices.at(icd.lookup_device(dev).phys_dev_index).vk_physical_device.handle)
+            return VK_ERROR_DEVICE_LOST;
+    }
+    if (pTagInfo && pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT) {
+        if (pTagInfo->object != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
+    }
+    if (pTagInfo && pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {
+        if (pTagInfo->object != (uint64_t)(uintptr_t)icd.instance_handle.handle) return VK_ERROR_DEVICE_LOST;
+    }
     return VK_SUCCESS;
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectNameEXT(VkDevice dev, const VkDebugMarkerObjectNameInfoEXT* pNameInfo) {
+    if (pNameInfo && pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {
+        VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pNameInfo->object);
+        if (pd != icd.physical_devices.at(icd.lookup_device(dev).phys_dev_index).vk_physical_device.handle)
+            return VK_ERROR_DEVICE_LOST;
+    }
+    if (pNameInfo && pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT) {
+        if (pNameInfo->object != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
+    }
+    if (pNameInfo && pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {
+        if (pNameInfo->object != (uint64_t)(uintptr_t)icd.instance_handle.handle) return VK_ERROR_DEVICE_LOST;
+    }
     return VK_SUCCESS;
 }
-VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectNameEXT(VkDevice dev, const VkDebugUtilsObjectTagInfoEXT* pTagInfo) {
+VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectNameEXT(VkDevice dev, const VkDebugUtilsObjectNameInfoEXT* pNameInfo) {
+    if (pNameInfo && pNameInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {
+        VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pNameInfo->objectHandle);
+        if (pd != icd.physical_devices.at(icd.lookup_device(dev).phys_dev_index).vk_physical_device.handle)
+            return VK_ERROR_DEVICE_LOST;
+    }
+    if (pNameInfo && pNameInfo->objectType == VK_OBJECT_TYPE_SURFACE_KHR) {
+        if (pNameInfo->objectHandle != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
+    }
+    if (pNameInfo && pNameInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {
+        if (pNameInfo->objectHandle != (uint64_t)(uintptr_t)icd.instance_handle.handle) return VK_ERROR_DEVICE_LOST;
+    }
     return VK_SUCCESS;
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectTagEXT(VkDevice dev, const VkDebugUtilsObjectTagInfoEXT* pTagInfo) {
+    if (pTagInfo && pTagInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {
+        VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pTagInfo->objectHandle);
+        if (pd != icd.physical_devices.at(icd.lookup_device(dev).phys_dev_index).vk_physical_device.handle)
+            return VK_ERROR_DEVICE_LOST;
+    }
+    if (pTagInfo && pTagInfo->objectType == VK_OBJECT_TYPE_SURFACE_KHR) {
+        if (pTagInfo->objectHandle != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
+    }
+    if (pTagInfo && pTagInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {
+        if (pTagInfo->objectHandle != (uint64_t)(uintptr_t)icd.instance_handle.handle) return VK_ERROR_DEVICE_LOST;
+    }
     return VK_SUCCESS;
 }
 VKAPI_ATTR void VKAPI_CALL test_vkQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo) {}

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -587,6 +587,7 @@ const char* get_platform_wsi_extension(const char* api_selection) {
 void setup_WSI_in_ICD(TestICD& icd, const char* api_selection) {
     icd.enable_icd_wsi = true;
     icd.add_instance_extensions({"VK_KHR_surface", get_platform_wsi_extension(api_selection)});
+    icd.min_icd_interface_version = std::max(icd.min_icd_interface_version, 3U);
 }
 void setup_WSI_in_create_instance(InstWrapper& inst, const char* api_selection) {
     inst.create_info.add_extensions({"VK_KHR_surface", get_platform_wsi_extension(api_selection)});

--- a/tests/loader_debug_ext_tests.cpp
+++ b/tests/loader_debug_ext_tests.cpp
@@ -926,9 +926,9 @@ void CheckDeviceFunctions(FrameworkEnvironment& env, bool use_GIPA, bool enable_
         // When querying from GDPA, these functions are found only if the extensions were enabled
         ASSERT_EQ(enable_debug_extensions, nullptr != DebugMarkerSetObjectTagEXT);
         ASSERT_EQ(enable_debug_extensions, nullptr != DebugMarkerSetObjectNameEXT);
+        ASSERT_EQ(enable_debug_extensions, nullptr != SetDebugUtilsObjectNameEXT);
+        ASSERT_EQ(enable_debug_extensions, nullptr != SetDebugUtilsObjectTagEXT);
         // When querying from GDPA, these functions should always be found
-        ASSERT_TRUE(nullptr != SetDebugUtilsObjectNameEXT);
-        ASSERT_TRUE(nullptr != SetDebugUtilsObjectTagEXT);
         ASSERT_TRUE(nullptr != QueueBeginDebugUtilsLabelEXT);
         ASSERT_TRUE(nullptr != QueueEndDebugUtilsLabelEXT);
         ASSERT_TRUE(nullptr != QueueInsertDebugUtilsLabelEXT);
@@ -936,13 +936,42 @@ void CheckDeviceFunctions(FrameworkEnvironment& env, bool use_GIPA, bool enable_
         ASSERT_TRUE(nullptr != CmdEndDebugUtilsLabelEXT);
         ASSERT_TRUE(nullptr != CmdInsertDebugUtilsLabelEXT);
     }
-    VkDebugUtilsObjectNameInfoEXT obj_name_info{};
-    obj_name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
-    obj_name_info.objectHandle = (uint64_t)swapchain;
-    obj_name_info.objectType = VK_OBJECT_TYPE_SWAPCHAIN_KHR;
-    obj_name_info.pObjectName = " Your mom!";
-    if (SetDebugUtilsObjectNameEXT) SetDebugUtilsObjectNameEXT(dev.dev, &obj_name_info);
+    if (SetDebugUtilsObjectNameEXT) {
+        VkDebugUtilsObjectNameInfoEXT obj_name_info{};
+        obj_name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+        obj_name_info.objectHandle = (uint64_t)swapchain;
+        obj_name_info.objectType = VK_OBJECT_TYPE_SWAPCHAIN_KHR;
+        obj_name_info.pObjectName = " Your mom!";
+        ASSERT_EQ(VK_SUCCESS, SetDebugUtilsObjectNameEXT(dev.dev, &obj_name_info));
 
+        obj_name_info.objectHandle = (uint64_t)(uintptr_t)surface;
+        obj_name_info.objectType = VK_OBJECT_TYPE_SURFACE_KHR;
+        obj_name_info.pObjectName = " Your moms surface!";
+        ASSERT_EQ(VK_SUCCESS, SetDebugUtilsObjectNameEXT(dev.dev, &obj_name_info));
+
+        obj_name_info.objectHandle = (uint64_t)(uintptr_t)phys_dev;
+        obj_name_info.objectType = VK_OBJECT_TYPE_PHYSICAL_DEVICE;
+        obj_name_info.pObjectName = "Physical Device AAAAAAAAA";
+        ASSERT_EQ(VK_SUCCESS, SetDebugUtilsObjectNameEXT(dev.dev, &obj_name_info));
+
+        obj_name_info.objectHandle = (uint64_t)(uintptr_t)inst.inst;
+        obj_name_info.objectType = VK_OBJECT_TYPE_INSTANCE;
+        ASSERT_EQ(VK_SUCCESS, SetDebugUtilsObjectNameEXT(dev.dev, &obj_name_info));
+    }
+    if (SetDebugUtilsObjectTagEXT) {
+        VkDebugUtilsObjectTagInfoEXT utils_object_tag{};
+        utils_object_tag.objectHandle = (uint64_t)(uintptr_t)inst.inst;
+        utils_object_tag.objectType = VK_OBJECT_TYPE_INSTANCE;
+        ASSERT_EQ(VK_SUCCESS, SetDebugUtilsObjectTagEXT(dev.dev, &utils_object_tag));
+
+        utils_object_tag.objectHandle = (uint64_t)(uintptr_t)phys_dev;
+        utils_object_tag.objectType = VK_OBJECT_TYPE_PHYSICAL_DEVICE;
+        ASSERT_EQ(VK_SUCCESS, SetDebugUtilsObjectTagEXT(dev.dev, &utils_object_tag));
+
+        utils_object_tag.objectHandle = (uint64_t)surface;
+        utils_object_tag.objectType = VK_OBJECT_TYPE_SURFACE_KHR;
+        ASSERT_EQ(VK_SUCCESS, SetDebugUtilsObjectTagEXT(dev.dev, &utils_object_tag));
+    }
     VkDebugMarkerObjectTagInfoEXT marker_object_tag{};
     VkDebugMarkerObjectNameInfoEXT marker_object_name{};
     if (use_GIPA && !enable_debug_extensions) {
@@ -950,12 +979,41 @@ void CheckDeviceFunctions(FrameworkEnvironment& env, bool use_GIPA, bool enable_
         ASSERT_DEATH(DebugMarkerSetObjectTagEXT(dev.dev, &marker_object_tag), "");
         ASSERT_DEATH(DebugMarkerSetObjectNameEXT(dev.dev, &marker_object_name), "");
     } else {
-        if (DebugMarkerSetObjectTagEXT) DebugMarkerSetObjectTagEXT(dev.dev, &marker_object_tag);
-        if (DebugMarkerSetObjectNameEXT) DebugMarkerSetObjectNameEXT(dev.dev, &marker_object_name);
+        if (DebugMarkerSetObjectTagEXT) {
+            marker_object_tag.object = (uint64_t)(uintptr_t)swapchain;
+            marker_object_tag.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT;
+            ASSERT_EQ(VK_SUCCESS, DebugMarkerSetObjectTagEXT(dev.dev, &marker_object_tag));
+
+            marker_object_tag.object = (uint64_t)(uintptr_t)phys_dev;
+            marker_object_tag.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT;
+            ASSERT_EQ(VK_SUCCESS, DebugMarkerSetObjectTagEXT(dev.dev, &marker_object_tag));
+
+            marker_object_tag.object = (uint64_t)surface;
+            marker_object_tag.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT;
+            ASSERT_EQ(VK_SUCCESS, DebugMarkerSetObjectTagEXT(dev.dev, &marker_object_tag));
+
+            marker_object_tag.object = (uint64_t)(uintptr_t)inst.inst;
+            marker_object_tag.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+            ASSERT_EQ(VK_SUCCESS, DebugMarkerSetObjectTagEXT(dev.dev, &marker_object_tag));
+        }
+        if (DebugMarkerSetObjectNameEXT) {
+            marker_object_name.object = (uint64_t)(uintptr_t)swapchain;
+            marker_object_name.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT;
+            ASSERT_EQ(VK_SUCCESS, DebugMarkerSetObjectNameEXT(dev.dev, &marker_object_name));
+
+            marker_object_name.object = (uint64_t)(uintptr_t)phys_dev;
+            marker_object_name.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT;
+            ASSERT_EQ(VK_SUCCESS, DebugMarkerSetObjectNameEXT(dev.dev, &marker_object_name));
+
+            marker_object_name.object = (uint64_t)surface;
+            marker_object_name.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT;
+            ASSERT_EQ(VK_SUCCESS, DebugMarkerSetObjectNameEXT(dev.dev, &marker_object_name));
+
+            marker_object_name.object = (uint64_t)(uintptr_t)inst.inst;
+            marker_object_name.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+            ASSERT_EQ(VK_SUCCESS, DebugMarkerSetObjectNameEXT(dev.dev, &marker_object_name));
+        }
     }
-    if (SetDebugUtilsObjectNameEXT) SetDebugUtilsObjectNameEXT(dev.dev, &obj_name_info);
-    VkDebugUtilsObjectTagInfoEXT utils_object_tag{};
-    if (SetDebugUtilsObjectTagEXT) SetDebugUtilsObjectTagEXT(dev.dev, &utils_object_tag);
     VkQueue queue{};
     dev.functions->vkGetDeviceQueue(dev.dev, 0, 0, &queue);
     VkDebugUtilsLabelEXT utils_label{};

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -83,19 +83,23 @@ TEST(ICDInterfaceVersion2Plus, version_4) {
 }
 
 TEST(ICDInterfaceVersion2Plus, l4_icd4) {
+    // TODO:
     // ICD must fail with VK_ERROR_INCOMPATIBLE_DRIVER for all vkCreateInstance calls with apiVersion set to > Vulkan 1.0
     // because both the loader and ICD support interface version <= 4. Otherwise, the ICD should behave as normal.
 }
 TEST(ICDInterfaceVersion2Plus, l4_icd5) {
+    // TODO:
     // ICD must fail with VK_ERROR_INCOMPATIBLE_DRIVER for all vkCreateInstance calls with apiVersion set to > Vulkan 1.0
     // because the loader is still at interface version <= 4. Otherwise, the ICD should behave as normal.
 }
 TEST(ICDInterfaceVersion2Plus, l5_icd4) {
+    // TODO:
     // Loader will fail with VK_ERROR_INCOMPATIBLE_DRIVER if it can't handle the apiVersion. ICD may pass for all apiVersions,
     // but since its interface is <= 4, it is best if it assumes it needs to do the work of rejecting anything > Vulkan 1.0 and
     // fail with VK_ERROR_INCOMPATIBLE_DRIVER. Otherwise, the ICD should behave as normal.
 }
 TEST(ICDInterfaceVersion2Plus, l5_icd5) {
+    // TODO:
     // Loader will fail with VK_ERROR_INCOMPATIBLE_DRIVER if it can't handle the apiVersion, and ICDs should fail with
     // VK_ERROR_INCOMPATIBLE_DRIVER only if they can not support the specified apiVersion. Otherwise, the ICD should behave as
     // normal.


### PR DESCRIPTION
Certain functions, like vkSetDebugUtilsObjectNameEXT can take a physical device as a parameter. When this function is queried through vkGetInstanceProcAddr, the trampoline is returned, whereas when queried through vkGetDeviceProcAddr, the trampoline wasn't returned, allowing the physical device parameter to not get unwrapped before calling down the chain, causing a crash.

This commit modifies the codegen to always use the trampoline for these functions, and adds tests for them. These changes require the the loader check that the appropriate extensions are enabled during the application's call to vkGetDeviceProcAddr, since it otherwise always return a non-null function pointer.

Fixes #1109 