### PR TITLE
Add guard for GetPhysDevProcAddr typedef

### DIFF
--- a/loader/generated/vk_layer_dispatch_table.h
+++ b/loader/generated/vk_layer_dispatch_table.h
@@ -24,7 +24,9 @@
 
 #pragma once
 
+#ifndef PFN_GetPhysicalDeviceProcAddr
 typedef PFN_vkVoidFunction (VKAPI_PTR *PFN_GetPhysicalDeviceProcAddr)(VkInstance instance, const char* pName);
+#endif
 
 // Instance function pointer dispatch table
 typedef struct VkLayerInstanceDispatchTable_ {

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -226,7 +226,9 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
         elif self.genOpts.filename == 'vk_layer_dispatch_table.h':
             preamble += '#pragma once\n'
             preamble += '\n'
+            preamble += '#ifndef PFN_GetPhysicalDeviceProcAddr\n'
             preamble += 'typedef PFN_vkVoidFunction (VKAPI_PTR *PFN_GetPhysicalDeviceProcAddr)(VkInstance instance, const char* pName);\n'
+            preamble += '#endif\n'
 
         write(copyright, file=self.outFile)
         write(preamble, file=self.outFile)


### PR DESCRIPTION
vk_layer_dispatch_table.h may be included after vk_icd.h and may cause multiple definitions. This commit adds a macro guard on whether the type is defined just in case.