### PR TITLE
WIP: Add loader settings struct support

### DIFF
--- a/docs/LoaderDebugging.md
+++ b/docs/LoaderDebugging.md
@@ -22,6 +22,8 @@
 - [Debugging Possible Driver Issues](#debugging-possible-driver-issues)
   - [Enable Driver Logging](#enable-driver-logging)
   - [Selectively Enable Specific Drivers](#selectively-enable-specific-drivers)
+- [Forcing Specific Layers In Order](#forcing-specific-layers-in-order)
+  - [Forcing A Crash If Layer Not Found](#forcing-a-crash-if-layer-not-found)
 
 ## Debugging Issues
 
@@ -329,3 +331,23 @@ For more info on how to use the filtering environment variables, refer to the
 [Driver Filtering](LoaderDriverInterface.md#driver-filtering) section of the
 [LoaderDriverInterface](LoaderDriverInterface.md) document.
 
+
+## Forcing Specific Layers In Order
+
+If adding layers using an environment variable, and the ordering is important,
+`VK_INSTANCE_LAYERS` can be used.
+The names of the layers supplied must be comma-delimited and contain the full
+name of each layer to loader.
+These layers will only load if they are found in one of the system installed
+paths or a path defined by one of the loader environment variables used to
+adjust layer paths (like `VK_LAYER_PATH` or `VK_ADD_LAYER_PATH`).
+
+### Forcing A Crash If Layer Not Found
+
+If you use `VK_INSTANCE_LAYERS`, and the loader fails to find a layer that
+was specified in the list, it will print an error message, but continue on
+its way.
+This could be problematic if a layer is absolutely required for the task.
+Setting the environment variable `VK_LOADER_LAYER_EXIT_ON_MISSING` equal to
+`1` will cause the loader to abort if the layer defined in
+`VK_INSTANCE_LAYERS` is not found and also an error message will be reported.

--- a/docs/LoaderInterfaceArchitecture.md
+++ b/docs/LoaderInterfaceArchitecture.md
@@ -717,6 +717,7 @@ discovery.
         &nbsp;&nbsp;* debug (only debug)<br/>
         &nbsp;&nbsp;* layer (layer-specific output)<br/>
         &nbsp;&nbsp;* driver (driver-specific output)<br/>
+        &nbsp;&nbsp;* setting (setting-specific output)<br/>
         &nbsp;&nbsp;* all (report out all messages)<br/><br/>
         To enable multiple options (outside of "all") like info, warning and
         error messages, set the value to "error,warn,info".

--- a/docs/LoaderInterfaceArchitecture.md
+++ b/docs/LoaderInterfaceArchitecture.md
@@ -658,6 +658,33 @@ discovery.
   </tr>
   <tr>
     <td><small>
+        <i>VK_INSTANCE_LAYERS</i>
+    </small></td>
+    <td><small>
+        Force the loader to add the given layers to the list of Enabled layers
+        normally passed into <b>vkCreateInstance</b>.
+        These layers are added first, and the loader will remove any duplicate
+        layers that appear in both this list as well as that passed into
+        <i>ppEnabledLayerNames</i>.
+    </small></td>
+    <td><small>
+        This has <b>NOT</b> been deprecated by <i>VK_LOADER_LAYERS_ENABLE</i>.
+        This allows explicit layer ordering which is not available in the new
+        filter environment variables<br/>
+        It also overrides any layers disabled with
+        <i>VK_LOADER_LAYERS_DISABLE</i>.
+    </small></td>
+    <td><small>
+        export<br/>
+        &nbsp;&nbsp;VK_INSTANCE_LAYERS=<br/>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;layer_a&gt;;&lt;layer_b&gt;<br/><br/>
+        set<br/>
+        &nbsp;&nbsp;VK_INSTANCE_LAYERS=<br/>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;layer_a&gt;;&lt;layer_b&gt;
+    </small></td>
+  </tr>
+  <tr>
+    <td><small>
         <i>VK_LAYER_PATH</i></small></td>
     <td><small>
         Override the loader's standard Layer library search folders and use the
@@ -703,6 +730,29 @@ discovery.
         <br/>
         set<br/>
         &nbsp;&nbsp;VK_LOADER_DEBUG=warn
+    </small></td>
+  </tr>
+  <tr>
+    <td><small>
+        <i>VK_LOADER_LOG_FILE</i>
+    </small></td>
+    <td><small>
+        Define the name of a log file to output the loader debug output to.
+        The data is appended to the file so each execution will cause the same
+        file to grow.<br/>
+        Messages enabled by <i>VK_LOADER_DEBUG</i> will be output to here, but
+        may also appear on the command-line as well.
+    </small></td>
+    <td><small>
+        This functionality is only available with Loaders built with version
+        1.3.244 of the Vulkan headers and later.
+    </small></td>
+    <td><small>
+        export<br/>
+        &nbsp;&nbsp;VK_LOADER_LOG_FILE=~/vulkan_loader_log.txt<br/>
+        <br/>
+        set<br/>
+        &nbsp;&nbsp;VK_LOADER_DEBUG=%TMP%\\vulkan_loader_log.txt<br/>
     </small></td>
   </tr>
   <tr>
@@ -826,6 +876,29 @@ discovery.
   </tr>
   <tr>
     <td><small>
+        <i>VK_LOADER_LAYER_EXIT_ON_MISSING</i>
+    </small></td>
+    <td><small>
+        If a layer requested with one of the Loader environment variables, such
+        as <i>VK_INSTANCE_LAYERS</i> is not found, exit the application and
+        trigger an error message.<br/>
+        This is useful for verifying that all the layers you desired loading
+        were properly loaded and making it obvious so time is not wasted.
+    </small></td>
+    <td><small>
+        This functionality is only available with Loaders built with version
+        1.3.244 of the Vulkan headers and later.
+    </small></td>
+    <td><small>
+        export<br/>
+        &nbsp;&nbsp;VK_LOADER_LAYER_EXIT_ON_MISSING=1<br/>
+        <br/>
+        set<br/>
+        &nbsp;&nbsp;VK_LOADER_LAYER_EXIT_ON_MISSING=1<br/>
+    </small></td>
+  </tr>
+  <tr>
+    <td><small>
         <i>VK_LOADER_LAYERS_ENABLE</i>
     </small></td>
     <td><small>
@@ -835,9 +908,6 @@ discovery.
         Known layers are those which are found by the loader taking into account
         default search paths and other environment variables
         (like <i>VK_LAYER_PATH</i>).
-        <br/>
-        This has replaced the older deprecated environment variable
-        <i>VK_INSTANCE_LAYERS</i>
     </small></td>
     <td><small>
         This functionality is only available with Loaders built with version
@@ -930,34 +1000,6 @@ may be removed in a future loader release.
         set<br/>
         &nbsp;&nbsp;VK_ICD_FILENAMES=<br/>
         &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<folder_a>\nvidia.json;<folder_b>\mesa.json
-    </small></td>
-  </tr>
-  <tr>
-    <td><small>
-        <i>VK_INSTANCE_LAYERS</i>
-    </small></td>
-    <td><small>
-        Force the loader to add the given layers to the list of Enabled layers
-        normally passed into <b>vkCreateInstance</b>.
-        These layers are added first, and the loader will remove any duplicate
-        layers that appear in both this list as well as that passed into
-        <i>ppEnabledLayerNames</i>.
-    </small></td>
-    <td><small>
-        This has been deprecated by <i>VK_LOADER_LAYERS_ENABLE</i>.
-        It also overrides any layers disabled with
-        <i>VK_LOADER_LAYERS_DISABLE</i>.
-    </small></td>
-    <td><small>
-        None
-    </small></td>
-    <td><small>
-        export<br/>
-        &nbsp;&nbsp;VK_INSTANCE_LAYERS=<br/>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;layer_a&gt;;&lt;layer_b&gt;<br/><br/>
-        set<br/>
-        &nbsp;&nbsp;VK_INSTANCE_LAYERS=<br/>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;layer_a&gt;;&lt;layer_b&gt;
     </small></td>
   </tr>
 </table>

--- a/docs/LoaderLayerInterface.md
+++ b/docs/LoaderLayerInterface.md
@@ -513,6 +513,16 @@ The original `VK_INSTANCE_LAYERS` can be viewed as a special case of the new
 Because of this, any layers enabled via `VK_INSTANCE_LAYERS` will be treated the
 same as layers enabled with `VK_LOADER_LAYERS_ENABLE` and will therefore
 override any disables supplied in `VK_LOADER_LAYERS_DISABLE`.
+There are several benefits to using `VK_INSTANCE_LAYERS` over
+`VK_LOADER_LAYERS_ENABLE`:
+  * `VK_INSTANCE_LAYERS` forces the loading of the layers defined in the strict
+    ordering they are defined.
+  * `VK_INSTANCE_LAYERS` requires the full name of the layer, which may be
+    beneficial to forcing only the specific layers
+  * `VK_INSTANCE_LAYERS` is guaranteed to work on very old loaders.
+  * `VK_INSTANCE_LAYERS` can be used with `VK_LOADER_LAYER_EXIT_ON_MISSING` to
+    make sure that a desired layer was properly loaded before continuing.
+
 
 ### Exception for Elevated Privileges
 

--- a/loader/asm_offset.c
+++ b/loader/asm_offset.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2017-2021 The Khronos Group Inc.
- * Copyright (c) 2017-2021 Valve Corporation
- * Copyright (c) 2017-2021 LunarG, Inc.
+ * Copyright (c) 2017-2023 The Khronos Group Inc.
+ * Copyright (c) 2017-2023 Valve Corporation
+ * Copyright (c) 2017-2023 LunarG, Inc.
  * Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,6 @@
 
 // This code generates an assembly file which provides offsets to get struct members from assembly code.
 
-#include <stdio.h>
 #include "loader_common.h"
 #include "log.h"
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1114,19 +1114,12 @@ static VkExtensionProperties *get_dev_extension_property(const char *name, const
 //                                    to this array.
 // The extension itself should be in a separate file that will be linked directly
 // with the loader.
-VkResult loader_get_icd_loader_instance_extensions(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list,
+VkResult loader_get_icd_loader_instance_extensions(const struct loader_instance *inst, const struct loader_settings *settings,
+                                                   struct loader_icd_tramp_list *icd_tramp_list,
                                                    struct loader_extension_list *inst_exts) {
     struct loader_extension_list icd_exts;
     VkResult res = VK_SUCCESS;
-    char *env_value;
-    bool filter_extensions = true;
-
-    // Check if a user wants to disable the instance extension filtering behavior
-    env_value = loader_getenv("VK_LOADER_DISABLE_INST_EXT_FILTER", inst);
-    if (NULL != env_value && atoi(env_value) != 0) {
-        filter_extensions = false;
-    }
-    loader_free_getenv(env_value, inst);
+    bool filter_extensions = !settings->disable_instance_extension_filter;
 
     // traverse scanned icd list adding non-duplicate extensions to the list
     for (uint32_t i = 0; i < icd_tramp_list->count; i++) {
@@ -1778,6 +1771,11 @@ out:
     return res;
 }
 
+// Settings used for pre-instance functions.
+// This is ref-counted so that we don't delete it while it's being
+// used.
+struct loader_pre_instance_settings pre_instance_settings;
+
 void loader_initialize(void) {
     // initialize mutexes
     loader_platform_thread_create_mutex(&loader_lock);
@@ -1785,8 +1783,12 @@ void loader_initialize(void) {
     loader_platform_thread_create_mutex(&loader_preload_icd_lock);
     loader_platform_thread_create_mutex(&loader_global_instance_list_lock);
 
-    // initialize logging
-    loader_debug_init();
+    if (VK_SUCCESS == generateSettingsStruct(NULL, &pre_instance_settings.settings)) {
+        loader_platform_thread_create_mutex(&pre_instance_settings.lock);
+        pre_instance_settings.ref_count = 1;
+        pre_instance_settings.ready = true;
+    }
+
 #if defined(_WIN32)
     windows_initialization();
 #endif
@@ -1803,6 +1805,14 @@ void loader_release() {
     // Guarantee release of the preloaded ICD libraries. This may have already been called in vkDestroyInstance.
     loader_unload_preloaded_icds();
 
+    if (pre_instance_settings.ready) {
+        assert(pre_instance_settings.ref_count == 1);
+        freeSettingsStruct(NULL, &pre_instance_settings.settings);
+        loader_platform_thread_delete_mutex(&pre_instance_settings.lock);
+        pre_instance_settings.ready = false;
+        pre_instance_settings.ref_count = 0;
+    }
+
     // release mutexes
     loader_platform_thread_delete_mutex(&loader_lock);
     loader_platform_thread_delete_mutex(&loader_json_lock);
@@ -1811,7 +1821,7 @@ void loader_release() {
 }
 
 // Preload the ICD libraries that are likely to be needed so we don't repeatedly load/unload them later
-void loader_preload_icds(void) {
+void loader_preload_icds(const struct loader_settings *settings) {
     loader_platform_thread_lock_mutex(&loader_preload_icd_lock);
 
     // Already preloaded, skip loading again.
@@ -1820,7 +1830,7 @@ void loader_preload_icds(void) {
         return;
     }
 
-    VkResult result = loader_icd_scan(NULL, &scanned_icds, NULL, NULL);
+    VkResult result = loader_icd_scan(NULL, settings, &scanned_icds, NULL, NULL);
     if (result != VK_SUCCESS) {
         loader_scanned_icd_clear(NULL, &scanned_icds);
     }
@@ -1980,8 +1990,8 @@ out:
 }
 
 // Verify that all component layers in a meta-layer are valid.
-static bool verify_meta_layer_component_layers(const struct loader_instance *inst, struct loader_layer_properties *prop,
-                                               struct loader_layer_list *instance_layers) {
+static bool verify_meta_layer_component_layers(const struct loader_instance *inst, const struct loader_settings *settings,
+                                               struct loader_layer_properties *prop, struct loader_layer_list *instance_layers) {
     bool success = true;
     loader_api_version meta_layer_version = loader_make_version(prop->info.specVersion);
 
@@ -2027,7 +2037,7 @@ static bool verify_meta_layer_component_layers(const struct loader_instance *ins
                        prop->info.layerName, comp_prop->info.layerName);
 
             // Make sure if the layer is using a meta-layer in its component list that we also verify that.
-            if (!verify_meta_layer_component_layers(inst, comp_prop, instance_layers)) {
+            if (!verify_meta_layer_component_layers(inst, settings, comp_prop, instance_layers)) {
                 loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
                            "Meta-layer %s component layer %s can not find all component layers."
                            "  Skipping this layer.",
@@ -2066,7 +2076,7 @@ static bool verify_meta_layer_component_layers(const struct loader_instance *ins
                    prop->num_component_layers);
 
         // If layer logging is on, list the internals included in the meta-layer
-        if ((loader_get_debug_level() & VULKAN_LOADER_LAYER_BIT) != 0) {
+        if ((settings->log_settings.enabled_log_flags & VULKAN_LOADER_LAYER_BIT) != 0) {
             for (uint32_t comp_layer = 0; comp_layer < prop->num_component_layers; comp_layer++) {
                 loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "  [%d] %s", comp_layer, prop->component_layer_names[comp_layer]);
             }
@@ -2076,7 +2086,8 @@ static bool verify_meta_layer_component_layers(const struct loader_instance *ins
 }
 
 // Verify that all meta-layers in a layer list are valid.
-static void verify_all_meta_layers(struct loader_instance *inst, const struct loader_envvar_filter *enable_filter,
+static void verify_all_meta_layers(struct loader_instance *inst, const struct loader_settings *settings,
+                                   const struct loader_envvar_filter *enable_filter,
                                    const struct loader_envvar_disable_layers_filter *disable_filter,
                                    struct loader_layer_list *instance_layers, bool *override_layer_present) {
     *override_layer_present = false;
@@ -2085,7 +2096,7 @@ static void verify_all_meta_layers(struct loader_instance *inst, const struct lo
 
         // If this is a meta-layer, make sure it is valid
         if ((prop->type_flags & VK_LAYER_TYPE_FLAG_META_LAYER) &&
-            !verify_meta_layer_component_layers(inst, prop, instance_layers)) {
+            !verify_meta_layer_component_layers(inst, settings, prop, instance_layers)) {
             loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0,
                        "Removing meta-layer %s from instance layer list since it appears invalid.", prop->info.layerName);
 
@@ -2869,6 +2880,26 @@ out:
     return result;
 }
 
+// Determine how long a give path is in a path list string
+size_t determine_data_file_path_size(const char *cur_path, size_t relative_path_size) {
+    size_t path_size = 0;
+
+    if (NULL != cur_path) {
+        // For each folder in cur_path, (detected by finding additional
+        // path separators in the string) we need to add the relative path on
+        // the end.  Plus, leave an additional two slots on the end to add an
+        // additional directory slash and path separator if needed
+        path_size += strlen(cur_path) + relative_path_size + 2;
+        for (const char *x = cur_path; *x; ++x) {
+            if (*x == PATH_SEPARATOR) {
+                path_size += relative_path_size + 2;
+            }
+        }
+    }
+
+    return path_size;
+}
+
 void copy_data_file_info(const char *cur_path, const char *relative_path, size_t relative_path_size, char **output_path) {
     if (NULL != cur_path) {
         uint32_t start = 0;
@@ -2987,46 +3018,39 @@ out:
 
 // Add any files found in the search_path.  If any path in the search path points to a specific JSON, attempt to
 // only open that one JSON.  Otherwise, if the path is a folder, search the folder for JSON files.
-VkResult add_data_files(const struct loader_instance *inst, char *search_path, struct loader_data_files *out_files,
-                        bool use_first_found_manifest) {
+VkResult add_data_files(const struct loader_instance *inst, uint32_t search_path_count, char **search_path_array,
+                        struct loader_data_files *out_files, bool use_first_found_manifest) {
     VkResult vk_result = VK_SUCCESS;
     DIR *dir_stream = NULL;
     struct dirent *dir_entry;
     char *cur_file;
-    char *next_file;
     char *name;
     char full_path[2048];
 #ifndef _WIN32
     char temp_path[2048];
 #endif
 
-    // Now, parse the paths
-    next_file = search_path;
-    while (NULL != next_file && *next_file != '\0') {
-        name = NULL;
-        cur_file = next_file;
-        next_file = loader_get_next_path(cur_file);
+    if (search_path_count == 0 || search_path_array == NULL) {
+        return VK_SUCCESS;
+    }
 
-        // Is this a JSON file, then try to open it.
-        size_t len = strlen(cur_file);
-        if (is_json(cur_file + len - 5, len)) {
+    for (uint32_t path = 0; path < search_path_count; ++path) {
+        cur_file = search_path_array[path];
+        size_t str_len = strlen(cur_file);
+
+        if (is_json(cur_file + str_len - 5, str_len)) {
 #ifdef _WIN32
             name = cur_file;
 #else
             // Only Linux has relative paths, make a copy of location so it isn't modified
-            size_t str_len;
-            if (NULL != next_file) {
-                str_len = next_file - cur_file + 1;
-            } else {
-                str_len = strlen(cur_file) + 1;
-            }
             if (str_len > sizeof(temp_path)) {
-                loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "add_data_files: Path to %s too long", cur_file);
+                loader_log(inst, VULKAN_LOADER_WARN_BIT, 0, "add_data_files: Path to %s too long", cur_file);
                 continue;
             }
             strcpy(temp_path, cur_file);
             name = temp_path;
 #endif
+
             loader_get_fullpath(cur_file, name, sizeof(full_path), full_path);
             name = full_path;
 
@@ -3077,352 +3101,96 @@ VkResult add_data_files(const struct loader_instance *inst, char *search_path, s
     }
 
 out:
-
     return vk_result;
 }
 
 // Look for data files in the provided paths, but first check the environment override to determine if we should use that
 // instead.
-static VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enum loader_data_files_type manifest_type,
-                                                const char *path_override, bool *override_active,
-                                                struct loader_data_files *out_files) {
+static VkResult read_data_files_in_search_paths(const struct loader_instance *inst, const struct loader_settings *settings,
+                                                enum loader_data_files_type manifest_type, const char *path_override,
+                                                bool *override_active, struct loader_data_files *out_files) {
     VkResult vk_result = VK_SUCCESS;
-    char *override_env = NULL;
-    const char *override_path = NULL;
-    char *relative_location = NULL;
-    char *additional_env = NULL;
-    size_t search_path_size = 0;
-    char *search_path = NULL;
-    char *cur_path_ptr = NULL;
     bool use_first_found_manifest = false;
-#ifndef _WIN32
-    size_t rel_size = 0;  // unused in windows, dont declare so no compiler warnings are generated
-#endif
-
-#if defined(_WIN32)
-    char *package_path = NULL;
-#else
-    // Determine how much space is needed to generate the full search path
-    // for the current manifest files.
-    char *xdg_config_home = loader_secure_getenv("XDG_CONFIG_HOME", inst);
-    char *xdg_config_dirs = loader_secure_getenv("XDG_CONFIG_DIRS", inst);
-
-#if !defined(__Fuchsia__) && !defined(__QNXNTO__)
-    if (NULL == xdg_config_dirs || '\0' == xdg_config_dirs[0]) {
-        xdg_config_dirs = FALLBACK_CONFIG_DIRS;
-    }
-#endif
-
-    char *xdg_data_home = loader_secure_getenv("XDG_DATA_HOME", inst);
-    char *xdg_data_dirs = loader_secure_getenv("XDG_DATA_DIRS", inst);
-
-#if !defined(__Fuchsia__) && !defined(__QNXNTO__)
-    if (NULL == xdg_data_dirs || '\0' == xdg_data_dirs[0]) {
-        xdg_data_dirs = FALLBACK_DATA_DIRS;
-    }
-#endif
-
-    char *home = NULL;
-    char *default_data_home = NULL;
-    char *default_config_home = NULL;
-    char *home_data_dir = NULL;
-    char *home_config_dir = NULL;
-
-    // Only use HOME if XDG_DATA_HOME is not present on the system
-    home = loader_secure_getenv("HOME", inst);
-    if (home != NULL) {
-        if (NULL == xdg_config_home || '\0' == xdg_config_home[0]) {
-            const char config_suffix[] = "/.config";
-            default_config_home =
-                loader_instance_heap_alloc(inst, strlen(home) + strlen(config_suffix) + 1, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-            if (default_config_home == NULL) {
-                vk_result = VK_ERROR_OUT_OF_HOST_MEMORY;
-                goto out;
-            }
-            strcpy(default_config_home, home);
-            strcat(default_config_home, config_suffix);
-        }
-        if (NULL == xdg_data_home || '\0' == xdg_data_home[0]) {
-            const char data_suffix[] = "/.local/share";
-            default_data_home =
-                loader_instance_heap_alloc(inst, strlen(home) + strlen(data_suffix) + 1, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-            if (default_data_home == NULL) {
-                vk_result = VK_ERROR_OUT_OF_HOST_MEMORY;
-                goto out;
-            }
-            strcpy(default_data_home, home);
-            strcat(default_data_home, data_suffix);
-        }
-    }
-
-    if (NULL != default_config_home) {
-        home_config_dir = default_config_home;
-    } else {
-        home_config_dir = xdg_config_home;
-    }
-    if (NULL != default_data_home) {
-        home_data_dir = default_data_home;
-    } else {
-        home_data_dir = xdg_data_home;
-    }
-#endif  // !_WIN32
-
+    char **search_path_array = NULL;
+    uint32_t search_path_count = 0;
+    bool override_path_active = false;
+    const char log_label[3][16] = {"driver", "implicit layer", "explicit layer"};
+    uint32_t label_index = 0;
+    uint32_t log_flags = 0;
     switch (manifest_type) {
         case LOADER_DATA_FILE_MANIFEST_DRIVER:
-            override_env = loader_secure_getenv(VK_DRIVER_FILES_ENV_VAR, inst);
-            if (NULL == override_env) {
-                // Not there, so fall back to the old name
-                override_env = loader_secure_getenv(VK_ICD_FILENAMES_ENV_VAR, inst);
-            }
-            additional_env = loader_secure_getenv(VK_ADDITIONAL_DRIVER_FILES_ENV_VAR, inst);
-            relative_location = VK_DRIVERS_INFO_RELATIVE_DIR;
-#if defined(_WIN32)
-            package_path = windows_get_app_package_manifest_path(inst);
-#endif
-            break;
-        case LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER:
-            relative_location = VK_ILAYERS_INFO_RELATIVE_DIR;
+        default:
+            log_flags |= VULKAN_LOADER_DRIVER_BIT;
             break;
         case LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER:
-            override_env = loader_secure_getenv(VK_LAYER_PATH_ENV_VAR, inst);
-            additional_env = loader_secure_getenv(VK_ADDITIONAL_LAYER_PATH_ENV_VAR, inst);
-            relative_location = VK_ELAYERS_INFO_RELATIVE_DIR;
+            log_flags |= VULKAN_LOADER_LAYER_BIT;
+            label_index = 2;
             break;
-        default:
-            assert(false && "Shouldn't get here!");
+        case LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER:
+            log_flags |= VULKAN_LOADER_LAYER_BIT;
+            label_index = 1;
             break;
     }
 
     // Log a message when VK_LAYER_PATH is set but the override layer paths take priority
-    if (manifest_type == LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER && NULL != override_env && NULL != path_override) {
-        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_LAYER_BIT, 0,
-                   "Ignoring VK_LAYER_PATH. The Override layer is active and has override paths set, which takes priority. "
-                   "VK_LAYER_PATH is set to %s",
-                   override_env);
+    if (manifest_type == LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER && NULL != path_override) {
+        loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0,
+                   "The Override layer is active and has override paths set! Ignoring any environment variable paths like "
+                   "`VK_LAYER_PATH` or `VK_ADD_LAYER_PATH`.");
     }
-
-    if (path_override != NULL) {
-        override_path = path_override;
-    } else if (override_env != NULL) {
-        override_path = override_env;
-    }
-
-    // Add two by default for NULL terminator and one path separator on end (just in case)
-    search_path_size = 2;
 
     // If there's an override, use that (and the local folder if required) and nothing else
-    if (NULL != override_path) {
-        // Local folder and null terminator
-        search_path_size += strlen(override_path) + 2;
-    } else {
-        // Add the size of any additional search paths defined in the additive environment variable
-        if (NULL != additional_env) {
-            search_path_size += determine_data_file_path_size(additional_env, 0) + 2;
-#if defined(_WIN32)
-        }
-        if (NULL != package_path) {
-            search_path_size += determine_data_file_path_size(package_path, 0) + 2;
-        }
-        if (search_path_size == 2) {
+    if (NULL != path_override && strlen(path_override) > 1) {
+        vk_result =
+            generateCompleteSearchPath(inst, manifest_type, path_override, NULL, NULL, &search_path_count, &search_path_array);
+        if (VK_SUCCESS != vk_result) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "read_data_files_in_search_paths: Failed using override %s path",
+                       log_label[label_index]);
             goto out;
         }
-#else  // !_WIN32
-        }
-
-        // Add the general search folders (with the appropriate relative folder added)
-        rel_size = strlen(relative_location);
-        if (rel_size > 0) {
-#if defined(__APPLE__)
-            search_path_size += MAXPATHLEN;
-#endif
-            // Only add the home folders if defined
-            if (NULL != home_config_dir) {
-                search_path_size += determine_data_file_path_size(home_config_dir, rel_size);
-            }
-            search_path_size += determine_data_file_path_size(xdg_config_dirs, rel_size);
-            search_path_size += determine_data_file_path_size(SYSCONFDIR, rel_size);
-#if defined(EXTRASYSCONFDIR)
-            search_path_size += determine_data_file_path_size(EXTRASYSCONFDIR, rel_size);
-#endif
-            // Only add the home folders if defined
-            if (NULL != home_data_dir) {
-                search_path_size += determine_data_file_path_size(home_data_dir, rel_size);
-            }
-            search_path_size += determine_data_file_path_size(xdg_data_dirs, rel_size);
-        }
-#endif  // !_WIN32
-    }
-
-    // Allocate the required space
-    search_path = loader_instance_heap_calloc(inst, search_path_size, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-    if (NULL == search_path) {
-        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "read_data_files_in_search_paths: Failed to allocate space for search path of length %d",
-                   (uint32_t)search_path_size);
-        vk_result = VK_ERROR_OUT_OF_HOST_MEMORY;
-        goto out;
-    }
-
-    cur_path_ptr = search_path;
-
-    // Add the remaining paths to the list
-    if (NULL != override_path) {
-        strcpy(cur_path_ptr, override_path);
-        cur_path_ptr += strlen(override_path);
+        override_path_active = true;
     } else {
-        // Add any additional search paths defined in the additive environment variable
-        if (NULL != additional_env) {
-            copy_data_file_info(additional_env, NULL, 0, &cur_path_ptr);
-        }
-
-#if defined(_WIN32)
-        if (NULL != package_path) {
-            copy_data_file_info(package_path, NULL, 0, &cur_path_ptr);
-        }
-#else
-        if (rel_size > 0) {
-#if defined(__APPLE__)
-            // Add the bundle's Resources dir to the beginning of the search path.
-            // Looks for manifests in the bundle first, before any system directories.
-            CFBundleRef main_bundle = CFBundleGetMainBundle();
-            if (NULL != main_bundle) {
-                CFURLRef ref = CFBundleCopyResourcesDirectoryURL(main_bundle);
-                if (NULL != ref) {
-                    if (CFURLGetFileSystemRepresentation(ref, TRUE, (UInt8 *)cur_path_ptr, search_path_size)) {
-                        cur_path_ptr += strlen(cur_path_ptr);
-                        *cur_path_ptr++ = DIRECTORY_SYMBOL;
-                        memcpy(cur_path_ptr, relative_location, rel_size);
-                        cur_path_ptr += rel_size;
-                        *cur_path_ptr++ = PATH_SEPARATOR;
-                        if (manifest_type == LOADER_DATA_FILE_MANIFEST_DRIVER) {
-                            use_first_found_manifest = true;
-                        }
-                    }
-                    CFRelease(ref);
-                }
-            }
-#endif  // __APPLE__
-
-            // Only add the home folders if not NULL
-            if (NULL != home_config_dir) {
-                copy_data_file_info(home_config_dir, relative_location, rel_size, &cur_path_ptr);
-            }
-            copy_data_file_info(xdg_config_dirs, relative_location, rel_size, &cur_path_ptr);
-            copy_data_file_info(SYSCONFDIR, relative_location, rel_size, &cur_path_ptr);
-#if defined(EXTRASYSCONFDIR)
-            copy_data_file_info(EXTRASYSCONFDIR, relative_location, rel_size, &cur_path_ptr);
-#endif
-
-            // Only add the home folders if not NULL
-            if (NULL != home_data_dir) {
-                copy_data_file_info(home_data_dir, relative_location, rel_size, &cur_path_ptr);
-            }
-            copy_data_file_info(xdg_data_dirs, relative_location, rel_size, &cur_path_ptr);
-        }
-
-        // Remove the last path separator
-        --cur_path_ptr;
-
-        assert(cur_path_ptr - search_path < (ptrdiff_t)search_path_size);
-        *cur_path_ptr = '\0';
-#endif  // !_WIN32
-    }
-
-    // Remove duplicate paths, or it would result in duplicate extensions, duplicate devices, etc.
-    // This uses minimal memory, but is O(N^2) on the number of paths. Expect only a few paths.
-    char path_sep_str[2] = {PATH_SEPARATOR, '\0'};
-    size_t search_path_updated_size = strlen(search_path);
-    for (size_t first = 0; first < search_path_updated_size;) {
-        // If this is an empty path, erase it
-        if (search_path[first] == PATH_SEPARATOR) {
-            memmove(&search_path[first], &search_path[first + 1], search_path_updated_size - first + 1);
-            search_path_updated_size -= 1;
-            continue;
-        }
-
-        size_t first_end = first + 1;
-        first_end += strcspn(&search_path[first_end], path_sep_str);
-        for (size_t second = first_end + 1; second < search_path_updated_size;) {
-            size_t second_end = second + 1;
-            second_end += strcspn(&search_path[second_end], path_sep_str);
-            if (first_end - first == second_end - second &&
-                !strncmp(&search_path[first], &search_path[second], second_end - second)) {
-                // Found duplicate. Include PATH_SEPARATOR in second_end, then erase it from search_path.
-                if (search_path[second_end] == PATH_SEPARATOR) {
-                    second_end++;
-                }
-                memmove(&search_path[second], &search_path[second_end], search_path_updated_size - second_end + 1);
-                search_path_updated_size -= second_end - second;
-            } else {
-                second = second_end + 1;
-            }
-        }
-        first = first_end + 1;
-    }
-    search_path_size = search_path_updated_size;
-
-    // Print out the paths being searched if debugging is enabled
-    uint32_t log_flags = 0;
-    if (search_path_size > 0) {
-        char *tmp_search_path = loader_instance_heap_alloc(inst, search_path_size + 1, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-        if (NULL != tmp_search_path) {
-            strncpy(tmp_search_path, search_path, search_path_size);
-            tmp_search_path[search_path_size] = '\0';
-            if (manifest_type == LOADER_DATA_FILE_MANIFEST_DRIVER) {
-                log_flags = VULKAN_LOADER_DRIVER_BIT;
-                loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "Searching for driver manifest files");
-            } else {
-                log_flags = VULKAN_LOADER_LAYER_BIT;
-                loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "Searching for layer manifest files");
-            }
-            loader_log(inst, log_flags, 0, "   In following locations:");
-            char *cur_file;
-            char *next_file = tmp_search_path;
-            while (NULL != next_file && *next_file != '\0') {
-                cur_file = next_file;
-                next_file = loader_get_next_path(cur_file);
-                loader_log(inst, log_flags, 0, "      %s", cur_file);
-            }
-            loader_instance_heap_free(inst, tmp_search_path);
+        assert(settings != NULL);
+        switch (manifest_type) {
+            case LOADER_DATA_FILE_MANIFEST_DRIVER:
+            default:
+                assert(settings->driver_search_paths != NULL);
+                assert(settings->driver_search_paths_count != 0);
+                search_path_array = settings->driver_search_paths;
+                search_path_count = settings->driver_search_paths_count;
+                break;
+            case LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER:
+                assert(settings->explicit_layer_search_paths != NULL);
+                assert(settings->explicit_layer_search_paths_count != 0);
+                search_path_array = settings->explicit_layer_search_paths;
+                search_path_count = settings->explicit_layer_search_paths_count;
+                break;
+            case LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER:
+                assert(settings->implicit_layer_search_paths != NULL);
+                assert(settings->implicit_layer_search_paths_count != 0);
+                search_path_array = settings->implicit_layer_search_paths;
+                search_path_count = settings->implicit_layer_search_paths_count;
+                break;
         }
     }
 
     // Now, parse the paths and add any manifest files found in them.
-    vk_result = add_data_files(inst, search_path, out_files, use_first_found_manifest);
+    vk_result = add_data_files(inst, search_path_count, search_path_array, out_files, use_first_found_manifest);
 
     if (log_flags != 0 && out_files->count > 0) {
-        loader_log(inst, log_flags, 0, "   Found the following files:");
+        loader_log(inst, log_flags, 0, "Found the following %s manifest files:", log_label[label_index]);
         for (uint32_t cur_file = 0; cur_file < out_files->count; ++cur_file) {
-            loader_log(inst, log_flags, 0, "      %s", out_files->filename_list[cur_file]);
+            loader_log(inst, log_flags, 0, "   %s", out_files->filename_list[cur_file]);
         }
     } else {
-        loader_log(inst, log_flags, 0, "   Found no files");
-    }
-
-    if (NULL != override_path) {
-        *override_active = true;
-    } else {
-        *override_active = false;
+        loader_log(inst, log_flags, 0, "Found no %s manifest files", log_label[label_index]);
     }
 
 out:
-
-    loader_free_getenv(additional_env, inst);
-    loader_free_getenv(override_env, inst);
-#if defined(_WIN32)
-    loader_instance_heap_free(inst, package_path);
-#else
-    loader_free_getenv(xdg_config_home, inst);
-    loader_free_getenv(xdg_config_dirs, inst);
-    loader_free_getenv(xdg_data_home, inst);
-    loader_free_getenv(xdg_data_dirs, inst);
-    loader_free_getenv(xdg_data_home, inst);
-    loader_free_getenv(home, inst);
-    loader_instance_heap_free(inst, default_data_home);
-    loader_instance_heap_free(inst, default_config_home);
-#endif
-
-    loader_instance_heap_free(inst, search_path);
+    if (override_path_active && search_path_array != NULL) {
+        freeSearchPath(inst, search_path_array);
+    }
+    *override_active = override_path_active;
 
     return vk_result;
 }
@@ -3450,8 +3218,9 @@ out:
 // Linux ICD  | dirs     | files
 // Linux Layer| dirs     | dirs
 
-VkResult loader_get_data_files(const struct loader_instance *inst, enum loader_data_files_type manifest_type,
-                               const char *path_override, struct loader_data_files *out_files) {
+VkResult loader_get_data_files(const struct loader_instance *inst, const struct loader_settings *settings,
+                               enum loader_data_files_type manifest_type, const char *path_override,
+                               struct loader_data_files *out_files) {
     VkResult res = VK_SUCCESS;
     bool override_active = false;
 
@@ -3469,7 +3238,7 @@ VkResult loader_get_data_files(const struct loader_instance *inst, enum loader_d
     out_files->alloc_count = 0;
     out_files->filename_list = NULL;
 
-    res = read_data_files_in_search_paths(inst, manifest_type, path_override, &override_active, out_files);
+    res = read_data_files_in_search_paths(inst, settings, manifest_type, path_override, &override_active, out_files);
     if (VK_SUCCESS != res) {
         goto out;
     }
@@ -3715,8 +3484,9 @@ out:
 // \returns
 // Vulkan result
 // (on result == VK_SUCCESS) a list of icds that were discovered
-VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list,
-                         const VkInstanceCreateInfo *pCreateInfo, bool *skipped_portability_drivers) {
+VkResult loader_icd_scan(const struct loader_instance *inst, const struct loader_settings *settings,
+                         struct loader_icd_tramp_list *icd_tramp_list, const VkInstanceCreateInfo *pCreateInfo,
+                         bool *skipped_portability_drivers) {
     struct loader_data_files manifest_files;
     VkResult res = VK_SUCCESS;
     bool lockedMutex = false;
@@ -3755,7 +3525,7 @@ VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_t
     }
 
     // Get a list of manifest files for ICDs
-    res = loader_get_data_files(inst, LOADER_DATA_FILE_MANIFEST_DRIVER, NULL, &manifest_files);
+    res = loader_get_data_files(inst, settings, LOADER_DATA_FILE_MANIFEST_DRIVER, NULL, &manifest_files);
     if (VK_SUCCESS != res) {
         goto out;
     }
@@ -3848,7 +3618,8 @@ out:
     return res;
 }
 
-VkResult loader_scan_for_layers(struct loader_instance *inst, struct loader_layer_list *instance_layers) {
+VkResult loader_scan_for_layers(struct loader_instance *inst, const struct loader_settings *settings,
+                                struct loader_layer_list *instance_layers) {
     VkResult res = VK_SUCCESS;
     char *file_str;
     struct loader_data_files manifest_files;
@@ -3879,7 +3650,7 @@ VkResult loader_scan_for_layers(struct loader_instance *inst, struct loader_laye
     loader_platform_thread_lock_mutex(&loader_json_lock);
 
     // Get a list of manifest files for any implicit layers
-    res = loader_get_data_files(inst, LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER, NULL, &manifest_files);
+    res = loader_get_data_files(inst, settings, LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER, NULL, &manifest_files);
     if (VK_SUCCESS != res) {
         goto out;
     }
@@ -3944,7 +3715,7 @@ VkResult loader_scan_for_layers(struct loader_instance *inst, struct loader_laye
     }
 
     // Get a list of manifest files for explicit layers
-    res = loader_get_data_files(inst, LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER, override_paths, &manifest_files);
+    res = loader_get_data_files(inst, settings, LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER, override_paths, &manifest_files);
     if (VK_SUCCESS != res) {
         goto out;
     }
@@ -3981,7 +3752,7 @@ VkResult loader_scan_for_layers(struct loader_instance *inst, struct loader_laye
 
     // Verify any meta-layers in the list are valid and all the component layers are
     // actually present in the available layer list
-    verify_all_meta_layers(inst, &enable_filter, &disable_filter, instance_layers, &override_layer_valid);
+    verify_all_meta_layers(inst, settings, &enable_filter, &disable_filter, instance_layers, &override_layer_valid);
 
     if (override_layer_valid) {
         loader_remove_layers_in_blacklist(inst, instance_layers);
@@ -4011,8 +3782,8 @@ out:
     return res;
 }
 
-VkResult loader_scan_for_implicit_layers(struct loader_instance *inst, struct loader_layer_list *instance_layers,
-                                         loader_platform_dl_handle **libs) {
+VkResult loader_scan_for_implicit_layers(struct loader_instance *inst, const struct loader_settings *settings,
+                                         struct loader_layer_list *instance_layers, loader_platform_dl_handle **libs) {
     struct loader_envvar_filter enable_filter;
     struct loader_envvar_disable_layers_filter disable_filter;
     char *file_str;
@@ -4038,7 +3809,7 @@ VkResult loader_scan_for_implicit_layers(struct loader_instance *inst, struct lo
         goto out;
     }
 
-    res = loader_get_data_files(inst, LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER, NULL, &manifest_files);
+    res = loader_get_data_files(inst, settings, LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER, NULL, &manifest_files);
     if (VK_SUCCESS != res || manifest_files.count == 0) {
         goto out;
     }
@@ -4115,7 +3886,8 @@ VkResult loader_scan_for_implicit_layers(struct loader_instance *inst, struct lo
     // explicit layer info as well.  Not to worry, though, all explicit layers not included
     // in the override layer will be removed below in loader_remove_layers_in_blacklist().
     if (override_layer_valid || implicit_metalayer_present) {
-        if (VK_SUCCESS != loader_get_data_files(inst, LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER, override_paths, &manifest_files)) {
+        if (VK_SUCCESS !=
+            loader_get_data_files(inst, settings, LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER, override_paths, &manifest_files)) {
             goto out;
         }
 
@@ -4147,7 +3919,7 @@ VkResult loader_scan_for_implicit_layers(struct loader_instance *inst, struct lo
 
     // Verify any meta-layers in the list are valid and all the component layers are
     // actually present in the available layer list
-    verify_all_meta_layers(inst, &enable_filter, &disable_filter, instance_layers, &override_layer_valid);
+    verify_all_meta_layers(inst, settings, &enable_filter, &disable_filter, instance_layers, &override_layer_valid);
 
     if (override_layer_valid || implicit_metalayer_present) {
         loader_remove_layers_not_in_implicit_meta_layers(inst, instance_layers);
@@ -4919,8 +4691,8 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
 
         // If layer debugging is enabled, let's print out the full callstack with layers in their
         // defined order.
-        if ((loader_get_debug_level() & VULKAN_LOADER_LAYER_BIT) != 0) {
-            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "vkCreateInstance layer callstack setup to:");
+        if ((inst->settings->log_settings.enabled_log_flags & VULKAN_LOADER_LAYER_BIT) != 0) {
+            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "vkCreateInstance ayer callstack set to:");
             loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   <Application>");
             loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "     ||");
             loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   <Loader>");
@@ -5182,13 +4954,13 @@ VkResult loader_create_device_chain(const VkPhysicalDevice pd, const VkDeviceCre
         // If layer debugging is enabled, let's print out the full callstack with layers in their
         // defined order.
         uint32_t layer_driver_bits = VULKAN_LOADER_LAYER_BIT | VULKAN_LOADER_DRIVER_BIT;
-        if ((loader_get_debug_level() & layer_driver_bits) != 0) {
+        if ((inst->settings->log_settings.enabled_log_flags & layer_driver_bits) != 0) {
             loader_log(inst, layer_driver_bits, 0, "vkCreateDevice layer callstack setup to:");
             loader_log(inst, layer_driver_bits, 0, "   <Application>");
             loader_log(inst, layer_driver_bits, 0, "     ||");
             loader_log(inst, layer_driver_bits, 0, "   <Loader>");
             loader_log(inst, layer_driver_bits, 0, "     ||");
-            if ((loader_get_debug_level() & VULKAN_LOADER_LAYER_BIT) != 0) {
+            if ((inst->settings->log_settings.enabled_log_flags & VULKAN_LOADER_LAYER_BIT) != 0) {
                 for (uint32_t cur_layer = 0; cur_layer < num_activated_layers; ++cur_layer) {
                     uint32_t index = num_activated_layers - cur_layer - 1;
                     loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   %s", activated_layers[index].name);
@@ -5278,8 +5050,6 @@ VkResult loader_validate_instance_extensions(struct loader_instance *inst, const
                                              const struct loader_layer_list *instance_layers,
                                              const VkInstanceCreateInfo *pCreateInfo) {
     VkExtensionProperties *extension_prop;
-    char *env_value;
-    bool check_if_known = true;
     VkResult res = VK_SUCCESS;
     struct loader_envvar_filter layers_enable_filter;
     struct loader_envvar_disable_layers_filter layers_disable_filter;
@@ -5343,13 +5113,7 @@ VkResult loader_validate_instance_extensions(struct loader_instance *inst, const
         }
 
         // Check if a user wants to disable the instance extension filtering behavior
-        env_value = loader_getenv("VK_LOADER_DISABLE_INST_EXT_FILTER", inst);
-        if (NULL != env_value && atoi(env_value) != 0) {
-            check_if_known = false;
-        }
-        loader_free_getenv(env_value, inst);
-
-        if (check_if_known) {
+        if (!inst->settings->disable_instance_extension_filter) {
             // See if the extension is in the list of supported extensions
             bool found = false;
             for (uint32_t j = 0; LOADER_INSTANCE_EXTENSIONS[j] != NULL; j++) {
@@ -6267,16 +6031,7 @@ out:
 
 #ifdef LOADER_ENABLE_LINUX_SORT
 bool is_linux_sort_enabled(struct loader_instance *inst) {
-    bool sort_items = inst->supports_get_dev_prop_2;
-    char *env_value = loader_getenv("VK_LOADER_DISABLE_SELECT", inst);
-    if (NULL != env_value) {
-        int32_t int_env_val = atoi(env_value);
-        loader_free_getenv(env_value, inst);
-        if (int_env_val != 0) {
-            sort_items = false;
-        }
-    }
-    return sort_items;
+    return inst->supports_get_dev_prop_2 && inst->settings->device_settings.device_sorting_enabled;
 }
 #endif  // LOADER_ENABLE_LINUX_SORT
 
@@ -6846,7 +6601,12 @@ terminator_EnumerateInstanceExtensionProperties(const VkEnumerateInstanceExtensi
     struct loader_extension_list local_ext_list;
     struct loader_icd_tramp_list icd_tramp_list;
     uint32_t copy_size;
-    VkResult res = VK_SUCCESS;
+
+    struct loader_settings *temporary_settings = NULL;
+    VkResult res = generateSettingsStruct(NULL, &temporary_settings);
+    if (VK_SUCCESS != res) {
+        goto out;
+    }
 
     memset(&local_ext_list, 0, sizeof(local_ext_list));
     memset(&instance_layers, 0, sizeof(instance_layers));
@@ -6860,7 +6620,7 @@ terminator_EnumerateInstanceExtensionProperties(const VkEnumerateInstanceExtensi
             goto out;
         }
 
-        res = loader_scan_for_layers(NULL, &instance_layers);
+        res = loader_scan_for_layers(NULL, temporary_settings, &instance_layers);
         if (VK_SUCCESS != res) {
             goto out;
         }
@@ -6873,23 +6633,23 @@ terminator_EnumerateInstanceExtensionProperties(const VkEnumerateInstanceExtensi
         }
     } else {
         // Preload ICD libraries so subsequent calls to EnumerateInstanceExtensionProperties don't have to load them
-        loader_preload_icds();
+        loader_preload_icds(temporary_settings);
 
         // Scan/discover all ICD libraries
-        res = loader_icd_scan(NULL, &icd_tramp_list, NULL, NULL);
+        res = loader_icd_scan(NULL, temporary_settings, &icd_tramp_list, NULL, NULL);
         // EnumerateInstanceExtensionProperties can't return anything other than OOM or VK_ERROR_LAYER_NOT_PRESENT
         if ((VK_SUCCESS != res && icd_tramp_list.count > 0) || res == VK_ERROR_OUT_OF_HOST_MEMORY) {
             goto out;
         }
         // Get extensions from all ICD's, merge so no duplicates
-        res = loader_get_icd_loader_instance_extensions(NULL, &icd_tramp_list, &local_ext_list);
+        res = loader_get_icd_loader_instance_extensions(NULL, temporary_settings, &icd_tramp_list, &local_ext_list);
         if (VK_SUCCESS != res) {
             goto out;
         }
         loader_scanned_icd_clear(NULL, &icd_tramp_list);
 
         // Append enabled implicit layers.
-        res = loader_scan_for_implicit_layers(NULL, &instance_layers, NULL);
+        res = loader_scan_for_implicit_layers(NULL, temporary_settings, &instance_layers, NULL);
         if (VK_SUCCESS != res) {
             goto out;
         }
@@ -6926,6 +6686,9 @@ out:
     loader_destroy_generic_list(NULL, (struct loader_generic_list *)&icd_tramp_list);
     loader_destroy_generic_list(NULL, (struct loader_generic_list *)&local_ext_list);
     loader_delete_layer_list_and_properties(NULL, &instance_layers);
+    if (temporary_settings != NULL) {
+        freeSettingsStruct(NULL, &temporary_settings);
+    }
     return res;
 }
 
@@ -6939,9 +6702,15 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateInstanceLayerProperties(const
 
     uint32_t copy_size;
 
+    struct loader_settings *temporary_settings = NULL;
+    VkResult res = generateSettingsStruct(NULL, &temporary_settings);
+    if (VK_SUCCESS != res) {
+        goto out;
+    }
+
     // Get layer libraries
     memset(&instance_layer_list, 0, sizeof(instance_layer_list));
-    result = loader_scan_for_layers(NULL, &instance_layer_list);
+    result = loader_scan_for_layers(NULL, temporary_settings, &instance_layer_list);
     if (VK_SUCCESS != result) {
         goto out;
     }
@@ -6964,8 +6733,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateInstanceLayerProperties(const
     }
 
 out:
-
     loader_delete_layer_list_and_properties(NULL, &instance_layer_list);
+    if (temporary_settings != NULL) {
+        freeSettingsStruct(NULL, &temporary_settings);
+    }
     return result;
 }
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2869,27 +2869,7 @@ out:
     return result;
 }
 
-static inline size_t determine_data_file_path_size(const char *cur_path, size_t relative_path_size) {
-    size_t path_size = 0;
-
-    if (NULL != cur_path) {
-        // For each folder in cur_path, (detected by finding additional
-        // path separators in the string) we need to add the relative path on
-        // the end.  Plus, leave an additional two slots on the end to add an
-        // additional directory slash and path separator if needed
-        path_size += strlen(cur_path) + relative_path_size + 2;
-        for (const char *x = cur_path; *x; ++x) {
-            if (*x == PATH_SEPARATOR) {
-                path_size += relative_path_size + 2;
-            }
-        }
-    }
-
-    return path_size;
-}
-
-static inline void copy_data_file_info(const char *cur_path, const char *relative_path, size_t relative_path_size,
-                                       char **output_path) {
+void copy_data_file_info(const char *cur_path, const char *relative_path, size_t relative_path_size, char **output_path) {
     if (NULL != cur_path) {
         uint32_t start = 0;
         uint32_t stop = 0;

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -97,6 +97,10 @@ void loader_initialize(void);
 void loader_release(void);
 void loader_preload_icds(void);
 void loader_unload_preloaded_icds(void);
+size_t determine_data_file_path_size(const char *cur_path, size_t relative_path_size);
+void copy_data_file_info(const char *cur_path, const char *relative_path, size_t relative_path_size, char **output_path);
+VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct);
+void freeSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct);
 bool has_vk_extension_property_array(const VkExtensionProperties *vk_ext_prop, const uint32_t count,
                                      const VkExtensionProperties *ext_array);
 bool has_vk_extension_property(const VkExtensionProperties *vk_ext_prop, const struct loader_extension_list *ext_list);

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -95,12 +95,10 @@ VkResult loader_validate_instance_extensions(struct loader_instance *inst, const
 
 void loader_initialize(void);
 void loader_release(void);
-void loader_preload_icds(void);
+void loader_preload_icds(const struct loader_settings *settings);
 void loader_unload_preloaded_icds(void);
-size_t determine_data_file_path_size(const char *cur_path, size_t relative_path_size);
 void copy_data_file_info(const char *cur_path, const char *relative_path, size_t relative_path_size, char **output_path);
-VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct);
-void freeSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct);
+size_t determine_data_file_path_size(const char *cur_path, size_t relative_path_size);
 bool has_vk_extension_property_array(const VkExtensionProperties *vk_ext_prop, const uint32_t count,
                                      const VkExtensionProperties *ext_array);
 bool has_vk_extension_property(const VkExtensionProperties *vk_ext_prop, const struct loader_extension_list *ext_list);
@@ -128,14 +126,17 @@ void loader_destroy_layer_list(const struct loader_instance *inst, struct loader
 void loader_delete_layer_list_and_properties(const struct loader_instance *inst, struct loader_layer_list *layer_list);
 VkResult loader_scanned_icd_init(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
 void loader_scanned_icd_clear(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
-VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list,
-                         const VkInstanceCreateInfo *pCreateInfo, bool *skipped_portability_drivers);
+VkResult loader_icd_scan(const struct loader_instance *inst, const struct loader_settings *settings,
+                         struct loader_icd_tramp_list *icd_tramp_list, const VkInstanceCreateInfo *pCreateInfo,
+                         bool *skipped_portability_drivers);
 void loader_icd_destroy(struct loader_instance *ptr_inst, struct loader_icd_term *icd_term,
                         const VkAllocationCallbacks *pAllocator);
-VkResult loader_scan_for_layers(struct loader_instance *inst, struct loader_layer_list *instance_layers);
-VkResult loader_scan_for_implicit_layers(struct loader_instance *inst, struct loader_layer_list *instance_layers,
-                                         loader_platform_dl_handle **libs);
-VkResult loader_get_icd_loader_instance_extensions(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list,
+VkResult loader_scan_for_layers(struct loader_instance *inst, const struct loader_settings *settings,
+                                struct loader_layer_list *instance_layers);
+VkResult loader_scan_for_implicit_layers(struct loader_instance *inst, const struct loader_settings *settings,
+                                         struct loader_layer_list *instance_layers, loader_platform_dl_handle **libs);
+VkResult loader_get_icd_loader_instance_extensions(const struct loader_instance *inst, const struct loader_settings *settings,
+                                                   struct loader_icd_tramp_list *icd_tramp_list,
                                                    struct loader_extension_list *inst_exts);
 struct loader_icd_term *loader_get_icd_and_device(const void *device, struct loader_device **found_dev, uint32_t *icd_index);
 struct loader_instance *loader_get_instance(const VkInstance instance);
@@ -180,8 +181,8 @@ VkResult setup_loader_tramp_phys_dev_groups(struct loader_instance *inst, uint32
 
 VkStringErrorFlags vk_string_validate(const int max_length, const char *char_array);
 char *loader_get_next_path(char *path);
-VkResult add_data_files(const struct loader_instance *inst, char *search_path, struct loader_data_files *out_files,
-                        bool use_first_found_manifest);
+VkResult add_data_files(const struct loader_instance *inst, uint32_t search_path_count, char **search_path_array,
+                        struct loader_data_files *out_files, bool use_first_found_manifest);
 
 loader_api_version loader_make_version(uint32_t version);
 loader_api_version loader_combine_version(uint32_t major, uint32_t minor, uint32_t patch);

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -106,8 +106,7 @@ bool has_vk_extension_property(const VkExtensionProperties *vk_ext_prop, const s
 VkResult loader_add_layer_properties_to_list(const struct loader_instance *inst, struct loader_layer_list *list,
                                              uint32_t prop_list_count, const struct loader_layer_properties *props);
 void loader_free_layer_properties(const struct loader_instance *inst, struct loader_layer_properties *layer_properties);
-VkResult loader_add_meta_layer(const struct loader_instance *inst, const struct loader_envvar_filter *enable_filter,
-                               const struct loader_envvar_disable_layers_filter *disable_filter,
+VkResult loader_add_meta_layer(const struct loader_instance *inst, const struct loader_settings *settings,
                                const struct loader_layer_properties *prop, struct loader_layer_list *target_list,
                                struct loader_layer_list *expanded_target_list, const struct loader_layer_list *source_list,
                                bool *out_found_all_component_layers);
@@ -180,7 +179,7 @@ VkResult setup_loader_tramp_phys_dev_groups(struct loader_instance *inst, uint32
                                             VkPhysicalDeviceGroupProperties *groups);
 
 VkStringErrorFlags vk_string_validate(const int max_length, const char *char_array);
-char *loader_get_next_path(char *path);
+char *loader_get_next_list_item(char *path, char separator);
 VkResult add_data_files(const struct loader_instance *inst, uint32_t search_path_count, char **search_path_array,
                         struct loader_data_files *out_files, bool use_first_found_manifest);
 

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -309,8 +309,8 @@ struct loader_settings {
     struct loader_instance_settings instance_settings;
     struct loader_log_settings log_settings;
     struct loader_driver_settings driver_settings;
-    struct loader_layer_settings layer_settings;
     struct loader_physical_device_settings physical_device_settings;
+    struct loader_layer_settings layer_settings;
 
     // Global path settings
     uint32_t driver_search_paths_count;

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -249,7 +249,7 @@ struct loader_log_settings {
 
 // Options for sorting or selecting a device based on specific information.
 // Currently only works for Linux
-struct loader_device_sorting_settings {
+struct loader_device_settings {
     bool device_sorting_enabled;
     bool device_select_enabled;
     char *device_select_string;
@@ -271,7 +271,14 @@ struct loader_settings {
     char **explicit_layer_search_paths;
 
     // Device settings
-    struct loader_device_sorting_settings device_sorting_settings;
+    struct loader_device_settings device_settings;
+};
+
+struct loader_pre_instance_settings {
+    bool ready;
+    loader_platform_thread_mutex lock;
+    struct loader_settings *settings;
+    uint32_t ref_count;
 };
 
 // Per instance structure

--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -30,6 +30,14 @@
 #include "loader_environment.h"
 #include "vk_loader_platform.h"
 
+#if defined(WIN32)
+#include "loader_windows.h"
+#endif
+#if defined(__APPLE__)
+#include <CoreFoundation/CoreFoundation.h>
+#include <sys/param.h>
+#endif
+
 #include "allocation.h"
 #include "loader.h"
 #include "log.h"
@@ -929,7 +937,7 @@ VkResult parseEnvLoaderLogSettings(struct loader_instance *inst, struct loader_l
             settings->log_filename[len] = '\0';
             settings->log_to_file = true;
         } else {
-            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "Failed allocating loader log file name");
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_SETTING_BIT, 0, "Failed allocating loader log file name");
             res = VK_ERROR_OUT_OF_HOST_MEMORY;
         }
     }
@@ -944,7 +952,7 @@ VkResult parseEnvInstanceSettings(struct loader_instance *inst, struct loader_in
     }
     env = loader_getenv("VK_LOADER_DISABLE_INST_EXT_FILTER", inst);
     if (NULL != env && atoi(env) != 0) {
-        loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Found environment var 'VK_LOADER_DISABLE_INST_EXT_FILTER' set to %s", env);
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "Found environment var 'VK_LOADER_DISABLE_INST_EXT_FILTER' set to %s", env);
         instance_settings->disable_instance_extension_filter = true;
     }
     loader_free_getenv(env, inst);
@@ -959,7 +967,7 @@ VkResult parseEnvLayerSettings(struct loader_instance *inst, struct loader_layer
     }
     env = loader_getenv("VK_LOADER_LAYER_EXIT_ON_MISSING", inst);
     if (NULL != env && atoi(env) != 0) {
-        loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Found environment var 'VK_LOADER_LAYER_EXIT_ON_MISSING' set to %s", env);
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "Found environment var 'VK_LOADER_LAYER_EXIT_ON_MISSING' set to %s", env);
         layer_settings->exit_on_missing_layer = true;
     }
     loader_free_getenv(env, inst);
@@ -1011,7 +1019,7 @@ VkResult parseEnvPhysicalDeviceSettings(struct loader_instance *inst,
     char *env_value = loader_getenv("VK_LOADER_DISABLE_SELECT", inst);
     if (NULL != env_value && atoi(env_value) != 0) {
         // Device select disabled so bail out early
-        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+        loader_log(inst, VULKAN_LOADER_DRIVER_BIT | VULKAN_LOADER_SETTING_BIT, 0,
                    "Found environment var `VK_LOADER_DISABLE_SELECT` set to non-zero.  Disabling device sorting.");
         loader_free_getenv(env_value, inst);
         physical_device_settings->device_sorting_enabled = false;
@@ -1019,12 +1027,13 @@ VkResult parseEnvPhysicalDeviceSettings(struct loader_instance *inst,
         char *selection = loader_getenv("VK_LOADER_DEVICE_SELECT", inst);
         size_t string_len = selection == NULL ? 0 : strlen(selection);
         if (NULL != selection && 1 < string_len) {
-            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+            loader_log(inst, VULKAN_LOADER_DRIVER_BIT | VULKAN_LOADER_SETTING_BIT, 0,
                        "Found environment var `VK_LOADER_DEVICE_SELECT` set %s", selection);
             physical_device_settings->device_select_string =
                 loader_instance_heap_alloc(inst, string_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
             if (NULL == physical_device_settings->device_select_string) {
-                loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "Failed allocating loader settings structure");
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_SETTING_BIT, 0,
+                           "Failed allocating loader settings structure");
                 res = VK_ERROR_OUT_OF_HOST_MEMORY;
             } else {
                 strncpy(physical_device_settings->device_select_string, selection, string_len);
@@ -1168,7 +1177,9 @@ VkResult loaderDefaultSearchPaths(const struct loader_instance *inst, char **def
         char **target_pointer = NULL;
         char *cur_path_ptr = NULL;
         size_t search_path_size = 2;  // Add two for NULL terminator and one path separator (just in case)
+#if !defined(_WIN32)
         size_t rel_size = 0;
+#endif
         bool settings_file_search = false;
         switch (pass) {
             case 0:
@@ -1246,6 +1257,7 @@ VkResult loaderDefaultSearchPaths(const struct loader_instance *inst, char **def
         // Looks for manifests in the bundle first, before any system directories.
         CFBundleRef main_bundle = CFBundleGetMainBundle();
         if (NULL != main_bundle) {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "Found Apple Main Bundle");
             CFURLRef ref = CFBundleCopyResourcesDirectoryURL(main_bundle);
             if (NULL != ref) {
                 if (CFURLGetFileSystemRepresentation(ref, TRUE, (UInt8 *)cur_path_ptr, search_path_size)) {
@@ -1253,10 +1265,9 @@ VkResult loaderDefaultSearchPaths(const struct loader_instance *inst, char **def
                     *cur_path_ptr++ = DIRECTORY_SYMBOL;
                     memcpy(cur_path_ptr, relative_folder, rel_size);
                     cur_path_ptr += rel_size;
+                    *cur_path_ptr = '\0';  // Just for debugging
+                    loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "Using path for Apple Bundle Path %s", *target_pointer);
                     *cur_path_ptr++ = PATH_SEPARATOR;
-                    if (manifest_type == LOADER_DATA_FILE_MANIFEST_DRIVER) {
-                        use_first_found_manifest = true;
-                    }
                 }
                 CFRelease(ref);
             }
@@ -1319,10 +1330,10 @@ out:
 // Loader File Settings handling
 
 // Determine if the environment variables indicate that driver should be modified.
+#define MAX_SETTINGS_LINE_LEN 1024
 VkResult parseSettingsFile(struct loader_instance *inst, struct loader_settings *settings,
                            uint32_t settings_file_search_paths_count, char **settings_file_search_paths) {
-    const uint32_t temp_string_len = 1024;
-    char temp_string[temp_string_len];
+    char temp_string[MAX_SETTINGS_LINE_LEN];
     const char loader_settings_file[] = "vk_loader_settings.txt";
     FILE *settings_file = NULL;
     if (NULL == settings || 0 == settings_file_search_paths_count || NULL == settings_file_search_paths) {
@@ -1330,14 +1341,21 @@ VkResult parseSettingsFile(struct loader_instance *inst, struct loader_settings 
     }
     for (uint32_t path = 0; path < settings_file_search_paths_count; ++path) {
         if (strlen(settings_file_search_paths[path]) > strlen(temp_string) - strlen(loader_settings_file) - 2) {
-            loader_log(inst, VULKAN_LOADER_WARN_BIT, 0, "Settings file path %s is too long, skipping.",
+            loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_SETTING_BIT, 0, "Settings file path %s is too long, skipping.",
                        settings_file_search_paths[path]);
             continue;
         }
-        snprintf(temp_string, temp_string_len, "%s%c%s", settings_file_search_paths[path], DIRECTORY_SYMBOL, loader_settings_file);
+        snprintf(temp_string, MAX_SETTINGS_LINE_LEN, "%s%c%s", settings_file_search_paths[path], DIRECTORY_SYMBOL,
+                 loader_settings_file);
+
+#if defined(_WIN32)
+        errno_t err = fopen_s(&settings_file, temp_string, "rt");
+        if (err == 0 && settings_file != NULL) {
+#else
         settings_file = fopen(temp_string, "rt");
         if (settings_file != NULL) {
-            loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "Using Loader settings file %s", temp_string);
+#endif
+            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_SETTING_BIT, 0, "Using Loader settings file %s", temp_string);
             break;
         }
     }
@@ -1429,7 +1447,7 @@ VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_sett
     struct loader_settings *settings =
         loader_instance_heap_calloc(inst, sizeof(struct loader_settings), VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
     if (settings == NULL) {
-        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "Failed allocating loader settings structure");
+        loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_SETTING_BIT, 0, "Failed allocating loader settings structure");
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
     *set_struct = settings;
@@ -1568,7 +1586,8 @@ VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_sett
         settings->log_settings.log_file = fopen(settings->log_settings.log_filename, "at");
         if (NULL == settings->log_settings.log_file) {
             settings->log_settings.log_to_file = false;
-            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "Failed opening loader log file %s", settings->log_settings.log_file);
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_SETTING_BIT, 0, "Failed opening loader log file %s",
+                       settings->log_settings.log_file);
         }
     }
 

--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -1329,6 +1329,120 @@ out:
 
 // Loader File Settings handling
 
+void logLoaderSettings(struct loader_instance *inst, struct loader_settings *settings) {
+    if ((settings->log_settings.enabled_log_flags & VULKAN_LOADER_SETTING_BIT) != 0) {
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "Settings Data");
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "-------------");
+
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "  Instance Settings");
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Disable Extension Filter:     %d",
+                   settings->instance_settings.disable_instance_extension_filter);
+
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "  Log Settings");
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Enabled Flags:                0x%08x",
+                   settings->log_settings.enabled_log_flags);
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Errors to StdOut:             %d",
+                   settings->log_settings.log_errors_to_stdout);
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Errors to StdErr:             %d",
+                   settings->log_settings.log_errors_to_stderr);
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Non-errors to StdOut:         %d",
+                   settings->log_settings.log_nonerrors_to_stdout);
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Non-errors to StdErr:         %d",
+                   settings->log_settings.log_nonerrors_to_stderr);
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Log File :                    %s", settings->log_settings.log_filename);
+
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "  Driver Settings");
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Search Paths:                 %d", settings->driver_search_paths_count);
+        if (settings->driver_search_paths != NULL) {
+            for (uint32_t path = 0; path < settings->driver_search_paths_count; ++path) {
+                loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "      Search Path[%02d]:            %s", path,
+                           settings->driver_search_paths[path]);
+            }
+        } else {
+            loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Search Paths:                 0");
+        }
+        if (settings->driver_settings.select_filters != NULL) {
+            loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Select Filters:               %d",
+                       settings->driver_settings.select_filters->count);
+            for (uint32_t filt = 0; filt < settings->driver_settings.select_filters->count; ++filt) {
+                loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "      Select Filter[%02d]:          %s", filt,
+                           settings->driver_settings.select_filters->filters[filt].value);
+            }
+        } else {
+            loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Select Filters:               0");
+        }
+        if (settings->driver_settings.disable_filters != NULL) {
+            loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Disable Filters:              %d",
+                       settings->driver_settings.disable_filters->count);
+            for (uint32_t filt = 0; filt < settings->driver_settings.disable_filters->count; ++filt) {
+                loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "      Disable Filter[%02d]:         %s", filt,
+                           settings->driver_settings.disable_filters->filters[filt].value);
+            }
+        } else {
+            loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Disable Filters:              0");
+        }
+
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "  Physical Device Settings");
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Sorting Enabled:              %d",
+                   settings->physical_device_settings.device_sorting_enabled);
+        if (settings->physical_device_settings.device_select_enabled &&
+            settings->physical_device_settings.device_select_string != NULL) {
+            loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Device Select:                %d",
+                       settings->physical_device_settings.device_select_string);
+        } else {
+            loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Device Select:                NULL");
+        }
+
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "  Layer Settings");
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Implicit Search Paths:        %d",
+                   settings->implicit_layer_search_paths_count);
+        if (settings->implicit_layer_search_paths != NULL) {
+            for (uint32_t path = 0; path < settings->implicit_layer_search_paths_count; ++path) {
+                loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "      Search Path[%02d]:            %s", path,
+                           settings->implicit_layer_search_paths[path]);
+            }
+        }
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Explicit Search Paths:        %d",
+                   settings->explicit_layer_search_paths_count);
+        if (settings->explicit_layer_search_paths != NULL) {
+            for (uint32_t path = 0; path < settings->explicit_layer_search_paths_count; ++path) {
+                loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "      Search Path[%02d]:            %s", path,
+                           settings->explicit_layer_search_paths[path]);
+            }
+        }
+        if (settings->layer_settings.enable_filters != NULL) {
+            loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Enable Filters:               %d",
+                       settings->layer_settings.enable_filters->count);
+            for (uint32_t filt = 0; filt < settings->layer_settings.enable_filters->count; ++filt) {
+                loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "      Enable Filter[%02d]:          %s", filt,
+                           settings->layer_settings.enable_filters->filters[filt].value);
+            }
+        } else {
+            loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Enable Filters:               0");
+        }
+        if (settings->layer_settings.disable_filters != NULL) {
+            loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Disable Filters:              %d",
+                       settings->layer_settings.disable_filters->additional_filters.count);
+            for (uint32_t filt = 0; filt < settings->layer_settings.disable_filters->additional_filters.count; ++filt) {
+                loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "      Disable Filter[%02d]:         %s", filt,
+                           settings->layer_settings.disable_filters->additional_filters.filters[filt].value);
+            }
+        } else {
+            loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Disable Filters:              0");
+        }
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Forced On Layers:             %d",
+                   settings->layer_settings.forced_on_layers_count);
+        if (settings->layer_settings.forced_on_layers != NULL) {
+            for (uint32_t layer = 0; layer < settings->layer_settings.forced_on_layers_count; ++layer) {
+                loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "      Forced Layer[%02d]:           %s", layer,
+                           settings->layer_settings.forced_on_layers[layer]);
+            }
+        }
+        loader_log(inst, VULKAN_LOADER_SETTING_BIT, 0, "    Exit On Missing Forced Layer: %d",
+                   settings->layer_settings.exit_on_missing_layer);
+    }
+}
+
 // Determine if the environment variables indicate that driver should be modified.
 #define MAX_SETTINGS_LINE_LEN 1024
 VkResult parseSettingsFile(struct loader_instance *inst, struct loader_settings *settings,
@@ -1340,7 +1454,7 @@ VkResult parseSettingsFile(struct loader_instance *inst, struct loader_settings 
         return VK_SUCCESS;
     }
     for (uint32_t path = 0; path < settings_file_search_paths_count; ++path) {
-        if (strlen(settings_file_search_paths[path]) > strlen(temp_string) - strlen(loader_settings_file) - 2) {
+        if (strlen(settings_file_search_paths[path]) > MAX_SETTINGS_LINE_LEN - strlen(loader_settings_file) - 2) {
             loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_SETTING_BIT, 0, "Settings file path %s is too long, skipping.",
                        settings_file_search_paths[path]);
             continue;
@@ -1590,6 +1704,8 @@ VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_sett
                        settings->log_settings.log_file);
         }
     }
+
+    logLoaderSettings(inst, settings);
 
 out:
     if (settings_file_search_paths != NULL) {

--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -21,6 +21,7 @@
  * Author: Chia-I Wu <olvaffe@gmail.com>
  * Author: Chia-I Wu <olv@lunarg.com>
  * Author: Mark Lobodzinski <mark@LunarG.com>
+ * Author: Mark Young <marky@LunarG.com>
  * Author: Lenny Komow <lenny@lunarg.com>
  * Author: Charles Giessen <charles@lunarg.com>
  *
@@ -619,9 +620,9 @@ void parseEnvDisableInstanceExtensions(struct loader_instance *inst, bool *disab
     loader_free_getenv(env, NULL);
 }
 
-// Determine if the environment variables indicate that driver sorting should be modified.
-VkResult parseEnvDeviceSortingSettings(struct loader_instance *inst, struct loader_device_sorting_settings *sorting_settings) {
-    if (NULL == sorting_settings) {
+// Determine if the environment variables indicate that driver should be modified.
+VkResult parseEnvDeviceSettings(struct loader_instance *inst, struct loader_device_settings *device_settings) {
+    if (NULL == device_settings) {
         return VK_SUCCESS;
     }
 
@@ -632,21 +633,22 @@ VkResult parseEnvDeviceSortingSettings(struct loader_instance *inst, struct load
         loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                    "Found environment var `VK_LOADER_DISABLE_SELECT` set to non-zero.  Disabling device sorting.");
         loader_free_getenv(env_value, inst);
+        device_settings->device_sorting_enabled = false;
     } else {
         char *selection = loader_getenv("VK_LOADER_DEVICE_SELECT", inst);
         size_t string_len = selection == NULL ? 0 : strlen(selection);
         if (NULL != selection && 1 < string_len) {
             loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                        "Found environment var `VK_LOADER_DEVICE_SELECT` set %s", selection);
-            sorting_settings->device_select_string =
+            device_settings->device_select_string =
                 loader_instance_heap_alloc(inst, string_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-            if (NULL == sorting_settings->device_select_string) {
+            if (NULL == device_settings->device_select_string) {
                 loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "Failed allocating loader settings structure");
                 return VK_ERROR_OUT_OF_HOST_MEMORY;
             }
-            strncpy(sorting_settings->device_select_string, selection, string_len);
-            sorting_settings->device_select_string[string_len] = '\0';
-            sorting_settings->device_select_enabled = true;
+            strncpy(device_settings->device_select_string, selection, string_len);
+            device_settings->device_select_string[string_len] = '\0';
+            device_settings->device_select_enabled = true;
             loader_free_getenv(selection, inst);
         }
     }
@@ -654,50 +656,26 @@ VkResult parseEnvDeviceSortingSettings(struct loader_instance *inst, struct load
     return VK_SUCCESS;
 }
 
-// Determine how long a give path is in a path list string
-size_t determine_data_file_path_size(const char *cur_path, size_t relative_path_size) {
-    size_t path_size = 0;
-
-    if (NULL != cur_path) {
-        // For each folder in cur_path, (detected by finding additional
-        // path separators in the string) we need to add the relative path on
-        // the end.  Plus, leave an additional two slots on the end to add an
-        // additional directory slash and path separator if needed
-        path_size += strlen(cur_path) + relative_path_size + 2;
-        for (const char *x = cur_path; *x; ++x) {
-            if (*x == PATH_SEPARATOR) {
-                path_size += relative_path_size + 2;
-            }
-        }
+// Free the paths we used for setting up the search paths for layers and drivers.
+void freeSearchPath(const struct loader_instance *inst, char **search_path) {
+    if (search_path != NULL && *search_path != NULL) {
+        loader_instance_heap_free(inst, *search_path);
+        *search_path = NULL;
     }
-
-    return path_size;
 }
 
 // Free the paths we used for setting up the search paths for layers and drivers.
-void loaderFreeSearchPaths(struct loader_instance *inst, char **driver_path, char **implicit_path, char **explicit_path,
-                           char **settings_path) {
-    if (driver_path != NULL && *driver_path != NULL) {
-        loader_instance_heap_free(inst, *driver_path);
-        *driver_path = NULL;
-    }
-    if (implicit_path != NULL && *implicit_path != NULL) {
-        loader_instance_heap_free(inst, *implicit_path);
-        *implicit_path = NULL;
-    }
-    if (explicit_path != NULL && *explicit_path != NULL) {
-        loader_instance_heap_free(inst, *explicit_path);
-        *explicit_path = NULL;
-    }
-    if (settings_path != NULL && *settings_path != NULL) {
-        loader_instance_heap_free(inst, *settings_path);
-        *settings_path = NULL;
-    }
+void freeSearchPaths(const struct loader_instance *inst, char **driver_path, char **implicit_path, char **explicit_path,
+                     char **settings_path) {
+    freeSearchPath(inst, driver_path);
+    freeSearchPath(inst, implicit_path);
+    freeSearchPath(inst, explicit_path);
+    freeSearchPath(inst, settings_path);
 }
 
 // Figure out the default search paths for driver and layers based on the current operating
 // system.
-VkResult loaderDefaultSearchPaths(struct loader_instance *inst, char **default_driver_path, char **default_implicit_path,
+VkResult loaderDefaultSearchPaths(const struct loader_instance *inst, char **default_driver_path, char **default_implicit_path,
                                   char **default_explicit_path, char **default_settings_path) {
     VkResult result = VK_SUCCESS;
     const char curPassString[4][24] = {{"Driver"}, {"Implicit Layers"}, {"Explicit Layers"}, {"Settings"}};
@@ -714,10 +692,17 @@ VkResult loaderDefaultSearchPaths(struct loader_instance *inst, char **default_d
     // for the current manifest files.
     char *xdg_config_home = loader_secure_getenv("XDG_CONFIG_HOME", inst);
     char *xdg_config_dirs = loader_secure_getenv("XDG_CONFIG_DIRS", inst);
+    bool env_xdg_config_dirs = true;
+    bool env_xdg_data_dirs = true;
 
 #if !defined(__Fuchsia__) && !defined(__QNXNTO__)
-    if (NULL == xdg_config_dirs || '\0' == xdg_config_dirs[0]) {
+    if (NULL != xdg_config_dirs && '\0' == xdg_config_dirs[0]) {
+        loader_free_getenv(xdg_config_dirs, inst);
+        xdg_config_dirs = NULL;
+    }
+    if (NULL == xdg_config_dirs) {
         xdg_config_dirs = FALLBACK_CONFIG_DIRS;
+        env_xdg_config_dirs = false;
     }
 #endif
 
@@ -725,8 +710,13 @@ VkResult loaderDefaultSearchPaths(struct loader_instance *inst, char **default_d
     char *xdg_data_dirs = loader_secure_getenv("XDG_DATA_DIRS", inst);
 
 #if !defined(__Fuchsia__) && !defined(__QNXNTO__)
-    if (NULL == xdg_data_dirs || '\0' == xdg_data_dirs[0]) {
+    if (NULL != xdg_data_dirs && '\0' == xdg_data_dirs[0]) {
+        loader_free_getenv(xdg_data_dirs, inst);
+        xdg_data_dirs = NULL;
+    }
+    if (NULL == xdg_data_dirs) {
         xdg_data_dirs = FALLBACK_DATA_DIRS;
+        env_xdg_data_dirs = false;
     }
 #endif
 
@@ -905,16 +895,20 @@ VkResult loaderDefaultSearchPaths(struct loader_instance *inst, char **default_d
 
 out:
     if (VK_SUCCESS != result) {
-        loaderFreeSearchPaths(inst, default_driver_path, default_implicit_path, default_explicit_path, default_settings_path);
+        freeSearchPaths(inst, default_driver_path, default_implicit_path, default_explicit_path, default_settings_path);
     }
 
 #if defined(_WIN32)
     loader_instance_heap_free(inst, package_path);
 #else
     loader_free_getenv(xdg_config_home, inst);
-    loader_free_getenv(xdg_config_dirs, inst);
+    if (env_xdg_config_dirs) {
+        loader_free_getenv(xdg_config_dirs, inst);
+    }
     loader_free_getenv(xdg_data_home, inst);
-    loader_free_getenv(xdg_data_dirs, inst);
+    if (env_xdg_data_dirs) {
+        loader_free_getenv(xdg_data_dirs, inst);
+    }
     loader_free_getenv(xdg_data_home, inst);
     loader_free_getenv(home, inst);
     loader_instance_heap_free(inst, default_data_home);
@@ -925,8 +919,8 @@ out:
 }
 
 // Read a path that is stored in an environment variable.
-VkResult readEnvVarPath(struct loader_instance *inst, uint32_t log_msg_flag, char **output_var, char *env_var) {
-    if (inst == NULL || output_var == NULL || env_var == NULL) {
+VkResult readEnvVarPath(const struct loader_instance *inst, uint32_t log_msg_flag, char **output_var, char *env_var) {
+    if (output_var == NULL || env_var == NULL) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
@@ -972,7 +966,7 @@ uint32_t getPathCount(char *path_list) {
 
 // Extract each individual paths listed in a path_list string and place it in a path_array for
 // easier use.
-VkResult addPathsToArray(struct loader_instance *inst, uint32_t log_msg_flag, char *path_list, char **path_array,
+VkResult addPathsToArray(const struct loader_instance *inst, uint32_t log_msg_flag, char *path_list, char **path_array,
                          uint32_t *start_index) {
     // Now, parse the paths
     char *cur_path;
@@ -1006,15 +1000,16 @@ VkResult addPathsToArray(struct loader_instance *inst, uint32_t log_msg_flag, ch
 // Generate the complete list of search paths using the environment variables (or file variables) and
 // the default paths for this platform.
 // NOTE: This can be overridden by the "override" layer later on.
-VkResult generateCompleteSearchPath(struct loader_instance *inst, enum loader_data_files_type search_type, char *default_path,
-                                    char *override_path, char *add_path, uint32_t *count, char ***value) {
+VkResult generateCompleteSearchPath(const struct loader_instance *inst, enum loader_data_files_type search_type,
+                                    const char *default_path, const char *override_path, const char *add_path, uint32_t *count,
+                                    char ***value) {
     uint32_t path_count = 0;
     uint32_t cur_path_index = 0;
     enum vulkan_loader_debug_flags log_msg_flag;
     uint8_t message_index = 0;
     const char message_str[4][20] = {{"driver"}, {"implicit layer"}, {"explicit layer"}, {"settings file"}};
 
-    if (inst == NULL || default_path == NULL || count == NULL || value == NULL) {
+    if (default_path == NULL || count == NULL || value == NULL) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
 
@@ -1043,6 +1038,7 @@ VkResult generateCompleteSearchPath(struct loader_instance *inst, enum loader_da
 
     char **path_array = NULL;
     char *modifiable_path = NULL;
+    char *cur_mod_ptr;
     bool failed = false;
 
     if (NULL != override_path) {
@@ -1053,9 +1049,10 @@ VkResult generateCompleteSearchPath(struct loader_instance *inst, enum loader_da
             failed = true;
         }
         if (!failed) {
-            strncpy(modifiable_path, override_path, cur_len);
-            modifiable_path[cur_len] = '\0';
-            path_count = getPathCount(modifiable_path);
+            cur_mod_ptr = modifiable_path;
+            strncpy(cur_mod_ptr, override_path, cur_len);
+            cur_mod_ptr[cur_len] = '\0';
+            path_count = getPathCount(cur_mod_ptr);
             path_array = loader_instance_heap_calloc(inst, sizeof(char *) * path_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
             if (path_array == NULL) {
                 loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for %s override path search array",
@@ -1064,9 +1061,10 @@ VkResult generateCompleteSearchPath(struct loader_instance *inst, enum loader_da
             }
         }
         if (!failed) {
-            strncpy(modifiable_path, override_path, cur_len);
-            modifiable_path[cur_len] = '\0';
-            if (addPathsToArray(inst, log_msg_flag, modifiable_path, path_array, &cur_path_index)) {
+            cur_mod_ptr = modifiable_path;
+            strncpy(cur_mod_ptr, override_path, cur_len);
+            cur_mod_ptr[cur_len] = '\0';
+            if (addPathsToArray(inst, log_msg_flag, cur_mod_ptr, path_array, &cur_path_index)) {
                 loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
                            "Failed copying paths from %s override path into search array", message_str[message_index]);
                 failed = true;
@@ -1085,14 +1083,16 @@ VkResult generateCompleteSearchPath(struct loader_instance *inst, enum loader_da
         if (!failed) {
             path_count = 0;
             if (add_path != NULL) {
-                strncpy(modifiable_path, add_path, add_len);
-                modifiable_path[add_len] = '\0';
-                path_count += getPathCount(modifiable_path);
+                cur_mod_ptr = modifiable_path;
+                strncpy(cur_mod_ptr, add_path, add_len);
+                cur_mod_ptr[add_len] = '\0';
+                path_count += getPathCount(cur_mod_ptr);
             }
             if (default_path != NULL) {
-                strncpy(modifiable_path, default_path, default_len);
-                modifiable_path[default_len] = '\0';
-                path_count += getPathCount(modifiable_path);
+                cur_mod_ptr = modifiable_path;
+                strncpy(cur_mod_ptr, default_path, default_len);
+                cur_mod_ptr[default_len] = '\0';
+                path_count += getPathCount(cur_mod_ptr);
             }
             path_array = loader_instance_heap_calloc(inst, sizeof(char *) * path_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
             if (path_array == NULL) {
@@ -1102,28 +1102,35 @@ VkResult generateCompleteSearchPath(struct loader_instance *inst, enum loader_da
             }
         }
         if (!failed && add_path != NULL) {
-            strncpy(modifiable_path, add_path, add_len);
-            modifiable_path[add_len] = '\0';
-            if (addPathsToArray(inst, log_msg_flag, modifiable_path, path_array, &cur_path_index)) {
+            cur_mod_ptr = modifiable_path;
+            strncpy(cur_mod_ptr, add_path, add_len);
+            cur_mod_ptr[add_len] = '\0';
+            if (addPathsToArray(inst, log_msg_flag, cur_mod_ptr, path_array, &cur_path_index)) {
                 loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
                            "Failed copying paths from additional %s path into search array", message_str[message_index]);
                 failed = true;
             }
         }
         if (!failed && default_path != NULL) {
-            strncpy(modifiable_path, default_path, default_len);
-            modifiable_path[default_len] = '\0';
-            if (addPathsToArray(inst, log_msg_flag, modifiable_path, path_array, &cur_path_index)) {
+            cur_mod_ptr = modifiable_path;
+            strncpy(cur_mod_ptr, default_path, default_len);
+            cur_mod_ptr[default_len] = '\0';
+            if (addPathsToArray(inst, log_msg_flag, cur_mod_ptr, path_array, &cur_path_index)) {
                 loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
                            "Failed copying paths from default %s path into search array", message_str[message_index]);
                 failed = true;
             }
         }
     }
+    if (modifiable_path != NULL) {
+        loader_instance_heap_free(inst, modifiable_path);
+    }
     if (failed) {
+        if (path_array != NULL) {
+            loader_instance_heap_free(inst, path_array);
+        }
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
-    loader_instance_heap_free(inst, modifiable_path);
 
     // Remove duplicate paths, or it would result in duplicate extensions, duplicate devices, etc.
     for (int32_t cur_path = 0; cur_path < (int32_t)path_count; ++cur_path) {
@@ -1152,6 +1159,8 @@ VkResult generateCompleteSearchPath(struct loader_instance *inst, enum loader_da
         }
     }
 
+    assert(path_array != NULL);
+    assert(path_count != 0);
     *count = path_count;
     *value = path_array;
     return VK_SUCCESS;
@@ -1173,13 +1182,12 @@ void freeSettingsStruct(struct loader_instance *inst, struct loader_settings **s
         }
         settings->log_settings.log_to_file = false;
     }
-    loader_instance_heap_free(inst, settings->log_settings.log_filename);
     settings->log_settings.log_filename = NULL;
 
     // Free device items
-    if (NULL != settings->device_sorting_settings.device_select_string) {
-        loader_instance_heap_free(inst, settings->device_sorting_settings.device_select_string);
-        settings->device_sorting_settings.device_select_string = NULL;
+    if (NULL != settings->device_settings.device_select_string) {
+        loader_instance_heap_free(inst, settings->device_settings.device_select_string);
+        settings->device_settings.device_select_string = NULL;
     }
 
     // Free search paths
@@ -1217,6 +1225,7 @@ void freeSettingsStruct(struct loader_instance *inst, struct loader_settings **s
 // This is generated from platform defaults, environment variables, and the loader settings
 // file.
 VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct) {
+    VkResult result = VK_SUCCESS;
     if (set_struct == NULL) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
@@ -1227,6 +1236,7 @@ VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_sett
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "Failed allocating loader settings structure");
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
+    *set_struct = settings;
 
     // Search paths, these are eventually used to fill in the final search paths
     // for each driver, implicit layers, and explicit layers.
@@ -1242,8 +1252,8 @@ VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_sett
     char *additional_explicit_layer_env_var_search_path = NULL;
     char *additional_explicit_layer_file_search_path = NULL;
     char *default_settings_file_search_path = NULL;
-    uint32_t settings_file_search_paths_count;
-    char **settings_file_search_paths;
+    uint32_t settings_file_search_paths_count = 0;
+    char **settings_file_search_paths = NULL;
 
     // Set defaults
     settings->log_settings.log_errors_to_stderr = true;
@@ -1255,79 +1265,82 @@ VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_sett
     settings->explicit_layer_search_paths_count = 0;
     settings->explicit_layer_search_paths = NULL;
 #if LOADER_ENABLE_LINUX_SORT
-    settings->device_sorting_settings.device_sorting_enabled = true;
+    settings->device_settings.device_sorting_enabled = true;
 #else
-    settings->device_sorting_settings.device_sorting_enabled = false;
+    settings->device_settings.device_sorting_enabled = false;
 #endif
-    settings->device_sorting_settings.device_select_enabled = false;
-    settings->device_sorting_settings.device_select_string = NULL;
-    if (VK_SUCCESS != loaderDefaultSearchPaths(inst, &default_driver_search_path, &default_implicit_layer_search_path,
-                                               &default_explicit_layer_search_path, &default_settings_file_search_path)) {
+    settings->device_settings.device_select_enabled = false;
+    settings->device_settings.device_select_string = NULL;
+    result = loaderDefaultSearchPaths(inst, &default_driver_search_path, &default_implicit_layer_search_path,
+                                      &default_explicit_layer_search_path, &default_settings_file_search_path);
+    if (VK_SUCCESS != result) {
         goto out;
     }
 
     // Find a settings file and load the settings out of that if one exists in one of the
     // appropriate locations.
-    if (VK_SUCCESS != generateCompleteSearchPath(inst, LOADER_DATA_FILE_SETTINGS_FILE, default_settings_file_search_path, NULL,
-                                                 NULL, &settings_file_search_paths_count, &settings_file_search_paths)) {
+    result = generateCompleteSearchPath(inst, LOADER_DATA_FILE_SETTINGS_FILE, default_settings_file_search_path, NULL, NULL,
+                                        &settings_file_search_paths_count, &settings_file_search_paths);
+    if (VK_SUCCESS != result) {
         goto out;
     }
+
     //
     // TODO: Read loader settings file here.
     //
 
     // Override any settings with environment variable versions
-    VkResult env_var_result = VK_SUCCESS;
     parseEnvLoaderDebugLogFlags(&settings->log_settings.enabled_log_flags);
     parseEnvDisableInstanceExtensions(inst, &settings->disable_instance_extension_filter);
-    env_var_result = parseEnvDeviceSortingSettings(inst, &settings->device_sorting_settings);
-    if (VK_SUCCESS != env_var_result) {
+    result = parseEnvDeviceSettings(inst, &settings->device_settings);
+    if (VK_SUCCESS != result) {
         goto out;
     }
-    if (VK_SUCCESS !=
-            readEnvVarPath(inst, VULKAN_LOADER_DRIVER_BIT, &override_driver_env_var_search_path, VK_DRIVER_FILES_ENV_VAR) &&
-        VK_SUCCESS !=
-            readEnvVarPath(inst, VULKAN_LOADER_DRIVER_BIT, &override_driver_env_var_search_path, VK_ICD_FILENAMES_ENV_VAR)) {
+    result = readEnvVarPath(inst, VULKAN_LOADER_DRIVER_BIT, &override_driver_env_var_search_path, VK_DRIVER_FILES_ENV_VAR);
+    if (VK_SUCCESS != result) {
+        result = readEnvVarPath(inst, VULKAN_LOADER_DRIVER_BIT, &override_driver_env_var_search_path, VK_ICD_FILENAMES_ENV_VAR);
+        if (VK_SUCCESS != result) {
+            goto out;
+        }
+    }
+    result =
+        readEnvVarPath(inst, VULKAN_LOADER_DRIVER_BIT, &additional_driver_env_var_search_path, VK_ADDITIONAL_DRIVER_FILES_ENV_VAR);
+    if (VK_SUCCESS != result) {
         goto out;
     }
-    if (VK_SUCCESS != readEnvVarPath(inst, VULKAN_LOADER_DRIVER_BIT, &additional_driver_env_var_search_path,
-                                     VK_ADDITIONAL_DRIVER_FILES_ENV_VAR)) {
+    result = readEnvVarPath(inst, VULKAN_LOADER_LAYER_BIT, &override_explicit_layer_env_var_search_path, VK_LAYER_PATH_ENV_VAR);
+    if (VK_SUCCESS != result) {
         goto out;
     }
-    if (VK_SUCCESS !=
-        readEnvVarPath(inst, VULKAN_LOADER_LAYER_BIT, &override_explicit_layer_env_var_search_path, VK_LAYER_PATH_ENV_VAR)) {
+    result = readEnvVarPath(inst, VULKAN_LOADER_LAYER_BIT, &additional_explicit_layer_env_var_search_path,
+                            VK_ADDITIONAL_LAYER_PATH_ENV_VAR);
+    if (VK_SUCCESS != result) {
         goto out;
     }
-    if (VK_SUCCESS != readEnvVarPath(inst, VULKAN_LOADER_LAYER_BIT, &additional_explicit_layer_env_var_search_path,
-                                     VK_ADDITIONAL_LAYER_PATH_ENV_VAR)) {
+    result = generateCompleteSearchPath(
+        inst, LOADER_DATA_FILE_MANIFEST_DRIVER, default_driver_search_path,
+        (override_driver_file_search_path == NULL) ? override_driver_env_var_search_path : override_driver_file_search_path,
+        (additional_driver_file_search_path == NULL) ? additional_driver_env_var_search_path : additional_driver_file_search_path,
+        &settings->driver_search_paths_count, &settings->driver_search_paths);
+    if (VK_SUCCESS != result) {
         goto out;
     }
-    if (VK_SUCCESS !=
-        generateCompleteSearchPath(
-            inst, LOADER_DATA_FILE_MANIFEST_DRIVER, default_driver_search_path,
-            (override_driver_file_search_path == NULL) ? override_driver_env_var_search_path : override_driver_file_search_path,
-            (additional_driver_file_search_path == NULL) ? additional_driver_env_var_search_path
-                                                         : additional_driver_file_search_path,
-            &settings->driver_search_paths_count, &settings->driver_search_paths)) {
+    result = generateCompleteSearchPath(inst, LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER, default_implicit_layer_search_path, NULL,
+                                        NULL, &settings->implicit_layer_search_paths_count, &settings->implicit_layer_search_paths);
+    if (VK_SUCCESS != result) {
         goto out;
     }
-    if (VK_SUCCESS != generateCompleteSearchPath(inst, LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER, default_implicit_layer_search_path,
-                                                 NULL, NULL, &settings->implicit_layer_search_paths_count,
-                                                 &settings->implicit_layer_search_paths)) {
-        goto out;
-    }
-    if (VK_SUCCESS != generateCompleteSearchPath(
-                          inst, LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER, default_explicit_layer_search_path,
-                          (override_explicit_layer_file_search_path == NULL) ? override_explicit_layer_env_var_search_path
-                                                                             : override_explicit_layer_file_search_path,
-                          (additional_explicit_layer_file_search_path == NULL) ? additional_explicit_layer_env_var_search_path
-                                                                               : additional_explicit_layer_file_search_path,
-                          &settings->explicit_layer_search_paths_count, &settings->explicit_layer_search_paths)) {
+    result = generateCompleteSearchPath(
+        inst, LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER, default_explicit_layer_search_path,
+        (override_explicit_layer_file_search_path == NULL) ? override_explicit_layer_env_var_search_path
+                                                           : override_explicit_layer_file_search_path,
+        (additional_explicit_layer_file_search_path == NULL) ? additional_explicit_layer_env_var_search_path
+                                                             : additional_explicit_layer_file_search_path,
+        &settings->explicit_layer_search_paths_count, &settings->explicit_layer_search_paths);
+    if (VK_SUCCESS != result) {
         goto out;
     }
 
-    // Return structure
-    *set_struct = settings;
 out:
     if (settings_file_search_paths != NULL) {
         for (uint32_t count = 0; count < settings_file_search_paths_count; ++count) {
@@ -1335,12 +1348,13 @@ out:
         }
         loader_instance_heap_free(inst, settings_file_search_paths);
     }
-    loaderFreeSearchPaths(inst, &default_driver_search_path, &default_implicit_layer_search_path,
-                          &default_explicit_layer_search_path, &default_settings_file_search_path);
-    loaderFreeSearchPaths(inst, &override_driver_env_var_search_path, NULL, &override_explicit_layer_env_var_search_path, NULL);
-    loaderFreeSearchPaths(inst, &additional_driver_env_var_search_path, NULL, &additional_explicit_layer_env_var_search_path, NULL);
-    if (env_var_result != VK_SUCCESS) {
+    freeSearchPaths(inst, &default_driver_search_path, &default_implicit_layer_search_path, &default_explicit_layer_search_path,
+                    &default_settings_file_search_path);
+    freeSearchPaths(inst, &override_driver_env_var_search_path, &override_explicit_layer_env_var_search_path,
+                    &additional_driver_env_var_search_path, &additional_explicit_layer_env_var_search_path);
+    if (result != VK_SUCCESS) {
         freeSettingsStruct(inst, &settings);
+        *set_struct = NULL;
     }
-    return env_var_result;
+    return result;
 }

--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -28,6 +28,7 @@
  */
 
 #include "loader_environment.h"
+#include "vk_loader_platform.h"
 
 #include "allocation.h"
 #include "loader.h"
@@ -240,48 +241,59 @@ void determine_filter_type(const char *filter_string, enum loader_filter_string_
 // Parse the provided filter string provided by the envrionment variable into the appropriate filter
 // struct variable.
 VkResult parse_generic_filter_environment_var(const struct loader_instance *inst, const char *env_var_name,
-                                              struct loader_envvar_filter *filter_struct) {
+                                              struct loader_envvar_filter **filter_struct) {
     VkResult result = VK_SUCCESS;
-    memset(filter_struct, 0, sizeof(struct loader_envvar_filter));
+    if (filter_struct == NULL) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
     char *env_var_value = loader_secure_getenv(env_var_name, inst);
     if (NULL == env_var_value) {
         return result;
     }
     if (strlen(env_var_value) > 0) {
         const size_t env_var_len = strlen(env_var_value);
-        // Allocate a separate string since strtok modifies the original string
-        char *parsing_string = loader_instance_heap_calloc(inst, env_var_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-        if (NULL != parsing_string) {
-            const char tokenizer[3] = ",";
-
-            for (uint32_t iii = 0; iii < env_var_len; ++iii) {
-                parsing_string[iii] = (char)tolower(env_var_value[iii]);
-            }
-            parsing_string[env_var_len] = '\0';
-
-            char *token = strtok(parsing_string, tokenizer);
-            while (NULL != token) {
-                enum loader_filter_string_type cur_filter_type;
-                const char *actual_start;
-                size_t actual_len;
-                determine_filter_type(token, &cur_filter_type, &actual_start, &actual_len);
-                if (actual_len > VK_MAX_EXTENSION_NAME_SIZE) {
-                    strncpy(filter_struct->filters[filter_struct->count].value, actual_start, VK_MAX_EXTENSION_NAME_SIZE);
-                } else {
-                    strncpy(filter_struct->filters[filter_struct->count].value, actual_start, actual_len);
-                }
-                filter_struct->filters[filter_struct->count].length = actual_len;
-                filter_struct->filters[filter_struct->count++].type = cur_filter_type;
-                if (filter_struct->count >= MAX_ADDITIONAL_FILTERS) {
-                    break;
-                }
-                token = strtok(NULL, tokenizer);
-            }
-            loader_instance_heap_free(inst, parsing_string);
-        } else {
+        *filter_struct =
+            loader_instance_heap_calloc(inst, sizeof(struct loader_envvar_filter), VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (NULL == *filter_struct) {
             loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                       "parse_generic_filter_environment_var: Failed to allocate space for parsing env var \'%s\'", env_var_name);
+                       "parse_generic_filter_environment_var: Failed to allocate space for filter struct for \'%s\'", env_var_name);
             result = VK_ERROR_OUT_OF_HOST_MEMORY;
+        } else {
+            // Allocate a separate string since strtok modifies the original string
+            char *parsing_string = loader_instance_heap_calloc(inst, env_var_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            if (NULL != parsing_string) {
+                const char tokenizer[3] = ",";
+
+                for (uint32_t iii = 0; iii < env_var_len; ++iii) {
+                    parsing_string[iii] = (char)tolower(env_var_value[iii]);
+                }
+                parsing_string[env_var_len] = '\0';
+
+                char *token = strtok(parsing_string, tokenizer);
+                while (NULL != token) {
+                    enum loader_filter_string_type cur_filter_type;
+                    const char *actual_start;
+                    size_t actual_len;
+                    determine_filter_type(token, &cur_filter_type, &actual_start, &actual_len);
+                    if (actual_len > VK_MAX_EXTENSION_NAME_SIZE) {
+                        strncpy((*filter_struct)->filters[(*filter_struct)->count].value, actual_start, VK_MAX_EXTENSION_NAME_SIZE);
+                    } else {
+                        strncpy((*filter_struct)->filters[(*filter_struct)->count].value, actual_start, actual_len);
+                    }
+                    (*filter_struct)->filters[(*filter_struct)->count].length = actual_len;
+                    (*filter_struct)->filters[(*filter_struct)->count++].type = cur_filter_type;
+                    if ((*filter_struct)->count >= MAX_ADDITIONAL_FILTERS) {
+                        break;
+                    }
+                    token = strtok(NULL, tokenizer);
+                }
+                loader_instance_heap_free(inst, parsing_string);
+            } else {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+                           "parse_generic_filter_environment_var: Failed to allocate space for parsing env var \'%s\'",
+                           env_var_name);
+                result = VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
         }
     }
     loader_free_getenv(env_var_value, inst);
@@ -292,63 +304,76 @@ VkResult parse_generic_filter_environment_var(const struct loader_instance *inst
 // all layers (either with "~all~", "*", or "**"), all implicit layers (with "~implicit~"), and all explicit layers
 // (with "~explicit~"), in addition to the other layer filtering behavior.
 VkResult parse_layers_disable_filter_environment_var(const struct loader_instance *inst,
-                                                     struct loader_envvar_disable_layers_filter *disable_struct) {
+                                                     struct loader_envvar_disable_layers_filter **disable_struct) {
     VkResult result = VK_SUCCESS;
-    memset(disable_struct, 0, sizeof(struct loader_envvar_disable_layers_filter));
+    if (NULL == disable_struct) {
+        goto out;
+    }
     char *env_var_value = loader_secure_getenv(VK_LAYERS_DISABLE_ENV_VAR, inst);
     if (NULL == env_var_value) {
-        goto out;
+        return result;
     }
     if (strlen(env_var_value) > 0) {
         const size_t env_var_len = strlen(env_var_value);
-        // Allocate a separate string since strtok modifies the original string
-        char *parsing_string = loader_instance_heap_calloc(inst, env_var_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-        if (NULL != parsing_string) {
-            const char tokenizer[3] = ",";
-
-            for (uint32_t iii = 0; iii < env_var_len; ++iii) {
-                parsing_string[iii] = (char)tolower(env_var_value[iii]);
-            }
-            parsing_string[env_var_len] = '\0';
-
-            char *token = strtok(parsing_string, tokenizer);
-            while (NULL != token) {
-                uint32_t cur_count = disable_struct->additional_filters.count;
-                enum loader_filter_string_type cur_filter_type;
-                const char *actual_start;
-                size_t actual_len;
-                determine_filter_type(token, &cur_filter_type, &actual_start, &actual_len);
-                if (cur_filter_type == FILTER_STRING_SPECIAL) {
-                    if (!strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_1, token) || !strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_2, token) ||
-                        !strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_3, token)) {
-                        disable_struct->disable_all = true;
-                    } else if (!strcmp(VK_LOADER_DISABLE_IMPLICIT_LAYERS_VAR, token)) {
-                        disable_struct->disable_all_implicit = true;
-                    } else if (!strcmp(VK_LOADER_DISABLE_EXPLICIT_LAYERS_VAR, token)) {
-                        disable_struct->disable_all_explicit = true;
-                    }
-                } else {
-                    if (actual_len > VK_MAX_EXTENSION_NAME_SIZE) {
-                        strncpy(disable_struct->additional_filters.filters[cur_count].value, actual_start,
-                                VK_MAX_EXTENSION_NAME_SIZE);
-                    } else {
-                        strncpy(disable_struct->additional_filters.filters[cur_count].value, actual_start, actual_len);
-                    }
-                    disable_struct->additional_filters.filters[cur_count].length = actual_len;
-                    disable_struct->additional_filters.filters[cur_count].type = cur_filter_type;
-                    disable_struct->additional_filters.count++;
-                    if (disable_struct->additional_filters.count >= MAX_ADDITIONAL_FILTERS) {
-                        break;
-                    }
-                }
-                token = strtok(NULL, tokenizer);
-            }
-            loader_instance_heap_free(inst, parsing_string);
-        } else {
+        *disable_struct = loader_instance_heap_calloc(inst, sizeof(struct loader_envvar_disable_layers_filter),
+                                                      VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (NULL == *disable_struct) {
             loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                       "parse_layers_disable_filter_environment_var: Failed to allocate space for parsing env var "
-                       "\'VK_LAYERS_DISABLE_ENV_VAR\'");
+                       "parse_generic_filter_environment_var: Failed to allocate space for disable filter struct for \'%s\'",
+                       VK_LAYERS_DISABLE_ENV_VAR);
             result = VK_ERROR_OUT_OF_HOST_MEMORY;
+        } else {
+            // Allocate a separate string since strtok modifies the original string
+            char *parsing_string = loader_instance_heap_calloc(inst, env_var_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            if (NULL != parsing_string) {
+                const char tokenizer[3] = ",";
+
+                for (uint32_t iii = 0; iii < env_var_len; ++iii) {
+                    parsing_string[iii] = (char)tolower(env_var_value[iii]);
+                }
+                parsing_string[env_var_len] = '\0';
+
+                char *token = strtok(parsing_string, tokenizer);
+                while (NULL != token) {
+                    uint32_t cur_count = (*disable_struct)->additional_filters.count;
+                    enum loader_filter_string_type cur_filter_type;
+                    const char *actual_start;
+                    size_t actual_len;
+                    determine_filter_type(token, &cur_filter_type, &actual_start, &actual_len);
+                    if (cur_filter_type == FILTER_STRING_SPECIAL) {
+                        if (!strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_1, token) ||
+                            !strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_2, token) ||
+                            !strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_3, token)) {
+                            (*disable_struct)->disable_all = true;
+                        } else if (!strcmp(VK_LOADER_DISABLE_IMPLICIT_LAYERS_VAR, token)) {
+                            (*disable_struct)->disable_all_implicit = true;
+                        } else if (!strcmp(VK_LOADER_DISABLE_EXPLICIT_LAYERS_VAR, token)) {
+                            (*disable_struct)->disable_all_explicit = true;
+                        }
+                    } else {
+                        if (actual_len > VK_MAX_EXTENSION_NAME_SIZE) {
+                            strncpy((*disable_struct)->additional_filters.filters[cur_count].value, actual_start,
+                                    VK_MAX_EXTENSION_NAME_SIZE);
+                        } else {
+                            strncpy((*disable_struct)->additional_filters.filters[cur_count].value, actual_start, actual_len);
+                        }
+                        (*disable_struct)->additional_filters.filters[cur_count].length = actual_len;
+                        (*disable_struct)->additional_filters.filters[cur_count].type = cur_filter_type;
+                        (*disable_struct)->additional_filters.count++;
+                        if ((*disable_struct)->additional_filters.count >= MAX_ADDITIONAL_FILTERS) {
+                            break;
+                        }
+                    }
+                    token = strtok(NULL, tokenizer);
+                }
+                loader_instance_heap_free(inst, parsing_string);
+            } else {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+                           "parse_layers_disable_filter_environment_var: Failed to allocate space for parsing env var "
+                           "'%s'",
+                           VK_LAYERS_DISABLE_ENV_VAR);
+                result = VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
         }
     }
     loader_free_getenv(env_var_value, inst);
@@ -420,62 +445,27 @@ bool check_name_matches_filter_environment_var(const struct loader_instance *ins
 
 // Get the layer name(s) from the env_name environment variable. If layer is found in
 // search_list then add it to layer_list.  But only add it to layer_list if type_flags matches.
-VkResult loader_add_environment_layers(struct loader_instance *inst, const enum layer_type_flags type_flags, const char *env_name,
-                                       const struct loader_envvar_filter *enable_filter,
-                                       const struct loader_envvar_disable_layers_filter *disable_filter,
+VkResult loader_add_environment_layers(struct loader_instance *inst, const enum layer_type_flags type_flags,
                                        struct loader_layer_list *target_list, struct loader_layer_list *expanded_target_list,
                                        const struct loader_layer_list *source_list) {
     VkResult res = VK_SUCCESS;
-    char *next, *name;
-    char *layer_env = loader_getenv(env_name, inst);
-    char **vk_inst_layers = NULL;
-    uint32_t vk_inst_layer_count = 0;
-    uint32_t separator_count = 0;
+    bool *vk_inst_layers_found = NULL;
 
-    // If the layer environment variable is present (i.e. VK_INSTANCE_LAYERS), we will always add it to the layer list.
-    if (layer_env != NULL) {
-        name = loader_stack_alloc(strlen(layer_env) + 1);
-        if (name != NULL) {
-            separator_count = 1;
-            for (uint32_t c = 0; c < strlen(layer_env); ++c) {
-                if (layer_env[c] == PATH_SEPARATOR) {
-                    separator_count++;
-                }
-            }
-
-            vk_inst_layers =
-                loader_instance_heap_calloc(inst, (separator_count * sizeof(char *)), VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-            if (vk_inst_layers == NULL) {
-                res = VK_ERROR_OUT_OF_HOST_MEMORY;
-                goto out;
-            }
-            for (uint32_t cur_layer = 0; cur_layer < separator_count; ++cur_layer) {
-                vk_inst_layers[cur_layer] =
-                    loader_instance_heap_calloc(inst, VK_MAX_EXTENSION_NAME_SIZE, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-                if (vk_inst_layers[cur_layer] == NULL) {
-                    res = VK_ERROR_OUT_OF_HOST_MEMORY;
-                    goto out;
-                }
-            }
-
-            strcpy(name, layer_env);
-
-            loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0, "env var \'%s\' defined and adding layers \"%s\"",
-                       env_name, name);
-
-            // First look for the old-fashion layers forced on with VK_INSTANCE_LAYERS
-            while (name && *name) {
-                next = loader_get_next_path(name);
-
-                if (strlen(name) > 0) {
-                    strncpy(vk_inst_layers[vk_inst_layer_count++], name, VK_MAX_EXTENSION_NAME_SIZE);
-                }
-                name = next;
-            }
+    if (inst->settings->layer_settings.forced_on_layers_count > 0) {
+        vk_inst_layers_found = loader_instance_heap_calloc(
+            inst, sizeof(bool) * inst->settings->layer_settings.forced_on_layers_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (vk_inst_layers_found == NULL) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_LAYER_BIT, 0,
+                       "Failed allocating check array for force array check");
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
         }
     }
 
-    // Loop through all the layers and check the enable/disable filters as well as the VK_INSTANCE_LAYERS value.
+    struct loader_envvar_filter *enable_filter = inst->settings->layer_settings.enable_filters;
+    struct loader_envvar_disable_layers_filter *disable_filter = inst->settings->layer_settings.disable_filters;
+
+    // Loop through all the layers and check the enable/disable filters as well as any that are forced on in
+    // the settings.
     for (uint32_t i = 0; i < source_list->count; i++) {
         struct loader_layer_properties *source_prop = &source_list->list[i];
 
@@ -500,7 +490,7 @@ VkResult loader_add_environment_layers(struct loader_instance *inst, const enum 
 
         // If we are supposed to filter through all layers, we need to compare the layer name against the filter.
         // This can override the disable above, so we want to do it second.
-        if (check_name_matches_filter_environment_var(inst, source_prop->info.layerName, enable_filter)) {
+        if (enable_filter != NULL && check_name_matches_filter_environment_var(inst, source_prop->info.layerName, enable_filter)) {
             adding = true;
             // Only way is_substring is true is if there are enable variables.  If that's the case, and we're past the
             // above, we should indicate that it was forced on in this way.
@@ -508,13 +498,14 @@ VkResult loader_add_environment_layers(struct loader_instance *inst, const enum 
                        "Layer \"%s\" forced enabled due to env var \'%s\'", source_prop->info.layerName, VK_LAYERS_ENABLE_ENV_VAR);
         } else {
             adding = false;
-            // If it's not in the enable filter, check the environment variable if it exists
-            if (vk_inst_layer_count > 0) {
-                for (uint32_t cur_layer = 0; cur_layer < vk_inst_layer_count; ++cur_layer) {
-                    if (!strcmp(vk_inst_layers[cur_layer], source_prop->info.layerName)) {
+            // If it's not in the enable filter, check if any layers are forced on in the settings
+            for (uint32_t cur_layer = 0; cur_layer < inst->settings->layer_settings.forced_on_layers_count; ++cur_layer) {
+                if (!strcmp(inst->settings->layer_settings.forced_on_layers[cur_layer], source_prop->info.layerName)) {
+                    if (!vk_inst_layers_found[cur_layer]) {
                         adding = true;
-                        break;
+                        vk_inst_layers_found[cur_layer] = true;
                     }
+                    break;
                 }
             }
         }
@@ -530,40 +521,363 @@ VkResult loader_add_environment_layers(struct loader_instance *inst, const enum 
             res = loader_add_layer_properties_to_list(inst, expanded_target_list, 1, source_prop);
             if (res == VK_ERROR_OUT_OF_HOST_MEMORY) goto out;
         } else {
-            res = loader_add_meta_layer(inst, enable_filter, disable_filter, source_prop, target_list, expanded_target_list,
-                                        source_list, NULL);
+            res = loader_add_meta_layer(inst, inst->settings, source_prop, target_list, expanded_target_list, source_list, NULL);
             if (res == VK_ERROR_OUT_OF_HOST_MEMORY) goto out;
         }
     }
 
-out:
-
-    if (NULL != vk_inst_layers) {
-        for (uint32_t cur_layer = 0; cur_layer < separator_count; ++cur_layer) {
-            loader_instance_heap_free(inst, vk_inst_layers[cur_layer]);
+    // Double check that all the forced on layers were found
+    for (uint32_t cur_layer = 0; cur_layer < inst->settings->layer_settings.forced_on_layers_count; ++cur_layer) {
+        if (!vk_inst_layers_found[cur_layer]) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_LAYER_BIT, 0, "Failed to find forced on layer '%s'!",
+                       inst->settings->layer_settings.forced_on_layers[cur_layer]);
+            if (inst->settings->layer_settings.exit_on_missing_layer) {
+                abort();
+            }
         }
-        loader_instance_heap_free(inst, vk_inst_layers);
     }
 
-    if (layer_env != NULL) {
-        loader_free_getenv(layer_env, inst);
+out:
+    if (vk_inst_layers_found != NULL) {
+        loader_instance_heap_free(inst, vk_inst_layers_found);
     }
 
     return res;
 }
 
+// Loader settings utility functions
+
+// Read a path that is stored in an environment variable.
+VkResult readEnvVarPath(const struct loader_instance *inst, uint32_t log_msg_flag, char **output_var, char *env_var) {
+    if (output_var == NULL || env_var == NULL) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    char *env_var_value = loader_secure_getenv(env_var, inst);
+    size_t env_var_size = env_var_value == NULL ? 0 : strlen(env_var_value);
+    if (NULL != env_var_value && env_var_size > 0) {
+        *output_var = loader_instance_heap_calloc(inst, env_var_size + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (NULL == *output_var) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for env var `%s` value", env_var);
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        } else {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT | log_msg_flag, 0, "Found environment var `%s`, using value: `%s`", env_var,
+                       env_var_value);
+            strncpy(*output_var, env_var_value, env_var_size);
+            (*output_var)[env_var_size] = '\0';
+        }
+        loader_free_getenv(env_var_value, inst);
+    }
+    return VK_SUCCESS;
+}
+
+// Determine how many actual items are listed in a in_list string
+uint32_t getListCount(char *in_list, char separator) {
+    uint32_t count = 0;
+    if (in_list == NULL) {
+        return 0;
+    }
+    // Now, parse the items
+    char *cur_path;
+    char *next_item = in_list;
+    while (NULL != next_item && *next_item != '\0') {
+        cur_path = next_item;
+        next_item = loader_get_next_list_item(cur_path, separator);
+
+        // Is this a JSON file, then try to open it.
+        size_t len = strlen(cur_path);
+        if (len > 1) {
+            count++;
+        }
+    }
+    return count;
+}
+
+// Extract each individual item listed in a in_list string and place it in a item_array for
+// easier use.
+VkResult addListItemsToArray(const struct loader_instance *inst, uint32_t log_msg_flag, char *in_list, char separator,
+                             char **item_array, uint32_t *start_index) {
+    // Now, parse the paths
+    char *cur_item;
+    char *next_item = in_list;
+    while (NULL != next_item && *next_item != '\0') {
+        cur_item = next_item;
+        next_item = loader_get_next_list_item(cur_item, separator);
+
+        // Is this a JSON file, then try to open it.
+        size_t len = strlen(cur_item);
+        if (len > 1) {
+            item_array[*start_index] = loader_instance_heap_alloc(inst, len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            if (item_array[*start_index] == NULL) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for path search element %d",
+                           *start_index);
+                for (uint32_t count = 0; count < *start_index; ++count) {
+                    loader_instance_heap_free(inst, item_array[count]);
+                    item_array[count] = NULL;
+                }
+                *start_index = 0;
+                return VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
+            strncpy(item_array[*start_index], cur_item, len);
+            item_array[*start_index][len] = '\0';
+            (*start_index)++;
+        }
+    }
+    return VK_SUCCESS;
+}
+
+VkResult readEnvVarList(struct loader_instance *inst, const char *env_var, const char separator,
+                        enum vulkan_loader_debug_flags log_flag, uint32_t *count, char ***item_array) {
+    VkResult res = VK_SUCCESS;
+    char *env = loader_getenv(env_var, inst);
+    if (env != NULL && strlen(env) > 0) {
+        bool failed = false;
+        char *modifiable_list = NULL;
+        char *cur_mod_ptr;
+        uint32_t cur_item_index = 0;
+        uint32_t item_count = 0;
+        size_t cur_len = strlen(env);
+        modifiable_list = loader_instance_heap_calloc(inst, cur_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (modifiable_list == NULL) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_flag, 0, "Failed alloc space for modifiable path string");
+            res = VK_ERROR_OUT_OF_HOST_MEMORY;
+            failed = true;
+        }
+        // NOTE: We're using the path count and add functions but they should work fine for the driver list
+        // which is separated with the path separator.
+        if (!failed) {
+            cur_mod_ptr = modifiable_list;
+            strncpy(cur_mod_ptr, env, cur_len);
+            cur_mod_ptr[cur_len] = '\0';
+            item_count = getListCount(cur_mod_ptr, separator);
+            if (item_count != 0) {
+                *item_array = loader_instance_heap_calloc(inst, sizeof(char *) * item_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+                if (*item_array == NULL) {
+                    loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_flag, 0, "Failed alloc space for `%s` list", env_var);
+                    res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                    failed = true;
+                } else {
+                    *count = item_count;
+                }
+            }
+            if (!failed) {
+                cur_mod_ptr = modifiable_list;
+                strncpy(cur_mod_ptr, env, cur_len);
+                cur_mod_ptr[cur_len] = '\0';
+                res = addListItemsToArray(inst, log_flag, cur_mod_ptr, separator, *item_array, &cur_item_index);
+                if (res != VK_SUCCESS) {
+                    loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_flag, 0, "Failed copying item content from `%s`", env_var);
+                    failed = true;
+                }
+            }
+        }
+
+        if (modifiable_list != NULL) {
+            loader_instance_heap_free(inst, modifiable_list);
+        }
+        if (failed) {
+            if (*item_array != NULL) {
+                loader_instance_heap_free(inst, *item_array);
+            }
+            *item_array = NULL;
+            *count = 0;
+        }
+    }
+    loader_free_getenv(env, inst);
+    return res;
+}
+
+// Generate the complete list of search paths using the environment variables (or file variables) and
+// the default paths for this platform.
+// NOTE: This can be overridden by the "override" layer later on.
+VkResult generateCompleteSearchPath(const struct loader_instance *inst, enum loader_data_files_type search_type,
+                                    const char *default_path, const char *override_path, const char *add_path, uint32_t *count,
+                                    char ***value) {
+    uint32_t path_count = 0;
+    uint32_t cur_path_index = 0;
+    enum vulkan_loader_debug_flags log_msg_flag;
+    uint8_t message_index = 0;
+    const char message_str[4][20] = {{"driver"}, {"implicit layer"}, {"explicit layer"}, {"settings file"}};
+
+    if (default_path == NULL || count == NULL || value == NULL) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    // Set to 0, just in case we have a failure.
+    *count = 0;
+
+    switch (search_type) {
+        case LOADER_DATA_FILE_MANIFEST_DRIVER:
+        default:
+            log_msg_flag = VULKAN_LOADER_DRIVER_BIT;
+            message_index = 0;
+            break;
+        case LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER:
+            log_msg_flag = VULKAN_LOADER_LAYER_BIT;
+            message_index = 2;
+            break;
+        case LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER:
+            log_msg_flag = VULKAN_LOADER_LAYER_BIT;
+            message_index = 1;
+            break;
+        case LOADER_DATA_FILE_SETTINGS_FILE:
+            log_msg_flag = VULKAN_LOADER_SETTING_BIT;
+            message_index = 3;
+            break;
+    }
+
+    char **path_array = NULL;
+    char *modifiable_path = NULL;
+    char *cur_mod_ptr;
+    VkResult res = VK_SUCCESS;
+    bool failed = false;
+
+    if (NULL != override_path) {
+        size_t cur_len = strlen(override_path);
+        modifiable_path = loader_instance_heap_calloc(inst, cur_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (modifiable_path == NULL) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for modifiable path string");
+            res = VK_ERROR_OUT_OF_HOST_MEMORY;
+            failed = true;
+        }
+        if (!failed) {
+            cur_mod_ptr = modifiable_path;
+            strncpy(cur_mod_ptr, override_path, cur_len);
+            cur_mod_ptr[cur_len] = '\0';
+            path_count = getListCount(cur_mod_ptr, PATH_SEPARATOR);
+            path_array = loader_instance_heap_calloc(inst, sizeof(char *) * path_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            if (path_array == NULL) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for %s override path search array",
+                           message_str[message_index]);
+                res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                failed = true;
+            }
+        }
+        if (!failed) {
+            cur_mod_ptr = modifiable_path;
+            strncpy(cur_mod_ptr, override_path, cur_len);
+            cur_mod_ptr[cur_len] = '\0';
+            res = addListItemsToArray(inst, log_msg_flag, cur_mod_ptr, PATH_SEPARATOR, path_array, &cur_path_index);
+            if (res != VK_SUCCESS) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
+                           "Failed copying paths from %s override path into search array", message_str[message_index]);
+                failed = true;
+            }
+        }
+    } else {
+        size_t add_len = add_path == NULL ? 0 : strlen(add_path);
+        size_t default_len = default_path == NULL ? 0 : strlen(default_path);
+        size_t max_len = add_len > default_len ? add_len : default_len;
+        assert(max_len > 0);
+        modifiable_path = loader_instance_heap_calloc(inst, max_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (modifiable_path == NULL) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for modifiable path string");
+            res = VK_ERROR_OUT_OF_HOST_MEMORY;
+            failed = true;
+        }
+        if (!failed) {
+            path_count = 0;
+            if (add_path != NULL) {
+                cur_mod_ptr = modifiable_path;
+                strncpy(cur_mod_ptr, add_path, add_len);
+                cur_mod_ptr[add_len] = '\0';
+                path_count += getListCount(cur_mod_ptr, PATH_SEPARATOR);
+            }
+            if (default_path != NULL) {
+                cur_mod_ptr = modifiable_path;
+                strncpy(cur_mod_ptr, default_path, default_len);
+                cur_mod_ptr[default_len] = '\0';
+                path_count += getListCount(cur_mod_ptr, PATH_SEPARATOR);
+            }
+            path_array = loader_instance_heap_calloc(inst, sizeof(char *) * path_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            if (path_array == NULL) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for standard %s path search array",
+                           message_str[message_index]);
+                res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                failed = true;
+            }
+        }
+        if (!failed && add_path != NULL) {
+            cur_mod_ptr = modifiable_path;
+            strncpy(cur_mod_ptr, add_path, add_len);
+            cur_mod_ptr[add_len] = '\0';
+            res = addListItemsToArray(inst, log_msg_flag, cur_mod_ptr, PATH_SEPARATOR, path_array, &cur_path_index);
+            if (res != VK_SUCCESS) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
+                           "Failed copying paths from additional %s path into search array", message_str[message_index]);
+                failed = true;
+            }
+        }
+        if (!failed && default_path != NULL) {
+            cur_mod_ptr = modifiable_path;
+            strncpy(cur_mod_ptr, default_path, default_len);
+            cur_mod_ptr[default_len] = '\0';
+            res = addListItemsToArray(inst, log_msg_flag, cur_mod_ptr, PATH_SEPARATOR, path_array, &cur_path_index);
+            if (res != VK_SUCCESS) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
+                           "Failed copying paths from default %s path into search array", message_str[message_index]);
+                failed = true;
+            }
+        }
+    }
+    if (modifiable_path != NULL) {
+        loader_instance_heap_free(inst, modifiable_path);
+    }
+    if (failed || res != VK_SUCCESS) {
+        if (path_array != NULL) {
+            loader_instance_heap_free(inst, path_array);
+        }
+        return res;
+    }
+
+    // Remove duplicate paths, or it would result in duplicate extensions, duplicate devices, etc.
+    for (int32_t cur_path = 0; cur_path < (int32_t)path_count; ++cur_path) {
+        for (int32_t check_path = cur_path + 1; check_path < (int32_t)path_count; ++check_path) {
+            if (!strcmp(path_array[check_path], path_array[cur_path])) {
+                loader_instance_heap_free(inst, path_array[check_path]);
+                for (int32_t copy_path = check_path; copy_path < (int32_t)path_count - 1; ++copy_path) {
+                    path_array[copy_path] = path_array[copy_path + 1];
+                }
+                path_array[--path_count] = NULL;
+                check_path--;
+            }
+        }
+    }
+
+    // Print out the paths being searched if debugging is enabled
+    if (path_count > 0) {
+        loader_log(inst, log_msg_flag, 0, "Search paths for %s manifest files set to following order:", message_str[message_index]);
+        for (uint32_t cur_path = 0; cur_path < path_count; ++cur_path) {
+            loader_log(inst, log_msg_flag, 0, "   %s", path_array[cur_path]);
+        }
+    } else {
+        if (path_array != NULL) {
+            loader_instance_heap_free(inst, path_array);
+            path_array = NULL;
+        }
+    }
+
+    assert(path_array != NULL);
+    assert(path_count != 0);
+    *count = path_count;
+    *value = path_array;
+    return VK_SUCCESS;
+}
+
 // Loader settings handling
 
-void parseEnvLoaderDebugLogFlags(uint32_t *debug_flags) {
+VkResult parseEnvLoaderLogSettings(struct loader_instance *inst, struct loader_log_settings *settings) {
     char *env = NULL;
     char *orig = NULL;
+    VkResult res = VK_SUCCESS;
 
-    if (NULL == debug_flags) {
-        return;
+    if (NULL == settings) {
+        return VK_ERROR_INITIALIZATION_FAILED;
     }
 
     // Parse comma-separated debug options
-    orig = env = loader_getenv("VK_LOADER_DEBUG", NULL);
+    uint32_t debug_flags = VULKAN_LOADER_ERROR_BIT;
+    orig = env = loader_getenv("VK_LOADER_DEBUG", inst);
     while (env) {
         char *p = strchr(env, ',');
         size_t len;
@@ -576,21 +890,23 @@ void parseEnvLoaderDebugLogFlags(uint32_t *debug_flags) {
 
         if (len > 0) {
             if (strncmp(env, "all", len) == 0) {
-                *debug_flags = ~0u;
+                debug_flags = ~0u;
             } else if (strncmp(env, "warn", len) == 0) {
-                *debug_flags |= VULKAN_LOADER_WARN_BIT;
+                debug_flags |= VULKAN_LOADER_WARN_BIT;
             } else if (strncmp(env, "info", len) == 0) {
-                *debug_flags |= VULKAN_LOADER_INFO_BIT;
+                debug_flags |= VULKAN_LOADER_INFO_BIT;
             } else if (strncmp(env, "perf", len) == 0) {
-                *debug_flags |= VULKAN_LOADER_PERF_BIT;
+                debug_flags |= VULKAN_LOADER_PERF_BIT;
             } else if (strncmp(env, "error", len) == 0) {
-                *debug_flags |= VULKAN_LOADER_ERROR_BIT;
+                debug_flags |= VULKAN_LOADER_ERROR_BIT;
             } else if (strncmp(env, "debug", len) == 0) {
-                *debug_flags |= VULKAN_LOADER_DEBUG_BIT;
+                debug_flags |= VULKAN_LOADER_DEBUG_BIT;
             } else if (strncmp(env, "layer", len) == 0) {
-                *debug_flags |= VULKAN_LOADER_LAYER_BIT;
+                debug_flags |= VULKAN_LOADER_LAYER_BIT;
             } else if (strncmp(env, "driver", len) == 0 || strncmp(env, "implem", len) == 0 || strncmp(env, "icd", len) == 0) {
-                *debug_flags |= VULKAN_LOADER_DRIVER_BIT;
+                debug_flags |= VULKAN_LOADER_DRIVER_BIT;
+            } else if (strncmp(env, "setting", len) == 0) {
+                debug_flags |= VULKAN_LOADER_SETTING_BIT;
             }
         }
 
@@ -600,32 +916,97 @@ void parseEnvLoaderDebugLogFlags(uint32_t *debug_flags) {
 
         env = p + 1;
     }
+    settings->enabled_log_flags = debug_flags;
+    loader_free_getenv(orig, inst);
 
-    loader_free_getenv(orig, NULL);
+    // Read the log-file name
+    env = loader_getenv("VK_LOADER_LOG_FILE", inst);
+    if (env != NULL && strlen(env) > 0) {
+        size_t len = strlen(env);
+        settings->log_filename = loader_instance_heap_alloc(inst, len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (NULL != settings->log_filename) {
+            strncpy(settings->log_filename, env, len);
+            settings->log_filename[len] = '\0';
+            settings->log_to_file = true;
+        } else {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "Failed allocating loader log file name");
+            res = VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+    }
+    loader_free_getenv(env, inst);
+    return res;
 }
 
-// Determine if the environment variables indicate that unknown instance extensions should be disabled.
-void parseEnvDisableInstanceExtensions(struct loader_instance *inst, bool *disable_instance_ext) {
+VkResult parseEnvInstanceSettings(struct loader_instance *inst, struct loader_instance_settings *instance_settings) {
     char *env = NULL;
-    if (NULL == disable_instance_ext) {
-        return;
+    if (NULL == instance_settings) {
+        return VK_ERROR_INITIALIZATION_FAILED;
     }
-    env = loader_getenv("VK_LOADER_DISABLE_INST_EXT_FILTER", NULL);
+    env = loader_getenv("VK_LOADER_DISABLE_INST_EXT_FILTER", inst);
     if (NULL != env && atoi(env) != 0) {
         loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Found environment var 'VK_LOADER_DISABLE_INST_EXT_FILTER' set to %s", env);
-        *disable_instance_ext = true;
-    } else {
-        *disable_instance_ext = false;
+        instance_settings->disable_instance_extension_filter = true;
     }
-    loader_free_getenv(env, NULL);
+    loader_free_getenv(env, inst);
+    return VK_SUCCESS;
 }
 
-// Determine if the environment variables indicate that driver should be modified.
-VkResult parseEnvDeviceSettings(struct loader_instance *inst, struct loader_device_settings *device_settings) {
-    if (NULL == device_settings) {
-        return VK_SUCCESS;
+VkResult parseEnvLayerSettings(struct loader_instance *inst, struct loader_layer_settings *layer_settings) {
+    VkResult res = VK_SUCCESS;
+    char *env = NULL;
+    if (NULL == layer_settings) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+    env = loader_getenv("VK_LOADER_LAYER_EXIT_ON_MISSING", inst);
+    if (NULL != env && atoi(env) != 0) {
+        loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Found environment var 'VK_LOADER_LAYER_EXIT_ON_MISSING' set to %s", env);
+        layer_settings->exit_on_missing_layer = true;
+    }
+    loader_free_getenv(env, inst);
+
+    res = readEnvVarList(inst, ENABLED_LAYERS_ENV, ',', VULKAN_LOADER_LAYER_BIT, &layer_settings->forced_on_layers_count,
+                         &layer_settings->forced_on_layers);
+    if (res != VK_SUCCESS) {
+        return res;
     }
 
+    res = parse_generic_filter_environment_var(inst, VK_LAYERS_ENABLE_ENV_VAR, &layer_settings->enable_filters);
+    if (VK_SUCCESS != res) {
+        return res;
+    }
+
+    res = parse_layers_disable_filter_environment_var(inst, &layer_settings->disable_filters);
+    if (VK_SUCCESS != res) {
+        return res;
+    }
+    return res;
+}
+
+VkResult parseEnvDriverSettings(struct loader_instance *inst, struct loader_driver_settings *driver_settings) {
+    VkResult res = VK_SUCCESS;
+    if (NULL == driver_settings) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    res = parse_generic_filter_environment_var(inst, VK_DRIVERS_SELECT_ENV_VAR, &driver_settings->select_filters);
+    if (VK_SUCCESS != res) {
+        return res;
+    }
+    res = parse_generic_filter_environment_var(inst, VK_DRIVERS_DISABLE_ENV_VAR, &driver_settings->disable_filters);
+    if (VK_SUCCESS != res) {
+        return res;
+    }
+
+    return res;
+}
+
+VkResult parseEnvPhysicalDeviceSettings(struct loader_instance *inst,
+                                        struct loader_physical_device_settings *physical_device_settings) {
+    if (NULL == physical_device_settings) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    VkResult res = VK_SUCCESS;
 #if LOADER_ENABLE_LINUX_SORT
     char *env_value = loader_getenv("VK_LOADER_DISABLE_SELECT", inst);
     if (NULL != env_value && atoi(env_value) != 0) {
@@ -633,27 +1014,44 @@ VkResult parseEnvDeviceSettings(struct loader_instance *inst, struct loader_devi
         loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                    "Found environment var `VK_LOADER_DISABLE_SELECT` set to non-zero.  Disabling device sorting.");
         loader_free_getenv(env_value, inst);
-        device_settings->device_sorting_enabled = false;
+        physical_device_settings->device_sorting_enabled = false;
     } else {
         char *selection = loader_getenv("VK_LOADER_DEVICE_SELECT", inst);
         size_t string_len = selection == NULL ? 0 : strlen(selection);
         if (NULL != selection && 1 < string_len) {
             loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                        "Found environment var `VK_LOADER_DEVICE_SELECT` set %s", selection);
-            device_settings->device_select_string =
+            physical_device_settings->device_select_string =
                 loader_instance_heap_alloc(inst, string_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-            if (NULL == device_settings->device_select_string) {
+            if (NULL == physical_device_settings->device_select_string) {
                 loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "Failed allocating loader settings structure");
-                return VK_ERROR_OUT_OF_HOST_MEMORY;
+                res = VK_ERROR_OUT_OF_HOST_MEMORY;
+            } else {
+                strncpy(physical_device_settings->device_select_string, selection, string_len);
+                physical_device_settings->device_select_string[string_len] = '\0';
+                physical_device_settings->device_select_enabled = true;
             }
-            strncpy(device_settings->device_select_string, selection, string_len);
-            device_settings->device_select_string[string_len] = '\0';
-            device_settings->device_select_enabled = true;
             loader_free_getenv(selection, inst);
         }
     }
 #endif  // LOADER_ENABLE_LINUX_SORT
-    return VK_SUCCESS;
+    return res;
+}
+
+void freeList(const struct loader_instance *inst, uint32_t *list_count, char ***list_ptr) {
+    if (list_ptr != NULL && list_count != NULL) {
+        char **list = *list_ptr;
+        if (list != NULL) {
+            for (uint32_t count = 0; count < *list_count; ++count) {
+                loader_instance_heap_free(inst, list[count]);
+            }
+            loader_instance_heap_free(inst, list);
+        }
+        *list_ptr = NULL;
+    }
+    if (list_count != NULL) {
+        *list_count = 0;
+    }
 }
 
 // Free the paths we used for setting up the search paths for layers and drivers.
@@ -918,253 +1316,43 @@ out:
     return result;
 }
 
-// Read a path that is stored in an environment variable.
-VkResult readEnvVarPath(const struct loader_instance *inst, uint32_t log_msg_flag, char **output_var, char *env_var) {
-    if (output_var == NULL || env_var == NULL) {
-        return VK_ERROR_INITIALIZATION_FAILED;
+// Loader File Settings handling
+
+// Determine if the environment variables indicate that driver should be modified.
+VkResult parseSettingsFile(struct loader_instance *inst, struct loader_settings *settings,
+                           uint32_t settings_file_search_paths_count, char **settings_file_search_paths) {
+    const uint32_t temp_string_len = 1024;
+    char temp_string[temp_string_len];
+    const char loader_settings_file[] = "vk_loader_settings.txt";
+    FILE *settings_file = NULL;
+    if (NULL == settings || 0 == settings_file_search_paths_count || NULL == settings_file_search_paths) {
+        return VK_SUCCESS;
+    }
+    for (uint32_t path = 0; path < settings_file_search_paths_count; ++path) {
+        if (strlen(settings_file_search_paths[path]) > strlen(temp_string) - strlen(loader_settings_file) - 2) {
+            loader_log(inst, VULKAN_LOADER_WARN_BIT, 0, "Settings file path %s is too long, skipping.",
+                       settings_file_search_paths[path]);
+            continue;
+        }
+        snprintf(temp_string, temp_string_len, "%s%c%s", settings_file_search_paths[path], DIRECTORY_SYMBOL, loader_settings_file);
+        settings_file = fopen(temp_string, "rt");
+        if (settings_file != NULL) {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "Using Loader settings file %s", temp_string);
+            break;
+        }
     }
 
-    char *env_var_value = loader_secure_getenv(env_var, inst);
-    size_t env_var_size = env_var_value == NULL ? 0 : strlen(env_var_value);
-    if (NULL != env_var_value && env_var_size > 1) {
-        *output_var = loader_instance_heap_calloc(inst, env_var_size + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-        if (NULL == *output_var) {
-            loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for env var `%s` value", env_var);
-            return VK_ERROR_OUT_OF_HOST_MEMORY;
-        } else {
-            loader_log(inst, VULKAN_LOADER_INFO_BIT | log_msg_flag, 0, "Found environment var `%s`, using value: `%s`", env_var,
-                       env_var_value);
-            strncpy(*output_var, env_var_value, env_var_size);
-            (*output_var)[env_var_size] = '\0';
-        }
-        loader_free_getenv(env_var_value, inst);
+    // Settings file is valid, so read in the settings
+    if (settings_file != NULL) {
+        // TODO: Read file
+
+        fclose(settings_file);
     }
+
     return VK_SUCCESS;
 }
 
-// Determine how many actual paths are listed in a path_list string
-uint32_t getPathCount(char *path_list) {
-    uint32_t count = 0;
-    if (path_list == NULL) {
-        return 0;
-    }
-    // Now, parse the paths
-    char *cur_path;
-    char *next_path = path_list;
-    while (NULL != next_path && *next_path != '\0') {
-        cur_path = next_path;
-        next_path = loader_get_next_path(cur_path);
-
-        // Is this a JSON file, then try to open it.
-        size_t len = strlen(cur_path);
-        if (len > 1) {
-            count++;
-        }
-    }
-    return count;
-}
-
-// Extract each individual paths listed in a path_list string and place it in a path_array for
-// easier use.
-VkResult addPathsToArray(const struct loader_instance *inst, uint32_t log_msg_flag, char *path_list, char **path_array,
-                         uint32_t *start_index) {
-    // Now, parse the paths
-    char *cur_path;
-    char *next_path = path_list;
-    while (NULL != next_path && *next_path != '\0') {
-        cur_path = next_path;
-        next_path = loader_get_next_path(cur_path);
-
-        // Is this a JSON file, then try to open it.
-        size_t len = strlen(cur_path);
-        if (len > 1) {
-            path_array[*start_index] = loader_instance_heap_alloc(inst, len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-            if (path_array[*start_index] == NULL) {
-                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for path search element %d",
-                           *start_index);
-                for (uint32_t count = 0; count < *start_index; ++count) {
-                    loader_instance_heap_free(inst, path_array[count]);
-                    path_array[count] = NULL;
-                }
-                *start_index = 0;
-                return VK_ERROR_OUT_OF_HOST_MEMORY;
-            }
-            strncpy(path_array[*start_index], cur_path, len);
-            path_array[*start_index][len] = '\0';
-            (*start_index)++;
-        }
-    }
-    return VK_SUCCESS;
-}
-
-// Generate the complete list of search paths using the environment variables (or file variables) and
-// the default paths for this platform.
-// NOTE: This can be overridden by the "override" layer later on.
-VkResult generateCompleteSearchPath(const struct loader_instance *inst, enum loader_data_files_type search_type,
-                                    const char *default_path, const char *override_path, const char *add_path, uint32_t *count,
-                                    char ***value) {
-    uint32_t path_count = 0;
-    uint32_t cur_path_index = 0;
-    enum vulkan_loader_debug_flags log_msg_flag;
-    uint8_t message_index = 0;
-    const char message_str[4][20] = {{"driver"}, {"implicit layer"}, {"explicit layer"}, {"settings file"}};
-
-    if (default_path == NULL || count == NULL || value == NULL) {
-        return VK_ERROR_INITIALIZATION_FAILED;
-    }
-
-    // Set to 0, just in case we have a failure.
-    *count = 0;
-
-    switch (search_type) {
-        case LOADER_DATA_FILE_MANIFEST_DRIVER:
-        default:
-            log_msg_flag = VULKAN_LOADER_DRIVER_BIT;
-            message_index = 0;
-            break;
-        case LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER:
-            log_msg_flag = VULKAN_LOADER_LAYER_BIT;
-            message_index = 2;
-            break;
-        case LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER:
-            log_msg_flag = VULKAN_LOADER_LAYER_BIT;
-            message_index = 1;
-            break;
-        case LOADER_DATA_FILE_SETTINGS_FILE:
-            log_msg_flag = VULKAN_LOADER_INFO_BIT;
-            message_index = 3;
-            break;
-    }
-
-    char **path_array = NULL;
-    char *modifiable_path = NULL;
-    char *cur_mod_ptr;
-    bool failed = false;
-
-    if (NULL != override_path) {
-        size_t cur_len = strlen(override_path);
-        modifiable_path = loader_instance_heap_calloc(inst, cur_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-        if (modifiable_path == NULL) {
-            loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for modifiable path string");
-            failed = true;
-        }
-        if (!failed) {
-            cur_mod_ptr = modifiable_path;
-            strncpy(cur_mod_ptr, override_path, cur_len);
-            cur_mod_ptr[cur_len] = '\0';
-            path_count = getPathCount(cur_mod_ptr);
-            path_array = loader_instance_heap_calloc(inst, sizeof(char *) * path_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-            if (path_array == NULL) {
-                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for %s override path search array",
-                           message_str[message_index]);
-                failed = true;
-            }
-        }
-        if (!failed) {
-            cur_mod_ptr = modifiable_path;
-            strncpy(cur_mod_ptr, override_path, cur_len);
-            cur_mod_ptr[cur_len] = '\0';
-            if (addPathsToArray(inst, log_msg_flag, cur_mod_ptr, path_array, &cur_path_index)) {
-                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
-                           "Failed copying paths from %s override path into search array", message_str[message_index]);
-                failed = true;
-            }
-        }
-    } else {
-        size_t add_len = add_path == NULL ? 0 : strlen(add_path);
-        size_t default_len = default_path == NULL ? 0 : strlen(default_path);
-        size_t max_len = add_len > default_len ? add_len : default_len;
-        assert(max_len > 0);
-        modifiable_path = loader_instance_heap_calloc(inst, max_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-        if (modifiable_path == NULL) {
-            loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for modifiable path string");
-            failed = true;
-        }
-        if (!failed) {
-            path_count = 0;
-            if (add_path != NULL) {
-                cur_mod_ptr = modifiable_path;
-                strncpy(cur_mod_ptr, add_path, add_len);
-                cur_mod_ptr[add_len] = '\0';
-                path_count += getPathCount(cur_mod_ptr);
-            }
-            if (default_path != NULL) {
-                cur_mod_ptr = modifiable_path;
-                strncpy(cur_mod_ptr, default_path, default_len);
-                cur_mod_ptr[default_len] = '\0';
-                path_count += getPathCount(cur_mod_ptr);
-            }
-            path_array = loader_instance_heap_calloc(inst, sizeof(char *) * path_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-            if (path_array == NULL) {
-                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for standard %s path search array",
-                           message_str[message_index]);
-                failed = true;
-            }
-        }
-        if (!failed && add_path != NULL) {
-            cur_mod_ptr = modifiable_path;
-            strncpy(cur_mod_ptr, add_path, add_len);
-            cur_mod_ptr[add_len] = '\0';
-            if (addPathsToArray(inst, log_msg_flag, cur_mod_ptr, path_array, &cur_path_index)) {
-                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
-                           "Failed copying paths from additional %s path into search array", message_str[message_index]);
-                failed = true;
-            }
-        }
-        if (!failed && default_path != NULL) {
-            cur_mod_ptr = modifiable_path;
-            strncpy(cur_mod_ptr, default_path, default_len);
-            cur_mod_ptr[default_len] = '\0';
-            if (addPathsToArray(inst, log_msg_flag, cur_mod_ptr, path_array, &cur_path_index)) {
-                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
-                           "Failed copying paths from default %s path into search array", message_str[message_index]);
-                failed = true;
-            }
-        }
-    }
-    if (modifiable_path != NULL) {
-        loader_instance_heap_free(inst, modifiable_path);
-    }
-    if (failed) {
-        if (path_array != NULL) {
-            loader_instance_heap_free(inst, path_array);
-        }
-        return VK_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
-    // Remove duplicate paths, or it would result in duplicate extensions, duplicate devices, etc.
-    for (int32_t cur_path = 0; cur_path < (int32_t)path_count; ++cur_path) {
-        for (int32_t check_path = cur_path + 1; check_path < (int32_t)path_count; ++check_path) {
-            if (!strcmp(path_array[check_path], path_array[cur_path])) {
-                loader_instance_heap_free(inst, path_array[check_path]);
-                for (int32_t copy_path = check_path; copy_path < (int32_t)path_count - 1; ++copy_path) {
-                    path_array[copy_path] = path_array[copy_path + 1];
-                }
-                path_array[--path_count] = NULL;
-                check_path--;
-            }
-        }
-    }
-
-    // Print out the paths being searched if debugging is enabled
-    if (path_count > 0) {
-        loader_log(inst, log_msg_flag, 0, "Search paths for %s manifest files set to following order:", message_str[message_index]);
-        for (uint32_t cur_path = 0; cur_path < path_count; ++cur_path) {
-            loader_log(inst, log_msg_flag, 0, "   %s", path_array[cur_path]);
-        }
-    } else {
-        if (path_array != NULL) {
-            loader_instance_heap_free(inst, path_array);
-            path_array = NULL;
-        }
-    }
-
-    assert(path_array != NULL);
-    assert(path_count != 0);
-    *count = path_count;
-    *value = path_array;
-    return VK_SUCCESS;
-}
+// Loader Settings Struct handling
 
 // Free the items that were allocated in the settings struct, and then the settings struct itself.
 void freeSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct) {
@@ -1174,46 +1362,54 @@ void freeSettingsStruct(struct loader_instance *inst, struct loader_settings **s
     struct loader_settings *settings = *set_struct;
 
     // Free log file info
-    if (settings->log_settings.log_to_file) {
+    if (settings->log_settings.log_filename != NULL) {
         loader_instance_heap_free(inst, settings->log_settings.log_filename);
+        settings->log_settings.log_filename = NULL;
+    }
+    if (settings->log_settings.log_to_file) {
         if (NULL != settings->log_settings.log_file) {
             fclose(settings->log_settings.log_file);
             settings->log_settings.log_file = NULL;
         }
         settings->log_settings.log_to_file = false;
     }
-    settings->log_settings.log_filename = NULL;
 
-    // Free device items
-    if (NULL != settings->device_settings.device_select_string) {
-        loader_instance_heap_free(inst, settings->device_settings.device_select_string);
-        settings->device_settings.device_select_string = NULL;
+    // Free instance items
+
+    // Free layer items
+    if (NULL != settings->layer_settings.forced_on_layers) {
+        freeList(inst, &settings->layer_settings.forced_on_layers_count, &settings->layer_settings.forced_on_layers);
+    }
+    if (NULL != settings->layer_settings.enable_filters) {
+        loader_instance_heap_free(inst, settings->layer_settings.enable_filters);
+    }
+    if (NULL != settings->layer_settings.disable_filters) {
+        loader_instance_heap_free(inst, settings->layer_settings.disable_filters);
+    }
+
+    // Free driver items
+    if (NULL != settings->driver_settings.select_filters) {
+        loader_instance_heap_free(inst, settings->driver_settings.select_filters);
+    }
+    if (NULL != settings->driver_settings.disable_filters) {
+        loader_instance_heap_free(inst, settings->driver_settings.disable_filters);
+    }
+
+    // Free physical device items
+    if (NULL != settings->physical_device_settings.device_select_string) {
+        loader_instance_heap_free(inst, settings->physical_device_settings.device_select_string);
+        settings->physical_device_settings.device_select_string = NULL;
     }
 
     // Free search paths
     if (NULL != settings->driver_search_paths) {
-        for (uint32_t count = 0; count < settings->driver_search_paths_count; ++count) {
-            loader_instance_heap_free(inst, settings->driver_search_paths[count]);
-        }
-        loader_instance_heap_free(inst, settings->driver_search_paths);
-        settings->driver_search_paths_count = 0;
-        settings->driver_search_paths = NULL;
+        freeList(inst, &settings->driver_search_paths_count, &settings->driver_search_paths);
     }
     if (NULL != settings->implicit_layer_search_paths) {
-        for (uint32_t count = 0; count < settings->implicit_layer_search_paths_count; ++count) {
-            loader_instance_heap_free(inst, settings->implicit_layer_search_paths[count]);
-        }
-        loader_instance_heap_free(inst, settings->implicit_layer_search_paths);
-        settings->implicit_layer_search_paths_count = 0;
-        settings->implicit_layer_search_paths = NULL;
+        freeList(inst, &settings->implicit_layer_search_paths_count, &settings->implicit_layer_search_paths);
     }
     if (NULL != settings->explicit_layer_search_paths) {
-        for (uint32_t count = 0; count < settings->explicit_layer_search_paths_count; ++count) {
-            loader_instance_heap_free(inst, settings->explicit_layer_search_paths[count]);
-        }
-        loader_instance_heap_free(inst, settings->explicit_layer_search_paths);
-        settings->explicit_layer_search_paths_count = 0;
-        settings->explicit_layer_search_paths = NULL;
+        freeList(inst, &settings->explicit_layer_search_paths_count, &settings->explicit_layer_search_paths);
     }
 
     // Free the rest of the struct
@@ -1256,21 +1452,30 @@ VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_sett
     char **settings_file_search_paths = NULL;
 
     // Set defaults
+    settings->log_settings.enabled_log_flags = VULKAN_LOADER_ERROR_BIT;
     settings->log_settings.log_errors_to_stderr = true;
     settings->log_settings.log_nonerrors_to_stdout = true;
+    settings->instance_settings.disable_instance_extension_filter = false;
+    settings->layer_settings.exit_on_missing_layer = false;
+    settings->layer_settings.forced_on_layers_count = 0;
+    settings->layer_settings.forced_on_layers = NULL;
+    settings->layer_settings.enable_filters = NULL;
+    settings->layer_settings.disable_filters = NULL;
+    settings->driver_settings.select_filters = NULL;
+    settings->driver_settings.disable_filters = NULL;
+#if LOADER_ENABLE_LINUX_SORT
+    settings->physical_device_settings.device_sorting_enabled = true;
+#else
+    settings->physical_device_settings.device_sorting_enabled = false;
+#endif
+    settings->physical_device_settings.device_select_enabled = false;
+    settings->physical_device_settings.device_select_string = NULL;
     settings->driver_search_paths_count = 0;
     settings->driver_search_paths = NULL;
     settings->implicit_layer_search_paths_count = 0;
     settings->implicit_layer_search_paths = NULL;
     settings->explicit_layer_search_paths_count = 0;
     settings->explicit_layer_search_paths = NULL;
-#if LOADER_ENABLE_LINUX_SORT
-    settings->device_settings.device_sorting_enabled = true;
-#else
-    settings->device_settings.device_sorting_enabled = false;
-#endif
-    settings->device_settings.device_select_enabled = false;
-    settings->device_settings.device_select_string = NULL;
     result = loaderDefaultSearchPaths(inst, &default_driver_search_path, &default_implicit_layer_search_path,
                                       &default_explicit_layer_search_path, &default_settings_file_search_path);
     if (VK_SUCCESS != result) {
@@ -1285,17 +1490,35 @@ VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_sett
         goto out;
     }
 
-    //
-    // TODO: Read loader settings file here.
-    //
-
-    // Override any settings with environment variable versions
-    parseEnvLoaderDebugLogFlags(&settings->log_settings.enabled_log_flags);
-    parseEnvDisableInstanceExtensions(inst, &settings->disable_instance_extension_filter);
-    result = parseEnvDeviceSettings(inst, &settings->device_settings);
+    // Read loader settings file here.
+    result = parseSettingsFile(inst, settings, settings_file_search_paths_count, settings_file_search_paths);
     if (VK_SUCCESS != result) {
         goto out;
     }
+
+    // Override any settings with environment variable versions
+    result = parseEnvLoaderLogSettings(inst, &settings->log_settings);
+    if (VK_SUCCESS != result) {
+        goto out;
+    }
+    result = parseEnvInstanceSettings(inst, &settings->instance_settings);
+    if (VK_SUCCESS != result) {
+        goto out;
+    }
+    result = parseEnvLayerSettings(inst, &settings->layer_settings);
+    if (VK_SUCCESS != result) {
+        goto out;
+    }
+    result = parseEnvDriverSettings(inst, &settings->driver_settings);
+    if (VK_SUCCESS != result) {
+        goto out;
+    }
+    result = parseEnvPhysicalDeviceSettings(inst, &settings->physical_device_settings);
+    if (VK_SUCCESS != result) {
+        goto out;
+    }
+
+    // Path settings
     result = readEnvVarPath(inst, VULKAN_LOADER_DRIVER_BIT, &override_driver_env_var_search_path, VK_DRIVER_FILES_ENV_VAR);
     if (VK_SUCCESS != result) {
         result = readEnvVarPath(inst, VULKAN_LOADER_DRIVER_BIT, &override_driver_env_var_search_path, VK_ICD_FILENAMES_ENV_VAR);
@@ -1341,12 +1564,17 @@ VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_sett
         goto out;
     }
 
+    if (settings->log_settings.log_to_file) {
+        settings->log_settings.log_file = fopen(settings->log_settings.log_filename, "at");
+        if (NULL == settings->log_settings.log_file) {
+            settings->log_settings.log_to_file = false;
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "Failed opening loader log file %s", settings->log_settings.log_file);
+        }
+    }
+
 out:
     if (settings_file_search_paths != NULL) {
-        for (uint32_t count = 0; count < settings_file_search_paths_count; ++count) {
-            loader_instance_heap_free(inst, settings_file_search_paths[count]);
-        }
-        loader_instance_heap_free(inst, settings_file_search_paths);
+        freeList(inst, &settings_file_search_paths_count, &settings_file_search_paths);
     }
     freeSearchPaths(inst, &default_driver_search_path, &default_implicit_layer_search_path, &default_explicit_layer_search_path,
                     &default_settings_file_search_path);

--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2014-2022 The Khronos Group Inc.
- * Copyright (c) 2014-2022 Valve Corporation
- * Copyright (c) 2014-2022 LunarG, Inc.
+ * Copyright (c) 2014-2023 The Khronos Group Inc.
+ * Copyright (c) 2014-2023 Valve Corporation
+ * Copyright (c) 2014-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,8 @@
 #include "allocation.h"
 #include "loader.h"
 #include "log.h"
+
+#include <vulkan/vulkan.h>
 
 #include <ctype.h>
 
@@ -547,4 +549,798 @@ out:
     }
 
     return res;
+}
+
+// Loader settings handling
+
+void parseEnvLoaderDebugLogFlags(uint32_t *debug_flags) {
+    char *env = NULL;
+    char *orig = NULL;
+
+    if (NULL == debug_flags) {
+        return;
+    }
+
+    // Parse comma-separated debug options
+    orig = env = loader_getenv("VK_LOADER_DEBUG", NULL);
+    while (env) {
+        char *p = strchr(env, ',');
+        size_t len;
+
+        if (p) {
+            len = p - env;
+        } else {
+            len = strlen(env);
+        }
+
+        if (len > 0) {
+            if (strncmp(env, "all", len) == 0) {
+                *debug_flags = ~0u;
+            } else if (strncmp(env, "warn", len) == 0) {
+                *debug_flags |= VULKAN_LOADER_WARN_BIT;
+            } else if (strncmp(env, "info", len) == 0) {
+                *debug_flags |= VULKAN_LOADER_INFO_BIT;
+            } else if (strncmp(env, "perf", len) == 0) {
+                *debug_flags |= VULKAN_LOADER_PERF_BIT;
+            } else if (strncmp(env, "error", len) == 0) {
+                *debug_flags |= VULKAN_LOADER_ERROR_BIT;
+            } else if (strncmp(env, "debug", len) == 0) {
+                *debug_flags |= VULKAN_LOADER_DEBUG_BIT;
+            } else if (strncmp(env, "layer", len) == 0) {
+                *debug_flags |= VULKAN_LOADER_LAYER_BIT;
+            } else if (strncmp(env, "driver", len) == 0 || strncmp(env, "implem", len) == 0 || strncmp(env, "icd", len) == 0) {
+                *debug_flags |= VULKAN_LOADER_DRIVER_BIT;
+            }
+        }
+
+        if (!p) {
+            break;
+        }
+
+        env = p + 1;
+    }
+
+    loader_free_getenv(orig, NULL);
+}
+
+// Determine if the environment variables indicate that unknown instance extensions should be disabled.
+void parseEnvDisableInstanceExtensions(struct loader_instance *inst, bool *disable_instance_ext) {
+    char *env = NULL;
+    if (NULL == disable_instance_ext) {
+        return;
+    }
+    env = loader_getenv("VK_LOADER_DISABLE_INST_EXT_FILTER", NULL);
+    if (NULL != env && atoi(env) != 0) {
+        loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Found environment var 'VK_LOADER_DISABLE_INST_EXT_FILTER' set to %s", env);
+        *disable_instance_ext = true;
+    } else {
+        *disable_instance_ext = false;
+    }
+    loader_free_getenv(env, NULL);
+}
+
+// Determine if the environment variables indicate that driver sorting should be modified.
+VkResult parseEnvDeviceSortingSettings(struct loader_instance *inst, struct loader_device_sorting_settings *sorting_settings) {
+    if (NULL == sorting_settings) {
+        return VK_SUCCESS;
+    }
+
+#if LOADER_ENABLE_LINUX_SORT
+    char *env_value = loader_getenv("VK_LOADER_DISABLE_SELECT", inst);
+    if (NULL != env_value && atoi(env_value) != 0) {
+        // Device select disabled so bail out early
+        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                   "Found environment var `VK_LOADER_DISABLE_SELECT` set to non-zero.  Disabling device sorting.");
+        loader_free_getenv(env_value, inst);
+    } else {
+        char *selection = loader_getenv("VK_LOADER_DEVICE_SELECT", inst);
+        size_t string_len = selection == NULL ? 0 : strlen(selection);
+        if (NULL != selection && 1 < string_len) {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                       "Found environment var `VK_LOADER_DEVICE_SELECT` set %s", selection);
+            sorting_settings->device_select_string =
+                loader_instance_heap_alloc(inst, string_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            if (NULL == sorting_settings->device_select_string) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "Failed allocating loader settings structure");
+                return VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
+            strncpy(sorting_settings->device_select_string, selection, string_len);
+            sorting_settings->device_select_string[string_len] = '\0';
+            sorting_settings->device_select_enabled = true;
+            loader_free_getenv(selection, inst);
+        }
+    }
+#endif  // LOADER_ENABLE_LINUX_SORT
+    return VK_SUCCESS;
+}
+
+// Determine how long a give path is in a path list string
+size_t determine_data_file_path_size(const char *cur_path, size_t relative_path_size) {
+    size_t path_size = 0;
+
+    if (NULL != cur_path) {
+        // For each folder in cur_path, (detected by finding additional
+        // path separators in the string) we need to add the relative path on
+        // the end.  Plus, leave an additional two slots on the end to add an
+        // additional directory slash and path separator if needed
+        path_size += strlen(cur_path) + relative_path_size + 2;
+        for (const char *x = cur_path; *x; ++x) {
+            if (*x == PATH_SEPARATOR) {
+                path_size += relative_path_size + 2;
+            }
+        }
+    }
+
+    return path_size;
+}
+
+// Free the paths we used for setting up the search paths for layers and drivers.
+void loaderFreeSearchPaths(struct loader_instance *inst, char **driver_path, char **implicit_path, char **explicit_path,
+                           char **settings_path) {
+    if (driver_path != NULL && *driver_path != NULL) {
+        loader_instance_heap_free(inst, *driver_path);
+        *driver_path = NULL;
+    }
+    if (implicit_path != NULL && *implicit_path != NULL) {
+        loader_instance_heap_free(inst, *implicit_path);
+        *implicit_path = NULL;
+    }
+    if (explicit_path != NULL && *explicit_path != NULL) {
+        loader_instance_heap_free(inst, *explicit_path);
+        *explicit_path = NULL;
+    }
+    if (settings_path != NULL && *settings_path != NULL) {
+        loader_instance_heap_free(inst, *settings_path);
+        *settings_path = NULL;
+    }
+}
+
+// Figure out the default search paths for driver and layers based on the current operating
+// system.
+VkResult loaderDefaultSearchPaths(struct loader_instance *inst, char **default_driver_path, char **default_implicit_path,
+                                  char **default_explicit_path, char **default_settings_path) {
+    VkResult result = VK_SUCCESS;
+    const char curPassString[4][24] = {{"Driver"}, {"Implicit Layers"}, {"Explicit Layers"}, {"Settings"}};
+    const char *relative_driver_folder = VK_DRIVERS_INFO_RELATIVE_DIR;
+    const char *relative_implicit_layer_folder = VK_ILAYERS_INFO_RELATIVE_DIR;
+    const char *relative_explicit_layer_folder = VK_ELAYERS_INFO_RELATIVE_DIR;
+    const char *relative_settings_folder = VK_SETTINGS_INFO_RELATIVE_DIR;
+
+#if defined(_WIN32)
+    // Driver only
+    char *package_path = windows_get_app_package_manifest_path(inst);
+#else
+    // Determine how much space is needed to generate the full search path
+    // for the current manifest files.
+    char *xdg_config_home = loader_secure_getenv("XDG_CONFIG_HOME", inst);
+    char *xdg_config_dirs = loader_secure_getenv("XDG_CONFIG_DIRS", inst);
+
+#if !defined(__Fuchsia__) && !defined(__QNXNTO__)
+    if (NULL == xdg_config_dirs || '\0' == xdg_config_dirs[0]) {
+        xdg_config_dirs = FALLBACK_CONFIG_DIRS;
+    }
+#endif
+
+    char *xdg_data_home = loader_secure_getenv("XDG_DATA_HOME", inst);
+    char *xdg_data_dirs = loader_secure_getenv("XDG_DATA_DIRS", inst);
+
+#if !defined(__Fuchsia__) && !defined(__QNXNTO__)
+    if (NULL == xdg_data_dirs || '\0' == xdg_data_dirs[0]) {
+        xdg_data_dirs = FALLBACK_DATA_DIRS;
+    }
+#endif
+
+    char *home = NULL;
+    char *default_data_home = NULL;
+    char *default_config_home = NULL;
+    char *home_data_dir = NULL;
+    char *home_config_dir = NULL;
+
+    // Only use HOME if XDG_DATA_HOME is not present on the system
+    home = loader_secure_getenv("HOME", inst);
+    if (home != NULL) {
+        if (NULL == xdg_config_home || '\0' == xdg_config_home[0]) {
+            const char config_suffix[] = "/.config";
+            default_config_home =
+                loader_instance_heap_alloc(inst, strlen(home) + strlen(config_suffix) + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            if (default_config_home == NULL) {
+                result = VK_ERROR_OUT_OF_HOST_MEMORY;
+                goto out;
+            }
+            strcpy(default_config_home, home);
+            strcat(default_config_home, config_suffix);
+        }
+        if (NULL == xdg_data_home || '\0' == xdg_data_home[0]) {
+            const char data_suffix[] = "/.local/share";
+            default_data_home =
+                loader_instance_heap_alloc(inst, strlen(home) + strlen(data_suffix) + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            if (default_data_home == NULL) {
+                result = VK_ERROR_OUT_OF_HOST_MEMORY;
+                goto out;
+            }
+            strcpy(default_data_home, home);
+            strcat(default_data_home, data_suffix);
+        }
+    }
+
+    if (NULL != default_config_home) {
+        home_config_dir = default_config_home;
+    } else {
+        home_config_dir = xdg_config_home;
+    }
+    if (NULL != default_data_home) {
+        home_data_dir = default_data_home;
+    } else {
+        home_data_dir = xdg_data_home;
+    }
+#endif  // !_WIN32
+
+    for (uint32_t pass = 0; pass < 4; ++pass) {
+        const char *relative_folder = NULL;
+        char **target_pointer = NULL;
+        char *cur_path_ptr = NULL;
+        size_t search_path_size = 2;  // Add two for NULL terminator and one path separator (just in case)
+        size_t rel_size = 0;
+        bool settings_file_search = false;
+        switch (pass) {
+            case 0:
+            default:
+                relative_folder = relative_driver_folder;
+                target_pointer = default_driver_path;
+                break;
+            case 1:
+                relative_folder = relative_implicit_layer_folder;
+                target_pointer = default_implicit_path;
+                break;
+            case 2:
+                relative_folder = relative_explicit_layer_folder;
+                target_pointer = default_explicit_path;
+                break;
+            case 3:
+                relative_folder = relative_settings_folder;
+                target_pointer = default_settings_path;
+                settings_file_search = true;
+                break;
+        }
+
+#if defined(_WIN32)
+        if (NULL != package_path) {
+            search_path_size += determine_data_file_path_size(package_path, 0) + 2;
+        }
+        if (search_path_size == 2) {
+            continue;
+        }
+#else  // !_WIN32
+
+        // Add the general search folders (with the appropriate relative folder added)
+        rel_size = strlen(relative_folder);
+#if defined(__APPLE__)
+        search_path_size += MAXPATHLEN;
+#endif
+        // Only add the home folders if defined
+        if (NULL != home_config_dir) {
+            search_path_size += determine_data_file_path_size(home_config_dir, rel_size);
+        }
+        search_path_size += determine_data_file_path_size(xdg_config_dirs, rel_size);
+        // Don't add system folders for settings file search
+        if (!settings_file_search) {
+            search_path_size += determine_data_file_path_size(SYSCONFDIR, rel_size);
+#if defined(EXTRASYSCONFDIR)
+            search_path_size += determine_data_file_path_size(EXTRASYSCONFDIR, rel_size);
+#endif
+        }
+        // Only add the home folders if defined
+        if (NULL != home_data_dir) {
+            search_path_size += determine_data_file_path_size(home_data_dir, rel_size);
+        }
+        search_path_size += determine_data_file_path_size(xdg_data_dirs, rel_size);
+#endif  // !_WIN32
+
+        // Allocate the required space
+        *target_pointer = loader_instance_heap_calloc(inst, search_path_size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (NULL == *target_pointer) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+                       "Failed to allocate space for default search path of %s files of length %d", curPassString[pass],
+                       (uint32_t)search_path_size);
+            result = VK_ERROR_OUT_OF_HOST_MEMORY;
+            goto out;
+        }
+
+        cur_path_ptr = *target_pointer;
+
+#if defined(_WIN32)
+        if (NULL != package_path) {
+            copy_data_file_info(package_path, NULL, 0, &cur_path_ptr);
+        }
+#else
+#if defined(__APPLE__)
+        // Add the bundle's Resources dir to the beginning of the search path.
+        // Looks for manifests in the bundle first, before any system directories.
+        CFBundleRef main_bundle = CFBundleGetMainBundle();
+        if (NULL != main_bundle) {
+            CFURLRef ref = CFBundleCopyResourcesDirectoryURL(main_bundle);
+            if (NULL != ref) {
+                if (CFURLGetFileSystemRepresentation(ref, TRUE, (UInt8 *)cur_path_ptr, search_path_size)) {
+                    cur_path_ptr += strlen(cur_path_ptr);
+                    *cur_path_ptr++ = DIRECTORY_SYMBOL;
+                    memcpy(cur_path_ptr, relative_folder, rel_size);
+                    cur_path_ptr += rel_size;
+                    *cur_path_ptr++ = PATH_SEPARATOR;
+                    if (manifest_type == LOADER_DATA_FILE_MANIFEST_DRIVER) {
+                        use_first_found_manifest = true;
+                    }
+                }
+                CFRelease(ref);
+            }
+        }
+#endif  // __APPLE__
+
+        // Only add the home folders if not NULL
+        if (NULL != home_config_dir) {
+            copy_data_file_info(home_config_dir, relative_folder, rel_size, &cur_path_ptr);
+        }
+        copy_data_file_info(xdg_config_dirs, relative_folder, rel_size, &cur_path_ptr);
+
+        // Don't add system folders for settings file search
+        if (!settings_file_search) {
+            copy_data_file_info(SYSCONFDIR, relative_folder, rel_size, &cur_path_ptr);
+#if defined(EXTRASYSCONFDIR)
+            copy_data_file_info(EXTRASYSCONFDIR, relative_folder, rel_size, &cur_path_ptr);
+#endif
+        }
+
+        // Only add the home folders if not NULL
+        if (NULL != home_data_dir) {
+            copy_data_file_info(home_data_dir, relative_folder, rel_size, &cur_path_ptr);
+        }
+        copy_data_file_info(xdg_data_dirs, relative_folder, rel_size, &cur_path_ptr);
+
+        // Remove the last path separator
+        --cur_path_ptr;
+
+        assert(cur_path_ptr - (*target_pointer) < (ptrdiff_t)search_path_size);
+        *cur_path_ptr = '\0';
+#endif  // !_WIN32
+    }
+
+out:
+    if (VK_SUCCESS != result) {
+        loaderFreeSearchPaths(inst, default_driver_path, default_implicit_path, default_explicit_path, default_settings_path);
+    }
+
+#if defined(_WIN32)
+    loader_instance_heap_free(inst, package_path);
+#else
+    loader_free_getenv(xdg_config_home, inst);
+    loader_free_getenv(xdg_config_dirs, inst);
+    loader_free_getenv(xdg_data_home, inst);
+    loader_free_getenv(xdg_data_dirs, inst);
+    loader_free_getenv(xdg_data_home, inst);
+    loader_free_getenv(home, inst);
+    loader_instance_heap_free(inst, default_data_home);
+    loader_instance_heap_free(inst, default_config_home);
+#endif
+
+    return result;
+}
+
+// Read a path that is stored in an environment variable.
+VkResult readEnvVarPath(struct loader_instance *inst, uint32_t log_msg_flag, char **output_var, char *env_var) {
+    if (inst == NULL || output_var == NULL || env_var == NULL) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    char *env_var_value = loader_secure_getenv(env_var, inst);
+    size_t env_var_size = env_var_value == NULL ? 0 : strlen(env_var_value);
+    if (NULL != env_var_value && env_var_size > 1) {
+        *output_var = loader_instance_heap_calloc(inst, env_var_size + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (NULL == *output_var) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for env var `%s` value", env_var);
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        } else {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT | log_msg_flag, 0, "Found environment var `%s`, using value: `%s`", env_var,
+                       env_var_value);
+            strncpy(*output_var, env_var_value, env_var_size);
+            (*output_var)[env_var_size] = '\0';
+        }
+        loader_free_getenv(env_var_value, inst);
+    }
+    return VK_SUCCESS;
+}
+
+// Determine how many actual paths are listed in a path_list string
+uint32_t getPathCount(char *path_list) {
+    uint32_t count = 0;
+    if (path_list == NULL) {
+        return 0;
+    }
+    // Now, parse the paths
+    char *cur_path;
+    char *next_path = path_list;
+    while (NULL != next_path && *next_path != '\0') {
+        cur_path = next_path;
+        next_path = loader_get_next_path(cur_path);
+
+        // Is this a JSON file, then try to open it.
+        size_t len = strlen(cur_path);
+        if (len > 1) {
+            count++;
+        }
+    }
+    return count;
+}
+
+// Extract each individual paths listed in a path_list string and place it in a path_array for
+// easier use.
+VkResult addPathsToArray(struct loader_instance *inst, uint32_t log_msg_flag, char *path_list, char **path_array,
+                         uint32_t *start_index) {
+    // Now, parse the paths
+    char *cur_path;
+    char *next_path = path_list;
+    while (NULL != next_path && *next_path != '\0') {
+        cur_path = next_path;
+        next_path = loader_get_next_path(cur_path);
+
+        // Is this a JSON file, then try to open it.
+        size_t len = strlen(cur_path);
+        if (len > 1) {
+            path_array[*start_index] = loader_instance_heap_alloc(inst, len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            if (path_array[*start_index] == NULL) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for path search element %d",
+                           *start_index);
+                for (uint32_t count = 0; count < *start_index; ++count) {
+                    loader_instance_heap_free(inst, path_array[count]);
+                    path_array[count] = NULL;
+                }
+                *start_index = 0;
+                return VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
+            strncpy(path_array[*start_index], cur_path, len);
+            path_array[*start_index][len] = '\0';
+            (*start_index)++;
+        }
+    }
+    return VK_SUCCESS;
+}
+
+// Generate the complete list of search paths using the environment variables (or file variables) and
+// the default paths for this platform.
+// NOTE: This can be overridden by the "override" layer later on.
+VkResult generateCompleteSearchPath(struct loader_instance *inst, enum loader_data_files_type search_type, char *default_path,
+                                    char *override_path, char *add_path, uint32_t *count, char ***value) {
+    uint32_t path_count = 0;
+    uint32_t cur_path_index = 0;
+    enum vulkan_loader_debug_flags log_msg_flag;
+    uint8_t message_index = 0;
+    const char message_str[4][20] = {{"driver"}, {"implicit layer"}, {"explicit layer"}, {"settings file"}};
+
+    if (inst == NULL || default_path == NULL || count == NULL || value == NULL) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    // Set to 0, just in case we have a failure.
+    *count = 0;
+
+    switch (search_type) {
+        case LOADER_DATA_FILE_MANIFEST_DRIVER:
+        default:
+            log_msg_flag = VULKAN_LOADER_DRIVER_BIT;
+            message_index = 0;
+            break;
+        case LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER:
+            log_msg_flag = VULKAN_LOADER_LAYER_BIT;
+            message_index = 2;
+            break;
+        case LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER:
+            log_msg_flag = VULKAN_LOADER_LAYER_BIT;
+            message_index = 1;
+            break;
+        case LOADER_DATA_FILE_SETTINGS_FILE:
+            log_msg_flag = VULKAN_LOADER_INFO_BIT;
+            message_index = 3;
+            break;
+    }
+
+    char **path_array = NULL;
+    char *modifiable_path = NULL;
+    bool failed = false;
+
+    if (NULL != override_path) {
+        size_t cur_len = strlen(override_path);
+        modifiable_path = loader_instance_heap_calloc(inst, cur_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (modifiable_path == NULL) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for modifiable path string");
+            failed = true;
+        }
+        if (!failed) {
+            strncpy(modifiable_path, override_path, cur_len);
+            modifiable_path[cur_len] = '\0';
+            path_count = getPathCount(modifiable_path);
+            path_array = loader_instance_heap_calloc(inst, sizeof(char *) * path_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            if (path_array == NULL) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for %s override path search array",
+                           message_str[message_index]);
+                failed = true;
+            }
+        }
+        if (!failed) {
+            strncpy(modifiable_path, override_path, cur_len);
+            modifiable_path[cur_len] = '\0';
+            if (addPathsToArray(inst, log_msg_flag, modifiable_path, path_array, &cur_path_index)) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
+                           "Failed copying paths from %s override path into search array", message_str[message_index]);
+                failed = true;
+            }
+        }
+    } else {
+        size_t add_len = add_path == NULL ? 0 : strlen(add_path);
+        size_t default_len = default_path == NULL ? 0 : strlen(default_path);
+        size_t max_len = add_len > default_len ? add_len : default_len;
+        assert(max_len > 0);
+        modifiable_path = loader_instance_heap_calloc(inst, max_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        if (modifiable_path == NULL) {
+            loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for modifiable path string");
+            failed = true;
+        }
+        if (!failed) {
+            path_count = 0;
+            if (add_path != NULL) {
+                strncpy(modifiable_path, add_path, add_len);
+                modifiable_path[add_len] = '\0';
+                path_count += getPathCount(modifiable_path);
+            }
+            if (default_path != NULL) {
+                strncpy(modifiable_path, default_path, default_len);
+                modifiable_path[default_len] = '\0';
+                path_count += getPathCount(modifiable_path);
+            }
+            path_array = loader_instance_heap_calloc(inst, sizeof(char *) * path_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            if (path_array == NULL) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0, "Failed alloc space for standard %s path search array",
+                           message_str[message_index]);
+                failed = true;
+            }
+        }
+        if (!failed && add_path != NULL) {
+            strncpy(modifiable_path, add_path, add_len);
+            modifiable_path[add_len] = '\0';
+            if (addPathsToArray(inst, log_msg_flag, modifiable_path, path_array, &cur_path_index)) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
+                           "Failed copying paths from additional %s path into search array", message_str[message_index]);
+                failed = true;
+            }
+        }
+        if (!failed && default_path != NULL) {
+            strncpy(modifiable_path, default_path, default_len);
+            modifiable_path[default_len] = '\0';
+            if (addPathsToArray(inst, log_msg_flag, modifiable_path, path_array, &cur_path_index)) {
+                loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_msg_flag, 0,
+                           "Failed copying paths from default %s path into search array", message_str[message_index]);
+                failed = true;
+            }
+        }
+    }
+    if (failed) {
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+    loader_instance_heap_free(inst, modifiable_path);
+
+    // Remove duplicate paths, or it would result in duplicate extensions, duplicate devices, etc.
+    for (int32_t cur_path = 0; cur_path < (int32_t)path_count; ++cur_path) {
+        for (int32_t check_path = cur_path + 1; check_path < (int32_t)path_count; ++check_path) {
+            if (!strcmp(path_array[check_path], path_array[cur_path])) {
+                loader_instance_heap_free(inst, path_array[check_path]);
+                for (int32_t copy_path = check_path; copy_path < (int32_t)path_count - 1; ++copy_path) {
+                    path_array[copy_path] = path_array[copy_path + 1];
+                }
+                path_array[--path_count] = NULL;
+                check_path--;
+            }
+        }
+    }
+
+    // Print out the paths being searched if debugging is enabled
+    if (path_count > 0) {
+        loader_log(inst, log_msg_flag, 0, "Search paths for %s manifest files set to following order:", message_str[message_index]);
+        for (uint32_t cur_path = 0; cur_path < path_count; ++cur_path) {
+            loader_log(inst, log_msg_flag, 0, "   %s", path_array[cur_path]);
+        }
+    } else {
+        if (path_array != NULL) {
+            loader_instance_heap_free(inst, path_array);
+            path_array = NULL;
+        }
+    }
+
+    *count = path_count;
+    *value = path_array;
+    return VK_SUCCESS;
+}
+
+// Free the items that were allocated in the settings struct, and then the settings struct itself.
+void freeSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct) {
+    if (set_struct == NULL || *set_struct == NULL) {
+        return;
+    }
+    struct loader_settings *settings = *set_struct;
+
+    // Free log file info
+    if (settings->log_settings.log_to_file) {
+        loader_instance_heap_free(inst, settings->log_settings.log_filename);
+        if (NULL != settings->log_settings.log_file) {
+            fclose(settings->log_settings.log_file);
+            settings->log_settings.log_file = NULL;
+        }
+        settings->log_settings.log_to_file = false;
+    }
+    loader_instance_heap_free(inst, settings->log_settings.log_filename);
+    settings->log_settings.log_filename = NULL;
+
+    // Free device items
+    if (NULL != settings->device_sorting_settings.device_select_string) {
+        loader_instance_heap_free(inst, settings->device_sorting_settings.device_select_string);
+        settings->device_sorting_settings.device_select_string = NULL;
+    }
+
+    // Free search paths
+    if (NULL != settings->driver_search_paths) {
+        for (uint32_t count = 0; count < settings->driver_search_paths_count; ++count) {
+            loader_instance_heap_free(inst, settings->driver_search_paths[count]);
+        }
+        loader_instance_heap_free(inst, settings->driver_search_paths);
+        settings->driver_search_paths_count = 0;
+        settings->driver_search_paths = NULL;
+    }
+    if (NULL != settings->implicit_layer_search_paths) {
+        for (uint32_t count = 0; count < settings->implicit_layer_search_paths_count; ++count) {
+            loader_instance_heap_free(inst, settings->implicit_layer_search_paths[count]);
+        }
+        loader_instance_heap_free(inst, settings->implicit_layer_search_paths);
+        settings->implicit_layer_search_paths_count = 0;
+        settings->implicit_layer_search_paths = NULL;
+    }
+    if (NULL != settings->explicit_layer_search_paths) {
+        for (uint32_t count = 0; count < settings->explicit_layer_search_paths_count; ++count) {
+            loader_instance_heap_free(inst, settings->explicit_layer_search_paths[count]);
+        }
+        loader_instance_heap_free(inst, settings->explicit_layer_search_paths);
+        settings->explicit_layer_search_paths_count = 0;
+        settings->explicit_layer_search_paths = NULL;
+    }
+
+    // Free the rest of the struct
+    loader_instance_heap_free(inst, settings);
+    *set_struct = NULL;
+}
+
+// Generate a settings structure containing all the settings necessary for the loader.
+// This is generated from platform defaults, environment variables, and the loader settings
+// file.
+VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct) {
+    if (set_struct == NULL) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+    *set_struct = NULL;
+    struct loader_settings *settings =
+        loader_instance_heap_calloc(inst, sizeof(struct loader_settings), VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+    if (settings == NULL) {
+        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "Failed allocating loader settings structure");
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    // Search paths, these are eventually used to fill in the final search paths
+    // for each driver, implicit layers, and explicit layers.
+    char *default_driver_search_path = NULL;
+    char *override_driver_env_var_search_path = NULL;
+    char *override_driver_file_search_path = NULL;
+    char *additional_driver_env_var_search_path = NULL;
+    char *additional_driver_file_search_path = NULL;
+    char *default_implicit_layer_search_path = NULL;
+    char *default_explicit_layer_search_path = NULL;
+    char *override_explicit_layer_env_var_search_path = NULL;
+    char *override_explicit_layer_file_search_path = NULL;
+    char *additional_explicit_layer_env_var_search_path = NULL;
+    char *additional_explicit_layer_file_search_path = NULL;
+    char *default_settings_file_search_path = NULL;
+    uint32_t settings_file_search_paths_count;
+    char **settings_file_search_paths;
+
+    // Set defaults
+    settings->log_settings.log_errors_to_stderr = true;
+    settings->log_settings.log_nonerrors_to_stdout = true;
+    settings->driver_search_paths_count = 0;
+    settings->driver_search_paths = NULL;
+    settings->implicit_layer_search_paths_count = 0;
+    settings->implicit_layer_search_paths = NULL;
+    settings->explicit_layer_search_paths_count = 0;
+    settings->explicit_layer_search_paths = NULL;
+#if LOADER_ENABLE_LINUX_SORT
+    settings->device_sorting_settings.device_sorting_enabled = true;
+#else
+    settings->device_sorting_settings.device_sorting_enabled = false;
+#endif
+    settings->device_sorting_settings.device_select_enabled = false;
+    settings->device_sorting_settings.device_select_string = NULL;
+    if (VK_SUCCESS != loaderDefaultSearchPaths(inst, &default_driver_search_path, &default_implicit_layer_search_path,
+                                               &default_explicit_layer_search_path, &default_settings_file_search_path)) {
+        goto out;
+    }
+
+    // Find a settings file and load the settings out of that if one exists in one of the
+    // appropriate locations.
+    if (VK_SUCCESS != generateCompleteSearchPath(inst, LOADER_DATA_FILE_SETTINGS_FILE, default_settings_file_search_path, NULL,
+                                                 NULL, &settings_file_search_paths_count, &settings_file_search_paths)) {
+        goto out;
+    }
+    //
+    // TODO: Read loader settings file here.
+    //
+
+    // Override any settings with environment variable versions
+    VkResult env_var_result = VK_SUCCESS;
+    parseEnvLoaderDebugLogFlags(&settings->log_settings.enabled_log_flags);
+    parseEnvDisableInstanceExtensions(inst, &settings->disable_instance_extension_filter);
+    env_var_result = parseEnvDeviceSortingSettings(inst, &settings->device_sorting_settings);
+    if (VK_SUCCESS != env_var_result) {
+        goto out;
+    }
+    if (VK_SUCCESS !=
+            readEnvVarPath(inst, VULKAN_LOADER_DRIVER_BIT, &override_driver_env_var_search_path, VK_DRIVER_FILES_ENV_VAR) &&
+        VK_SUCCESS !=
+            readEnvVarPath(inst, VULKAN_LOADER_DRIVER_BIT, &override_driver_env_var_search_path, VK_ICD_FILENAMES_ENV_VAR)) {
+        goto out;
+    }
+    if (VK_SUCCESS != readEnvVarPath(inst, VULKAN_LOADER_DRIVER_BIT, &additional_driver_env_var_search_path,
+                                     VK_ADDITIONAL_DRIVER_FILES_ENV_VAR)) {
+        goto out;
+    }
+    if (VK_SUCCESS !=
+        readEnvVarPath(inst, VULKAN_LOADER_LAYER_BIT, &override_explicit_layer_env_var_search_path, VK_LAYER_PATH_ENV_VAR)) {
+        goto out;
+    }
+    if (VK_SUCCESS != readEnvVarPath(inst, VULKAN_LOADER_LAYER_BIT, &additional_explicit_layer_env_var_search_path,
+                                     VK_ADDITIONAL_LAYER_PATH_ENV_VAR)) {
+        goto out;
+    }
+    if (VK_SUCCESS !=
+        generateCompleteSearchPath(
+            inst, LOADER_DATA_FILE_MANIFEST_DRIVER, default_driver_search_path,
+            (override_driver_file_search_path == NULL) ? override_driver_env_var_search_path : override_driver_file_search_path,
+            (additional_driver_file_search_path == NULL) ? additional_driver_env_var_search_path
+                                                         : additional_driver_file_search_path,
+            &settings->driver_search_paths_count, &settings->driver_search_paths)) {
+        goto out;
+    }
+    if (VK_SUCCESS != generateCompleteSearchPath(inst, LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER, default_implicit_layer_search_path,
+                                                 NULL, NULL, &settings->implicit_layer_search_paths_count,
+                                                 &settings->implicit_layer_search_paths)) {
+        goto out;
+    }
+    if (VK_SUCCESS != generateCompleteSearchPath(
+                          inst, LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER, default_explicit_layer_search_path,
+                          (override_explicit_layer_file_search_path == NULL) ? override_explicit_layer_env_var_search_path
+                                                                             : override_explicit_layer_file_search_path,
+                          (additional_explicit_layer_file_search_path == NULL) ? additional_explicit_layer_env_var_search_path
+                                                                               : additional_explicit_layer_file_search_path,
+                          &settings->explicit_layer_search_paths_count, &settings->explicit_layer_search_paths)) {
+        goto out;
+    }
+
+    // Return structure
+    *set_struct = settings;
+out:
+    if (settings_file_search_paths != NULL) {
+        for (uint32_t count = 0; count < settings_file_search_paths_count; ++count) {
+            loader_instance_heap_free(inst, settings_file_search_paths[count]);
+        }
+        loader_instance_heap_free(inst, settings_file_search_paths);
+    }
+    loaderFreeSearchPaths(inst, &default_driver_search_path, &default_implicit_layer_search_path,
+                          &default_explicit_layer_search_path, &default_settings_file_search_path);
+    loaderFreeSearchPaths(inst, &override_driver_env_var_search_path, NULL, &override_explicit_layer_env_var_search_path, NULL);
+    loaderFreeSearchPaths(inst, &additional_driver_env_var_search_path, NULL, &additional_explicit_layer_env_var_search_path, NULL);
+    if (env_var_result != VK_SUCCESS) {
+        freeSettingsStruct(inst, &settings);
+    }
+    return env_var_result;
 }

--- a/loader/loader_environment.h
+++ b/loader/loader_environment.h
@@ -44,15 +44,9 @@ char *loader_secure_getenv(const char *name, const struct loader_instance *inst)
 
 #endif
 
-VkResult parse_generic_filter_environment_var(const struct loader_instance *inst, const char *env_var_name,
-                                              struct loader_envvar_filter *filter_struct);
-VkResult parse_layers_disable_filter_environment_var(const struct loader_instance *inst,
-                                                     struct loader_envvar_disable_layers_filter *disable_struct);
 bool check_name_matches_filter_environment_var(const struct loader_instance *inst, const char *name,
                                                const struct loader_envvar_filter *filter_struct);
-VkResult loader_add_environment_layers(struct loader_instance *inst, const enum layer_type_flags type_flags, const char *env_name,
-                                       const struct loader_envvar_filter *enable_filter,
-                                       const struct loader_envvar_disable_layers_filter *disable_filter,
+VkResult loader_add_environment_layers(struct loader_instance *inst, const enum layer_type_flags type_flags,
                                        struct loader_layer_list *target_list, struct loader_layer_list *expanded_target_list,
                                        const struct loader_layer_list *source_list);
 
@@ -61,6 +55,6 @@ VkResult loader_add_environment_layers(struct loader_instance *inst, const enum 
 VkResult generateCompleteSearchPath(const struct loader_instance *inst, enum loader_data_files_type search_type,
                                     const char *default_path, const char *override_path, const char *add_path, uint32_t *count,
                                     char ***value);
-void freeSearchPath(const struct loader_instance *inst, char **search_path);
+void freeList(const struct loader_instance *inst, uint32_t *count, char ***list);
 VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struc);
 void freeSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct);

--- a/loader/loader_environment.h
+++ b/loader/loader_environment.h
@@ -56,5 +56,6 @@ VkResult generateCompleteSearchPath(const struct loader_instance *inst, enum loa
                                     const char *default_path, const char *override_path, const char *add_path, uint32_t *count,
                                     char ***value);
 void freeList(const struct loader_instance *inst, uint32_t *count, char ***list);
+void freeSearchPath(const struct loader_instance *inst, char **search_path);
 VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struc);
 void freeSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct);

--- a/loader/loader_environment.h
+++ b/loader/loader_environment.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2014-2021 The Khronos Group Inc.
- * Copyright (c) 2014-2021 Valve Corporation
- * Copyright (c) 2014-2021 LunarG, Inc.
+ * Copyright (c) 2014-2023 The Khronos Group Inc.
+ * Copyright (c) 2014-2023 Valve Corporation
+ * Copyright (c) 2014-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,3 +55,12 @@ VkResult loader_add_environment_layers(struct loader_instance *inst, const enum 
                                        const struct loader_envvar_disable_layers_filter *disable_filter,
                                        struct loader_layer_list *target_list, struct loader_layer_list *expanded_target_list,
                                        const struct loader_layer_list *source_list);
+
+// Functionality used for the new loader settings structure and file
+
+VkResult generateCompleteSearchPath(const struct loader_instance *inst, enum loader_data_files_type search_type,
+                                    const char *default_path, const char *override_path, const char *add_path, uint32_t *count,
+                                    char ***value);
+void freeSearchPath(const struct loader_instance *inst, char **search_path);
+VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struc);
+void freeSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct);

--- a/loader/loader_environment.h
+++ b/loader/loader_environment.h
@@ -52,10 +52,9 @@ VkResult loader_add_environment_layers(struct loader_instance *inst, const enum 
 
 // Functionality used for the new loader settings structure and file
 
-VkResult generateCompleteSearchPath(const struct loader_instance *inst, enum loader_data_files_type search_type,
+VkResult generateCompleteSearchList(const struct loader_instance *inst, enum loader_data_files_type search_type,
                                     const char *default_path, const char *override_path, const char *add_path, uint32_t *count,
                                     char ***value);
 void freeList(const struct loader_instance *inst, uint32_t *count, char ***list);
-void freeSearchPath(const struct loader_instance *inst, char **search_path);
 VkResult generateSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struc);
 void freeSettingsStruct(struct loader_instance *inst, struct loader_settings **set_struct);

--- a/loader/loader_linux.c
+++ b/loader/loader_linux.c
@@ -206,15 +206,15 @@ int32_t compare_device_groups(const void *a, const void *b) {
 // Search for the default device using the loader environment variable.
 static void linux_env_var_default_device(struct loader_instance *inst, uint32_t device_count,
                                          struct LinuxSortedDeviceInfo *sorted_device_info) {
-    if (inst->settings->device_settings.device_select_enabled) {
+    if (inst->settings->physical_device_settings.device_select_enabled) {
         loader_log(inst, VULKAN_LOADER_DEBUG_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                    "linux_env_var_default_device:  Found \'VK_LOADER_DEVICE_SELECT\' set to %s",
-                   inst->settings->device_settings.device_select_string);
+                   inst->settings->physical_device_settings.device_select_string);
 
         // The environment variable exists, so grab the vendor ID and device ID of the
         // selected default device
         unsigned vendor_id, device_id;
-        int32_t matched = sscanf(inst->settings->device_settings.device_select_string, "%x:%x", &vendor_id, &device_id);
+        int32_t matched = sscanf(inst->settings->physical_device_settings.device_select_string, "%x:%x", &vendor_id, &device_id);
         if (matched == 2) {
             for (int32_t i = 0; i < (int32_t)device_count; ++i) {
                 if (sorted_device_info[i].vendor_id == vendor_id && sorted_device_info[i].device_id == device_id) {

--- a/loader/loader_linux.c
+++ b/loader/loader_linux.c
@@ -218,9 +218,8 @@ static void linux_env_var_default_device(struct loader_instance *inst, uint32_t 
         if (matched == 2) {
             for (int32_t i = 0; i < (int32_t)device_count; ++i) {
                 if (sorted_device_info[i].vendor_id == vendor_id && sorted_device_info[i].device_id == device_id) {
-                    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
-                               "linux_env_var_default_device:  Found default at index %u \'%s\'", i,
-                               sorted_device_info[i].device_name);
+                    loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "linux_env_var_default_device:  Found default at index %u \'%s\'",
+                               i, sorted_device_info[i].device_name);
                     sorted_device_info[i].default_device = true;
                     break;
                 }
@@ -243,8 +242,8 @@ VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32
         goto out;
     }
 
-    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "linux_read_sorted_physical_devices:");
-    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "     Original order:");
+    loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "linux_read_sorted_physical_devices:");
+    loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "     Original order:");
 
     // Grab all the necessary info we can about each device
     uint32_t index = 0;
@@ -310,8 +309,7 @@ VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32
                     sorted_device_info[index].has_pci_bus_info = false;
                 }
             }
-            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "           [%u] %s", index,
-                       sorted_device_info[index].device_name);
+            loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "           [%u] %s", index, sorted_device_info[index].device_name);
             index++;
         }
     }
@@ -323,7 +321,7 @@ VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32
     qsort(sorted_device_info, phys_dev_count, sizeof(struct LinuxSortedDeviceInfo), compare_devices);
 
     // If we have a selected index, add that first.
-    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "     Sorted order:");
+    loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "     Sorted order:");
 
     // Add all others after (they've already been sorted)
     for (uint32_t dev = 0; dev < phys_dev_count; ++dev) {
@@ -331,8 +329,8 @@ VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32
         sorted_device_term[dev]->icd_index = sorted_device_info[dev].icd_index;
         sorted_device_term[dev]->phys_dev = sorted_device_info[dev].physical_device;
         loader_set_dispatch((void *)sorted_device_term[dev], inst->disp);
-        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "           [%u] %s  %s", dev,
-                   sorted_device_info[dev].device_name, (sorted_device_info[dev].default_device ? "[default]" : ""));
+        loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "           [%u] %s  %s", dev, sorted_device_info[dev].device_name,
+                   (sorted_device_info[dev].default_device ? "[default]" : ""));
     }
 
 out:
@@ -347,10 +345,10 @@ VkResult linux_sort_physical_device_groups(struct loader_instance *inst, uint32_
     VkResult res = VK_SUCCESS;
     bool app_is_vulkan_1_1 = loader_check_version_meets_required(LOADER_VERSION_1_1_0, inst->app_api_version);
 
-    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "linux_sort_physical_device_groups:  Original order:");
+    loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "linux_sort_physical_device_groups:  Original order:");
 
     for (uint32_t group = 0; group < group_count; ++group) {
-        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "           Group %u", group);
+        loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "           Group %u", group);
 
         struct loader_icd_term *icd_term = sorted_group_term[group].this_icd_term;
         for (uint32_t gpu = 0; gpu < sorted_group_term[group].group_props.physicalDeviceCount; ++gpu) {
@@ -413,7 +411,7 @@ VkResult linux_sort_physical_device_groups(struct loader_instance *inst, uint32_
                     sorted_group_term[group].internal_device_info[gpu].has_pci_bus_info = false;
                 }
             }
-            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "               [%u] %s", gpu,
+            loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "               [%u] %s", gpu,
                        sorted_group_term[group].internal_device_info[gpu].device_name);
         }
 
@@ -436,11 +434,11 @@ VkResult linux_sort_physical_device_groups(struct loader_instance *inst, uint32_
     qsort(sorted_group_term, group_count, sizeof(struct loader_physical_device_group_term), compare_device_groups);
 
     if (inst->settings->log_settings.enabled_log_flags & (VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT)) {
-        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "linux_sort_physical_device_groups:  Sorted order:");
+        loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "linux_sort_physical_device_groups:  Sorted order:");
         for (uint32_t group = 0; group < group_count; ++group) {
-            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "           Group %u", group);
+            loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "           Group %u", group);
             for (uint32_t gpu = 0; gpu < sorted_group_term[group].group_props.physicalDeviceCount; ++gpu) {
-                loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "               [%u] %s %p %s", gpu,
+                loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "               [%u] %s %p %s", gpu,
                            sorted_group_term[group].internal_device_info[gpu].device_name,
                            sorted_group_term[group].internal_device_info[gpu].physical_device,
                            (sorted_group_term[group].internal_device_info[gpu].default_device ? "[default]" : ""));

--- a/loader/loader_linux.c
+++ b/loader/loader_linux.c
@@ -206,15 +206,15 @@ int32_t compare_device_groups(const void *a, const void *b) {
 // Search for the default device using the loader environment variable.
 static void linux_env_var_default_device(struct loader_instance *inst, uint32_t device_count,
                                          struct LinuxSortedDeviceInfo *sorted_device_info) {
-    char *selection = loader_getenv("VK_LOADER_DEVICE_SELECT", inst);
-    if (NULL != selection) {
+    if (inst->settings->device_settings.device_select_enabled) {
         loader_log(inst, VULKAN_LOADER_DEBUG_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
-                   "linux_env_var_default_device:  Found \'VK_LOADER_DEVICE_SELECT\' set to %s", selection);
+                   "linux_env_var_default_device:  Found \'VK_LOADER_DEVICE_SELECT\' set to %s",
+                   inst->settings->device_settings.device_select_string);
 
         // The environment variable exists, so grab the vendor ID and device ID of the
         // selected default device
         unsigned vendor_id, device_id;
-        int32_t matched = sscanf(selection, "%x:%x", &vendor_id, &device_id);
+        int32_t matched = sscanf(inst->settings->device_settings.device_select_string, "%x:%x", &vendor_id, &device_id);
         if (matched == 2) {
             for (int32_t i = 0; i < (int32_t)device_count; ++i) {
                 if (sorted_device_info[i].vendor_id == vendor_id && sorted_device_info[i].device_id == device_id) {
@@ -226,8 +226,6 @@ static void linux_env_var_default_device(struct loader_instance *inst, uint32_t 
                 }
             }
         }
-
-        loader_free_getenv(selection, inst);
     }
 }
 
@@ -437,7 +435,7 @@ VkResult linux_sort_physical_device_groups(struct loader_instance *inst, uint32_
     // Sort device groups by PCI info
     qsort(sorted_group_term, group_count, sizeof(struct loader_physical_device_group_term), compare_device_groups);
 
-    if (loader_get_debug_level() & (VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT)) {
+    if (inst->settings->log_settings.enabled_log_flags & (VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT)) {
         loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "linux_sort_physical_device_groups:  Sorted order:");
         for (uint32_t group = 0; group < group_count; ++group) {
             loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "           Group %u", group);

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -184,10 +184,10 @@ bool windows_get_device_registry_entry(const struct loader_instance *inst, char 
 
     if (ret != ERROR_SUCCESS) {
         if (ret == ERROR_FILE_NOT_FOUND) {
-            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+            loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0,
                        "windows_get_device_registry_entry: Device ID(%d) Does not contain a value for \"%s\"", dev_id, value_name);
         } else {
-            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+            loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0,
                        "windows_get_device_registry_entry: DeviceID(%d) Failed to obtain %s size", dev_id, value_name);
         }
         goto out;
@@ -701,7 +701,7 @@ VkResult windows_read_data_files_in_registry(const struct loader_instance *inst,
                                              struct loader_data_files *out_files) {
     VkResult vk_result = VK_SUCCESS;
     char *search_path = NULL;
-    const char **search_path_array = NULL;
+    char **search_path_array = NULL;
     uint32_t search_path_count = 0;
     uint32_t log_target_flag = 0;
 

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -418,7 +418,7 @@ VkResult windows_get_registry_files(const struct loader_instance *inst, char *lo
     }
 
     while (*loc) {
-        next = loader_get_next_path(loc);
+        next = loader_get_next_list_item(loc, PATH_SEPARATOR);
         access_flags = KEY_QUERY_VALUE;
         rtn_value = RegOpenKeyEx(hive, loc, 0, access_flags, &key);
         if (ERROR_SUCCESS == rtn_value) {

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -776,7 +776,7 @@ VkResult windows_read_data_files_in_registry(const struct loader_instance *inst,
     }
 
     // Now, parse the paths and add any manifest files found in them.
-    vk_result = generateCompleteSearchPath(inst, data_file_type, search_path, NULL, NULL, &search_path_count, &search_path_array);
+    vk_result = generateCompleteSearchList(inst, data_file_type, search_path, NULL, NULL, &search_path_count, &search_path_array);
     if (VK_SUCCESS != vk_result) {
         goto out;
     }
@@ -784,7 +784,7 @@ VkResult windows_read_data_files_in_registry(const struct loader_instance *inst,
 
 out:
     if (search_path_array != NULL) {
-        freeSearchPath(inst, search_path_array);
+        freeList(inst, &search_path_count, &search_path_array);
     }
 
     loader_instance_heap_free(inst, search_path);

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -69,7 +69,7 @@ void windows_initialization(void) {
 
     // Get a module handle to a static function inside of this source
     if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                          (LPCSTR)&loader_debug_init, &module_handle) != 0 &&
+                          (LPCSTR)&loader_log, &module_handle) != 0 &&
         GetModuleFileName(module_handle, dll_location, sizeof(dll_location)) != 0) {
         loader_log(NULL, VULKAN_LOADER_INFO_BIT, 0, "Using Vulkan Loader %s", dll_location);
     }
@@ -701,6 +701,8 @@ VkResult windows_read_data_files_in_registry(const struct loader_instance *inst,
                                              struct loader_data_files *out_files) {
     VkResult vk_result = VK_SUCCESS;
     char *search_path = NULL;
+    const char **search_path_array = NULL;
+    uint32_t search_path_count = 0;
     uint32_t log_target_flag = 0;
 
     if (data_file_type == LOADER_DATA_FILE_MANIFEST_DRIVER) {
@@ -774,9 +776,16 @@ VkResult windows_read_data_files_in_registry(const struct loader_instance *inst,
     }
 
     // Now, parse the paths and add any manifest files found in them.
-    vk_result = add_data_files(inst, search_path, out_files, false);
+    vk_result = generateCompleteSearchPath(inst, data_file_type, search_path, NULL, NULL, &search_path_count, &search_path_array);
+    if (VK_SUCCESS != vk_result) {
+        goto out;
+    }
+    vk_result = add_data_files(inst, search_path_count, search_path_array, out_files, false);
 
 out:
+    if (search_path_array != NULL) {
+        freeSearchPath(inst, search_path_array);
+    }
 
     loader_instance_heap_free(inst, search_path);
 

--- a/loader/log.c
+++ b/loader/log.c
@@ -71,10 +71,12 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
             severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
         } else if ((msg_type & VULKAN_LOADER_DEBUG_BIT) != 0) {
             severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
-        } else if ((msg_type & VULKAN_LOADER_LAYER_BIT) != 0 || (msg_type & VULKAN_LOADER_DRIVER_BIT) != 0 ||
-                   (msg_type & VULKAN_LOADER_SETTING_BIT) != 0) {
-            // Just driver, layer, or setting bit should be treated as an info message in debug utils.
+        } else if ((msg_type & VULKAN_LOADER_LAYER_BIT) != 0 || (msg_type & VULKAN_LOADER_DRIVER_BIT) != 0) {
+            // Just driver or layer bit should be treated as an info message in debug utils.
             severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+        } else if ((msg_type & VULKAN_LOADER_SETTING_BIT) != 0) {
+            // Just setting bit should be treated as a verbose message in debug utils.
+            severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
         }
 
         if ((msg_type & VULKAN_LOADER_PERF_BIT) != 0) {
@@ -208,6 +210,7 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
             // NOTE: We allow the same message to go to all 3 if the user desires.
             if (settings->log_settings.log_to_file && settings->log_settings.log_file != NULL) {
                 fprintf(settings->log_settings.log_file, "%s\n", cmd_line_msg);
+                fflush(settings->log_settings.log_file);
             }
             if ((is_error && settings->log_settings.log_errors_to_stderr) ||
                 (!is_error && settings->log_settings.log_nonerrors_to_stderr)) {

--- a/loader/log.h
+++ b/loader/log.h
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2014-2021 The Khronos Group Inc.
- * Copyright (c) 2014-2021 Valve Corporation
- * Copyright (c) 2014-2021 LunarG, Inc.
+ * Copyright (c) 2014-2023 The Khronos Group Inc.
+ * Copyright (c) 2014-2023 Valve Corporation
+ * Copyright (c) 2014-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,13 +38,6 @@ enum vulkan_loader_debug_flags {
     VULKAN_LOADER_DRIVER_BIT = 0x40,
     VULKAN_LOADER_VALIDATION_BIT = 0x80,
 };
-
-// Checks for the environment variable VK_LOADER_DEBUG and sets up the current debug level accordingly
-// This should be called before any Vulkan API calls, eg in the initialization of the .dll or .so
-void loader_debug_init(void);
-
-// Returns a bitmask that indicates the current flags that should be output
-uint32_t loader_get_debug_level(void);
 
 // Logs a message to stderr
 // May output to DebugUtils if the instance isn't null and the extension is enabled.

--- a/loader/log.h
+++ b/loader/log.h
@@ -36,7 +36,8 @@ enum vulkan_loader_debug_flags {
     VULKAN_LOADER_DEBUG_BIT = 0x10,
     VULKAN_LOADER_LAYER_BIT = 0x20,
     VULKAN_LOADER_DRIVER_BIT = 0x40,
-    VULKAN_LOADER_VALIDATION_BIT = 0x80,
+    VULKAN_LOADER_SETTING_BIT = 0x80,
+    VULKAN_LOADER_VALIDATION_BIT = 0x100,
 };
 
 // Logs a message to stderr

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -503,6 +503,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         }
     }
 
+    // Initialize the loader settings struct
+    if (VK_SUCCESS != generateSettingsStruct(ptr_instance, &ptr_instance->settings)) {
+        goto out;
+    }
+
     // Due to implicit layers need to get layer list even if
     // enabledLayerCount == 0 and VK_INSTANCE_LAYERS is unset. For now always
     // get layer list via loader_scan_for_layers().
@@ -708,6 +713,8 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
         }
         loader_instance_heap_free(ptr_instance, ptr_instance->phys_devs_tramp);
     }
+
+    freeSettingsStruct(ptr_instance, &ptr_instance->settings);
 
     // Destroy the debug callbacks created during instance creation
     destroy_debug_callbacks_chain(ptr_instance, pAllocator);

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -21,6 +21,7 @@
  * Author: Jon Ashburn <jon@lunarg.com>
  * Author: Tony Barbour <tony@LunarG.com>
  * Author: Chia-I Wu <olv@lunarg.com>
+ * Author: Mark Young <marky@LunarG.com>
  * Author: Charles Giessen <charles@lunarg.com>
  */
 
@@ -32,6 +33,7 @@
 #include "gpa_helper.h"
 #include "loader.h"
 #include "log.h"
+#include "loader_environment.h"
 #include "vk_loader_extensions.h"
 #include "vk_loader_platform.h"
 #include "wsi.h"
@@ -145,7 +147,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
     LOADER_PLATFORM_THREAD_ONCE(&once_init, loader_initialize);
 
     // We know we need to call at least the terminator
-    VkResult res = VK_SUCCESS;
     VkEnumerateInstanceExtensionPropertiesChain chain_tail = {
         .header =
             {
@@ -159,14 +160,21 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
     VkEnumerateInstanceExtensionPropertiesChain *chain_head = &chain_tail;
 
     // Get the implicit layers
+    VkResult res = VK_SUCCESS;
     struct loader_layer_list layers;
     loader_platform_dl_handle *libs = NULL;
     size_t lib_count = 0;
     memset(&layers, 0, sizeof(layers));
 
-    res = loader_scan_for_implicit_layers(NULL, &layers, &libs);
+    struct loader_settings *temporary_settings = NULL;
+    res = generateSettingsStruct(NULL, &temporary_settings);
     if (VK_SUCCESS != res) {
-        return res;
+        goto out;
+    }
+
+    res = loader_scan_for_implicit_layers(NULL, temporary_settings, &layers, &libs);
+    if (VK_SUCCESS != res) {
+        goto out;
     }
 
     // Prepend layers onto the chain if they implement this entry point
@@ -214,6 +222,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
         res = chain_head->pfnNextLayer(chain_head->pNextLink, pLayerName, pPropertyCount, pProperties);
     }
 
+out:
     // Free up the layers
     loader_delete_layer_list_and_properties(NULL, &layers);
 
@@ -229,7 +238,9 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
         loader_platform_close_library(libs[i]);
     }
     loader_free(NULL, libs);
-
+    if (temporary_settings != NULL) {
+        freeSettingsStruct(NULL, &temporary_settings);
+    }
     return res;
 }
 
@@ -238,7 +249,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
     LOADER_PLATFORM_THREAD_ONCE(&once_init, loader_initialize);
 
     // We know we need to call at least the terminator
-    VkResult res = VK_SUCCESS;
     VkEnumerateInstanceLayerPropertiesChain chain_tail = {
         .header =
             {
@@ -252,14 +262,21 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
     VkEnumerateInstanceLayerPropertiesChain *chain_head = &chain_tail;
 
     // Get the implicit layers
+    VkResult res = VK_SUCCESS;
     struct loader_layer_list layers;
     loader_platform_dl_handle *libs = NULL;
     size_t lib_count = 0;
     memset(&layers, 0, sizeof(layers));
 
-    res = loader_scan_for_implicit_layers(NULL, &layers, &libs);
+    struct loader_settings *temporary_settings = NULL;
+    res = generateSettingsStruct(NULL, &temporary_settings);
     if (VK_SUCCESS != res) {
-        return res;
+        goto out;
+    }
+
+    res = loader_scan_for_implicit_layers(NULL, temporary_settings, &layers, &libs);
+    if (VK_SUCCESS != res) {
+        goto out;
     }
 
     // Prepend layers onto the chain if they implement this entry point
@@ -302,6 +319,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
         res = chain_head->pfnNextLayer(chain_head->pNextLink, pPropertyCount, pProperties);
     }
 
+out:
     // Free up the layers
     loader_delete_layer_list_and_properties(NULL, &layers);
 
@@ -317,7 +335,9 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
         loader_platform_close_library(libs[i]);
     }
     loader_free(NULL, libs);
-
+    if (temporary_settings != NULL) {
+        freeSettingsStruct(NULL, &temporary_settings);
+    }
     return res;
 }
 
@@ -333,7 +353,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
     }
 
     // We know we need to call at least the terminator
-    VkResult res = VK_SUCCESS;
     VkEnumerateInstanceVersionChain chain_tail = {
         .header =
             {
@@ -347,14 +366,21 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
     VkEnumerateInstanceVersionChain *chain_head = &chain_tail;
 
     // Get the implicit layers
+    VkResult res = VK_SUCCESS;
     struct loader_layer_list layers;
     loader_platform_dl_handle *libs = NULL;
     size_t lib_count = 0;
     memset(&layers, 0, sizeof(layers));
 
-    res = loader_scan_for_implicit_layers(NULL, &layers, &libs);
+    struct loader_settings *temporary_settings = NULL;
+    res = generateSettingsStruct(NULL, &temporary_settings);
     if (VK_SUCCESS != res) {
-        return res;
+        goto out;
+    }
+
+    res = loader_scan_for_implicit_layers(NULL, temporary_settings, &layers, &libs);
+    if (VK_SUCCESS != res) {
+        goto out;
     }
 
     // Prepend layers onto the chain if they implement this entry point
@@ -400,6 +426,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
         res = chain_head->pfnNextLayer(chain_head->pNextLink, pApiVersion);
     }
 
+out:
     // Free up the layers
     loader_delete_layer_list_and_properties(NULL, &layers);
 
@@ -415,7 +442,9 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
         loader_platform_close_library(libs[i]);
     }
     loader_free(NULL, libs);
-
+    if (temporary_settings != NULL) {
+        freeSettingsStruct(NULL, &temporary_settings);
+    }
     return res;
 }
 
@@ -480,6 +509,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         goto out;
     }
 
+    // Initialize the loader settings struct
+    res = generateSettingsStruct(ptr_instance, &ptr_instance->settings);
+    if (VK_SUCCESS != res) {
+        goto out;
+    }
+
     // Check the VkInstanceCreateInfoFlags wether to allow the portability enumeration flag
     if ((pCreateInfo->flags & VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR) == 1) {
         // Make sure the extension has been enabled
@@ -503,16 +538,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         }
     }
 
-    // Initialize the loader settings struct
-    if (VK_SUCCESS != generateSettingsStruct(ptr_instance, &ptr_instance->settings)) {
-        goto out;
-    }
-
     // Due to implicit layers need to get layer list even if
     // enabledLayerCount == 0 and VK_INSTANCE_LAYERS is unset. For now always
     // get layer list via loader_scan_for_layers().
     memset(&ptr_instance->instance_layer_list, 0, sizeof(ptr_instance->instance_layer_list));
-    res = loader_scan_for_layers(ptr_instance, &ptr_instance->instance_layer_list);
+    res = loader_scan_for_layers(ptr_instance, ptr_instance->settings, &ptr_instance->instance_layer_list);
     if (VK_SUCCESS != res) {
         goto out;
     }
@@ -528,7 +558,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
 
     // Scan/discover all System and Environment Variable ICD libraries
     bool skipped_portability_drivers = false;
-    res = loader_icd_scan(ptr_instance, &ptr_instance->icd_tramp_list, pCreateInfo, &skipped_portability_drivers);
+    res = loader_icd_scan(ptr_instance, ptr_instance->settings, &ptr_instance->icd_tramp_list, pCreateInfo,
+                          &skipped_portability_drivers);
     if (res == VK_ERROR_OUT_OF_HOST_MEMORY) {
         goto out;
     }
@@ -549,7 +580,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
     }
 
     // Get extensions from all ICD's, merge so no duplicates, then validate
-    res = loader_get_icd_loader_instance_extensions(ptr_instance, &ptr_instance->icd_tramp_list, &ptr_instance->ext_list);
+    res = loader_get_icd_loader_instance_extensions(ptr_instance, ptr_instance->settings, &ptr_instance->icd_tramp_list,
+                                                    &ptr_instance->ext_list);
     if (res != VK_SUCCESS) {
         goto out;
     }
@@ -656,6 +688,9 @@ out:
                 memset(&ptr_instance->enabled_layer_names, 0, sizeof(ptr_instance->enabled_layer_names));
             }
 
+            // Free the instance settings
+            freeSettingsStruct(ptr_instance, &ptr_instance->settings);
+
             loader_instance_heap_free(ptr_instance, ptr_instance);
         } else {
             // success path, swap out created debug callbacks out so they aren't used until instance destruction
@@ -714,10 +749,11 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
         loader_instance_heap_free(ptr_instance, ptr_instance->phys_devs_tramp);
     }
 
-    freeSettingsStruct(ptr_instance, &ptr_instance->settings);
-
     // Destroy the debug callbacks created during instance creation
     destroy_debug_callbacks_chain(ptr_instance, pAllocator);
+
+    // Free the instance settings
+    freeSettingsStruct(ptr_instance, &ptr_instance->settings);
 
     loader_instance_heap_free(ptr_instance, ptr_instance->disp);
     loader_instance_heap_free(ptr_instance, ptr_instance);

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -98,6 +98,7 @@
 #define VK_LAYERS_DISABLE_ENV_VAR "VK_LOADER_LAYERS_DISABLE"
 #define VK_DRIVERS_SELECT_ENV_VAR "VK_LOADER_DRIVERS_SELECT"
 #define VK_DRIVERS_DISABLE_ENV_VAR "VK_LOADER_DRIVERS_DISABLE"
+
 #define VK_LOADER_DISABLE_ALL_LAYERS_VAR_1 "~all~"
 #define VK_LOADER_DISABLE_ALL_LAYERS_VAR_2 "*"
 #define VK_LOADER_DISABLE_ALL_LAYERS_VAR_3 "**"
@@ -107,7 +108,6 @@
 // Override layer information
 #define VK_OVERRIDE_LAYER_NAME "VK_LAYER_LUNARG_override"
 
-#define LAYERS_PATH_ENV "VK_LAYER_PATH"
 #define ENABLED_LAYERS_ENV "VK_INSTANCE_LAYERS"
 
 #if defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNXNTO__) || defined(__FreeBSD__) || \

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -3563,8 +3563,6 @@ TEST(TestLayers, InstEnvironEnableExplicitLayer) {
     ASSERT_DEATH(inst4.functions->vkCreateInstance(inst4.create_info.get(), inst4.callbacks, &inst4.inst), "");
     ASSERT_TRUE(env.debug_log.find("Failed to find forced on layer 'VK_LAYER_LUNARG_bad_layer'"));
     exit_on_missing_layer.remove_value();
-
- 
 }
 
 // Verify that VK_LOADER_LAYERS_ENABLE work.  To test this, make sure that an explicit layer does not affect an instance until

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -1760,10 +1760,10 @@ TEST(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate(VK_ERROR_LAYER_NOT_PRESENT);
     ASSERT_FALSE(env.debug_log.find(std::string("Insert instance layer \"") + env_var_layer_name));
+    ASSERT_TRUE(env.debug_log.find(std::string("Found environment var `VK_LAYER_PATH`, using value: `") +
+                                   env.env_var_vk_layer_paths.value()));
     ASSERT_TRUE(env.debug_log.find(
-        std::string("Ignoring VK_LAYER_PATH. The Override layer is active and has override paths set, which takes priority. "
-                    "VK_LAYER_PATH is set to ") +
-        env.env_var_vk_layer_paths.value()));
+        std::string("Ignoring any environment variable paths like `VK_LAYER_PATH` or `VK_ADD_LAYER_PATH`")));
 
     env.layers.clear();
 }


### PR DESCRIPTION
Kept the changes separate for now, but this moves all settings environment variables into a settings struct that is used everywhere.

Unfortunately, we also have to generate and keep a pre-instance version around for when there is no instance data.  I still generate a struct per-pre-Instance call also, though, because the settings may have changed.  The main need for the pre-instance global struct is for the log messages.  Since I can't update that to take a default settings struct for every log message, I needed the global one.  If you (@charles-lunarg ) have a better idea about that, I'm all ears.

