### PR TITLE
Log when VK_LAYER_PATH is ignored

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2990,6 +2990,14 @@ static VkResult read_data_files_in_search_paths(const struct loader_instance *in
             break;
     }
 
+    // Log a message when VK_LAYER_PATH is set but the override layer paths take priority
+    if (manifest_type == LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER && NULL != override_env && NULL != path_override) {
+        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_LAYER_BIT, 0,
+                   "Ignoring VK_LAYER_PATH. The Override layer is active and has override paths set, which takes priority. "
+                   "VK_LAYER_PATH is set to %s",
+                   override_env);
+    }
+
     if (path_override != NULL) {
         override_path = path_override;
     } else if (override_env != NULL) {
@@ -4742,12 +4750,12 @@ void loader_activate_instance_layer_extensions(struct loader_instance *inst, VkI
 VkResult loader_create_device_chain(const VkPhysicalDevice pd, const VkDeviceCreateInfo *pCreateInfo,
                                     const VkAllocationCallbacks *pAllocator, const struct loader_instance *inst,
                                     struct loader_device *dev, PFN_vkGetInstanceProcAddr callingLayer,
-                                    PFN_vkGetDeviceProcAddr *layerNextGDPA) __attribute__ ((optnone)) {
+                                    PFN_vkGetDeviceProcAddr *layerNextGDPA) __attribute__((optnone)) {
 #else
-    VkResult loader_create_device_chain(const VkPhysicalDevice pd, const VkDeviceCreateInfo *pCreateInfo,
-                                        const VkAllocationCallbacks *pAllocator, const struct loader_instance *inst,
-                                        struct loader_device *dev, PFN_vkGetInstanceProcAddr callingLayer,
-                                        PFN_vkGetDeviceProcAddr *layerNextGDPA) {
+VkResult loader_create_device_chain(const VkPhysicalDevice pd, const VkDeviceCreateInfo *pCreateInfo,
+                                    const VkAllocationCallbacks *pAllocator, const struct loader_instance *inst,
+                                    struct loader_device *dev, PFN_vkGetInstanceProcAddr callingLayer,
+                                    PFN_vkGetDeviceProcAddr *layerNextGDPA) {
 #endif
     uint32_t num_activated_layers = 0;
     struct activated_layer_info *activated_layers = NULL;

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -1766,6 +1766,10 @@ TEST(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate(VK_ERROR_LAYER_NOT_PRESENT);
     ASSERT_FALSE(env.debug_log.find(std::string("Insert instance layer \"") + env_var_layer_name));
+    ASSERT_TRUE(
+        env.debug_log.find("Ignoring VK_LAYER_PATH. The Override layer is active and has override paths set, which takes priority. "
+                           "VK_LAYER_PATH is set to " +
+                           env.env_var_vk_layer_paths));
 
     env.layers.clear();
     remove_env_var("VK_LAYER_PATH");
@@ -2096,14 +2100,15 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd().add_physical_device({});
 
-    { 
+    {
         // verify layer loads successfully when setting VK_LAYER_PATH to a full filepath
         const char* regular_layer_name_1 = "RegularLayer1";
-        env.add_explicit_layer(
-        TestLayerDetails(
-            ManifestLayer{}.add_layer(
-                ManifestLayer::LayerDescription{}.set_name(regular_layer_name_1).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
-            "regular_layer_1.json").set_discovery_type(ManifestDiscoveryType::env_var).set_is_dir(false));
+        env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                                              .set_name(regular_layer_name_1)
+                                                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+                                                "regular_layer_1.json")
+                                   .set_discovery_type(ManifestDiscoveryType::env_var)
+                                   .set_is_dir(false));
 
         InstWrapper inst(env.vulkan_functions);
         inst.create_info.add_layer(regular_layer_name_1);
@@ -2117,21 +2122,23 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, &layer_props);
         EXPECT_TRUE(string_eq(layer_props.layerName, regular_layer_name_1));
     }
-    { 
+    {
         // verify layers load successfully when setting VK_LAYER_PATH to multiple full filepaths
         const char* regular_layer_name_1 = "RegularLayer1";
-        env.add_explicit_layer(
-            TestLayerDetails(
-                ManifestLayer{}.add_layer(
-                    ManifestLayer::LayerDescription{}.set_name(regular_layer_name_1).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
-                "regular_layer_1.json").set_discovery_type(ManifestDiscoveryType::env_var).set_is_dir(false));
+        env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                                              .set_name(regular_layer_name_1)
+                                                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+                                                "regular_layer_1.json")
+                                   .set_discovery_type(ManifestDiscoveryType::env_var)
+                                   .set_is_dir(false));
 
         const char* regular_layer_name_2 = "RegularLayer2";
-        env.add_explicit_layer(
-            TestLayerDetails(
-                ManifestLayer{}.add_layer(
-                    ManifestLayer::LayerDescription{}.set_name(regular_layer_name_2).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
-                "regular_layer_2.json").set_discovery_type(ManifestDiscoveryType::env_var).set_is_dir(false));
+        env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                                              .set_name(regular_layer_name_2)
+                                                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+                                                "regular_layer_2.json")
+                                   .set_discovery_type(ManifestDiscoveryType::env_var)
+                                   .set_is_dir(false));
 
         InstWrapper inst(env.vulkan_functions);
         inst.create_info.add_layer(regular_layer_name_1);
@@ -2146,21 +2153,21 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
         env.vulkan_functions.vkEnumerateDeviceLayerProperties(phys_dev, &count, layer_props.data());
         EXPECT_TRUE(check_permutation({regular_layer_name_1, regular_layer_name_2}, layer_props));
     }
-    { 
+    {
         // verify layers load successfully when setting VK_LAYER_PATH to a directory
         const char* regular_layer_name_1 = "RegularLayer1";
-        env.add_explicit_layer(
-            TestLayerDetails(
-                ManifestLayer{}.add_layer(
-                    ManifestLayer::LayerDescription{}.set_name(regular_layer_name_1).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
-                "regular_layer_1.json").set_discovery_type(ManifestDiscoveryType::env_var));
+        env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                                              .set_name(regular_layer_name_1)
+                                                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+                                                "regular_layer_1.json")
+                                   .set_discovery_type(ManifestDiscoveryType::env_var));
 
         const char* regular_layer_name_2 = "RegularLayer2";
-        env.add_explicit_layer(
-            TestLayerDetails(
-                ManifestLayer{}.add_layer(
-                    ManifestLayer::LayerDescription{}.set_name(regular_layer_name_2).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
-                "regular_layer_2.json").set_discovery_type(ManifestDiscoveryType::env_var));
+        env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                                              .set_name(regular_layer_name_2)
+                                                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+                                                "regular_layer_2.json")
+                                   .set_discovery_type(ManifestDiscoveryType::env_var));
 
         InstWrapper inst(env.vulkan_functions);
         inst.create_info.add_layer(regular_layer_name_1);


### PR DESCRIPTION
The current design of the loader make the Override Layer, with its override paths, take priority over VK_LAYER_PATH. This is fine, but if the override layer accidentally was left around, it can cause confusion as VK_LAYER_PATH suddenly stops working for no apparent reason. This commit adds a log message to indicate that it is being ignored.
