### PR TITLE
Implement VK_LUNARG_direct_driver_loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,9 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang
 
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         target_compile_options(loader_common_options INTERFACE -Wno-stringop-truncation -Wno-stringop-overflow)
+        if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.1)
+            target_compile_options(loader_common_options INTERFACE -Wshadow=local) #only added in GCC 7
+        endif()
     endif()
 
     if(UNIX)

--- a/docs/LoaderApplicationInterface.md
+++ b/docs/LoaderApplicationInterface.md
@@ -4,15 +4,15 @@
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
 [2]: https://www.khronos.org/vulkan/
 
-# Application Interface to Loader
+# Application Interface to Loader <!-- omit from toc -->
 [![Creative Commons][3]][4]
 
-<!-- Copyright &copy; 2015-2022 LunarG, Inc. -->
+<!-- Copyright &copy; 2015-2023 LunarG, Inc. -->
 
 [3]: https://i.creativecommons.org/l/by-nd/4.0/88x31.png "Creative Commons License"
 [4]: https://creativecommons.org/licenses/by-nd/4.0/
 
-## Table of Contents
+## Table of Contents <!-- omit from toc -->
 
 - [Overview](#overview)
 - [Interfacing with Vulkan Functions](#interfacing-with-vulkan-functions)

--- a/docs/LoaderDebugging.md
+++ b/docs/LoaderDebugging.md
@@ -4,14 +4,14 @@
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
 [2]: https://www.khronos.org/vulkan/
 
-# Debugging The Vulkan Desktop Loader
+# Debugging The Vulkan Desktop Loader <!-- omit from toc -->
 [![Creative Commons][3]][4]
 
-<!-- Copyright &copy; 2015-2022 LunarG, Inc. -->
+<!-- Copyright &copy; 2015-2023 LunarG, Inc. -->
 
 [3]: https://i.creativecommons.org/l/by-nd/4.0/88x31.png "Creative Commons License"
 [4]: https://creativecommons.org/licenses/by-nd/4.0/
-## Table of Contents
+## Table of Contents <!-- omit from toc -->
 
 - [Debugging Issues](#debugging-issues)
 - [Loader Logging](#loader-logging)

--- a/docs/LoaderInterfaceArchitecture.md
+++ b/docs/LoaderInterfaceArchitecture.md
@@ -4,14 +4,14 @@
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
 [2]: https://www.khronos.org/vulkan/
 
-# Architecture of the Vulkan Loader Interfaces
+# Architecture of the Vulkan Loader Interfaces <!-- omit from toc -->
 [![Creative Commons][3]][4]
 
-<!-- Copyright &copy; 2015-2022 LunarG, Inc. -->
+<!-- Copyright &copy; 2015-2023 LunarG, Inc. -->
 
 [3]: https://i.creativecommons.org/l/by-nd/4.0/88x31.png "Creative Commons License"
 [4]: https://creativecommons.org/licenses/by-nd/4.0/
-## Table of Contents
+## Table of Contents <!-- omit from toc -->
 
 - [Overview](#overview)
   - [Who Should Read This Document](#who-should-read-this-document)

--- a/docs/LoaderLayerInterface.md
+++ b/docs/LoaderLayerInterface.md
@@ -4,16 +4,16 @@
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
 [2]: https://www.khronos.org/vulkan/
 
-# Layer Interface to the Loader
+# Layer Interface to the Loader <!-- omit from toc -->
 [![Creative Commons][3]][4]
 
-<!-- Copyright &copy; 2015-2022 LunarG, Inc. -->
+<!-- Copyright &copy; 2015-2023 LunarG, Inc. -->
 
 [3]: https://i.creativecommons.org/l/by-nd/4.0/88x31.png "Creative Commons License"
 [4]: https://creativecommons.org/licenses/by-nd/4.0/
 
 
-## Table of Contents
+## Table of Contents <!-- omit from toc -->
 
 - [Overview](#overview)
 - [Layer Discovery](#layer-discovery)
@@ -30,6 +30,7 @@
     - [Layer Disable Filtering](#layer-disable-filtering)
     - [Layer Special Case Disable](#layer-special-case-disable)
     - [Layer Disable Warning](#layer-disable-warning)
+      - [`VK_INSTANCE_LAYERS`](#vk_instance_layers)
   - [Exception for Elevated Privileges](#exception-for-elevated-privileges)
 - [Layer Version Negotiation](#layer-version-negotiation)
 - [Layer Call Chains and Distributed Dispatch](#layer-call-chains-and-distributed-dispatch)
@@ -53,6 +54,7 @@
   - [Versioning and Activation Interactions](#versioning-and-activation-interactions)
 - [Layer Manifest File Format](#layer-manifest-file-format)
   - [Layer Manifest File Version History](#layer-manifest-file-version-history)
+  - [Layer Manifest File Version 1.2.1](#layer-manifest-file-version-121)
     - [Layer Manifest File Version 1.2.0](#layer-manifest-file-version-120)
     - [Layer Manifest File Version 1.1.2](#layer-manifest-file-version-112)
     - [Layer Manifest File Version 1.1.1](#layer-manifest-file-version-111)
@@ -504,7 +506,7 @@ Disabling layers, whether just through normal usage of
 `~all~` or `~explicit~` could cause application breakage if the application is
 relying on features provided by one or more explicit layers.
 
-##### VK_INSTANCE_LAYERS
+##### `VK_INSTANCE_LAYERS`
 
 The original `VK_INSTANCE_LAYERS` can be viewed as a special case of the new
 `VK_LOADER_LAYERS_ENABLE`.

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2014-2022 The Khronos Group Inc.
- * Copyright (c) 2014-2022 Valve Corporation
- * Copyright (c) 2014-2022 LunarG, Inc.
+ * Copyright (c) 2014-2023 The Khronos Group Inc.
+ * Copyright (c) 2014-2023 Valve Corporation
+ * Copyright (c) 2014-2023 LunarG, Inc.
  * Copyright (C) 2015 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1177,6 +1177,12 @@ VkResult loader_get_icd_loader_instance_extensions(const struct loader_instance 
     loader_add_to_ext_list(inst, inst_exts, sizeof(portability_enumeration_extension_info) / sizeof(VkExtensionProperties),
                            portability_enumeration_extension_info);
 
+    static const VkExtensionProperties direct_driver_loading_extension_info[] = {
+        {VK_LUNARG_DIRECT_DRIVER_LOADING_EXTENSION_NAME, VK_LUNARG_DIRECT_DRIVER_LOADING_SPEC_VERSION}};
+
+    // Add VK_LUNARG_direct_driver_loading
+    loader_add_to_ext_list(inst, inst_exts, sizeof(direct_driver_loading_extension_info) / sizeof(VkExtensionProperties),
+                           direct_driver_loading_extension_info);
 out:
     return res;
 }
@@ -1325,27 +1331,244 @@ bool loader_get_icd_interface_version(PFN_vkNegotiateLoaderICDInterfaceVersion f
 void loader_scanned_icd_clear(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list) {
     if (0 != icd_tramp_list->capacity) {
         for (uint32_t i = 0; i < icd_tramp_list->count; i++) {
-            loader_platform_close_library(icd_tramp_list->scanned_list[i].handle);
+            if (icd_tramp_list->scanned_list[i].handle) {
+                loader_platform_close_library(icd_tramp_list->scanned_list[i].handle);
+                icd_tramp_list->scanned_list[i].handle = NULL;
+            }
             loader_instance_heap_free(inst, icd_tramp_list->scanned_list[i].lib_name);
         }
         loader_instance_heap_free(inst, icd_tramp_list->scanned_list);
-        icd_tramp_list->capacity = 0;
-        icd_tramp_list->count = 0;
-        icd_tramp_list->scanned_list = NULL;
     }
+    icd_tramp_list->capacity = 0;
+    icd_tramp_list->count = 0;
+    icd_tramp_list->scanned_list = NULL;
 }
 
-static VkResult loader_scanned_icd_init(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list) {
-    VkResult err = VK_SUCCESS;
+VkResult loader_scanned_icd_init(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list) {
+    VkResult res = VK_SUCCESS;
     loader_scanned_icd_clear(inst, icd_tramp_list);
     icd_tramp_list->capacity = 8 * sizeof(struct loader_scanned_icd);
     icd_tramp_list->scanned_list = loader_instance_heap_alloc(inst, icd_tramp_list->capacity, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
     if (NULL == icd_tramp_list->scanned_list) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "loader_scanned_icd_init: Realloc failed for layer list when attempting to add new layer");
-        err = VK_ERROR_OUT_OF_HOST_MEMORY;
+        res = VK_ERROR_OUT_OF_HOST_MEMORY;
     }
-    return err;
+    return res;
+}
+
+VkResult loader_add_direct_driver(const struct loader_instance *inst, uint32_t index,
+                                  const VkDirectDriverLoadingInfoLUNARG *pDriver, struct loader_icd_tramp_list *icd_tramp_list) {
+    // Assume pDriver is valid, since there is no real way to check it. Calling code should make sure the pointer to the array of
+    // VkDirectDriverLoadingInfoLUNARG structures is non-null.
+    if (NULL == pDriver->pfnGetInstanceProcAddr) {
+        loader_log(
+            inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+            "loader_add_direct_driver: VkDirectDriverLoadingInfoLUNARG structure at index %d contains a NULL pointer for the "
+            "pfnGetInstanceProcAddr member, skipping.",
+            index);
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    PFN_vkGetInstanceProcAddr fp_get_proc_addr = pDriver->pfnGetInstanceProcAddr;
+    PFN_vkCreateInstance fp_create_inst = NULL;
+    PFN_vkEnumerateInstanceExtensionProperties fp_get_inst_ext_props = NULL;
+    PFN_GetPhysicalDeviceProcAddr fp_get_phys_dev_proc_addr = NULL;
+    PFN_vkNegotiateLoaderICDInterfaceVersion fp_negotiate_icd_version = NULL;
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+    PFN_vk_icdEnumerateAdapterPhysicalDevices fp_enum_dxgi_adapter_phys_devs = NULL;
+#endif
+    struct loader_scanned_icd *new_scanned_icd;
+    uint32_t interface_version = 0;
+
+    // Try to get the negotiate ICD interface version function
+    fp_negotiate_icd_version = (PFN_vk_icdNegotiateLoaderICDInterfaceVersion)pDriver->pfnGetInstanceProcAddr(
+        NULL, "vk_icdNegotiateLoaderICDInterfaceVersion");
+
+    if (NULL == fp_negotiate_icd_version) {
+        loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                   "loader_add_direct_driver: Could not get 'vk_icdNegotiateLoaderICDInterfaceVersion' from "
+                   "VkDirectDriverLoadingInfoLUNARG structure at "
+                   "index %d, skipping.",
+                   index);
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    if (!loader_get_icd_interface_version(fp_negotiate_icd_version, &interface_version)) {
+        loader_log(
+            inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+            "loader_add_direct_driver: VkDirectDriverLoadingInfoLUNARG structure at index %d supports interface version %d, "
+            "which is incompatible with the Loader Driver Interface version that supports the VK_LUNARG_direct_driver_loading "
+            "extension, skipping.",
+            index, interface_version);
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    if (interface_version < 7) {
+        loader_log(
+            inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+            "loader_add_direct_driver: VkDirectDriverLoadingInfoLUNARG structure at index %d supports interface version %d, "
+            "which is incompatible with the Loader Driver Interface version that supports the VK_LUNARG_direct_driver_loading "
+            "extension, skipping.",
+            index, interface_version);
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    fp_create_inst = (PFN_vkCreateInstance)pDriver->pfnGetInstanceProcAddr(NULL, "vkCreateInstance");
+    if (NULL == fp_create_inst) {
+        loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                   "loader_add_direct_driver: Could not get 'vkCreateInstance' from VkDirectDriverLoadingInfoLUNARG structure at "
+                   "index %d, skipping.",
+                   index);
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+    fp_get_inst_ext_props =
+        (PFN_vkEnumerateInstanceExtensionProperties)pDriver->pfnGetInstanceProcAddr(NULL, "vkEnumerateInstanceExtensionProperties");
+    if (NULL == fp_get_inst_ext_props) {
+        loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                   "loader_add_direct_driver: Could not get 'vkEnumerateInstanceExtensionProperties' from "
+                   "VkDirectDriverLoadingInfoLUNARG structure at index %d, skipping.",
+                   index);
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    fp_get_phys_dev_proc_addr =
+        (PFN_vk_icdGetPhysicalDeviceProcAddr)pDriver->pfnGetInstanceProcAddr(NULL, "vk_icdGetPhysicalDeviceProcAddr");
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+    // Query "vk_icdEnumerateAdapterPhysicalDevices" with vk_icdGetInstanceProcAddr if the library reports interface version
+    // 7 or greater, otherwise fallback to loading it from the platform dynamic linker
+    fp_enum_dxgi_adapter_phys_devs =
+        (PFN_vk_icdEnumerateAdapterPhysicalDevices)pDriver->pfnGetInstanceProcAddr(NULL, "vk_icdEnumerateAdapterPhysicalDevices");
+#endif
+
+    // check for enough capacity
+    if ((icd_tramp_list->count * sizeof(struct loader_scanned_icd)) >= icd_tramp_list->capacity) {
+        void *new_ptr = loader_instance_heap_realloc(inst, icd_tramp_list->scanned_list, icd_tramp_list->capacity,
+                                                     icd_tramp_list->capacity * 2, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (NULL == new_ptr) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "loader_add_direct_driver: Realloc failed on icd library list for ICD %s");
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+        icd_tramp_list->scanned_list = new_ptr;
+
+        // double capacity
+        icd_tramp_list->capacity *= 2;
+    }
+
+    // Driver must be 1.1 to support version 7
+    uint32_t api_version = VK_API_VERSION_1_1;
+    PFN_vkEnumerateInstanceVersion icd_enumerate_instance_version =
+        (PFN_vkEnumerateInstanceVersion)pDriver->pfnGetInstanceProcAddr(NULL, "vkEnumerateInstanceVersion");
+
+    if (icd_enumerate_instance_version) {
+        VkResult res = icd_enumerate_instance_version(&api_version);
+        if (res != VK_SUCCESS) {
+            return res;
+        }
+    }
+
+    new_scanned_icd = &(icd_tramp_list->scanned_list[icd_tramp_list->count]);
+    new_scanned_icd->handle = NULL;
+    new_scanned_icd->api_version = api_version;
+    new_scanned_icd->GetInstanceProcAddr = fp_get_proc_addr;
+    new_scanned_icd->GetPhysicalDeviceProcAddr = fp_get_phys_dev_proc_addr;
+    new_scanned_icd->EnumerateInstanceExtensionProperties = fp_get_inst_ext_props;
+    new_scanned_icd->CreateInstance = fp_create_inst;
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+    new_scanned_icd->EnumerateAdapterPhysicalDevices = fp_enum_dxgi_adapter_phys_devs;
+#endif
+    new_scanned_icd->interface_version = interface_version;
+
+    new_scanned_icd->lib_name = NULL;
+    icd_tramp_list->count++;
+
+    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+               "loader_add_direct_driver: Adding driver found in index %d of "
+               "VkDirectDriverLoadingListLUNARG::pDrivers structure. pfnGetInstanceProcAddr was set to %p",
+               index, pDriver->pfnGetInstanceProcAddr);
+
+    return VK_SUCCESS;
+}
+
+// Search through VkInstanceCreateInfo's pNext chain for any drivers from the direct driver loading extension and load them.
+VkResult loader_scan_for_direct_drivers(const struct loader_instance *inst, const VkInstanceCreateInfo *pCreateInfo,
+                                        struct loader_icd_tramp_list *icd_tramp_list, bool *direct_driver_loading_exclusive_mode) {
+    if (NULL == pCreateInfo) {
+        // Don't do this logic unless we are being called from vkCreateInstance, when pCreateInfo will be non-null
+        return VK_SUCCESS;
+    }
+    bool direct_driver_loading_enabled = false;
+    // Try to if VK_LUNARG_direct_driver_loading is enabled and if we are using it exclusively
+    // Skip this step if inst is NULL, aka when this function is being called before instance creation
+    if (inst != NULL && pCreateInfo->ppEnabledExtensionNames && pCreateInfo->enabledExtensionCount > 0) {
+        // Look through the enabled extension list, make sure VK_LUNARG_direct_driver_loading is present
+        for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
+            if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_LUNARG_DIRECT_DRIVER_LOADING_EXTENSION_NAME) == 0) {
+                direct_driver_loading_enabled = true;
+                break;
+            }
+        }
+    }
+    const VkDirectDriverLoadingListLUNARG *ddl_list = NULL;
+    // Find the VkDirectDriverLoadingListLUNARG struct in the pNext chain of vkInstanceCreateInfo
+    const VkBaseOutStructure *chain = pCreateInfo->pNext;
+    while (chain) {
+        if (chain->sType == VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_LIST_LUNARG) {
+            ddl_list = (VkDirectDriverLoadingListLUNARG *)chain;
+            break;
+        }
+        chain = (const VkBaseOutStructure *)chain->pNext;
+    }
+    if (NULL == ddl_list) {
+        if (direct_driver_loading_enabled) {
+            loader_log(
+                inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                "loader_scan_for_direct_drivers: The VK_LUNARG_direct_driver_loading extension was enabled but the pNext chain of "
+                "VkInstanceCreateInfo did not contain the "
+                "VkDirectDriverLoadingListLUNARG structure.");
+        }
+        // Always want to exit early if there was no VkDirectDriverLoadingListLUNARG in the pNext chain
+        return VK_SUCCESS;
+    }
+
+    if (!direct_driver_loading_enabled) {
+        loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                   "loader_scan_for_direct_drivers: The pNext chain of VkInstanceCreateInfo contained the "
+                   "VkDirectDriverLoadingListLUNARG structure, but the VK_LUNARG_direct_driver_loading extension was "
+                   "not enabled.");
+        return VK_SUCCESS;
+    }
+    // If we are using exclusive mode, skip looking for any more drivers from system or environment variables
+    if (ddl_list->mode == VK_DIRECT_DRIVER_LOADING_MODE_EXCLUSIVE_LUNARG) {
+        *direct_driver_loading_exclusive_mode = true;
+        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                   "loader_scan_for_direct_drivers: The VK_LUNARG_direct_driver_loading extension is active and specified "
+                   "VK_DIRECT_DRIVER_LOADING_MODE_EXCLUSIVE_LUNARG, skipping system and environment "
+                   "variable driver search mechanisms.");
+    }
+    if (NULL == ddl_list->pDrivers) {
+        loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                   "loader_scan_for_direct_drivers: The VkDirectDriverLoadingListLUNARG structure in the pNext chain of "
+                   "VkInstanceCreateInfo has a NULL pDrivers member.");
+        return VK_SUCCESS;
+    }
+    if (ddl_list->driverCount == 0) {
+        loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                   "loader_scan_for_direct_drivers: The VkDirectDriverLoadingListLUNARG structure in the pNext chain of "
+                   "VkInstanceCreateInfo has a non-null pDrivers member but a driverCount member with a value "
+                   "of zero.");
+        return VK_SUCCESS;
+    }
+    // Go through all VkDirectDriverLoadingInfoLUNARG entries and add each driver
+    // Because icd_tramp's are prepended, this will result in the drivers appearing at the end
+    for (uint32_t i = 0; i < ddl_list->driverCount; i++) {
+        VkResult res = loader_add_direct_driver(inst, i, &ddl_list->pDrivers[i], icd_tramp_list);
+        if (res == VK_ERROR_OUT_OF_HOST_MEMORY) {
+            return res;
+        }
+    }
+
+    return VK_SUCCESS;
 }
 
 static VkResult loader_scanned_icd_add(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list,
@@ -1596,8 +1819,7 @@ void loader_preload_icds(void) {
         return;
     }
 
-    memset(&scanned_icds, 0, sizeof(scanned_icds));
-    VkResult result = loader_icd_scan(NULL, &scanned_icds, NULL);
+    VkResult result = loader_icd_scan(NULL, &scanned_icds, NULL, NULL);
     if (result != VK_SUCCESS) {
         loader_scanned_icd_clear(NULL, &scanned_icds);
     }
@@ -3513,7 +3735,7 @@ out:
 // Vulkan result
 // (on result == VK_SUCCESS) a list of icds that were discovered
 VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list,
-                         bool *skipped_portability_drivers) {
+                         const VkInstanceCreateInfo *pCreateInfo, bool *skipped_portability_drivers) {
     struct loader_data_files manifest_files;
     VkResult res = VK_SUCCESS;
     bool lockedMutex = false;
@@ -3523,6 +3745,23 @@ VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_t
     // Before we begin anything, init manifest_files to avoid a delete of garbage memory if
     // a failure occurs before allocating the manifest filename_list.
     memset(&manifest_files, 0, sizeof(struct loader_data_files));
+
+    // Set up the ICD Trampoline list so elements can be written into it.
+    res = loader_scanned_icd_init(inst, icd_tramp_list);
+    if (res == VK_ERROR_OUT_OF_HOST_MEMORY) {
+        return res;
+    }
+
+    bool direct_driver_loading_exclusive_mode = false;
+    res = loader_scan_for_direct_drivers(inst, pCreateInfo, icd_tramp_list, &direct_driver_loading_exclusive_mode);
+    if (res == VK_ERROR_OUT_OF_HOST_MEMORY) {
+        goto out;
+    }
+    if (direct_driver_loading_exclusive_mode) {
+        // Make sure to jump over the system & env-var driver discovery mechanisms if exclusive mode is set, even if no drivers
+        // were successfully found through the direct driver loading mechanism
+        goto out;
+    }
 
     // Parse the filter environment variables to determine if we have any special behavior
     res = parse_generic_filter_environment_var(inst, VK_DRIVERS_SELECT_ENV_VAR, &select_filter);
@@ -3534,14 +3773,9 @@ VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_t
         goto out;
     }
 
-    res = loader_scanned_icd_init(inst, icd_tramp_list);
-    if (VK_SUCCESS != res) {
-        goto out;
-    }
-
     // Get a list of manifest files for ICDs
     res = loader_get_data_files(inst, LOADER_DATA_FILE_MANIFEST_DRIVER, NULL, &manifest_files);
-    if (VK_SUCCESS != res || manifest_files.count == 0) {
+    if (VK_SUCCESS != res) {
         goto out;
     }
 
@@ -4012,9 +4246,9 @@ static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL loader_gpa_instance_terminator(V
         return (PFN_vkVoidFunction)terminator_CreateDevice;
     }
 
-    // The VK_EXT_debug_utils functions need a special case here so the terminators can still be found from vkGetInstanceProcAddr
-    // This is because VK_EXT_debug_utils is an instance level extension with device level functions, and is 'supported' by the
-    // loader. There needs to be a terminator in case a driver doesn't support VK_EXT_debug_utils.
+    // The VK_EXT_debug_utils functions need a special case here so the terminators can still be found from
+    // vkGetInstanceProcAddr This is because VK_EXT_debug_utils is an instance level extension with device level functions, and
+    // is 'supported' by the loader. There needs to be a terminator in case a driver doesn't support VK_EXT_debug_utils.
     if (!strcmp(pName, "vkSetDebugUtilsObjectNameEXT")) {
         return (PFN_vkVoidFunction)terminator_SetDebugUtilsObjectNameEXT;
     }
@@ -6014,8 +6248,8 @@ bool is_linux_sort_enabled(struct loader_instance *inst) {
 }
 #endif  // LOADER_ENABLE_LINUX_SORT
 
-// Look for physical_device in the provided phys_devs list, return true if found and put the index into out_idx, otherwise return
-// false
+// Look for physical_device in the provided phys_devs list, return true if found and put the index into out_idx, otherwise
+// return false
 bool find_phys_dev(VkPhysicalDevice physical_device, uint32_t phys_devs_count, struct loader_physical_device_term **phys_devs,
                    uint32_t *out_idx) {
     if (NULL == phys_devs) return false;
@@ -6046,8 +6280,8 @@ VkResult check_and_add_to_new_phys_devs(struct loader_instance *inst, VkPhysical
         return VK_SUCCESS;
     }
 
-    // Exit in case something is already present - this shouldn't happen but better to be safe than overwrite existing data since
-    // this code has been refactored a half dozen times.
+    // Exit in case something is already present - this shouldn't happen but better to be safe than overwrite existing data
+    // since this code has been refactored a half dozen times.
     if (NULL != new_phys_devs[idx]) {
         return VK_SUCCESS;
     }
@@ -6610,7 +6844,7 @@ terminator_EnumerateInstanceExtensionProperties(const VkEnumerateInstanceExtensi
         loader_preload_icds();
 
         // Scan/discover all ICD libraries
-        res = loader_icd_scan(NULL, &icd_tramp_list, NULL);
+        res = loader_icd_scan(NULL, &icd_tramp_list, NULL, NULL);
         // EnumerateInstanceExtensionProperties can't return anything other than OOM or VK_ERROR_LAYER_NOT_PRESENT
         if ((VK_SUCCESS != res && icd_tramp_list.count > 0) || res == VK_ERROR_OUT_OF_HOST_MEMORY) {
             goto out;

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2014-2022 The Khronos Group Inc.
- * Copyright (c) 2014-2022 Valve Corporation
- * Copyright (c) 2014-2022 LunarG, Inc.
+ * Copyright (c) 2014-2023 The Khronos Group Inc.
+ * Copyright (c) 2014-2023 Valve Corporation
+ * Copyright (c) 2014-2023 LunarG, Inc.
  * Copyright (C) 2015 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -122,9 +122,10 @@ void loader_destroy_generic_list(const struct loader_instance *inst, struct load
 void loader_destroy_layer_list(const struct loader_instance *inst, struct loader_device *device,
                                struct loader_layer_list *layer_list);
 void loader_delete_layer_list_and_properties(const struct loader_instance *inst, struct loader_layer_list *layer_list);
+VkResult loader_scanned_icd_init(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
 void loader_scanned_icd_clear(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
 VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list,
-                         bool *skipped_portability_drivers);
+                         const VkInstanceCreateInfo *pCreateInfo, bool *skipped_portability_drivers);
 void loader_icd_destroy(struct loader_instance *ptr_inst, struct loader_icd_term *icd_term,
                         const VkAllocationCallbacks *pAllocator);
 VkResult loader_scan_for_layers(struct loader_instance *inst, struct loader_layer_list *instance_layers);

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (C) 2015 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -521,13 +521,14 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         }
     }
 
-    // Scan/discover all ICD libraries
-    memset(&ptr_instance->icd_tramp_list, 0, sizeof(ptr_instance->icd_tramp_list));
+    // Scan/discover all System and Environment Variable ICD libraries
     bool skipped_portability_drivers = false;
-    res = loader_icd_scan(ptr_instance, &ptr_instance->icd_tramp_list, &skipped_portability_drivers);
+    res = loader_icd_scan(ptr_instance, &ptr_instance->icd_tramp_list, pCreateInfo, &skipped_portability_drivers);
     if (res == VK_ERROR_OUT_OF_HOST_MEMORY) {
         goto out;
-    } else if (ptr_instance->icd_tramp_list.count == 0) {
+    }
+
+    if (ptr_instance->icd_tramp_list.count == 0) {
         // No drivers found
         if (skipped_portability_drivers) {
             loader_log(
@@ -700,8 +701,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
     loader_instance_heap_free(ptr_instance, ptr_instance);
     loader_platform_thread_unlock_mutex(&loader_lock);
 
-    // Unload preloaded layers, so if vkEnumerateInstanceExtensionProperties or vkCreateInstance is called again, the ICD's are up
-    // to date
+    // Unload preloaded layers, so if vkEnumerateInstanceExtensionProperties or vkCreateInstance is called again, the ICD's are
+    // up to date
     loader_unload_preloaded_icds();
 }
 
@@ -793,9 +794,9 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceProperties(VkPhysica
     const VkLayerInstanceDispatchTable *disp;
     VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device(physicalDevice);
     if (VK_NULL_HANDLE == unwrapped_phys_dev) {
-        loader_log(
-            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
-            "vkGetPhysicalDeviceProperties: Invalid physicalDevice [VUID-vkGetPhysicalDeviceProperties-physicalDevice-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkGetPhysicalDeviceProperties: Invalid physicalDevice "
+                   "[VUID-vkGetPhysicalDeviceProperties-physicalDevice-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
     disp = loader_get_instance_layer_dispatch(physicalDevice);
@@ -2930,9 +2931,9 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkCmdDrawIndexedIndirectCount(VkCommand
                                                                        uint32_t stride) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     if (NULL == disp) {
-        loader_log(
-            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
-            "vkCmdDrawIndexedIndirectCount: Invalid commandBuffer [VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkCmdDrawIndexedIndirectCount: Invalid commandBuffer "
+                   "[VUID-vkCmdDrawIndexedIndirectCount-commandBuffer-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
     disp->CmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
@@ -2995,9 +2996,9 @@ LOADER_EXPORT VKAPI_ATTR uint64_t VKAPI_CALL
 vkGetDeviceMemoryOpaqueCaptureAddress(VkDevice device, const VkDeviceMemoryOpaqueCaptureAddressInfo *pInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(device);
     if (NULL == disp) {
-        loader_log(
-            NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
-            "vkGetDeviceMemoryOpaqueCaptureAddress: Invalid device [VUID-vkGetDeviceMemoryOpaqueCaptureAddress-device-parameter]");
+        loader_log(NULL, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
+                   "vkGetDeviceMemoryOpaqueCaptureAddress: Invalid device "
+                   "[VUID-vkGetDeviceMemoryOpaqueCaptureAddress-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
     return disp->GetDeviceMemoryOpaqueCaptureAddress(device, pInfo);

--- a/tests/framework/README.md
+++ b/tests/framework/README.md
@@ -133,7 +133,7 @@ This is due to some functions being used to query other functions, which the shi
 There are many utilities that the test framework and tests have access to. These include:
 * Including common C and C++ headers
 * `FRAMEWORK_EXPORT` - macro used for exporting shared library funtions
-* Environment Variable helpers: `get_env_var`, `set_env_var`, `remove_env_var`
+* Environment Variable Wrapper: `EnvVarWrapper` for creating, setting, getting, and removing environment variables in a RAII manner
 * Windows API error handling helpers
 * filesystem abstractions:
   * `fs::path` - wrapper around std::string that has a similar API to C++17's `filesystem::path` library

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021-2022 The Khronos Group Inc.
- * Copyright (c) 2021-2022 Valve Corporation
- * Copyright (c) 2021-2022 LunarG, Inc.
+ * Copyright (c) 2021-2023 The Khronos Group Inc.
+ * Copyright (c) 2021-2023 Valve Corporation
+ * Copyright (c) 2021-2023 LunarG, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and/or associated documentation files (the "Materials"), to
@@ -76,6 +76,14 @@ inline std::ostream& operator<<(std::ostream& os, const InterfaceVersionCheck& r
 
 struct TestICD {
     fs::path manifest_file_path;
+
+    BUILDER_VALUE(TestICD, bool, exposes_vk_icdNegotiateLoaderICDInterfaceVersion, true)
+    BUILDER_VALUE(TestICD, bool, exposes_vkEnumerateInstanceExtensionProperties, true)
+    BUILDER_VALUE(TestICD, bool, exposes_vkCreateInstance, true)
+    BUILDER_VALUE(TestICD, bool, exposes_vk_icdGetPhysicalDeviceProcAddr, true)
+#if defined(WIN32)
+    BUILDER_VALUE(TestICD, bool, exposes_vk_icdEnumerateAdapterPhysicalDevices, true)
+#endif
 
     CalledICDGIPA called_vk_icd_gipa = CalledICDGIPA::not_called;
     CalledNegotiateInterface called_negotiate_interface = CalledNegotiateInterface::not_called;

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021 The Khronos Group Inc.
- * Copyright (c) 2021 Valve Corporation
- * Copyright (c) 2021 LunarG, Inc.
+ * Copyright (c) 2021-2023 The Khronos Group Inc.
+ * Copyright (c) 2021-2023 Valve Corporation
+ * Copyright (c) 2021-2023 LunarG, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and/or associated documentation files (the "Materials"), to
@@ -57,13 +57,13 @@ void print_error_message(LSTATUS status, const char* function_name, std::string 
     LocalFree(lpMsgBuf);
 }
 
-void set_env_var(std::string const& name, std::string const& value) {
-    BOOL ret = SetEnvironmentVariableW(widen(name).c_str(), widen(value).c_str());
+void EnvVarWrapper::set_env_var() {
+    BOOL ret = SetEnvironmentVariableW(widen(name).c_str(), widen(cur_value).c_str());
     if (ret == 0) {
         print_error_message(ERROR_SETENV_FAILED, "SetEnvironmentVariableW");
     }
 }
-void remove_env_var(std::string const& name) { SetEnvironmentVariableW(widen(name).c_str(), nullptr); }
+void EnvVarWrapper::remove_env_var() const { SetEnvironmentVariableW(widen(name).c_str(), nullptr); }
 std::string get_env_var(std::string const& name, bool report_failure) {
     std::wstring name_utf16 = widen(name);
     DWORD value_size = GetEnvironmentVariableW(name_utf16.c_str(), nullptr, 0);
@@ -79,8 +79,8 @@ std::string get_env_var(std::string const& name, bool report_failure) {
 }
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 
-void set_env_var(std::string const& name, std::string const& value) { setenv(name.c_str(), value.c_str(), 1); }
-void remove_env_var(std::string const& name) { unsetenv(name.c_str()); }
+void EnvVarWrapper::set_env_var() { setenv(name.c_str(), cur_value.c_str(), 1); }
+void EnvVarWrapper::remove_env_var() const { unsetenv(name.c_str()); }
 std::string get_env_var(std::string const& name, bool report_failure) {
     char* ret = getenv(name.c_str());
     if (ret == nullptr) {

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021-2022 The Khronos Group Inc.
- * Copyright (c) 2021-2022 Valve Corporation
- * Copyright (c) 2021-2022 LunarG, Inc.
+ * Copyright (c) 2021-2023 The Khronos Group Inc.
+ * Copyright (c) 2021-2023 Valve Corporation
+ * Copyright (c) 2021-2023 LunarG, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and/or associated documentation files (the "Materials"), to
@@ -189,11 +189,11 @@ TEST(EnumerateInstanceExtensionProperties, UsageChecks) {
     env.reset_icd().add_instance_extensions({first_ext, second_ext});
 
     {  // One Pass
-        uint32_t extension_count = 5;
-        std::array<VkExtensionProperties, 5> extensions;
+        uint32_t extension_count = 6;
+        std::array<VkExtensionProperties, 6> extensions;
         ASSERT_EQ(VK_SUCCESS,
                   env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data()));
-        ASSERT_EQ(extension_count, 5U);  // return debug report & debug utils & portability enumeration + our two extensions
+        ASSERT_EQ(extension_count, 6U);  // default extensions + our two extensions
 
         // loader always adds the debug report & debug utils extensions
         ASSERT_TRUE(first_ext.extensionName == extensions[0].extensionName);
@@ -204,13 +204,13 @@ TEST(EnumerateInstanceExtensionProperties, UsageChecks) {
     }
     {  // Two Pass
         uint32_t extension_count = 0;
-        std::array<VkExtensionProperties, 5> extensions;
+        std::array<VkExtensionProperties, 6> extensions;
         ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-        ASSERT_EQ(extension_count, 5U);  // return debug report & debug utils + our two extensions
+        ASSERT_EQ(extension_count, 6U);  // return default extensions + our extension
 
         ASSERT_EQ(VK_SUCCESS,
                   env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data()));
-        ASSERT_EQ(extension_count, 5U);
+        ASSERT_EQ(extension_count, 6U);
         // loader always adds the debug report & debug utils extensions
         ASSERT_TRUE(first_ext.extensionName == extensions[0].extensionName);
         ASSERT_TRUE(second_ext.extensionName == extensions[1].extensionName);
@@ -225,10 +225,10 @@ TEST(EnumerateInstanceExtensionProperties, PropertyCountLessThanAvailable) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
 
     uint32_t extension_count = 0;
-    std::array<VkExtensionProperties, 2> extensions;
+    std::array<VkExtensionProperties, 4> extensions;
     {  // use nullptr for null string
         ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-        ASSERT_EQ(extension_count, 3U);  // return debug report & debug utils & portability enumeration
+        ASSERT_EQ(extension_count, 4U);  // return debug report & debug utils & portability enumeration & direct driver loading
         extension_count = 1;             // artificially remove one extension
 
         ASSERT_EQ(VK_INCOMPLETE,
@@ -239,7 +239,7 @@ TEST(EnumerateInstanceExtensionProperties, PropertyCountLessThanAvailable) {
     }
     {  // use "" for null string
         ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties("", &extension_count, nullptr));
-        ASSERT_EQ(extension_count, 3U);  // return debug report & debug utils & portability enumeration
+        ASSERT_EQ(extension_count, 4U);  // return debug report & debug utils & portability enumeration & direct driver loading
         extension_count = 1;             // artificially remove one extension
 
         ASSERT_EQ(VK_INCOMPLETE,
@@ -260,26 +260,27 @@ TEST(EnumerateInstanceExtensionProperties, FilterUnkownInstanceExtensions) {
     {
         uint32_t extension_count = 0;
         ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties("", &extension_count, nullptr));
-        ASSERT_EQ(extension_count, 3U);  // return debug report & debug utils & portability enumeration
+        ASSERT_EQ(extension_count, 4U);  // debug report & debug utils & portability enumeration & direct driver loading
 
-        std::array<VkExtensionProperties, 3> extensions;
+        std::array<VkExtensionProperties, 4> extensions;
         ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties("", &extension_count, extensions.data()));
-        ASSERT_EQ(extension_count, 3U);
+        ASSERT_EQ(extension_count, 4U);  // debug report & debug utils & portability enumeration & direct driver loading
         // loader always adds the debug report & debug utils extensions
         ASSERT_TRUE(string_eq(extensions[0].extensionName, "VK_EXT_debug_report"));
         ASSERT_TRUE(string_eq(extensions[1].extensionName, "VK_EXT_debug_utils"));
         ASSERT_TRUE(string_eq(extensions[2].extensionName, "VK_KHR_portability_enumeration"));
+        ASSERT_TRUE(string_eq(extensions[3].extensionName, "VK_LUNARG_direct_driver_loading"));
     }
     {  // Disable unknown instance extension filtering
-        set_env_var("VK_LOADER_DISABLE_INST_EXT_FILTER", "1");
+        EnvVarWrapper disable_inst_ext_filter_env_var{"VK_LOADER_DISABLE_INST_EXT_FILTER", "1"};
 
         uint32_t extension_count = 0;
         ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties("", &extension_count, nullptr));
-        ASSERT_EQ(extension_count, 5U);
+        ASSERT_EQ(extension_count, 6U);
 
-        std::array<VkExtensionProperties, 5> extensions;
+        std::array<VkExtensionProperties, 6> extensions;
         ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties("", &extension_count, extensions.data()));
-        ASSERT_EQ(extension_count, 5U);
+        ASSERT_EQ(extension_count, 6U);
 
         ASSERT_EQ(extensions[0], first_ext.get());
         ASSERT_EQ(extensions[1], second_ext.get());
@@ -287,6 +288,7 @@ TEST(EnumerateInstanceExtensionProperties, FilterUnkownInstanceExtensions) {
         ASSERT_TRUE(string_eq(extensions[2].extensionName, "VK_EXT_debug_report"));
         ASSERT_TRUE(string_eq(extensions[3].extensionName, "VK_EXT_debug_utils"));
         ASSERT_TRUE(string_eq(extensions[4].extensionName, "VK_KHR_portability_enumeration"));
+        ASSERT_TRUE(string_eq(extensions[5].extensionName, "VK_LUNARG_direct_driver_loading"));
     }
 }
 
@@ -2814,8 +2816,7 @@ TEST(SortedPhysicalDevices, DevicesSortEnabled11) {
 TEST(SortedPhysicalDevices, DevicesSortedDisabled) {
     FrameworkEnvironment env{};
 
-    set_env_var("VK_LOADER_DISABLE_SELECT", "1");
-    EnvVarCleaner disable_select_cleaner("VK_LOADER_DISABLE_SELECT");
+    EnvVarWrapper disable_select_env_var{"VK_LOADER_DISABLE_SELECT", "1"};
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
@@ -3107,8 +3108,7 @@ TEST(SortedPhysicalDevices, DeviceGroupsSortedEnabled) {
 TEST(SortedPhysicalDevices, DeviceGroupsSortedDisabled) {
     FrameworkEnvironment env{};
 
-    set_env_var("VK_LOADER_DISABLE_SELECT", "1");
-    EnvVarCleaner disable_select_cleaner("VK_LOADER_DISABLE_SELECT");
+    EnvVarWrapper disable_select_env_var{"VK_LOADER_DISABLE_SELECT", "1"};
 
     // ICD 0: Vulkan 1.1
     //   PhysDev 0: pd0, Discrete, Vulkan 1.1, Bus 7
@@ -3472,19 +3472,21 @@ TEST(PortabilityICDConfiguration, PortabilityAndRegularICDPreInstanceFunctions) 
     {
         // check that enumerating instance extensions work with a portability driver present
         uint32_t extension_count = 0;
-        std::array<VkExtensionProperties, 5> extensions;
+        std::array<VkExtensionProperties, 6> extensions;
         ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, nullptr));
-        ASSERT_EQ(extension_count, 5U);  // return debug report & debug utils + our two extensions
+        // loader always adds the debug report, debug utils extensions, portability enumeration, direct driver loading
+        ASSERT_EQ(extension_count, 6U);
 
         ASSERT_EQ(VK_SUCCESS,
                   env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &extension_count, extensions.data()));
-        ASSERT_EQ(extension_count, 5U);
-        // loader always adds the debug report & debug utils extensions
+        ASSERT_EQ(extension_count, 6U);
+        // loader always adds the debug report, debug utils extensions, portability enumeration, direct driver loading
         ASSERT_TRUE(first_ext.extensionName == extensions[0].extensionName);
         ASSERT_TRUE(second_ext.extensionName == extensions[1].extensionName);
         ASSERT_TRUE(string_eq("VK_EXT_debug_report", extensions[2].extensionName));
         ASSERT_TRUE(string_eq("VK_EXT_debug_utils", extensions[3].extensionName));
         ASSERT_TRUE(string_eq("VK_KHR_portability_enumeration", extensions[4].extensionName));
+        ASSERT_TRUE(string_eq("VK_LUNARG_direct_driver_loading", extensions[5].extensionName));
     }
 
     const char* layer_name = "TestLayer";
@@ -3555,7 +3557,7 @@ TEST(DuplicateRegistryEntries, Drivers) {
     auto null_path = env.get_folder(ManifestLocation::null).location() / "test_icd_0.json";
     env.platform_shim->add_manifest(ManifestCategory::icd, null_path.str());
 
-    env.add_icd(TestICDDetails{TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA}.set_discovery_type(ManifestDiscoveryType::none));
+    env.add_icd(TestICDDetails{TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA}.set_discovery_type(ManifestDiscoveryType::null_dir));
     auto& driver = env.get_test_icd();
     driver.physical_devices.emplace_back("physical_device_0");
     driver.adapterLUID = _LUID{10, 1000};
@@ -3574,7 +3576,8 @@ TEST(DuplicateRegistryEntries, Drivers) {
 // Check that valid symlinks do not cause the loader to crash when directly in an XDG env-var
 TEST(ManifestDiscovery, ValidSymlinkInXDGEnvVar) {
     FrameworkEnvironment env{true, false};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA).set_discovery_type(ManifestDiscoveryType::none));
+    env.add_icd(
+        TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA).set_discovery_type(ManifestDiscoveryType::override_folder));
     env.get_test_icd().physical_devices.push_back({});
     auto driver_path = env.get_icd_manifest_path(0);
     std::string symlink_name = "symlink_to_driver.json";
@@ -3582,7 +3585,7 @@ TEST(ManifestDiscovery, ValidSymlinkInXDGEnvVar) {
     env.get_folder(ManifestLocation::driver_env_var).add_existing_file(symlink_name);
     int res = symlink(driver_path.c_str(), symlink_path.c_str());
     ASSERT_EQ(res, 0);
-    set_env_var("XDG_CONFIG_DIRS", symlink_path.str());
+    EnvVarWrapper xdg_config_dirs_env_var{"XDG_CONFIG_DIRS", symlink_path.str()};
 
     InstWrapper inst{env.vulkan_functions};
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
@@ -3592,7 +3595,8 @@ TEST(ManifestDiscovery, ValidSymlinkInXDGEnvVar) {
 // Check that valid symlinks do not cause the loader to crash
 TEST(ManifestDiscovery, ValidSymlink) {
     FrameworkEnvironment env{true, false};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA).set_discovery_type(ManifestDiscoveryType::none));
+    env.add_icd(
+        TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA).set_discovery_type(ManifestDiscoveryType::override_folder));
     env.get_test_icd().physical_devices.push_back({});
 
     auto driver_path = env.get_icd_manifest_path(0);
@@ -3619,7 +3623,7 @@ TEST(ManifestDiscovery, InvalidSymlinkXDGEnvVar) {
     ASSERT_EQ(res, 0);
     env.get_folder(ManifestLocation::driver_env_var).add_existing_file(symlink_name);
 
-    set_env_var("XDG_CONFIG_DIRS", symlink_path.str());
+    EnvVarWrapper xdg_config_dirs_env_var{symlink_path.str()};
 
     InstWrapper inst{env.vulkan_functions};
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);

--- a/tests/loader_testing_main.cpp
+++ b/tests/loader_testing_main.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2021 The Khronos Group Inc.
- * Copyright (c) 2021 Valve Corporation
- * Copyright (c) 2021 LunarG, Inc.
+ * Copyright (c) 2021-2023 The Khronos Group Inc.
+ * Copyright (c) 2021-2023 Valve Corporation
+ * Copyright (c) 2021-2023 LunarG, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and/or associated documentation files (the "Materials"), to
@@ -44,32 +44,49 @@ int main(int argc, char** argv) {
     // clean up folders from old test
     fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "null_dir");
     fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "icd_manifests");
-    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "portability_icd_manifests");
+    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "icd_env_vars_manifests");
     fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "explicit_layer_manifests");
+    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "explicit_env_var_layer_folder");
+    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "explicit_add_env_var_layer_folder");
     fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "implicit_layer_manifests");
+    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "override_layer_manifests");
+    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "app_package_manifests");
+    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "macos_bundle");
 
     // make sure the tests don't find these env-vars if they were set on the system
-    remove_env_var("VK_ICD_FILENAMES");
-    remove_env_var("VK_DRIVER_FILES");
-    remove_env_var("VK_ADD_DRIVER_FILES");
-    remove_env_var("VK_LAYER_PATH");
-    remove_env_var("VK_ADD_LAYER_PATH");
-    remove_env_var("VK_INSTANCE_LAYERS");
-    remove_env_var("VK_LOADER_DRIVERS_SELECT");
-    remove_env_var("VK_LOADER_DRIVERS_DISABLE");
-    remove_env_var("VK_LOADER_LAYERS_ENABLE");
-    remove_env_var("VK_LOADER_LAYERS_DISABLE");
-    remove_env_var("VK_LOADER_DEBUG");
-    remove_env_var("VK_LOADER_DISABLE_INST_EXT_FILTER");
+    EnvVarWrapper vk_icd_filenames_env_var{"VK_ICD_FILENAMES"};
+    EnvVarWrapper vk_driver_files_env_var{"VK_DRIVER_FILES"};
+    EnvVarWrapper vk_add_driver_files_env_var{"VK_ADD_DRIVER_FILES"};
+    EnvVarWrapper vk_layer_path_env_var{"VK_LAYER_PATH"};
+    EnvVarWrapper vk_add_layer_path_env_var{"VK_ADD_LAYER_PATH"};
+    EnvVarWrapper vk_instance_layers_env_var{"VK_INSTANCE_LAYERS"};
+    EnvVarWrapper vk_loader_drivers_select_env_var{"VK_LOADER_DRIVERS_SELECT"};
+    EnvVarWrapper vk_loader_drivers_disable_env_var{"VK_LOADER_DRIVERS_DISABLE"};
+    EnvVarWrapper vk_loader_layers_enable_env_var{"VK_LOADER_LAYERS_ENABLE"};
+    EnvVarWrapper vk_loader_layers_disable_env_var{"VK_LOADER_LAYERS_DISABLE"};
+    EnvVarWrapper vk_loader_debug_env_var{"VK_LOADER_DEBUG"};
+    EnvVarWrapper vk_loader_disable_inst_ext_filter_env_var{"VK_LOADER_DISABLE_INST_EXT_FILTER"};
+    vk_icd_filenames_env_var.remove_value();
+    vk_driver_files_env_var.remove_value();
+    vk_add_driver_files_env_var.remove_value();
+    vk_layer_path_env_var.remove_value();
+    vk_add_layer_path_env_var.remove_value();
+    vk_instance_layers_env_var.remove_value();
+    vk_loader_drivers_select_env_var.remove_value();
+    vk_loader_drivers_disable_env_var.remove_value();
+    vk_loader_layers_enable_env_var.remove_value();
+    vk_loader_layers_disable_env_var.remove_value();
+    vk_loader_debug_env_var.remove_value();
+    vk_loader_disable_inst_ext_filter_env_var.remove_value();
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-    set_env_var("XDG_CONFIG_HOME", "/etc");
-    set_env_var("XDG_CONFIG_DIRS", "/etc");
-    set_env_var("XDG_DATA_HOME", "/etc");
-    set_env_var("XDG_DATA_DIRS", "/etc");
+    EnvVarWrapper xdg_config_home_env_var{"XDG_CONFIG_HOME", "/etc"};
+    EnvVarWrapper xdg_config_dirs_env_var{"XDG_CONFIG_DIRS", "/etc"};
+    EnvVarWrapper xdg_data_home_env_var{"XDG_DATA_HOME", "/etc"};
+    EnvVarWrapper xdg_data_dirs_env_var{"XDG_DATA_DIRS", "/etc"};
 #endif
 #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-    set_env_var("HOME", "/home/fake_home");
+    EnvVarWrapper home_env_var{"HOME", "/home/fake_home"};
 #endif
     ::testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();


### PR DESCRIPTION
VK_LUNARG_direct_driver_loading is an instance extension which allows applictations to include drivers directly to the loader, instead of relying on system installed drivers or environment variables specifying where the desired driver is located. This allows applications to 'ship' a driver with themselves and easily provide it to the system loader.

Changes related to direct driver loading:
* Source implementation
* Documentation of new extension, interactions with existing driver discovery mechanism, and issues with implicit layers
* Extensive tests covering many feature combinations.

Changes also made in this commit:
* Add EnvVarWrapper which more cleanly handles setting, modifying, and removing Environment Variables. This has the effect of allowing all tests to run from the test executable without leaking env-vars, which previously caused spurious test failure. Note - CTest runs each test in a separate process which hides this issue.
* Adds -Wshadow=local for the gcc compiler. The MSVC compiler already enables this check with W4 so it was added for consistency.
* Add <!-- omit from toc --> to Documenation pages. This prevents the "Markdown all in one" extension from adding labels to the table of contents.
* Add ManifestDiscoveryType::null_dir, to separate tests that want to write a manifest file to a place the loader normally does not search and tests which do not write any manifest file at all.