### PR TITLE
docs: Notify users about upcoming master to main change

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project provides the Khronos official Vulkan ICD desktop loader for Windows, Linux, and MacOS.
 
+## master to main upcoming change (January 23, 2023)
+
+See https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5084 for details.
+
 ## CI Build Status
 
 [![Build Status](https://github.com/KhronosGroup/Vulkan-Loader/workflows/CI%20Build/badge.svg?branch=master)](https://github.com/KhronosGroup/Vulkan-Loader/actions)


### PR DESCRIPTION
I'll also update https://github.com/KhronosGroup/Vulkan-Loader/issues/1107 with the impending date

Note: This date matches VVL's date which would make life simpler:
https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5130