### PR TITLE
build: Remove VS2015 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-# If we are building in Visual Studio 2015 and with a CMake version 3.19 or greater, we need to set this variable
-# so that CMake will choose a Windows SDK version higher than 10.0.14393.0, as dxgi1_6.h is only found in Windows SDK
-# 10.0.17763 and higher.
-set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM OFF)
-
 project(Vulkan-Loader)
 
 # Gets the header version used during code generation

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -236,17 +236,7 @@ class FolderManager {
 // src - std::string to read from
 // dst - char array to write to
 // size_dst - number of characters in the dst array
-inline void copy_string_to_char_array(std::string const& src, char* dst, size_t size_dst) {
-// Creates a spurious C4996 Warning in VS 2015 - ignore it
-#if defined(WIN32)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
-    dst[src.copy(dst, size_dst - 1)] = 0;
-#if defined(WIN32)
-#pragma warning(pop)
-#endif
-}
+inline void copy_string_to_char_array(std::string const& src, char* dst, size_t size_dst) { dst[src.copy(dst, size_dst - 1)] = 0; }
 
 #if defined(WIN32)
 // Convert an UTF-16 wstring to an UTF-8 string


### PR DESCRIPTION
> VS2015 is no longer supported

Here is my source in case someone needs it:
https://www.lunarg.com/wp-content/uploads/2023/01/Progress-Report-DEC2021-Vulkan-Ecosystem-Survey-Public-Report.pdf

> Deprecate Visual Studio 2015 - Completed
a. SDK and several repositories will no longer build, test, and support VS2015