### PR TITLE
Cleanup leaked VkSurfaceKHR's

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5796,6 +5796,13 @@ VKAPI_ATTR void VKAPI_CALL terminator_DestroyInstance(VkInstance instance, const
     if (NULL == ptr_instance) {
         return;
     }
+
+    // Remove any surfaces that the application leaked.
+    // The terminator updates the chain, so we just need to call it until nothing is left.
+    while (ptr_instance->icd_surface_chain_head) {
+        terminator_DestroySurfaceKHR(instance, (VkSurfaceKHR)(uintptr_t)ptr_instance->icd_surface_chain_head, pAllocator);
+    }
+
     struct loader_icd_term *icd_terms = ptr_instance->icd_terms;
     struct loader_icd_term *next_icd_term;
 

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -230,6 +230,9 @@ struct loader_instance_dispatch_table {
 // Unique magic number identifier for the loader.
 #define LOADER_MAGIC_NUMBER 0x10ADED010110ADEDUL
 
+// Forward declare VkIcdSurface which comes from wsi.h
+typedef struct VkIcdSurface VkIcdSurface;
+
 // Per instance structure
 struct loader_instance {
     struct loader_instance_dispatch_table *disp;  // must be first entry in structure
@@ -294,6 +297,8 @@ struct loader_instance {
     VkLayerDbgFunctionNode *InstanceCreationDeletionDebugFunctionHead;
 
     VkAllocationCallbacks alloc_callbacks;
+
+    VkIcdSurface *icd_surface_chain_head;
 
     bool portability_enumeration_enabled;
 

--- a/loader/wsi.h
+++ b/loader/wsi.h
@@ -24,7 +24,7 @@
 
 #include "loader_common.h"
 
-typedef struct {
+typedef struct VkIcdSurface {
     union {
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
         VkIcdSurfaceWayland wayland_surf;
@@ -67,6 +67,7 @@ typedef struct {
     uint32_t non_platform_offset;  // Start offset to base_size
     uint32_t entire_size;          // Size of entire VkIcdSurface
     VkSurfaceKHR *real_icd_surfaces;
+    struct VkIcdSurface *next_surface;
 } VkIcdSurface;
 
 bool wsi_swapchain_instance_gpa(struct loader_instance *ptr_instance, const char *name, void **addr);


### PR DESCRIPTION
If the application does not call vkDestroySurfaceKHR on all created surfaces, this causes memory leaks inside the driver. While it is invalid behavior to not destroy all child objects before destroying the parent, the Validation Layer tests need to do this to exercise the various VUID's regarding object leaks. Because the loader is responsible for allocating the surface memory, it should strive to clean it up afterwards in case the application did not.