### PR TITLE
Clarify the VK_LOADER_DRIVERS_SELECT example

### DIFF
--- a/docs/LoaderInterfaceArchitecture.md
+++ b/docs/LoaderInterfaceArchitecture.md
@@ -781,10 +781,10 @@ discovery.
     </small></td>
     <td><small>
         export<br/>
-        &nbsp;&nbsp;VK_LOADER_DRIVERS_SELECT=nvidia<br/>
+        &nbsp;&nbsp;VK_LOADER_DRIVERS_SELECT=nvidia*<br/>
         <br/>
         set<br/>
-        &nbsp;&nbsp;VK_LOADER_DRIVERS_SELECT=nvidia<br/><br/>
+        &nbsp;&nbsp;VK_LOADER_DRIVERS_SELECT=nvidia*<br/><br/>
         The above would select only the Nvidia driver if it was present on the
         system and already visible to the loader.
     </small></td>

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -474,6 +474,24 @@ TEST(EnvVarICDOverrideSetup, FilterSelectDriver) {
     ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("Found ICD manifest file", "CDE_ICD.json"));
     ASSERT_FALSE(env.debug_log.find_prefix_then_postfix("CDE_ICD.json", "ignored because not selected by env var"));
     ASSERT_FALSE(env.debug_log.find_prefix_then_postfix("CDE_ICD.json", "ignored because it was disabled by env var"));
+
+    // The full-name string is not a valid match if it doesn't also include the file extension
+    env.debug_log.clear();
+    filter_select_env_var.set_new_value("ABC_ICD");
+
+    InstWrapper inst8{env.vulkan_functions};
+    FillDebugUtilsCreateDetails(inst8.create_info, env.debug_log);
+    inst8.CheckCreate(VK_ERROR_INCOMPATIBLE_DRIVER);
+
+    ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("Found ICD manifest file", "ABC_ICD.json"));
+    ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("ABC_ICD.json", "ignored because not selected by env var"));
+    ASSERT_FALSE(env.debug_log.find_prefix_then_postfix("ABC_ICD.json", "ignored because it was disabled by env var"));
+    ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("Found ICD manifest file", "BCD_ICD.json"));
+    ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("BCD_ICD.json", "ignored because not selected by env var"));
+    ASSERT_FALSE(env.debug_log.find_prefix_then_postfix("BCD_ICD.json", "ignored because it was disabled by env var"));
+    ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("Found ICD manifest file", "CDE_ICD.json"));
+    ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("CDE_ICD.json", "ignored because not selected by env var"));
+    ASSERT_FALSE(env.debug_log.find_prefix_then_postfix("CDE_ICD.json", "ignored because it was disabled by env var"));
 }
 
 // Test that the driver filter disable disables driver manifest files that match the filter


### PR DESCRIPTION
In the documentation examples, if we set
`VK_LOADER_DRIVERS_SELECT=nvidia`, we are saying to the loader to select only the driver whose JSON manifest is called exactly `nvidia`.

This is likely not what we want, because the Nvidia drivers are usually called something like `nvidia_icd.json`, and not just `nvidia` without a file extension.

In the "Behavior" column it already states that:
"Since drivers don’t have a name like layers, this glob is used to compare against the manifest filename."
So, to avoid confusion, we just need to change the example to reflect how the loader glob works.

This commit also adds an additional automated test to ensure that this full-name string glob actually works as described in the documentation.