### PR TITLE
cmake: Use CMAKE_MSVC_RUNTIME_LIBRARY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,9 @@ endif()
 # way while waiting for when updating can occur
 string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
+# Use static MSVCRT libraries
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 if(WIN32)
     option(ENABLE_WIN10_ONECORE "Link the loader with OneCore umbrella libraries" OFF)
 endif()

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -22,28 +22,6 @@ target_link_libraries(loader_specific_options INTERFACE loader_common_options Vu
 target_include_directories(loader_specific_options INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/generated ${CMAKE_CURRENT_BINARY_DIR})
 
 if(WIN32)
-    if(MSVC)
-        # Use static MSVCRT libraries
-        foreach(configuration
-                in
-                CMAKE_C_FLAGS_DEBUG
-                CMAKE_C_FLAGS_MINSIZEREL
-                CMAKE_C_FLAGS_RELEASE
-                CMAKE_C_FLAGS_RELWITHDEBINFO
-                CMAKE_CXX_FLAGS_DEBUG
-                CMAKE_CXX_FLAGS_MINSIZEREL
-                CMAKE_CXX_FLAGS_RELEASE
-                CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            if(${configuration} MATCHES "/MD")
-                string(REGEX
-                    REPLACE "/MD"
-                            "/MT"
-                            ${configuration}
-                            "${${configuration}}")
-            endif()
-        endforeach()
-    endif()
-
     if(ENABLE_WIN10_ONECORE)
         # Note: When linking your app or driver to OneCore.lib, be sure to remove any links to non-umbrella libs (such as
         # kernel32.lib).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,7 +77,7 @@ endif()
 
 # must happen after the dll's get copied over
 if(NOT CMAKE_CROSSCOMPILING)
-    gtest_discover_tests(test_regression PROPERTIES DISCOVERY_TIMEOUT 100)
+    gtest_discover_tests(test_regression PROPERTIES DISCOVERY_TIMEOUT 1000)
 else()
     gtest_add_tests(TARGET test_regression)
 endif()


### PR DESCRIPTION
CMAKE_MSVC_RUNTIME_LIBRARY was added in 3.15