### PR TITLE
Call DestroyInstance on each driver in error path

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -647,6 +647,7 @@ void loader_destroy_generic_list(const struct loader_instance *inst, struct load
     loader_instance_heap_free(inst, list->list);
     list->count = 0;
     list->capacity = 0;
+    list->list = NULL;
 }
 
 // Append non-duplicate extension properties defined in props to the given ext_list.

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -632,8 +632,23 @@ out:
             struct loader_icd_term *icd_term = NULL;
             while (NULL != ptr_instance->icd_terms) {
                 icd_term = ptr_instance->icd_terms;
+                // Call destroy Instance on each driver in case we successfully called down the chain but failed on
+                // our way back out of it.
+                if (icd_term->instance) {
+                    icd_term->dispatch.DestroyInstance(icd_term->instance, pAllocator);
+                }
+                icd_term->instance = VK_NULL_HANDLE;
                 ptr_instance->icd_terms = icd_term->next;
                 loader_icd_destroy(ptr_instance, icd_term, pAllocator);
+            }
+
+            for (uint32_t i = 0, n = ptr_instance->enabled_layer_count; i < n; ++i) {
+                loader_instance_heap_free(ptr_instance, ptr_instance->enabled_layer_names[i]);
+            }
+
+            if (ptr_instance->enabled_layer_count > 0) {
+                loader_instance_heap_free(ptr_instance, ptr_instance->enabled_layer_names);
+                memset(&ptr_instance->enabled_layer_names, 0, sizeof(ptr_instance->enabled_layer_names));
             }
 
             loader_instance_heap_free(ptr_instance, ptr_instance);


### PR DESCRIPTION
If CreateInstance successfully calls terminator_CreateInstance but subsequently fails on the way back up the chain, the loader should call DestroyInstance on each driver to give them a chance to clean up. This path is possible during CTS OOM tests which cause VVL to fail which then causes leaks to occur.

Additionally, the layer name allocations needed to be cleaned up in this error path as well, since there is no chance for vkDestroyInstance to run.