### PR TITLE
Set github actions to only have read only permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 # Author: Lenny Komow <lenny@lunarg.com>
+# Author: Charles Giessen <charles@lunarg.com>
 
 name: CI Build
 
@@ -22,6 +23,8 @@ on:
     pull_request:
         branches:
             - main
+
+permissions: read-all
 
 jobs:
     linux:


### PR DESCRIPTION
Because the loader only uses github actions to perform CI runs, it is good to set the 'read-all' only, helping harden the github actions runners from potentially compromised access.

For more context
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions

Fixes #1148