### PR TITLE
Remove unnecessary static in source

### DIFF
--- a/loader/debug_utils.c
+++ b/loader/debug_utils.c
@@ -66,9 +66,10 @@ VkResult util_CreateDebugUtilsMessenger(struct loader_instance *inst, const VkDe
     return VK_SUCCESS;
 }
 
-static VKAPI_ATTR VkResult VKAPI_CALL
-debug_utils_CreateDebugUtilsMessengerEXT(VkInstance instance, const VkDebugUtilsMessengerCreateInfoEXT *pCreateInfo,
-                                         const VkAllocationCallbacks *pAllocator, VkDebugUtilsMessengerEXT *pMessenger) {
+VKAPI_ATTR VkResult VKAPI_CALL debug_utils_CreateDebugUtilsMessengerEXT(VkInstance instance,
+                                                                        const VkDebugUtilsMessengerCreateInfoEXT *pCreateInfo,
+                                                                        const VkAllocationCallbacks *pAllocator,
+                                                                        VkDebugUtilsMessengerEXT *pMessenger) {
     struct loader_instance *inst = loader_get_instance(instance);
     loader_platform_thread_lock_mutex(&loader_lock);
     VkResult result = inst->disp->layer_inst_disp.CreateDebugUtilsMessengerEXT(inst->instance, pCreateInfo, pAllocator, pMessenger);
@@ -149,16 +150,17 @@ VkResult util_CreateDebugUtilsMessengers(struct loader_instance *inst, const voi
     return VK_SUCCESS;
 }
 
-static VKAPI_ATTR void VKAPI_CALL debug_utils_SubmitDebugUtilsMessageEXT(
-    VkInstance instance, VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes,
-    const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData) {
+VKAPI_ATTR void VKAPI_CALL debug_utils_SubmitDebugUtilsMessageEXT(VkInstance instance,
+                                                                  VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+                                                                  VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+                                                                  const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData) {
     struct loader_instance *inst = loader_get_instance(instance);
 
     inst->disp->layer_inst_disp.SubmitDebugUtilsMessageEXT(inst->instance, messageSeverity, messageTypes, pCallbackData);
 }
 
-static VKAPI_ATTR void VKAPI_CALL debug_utils_DestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT messenger,
-                                                                            const VkAllocationCallbacks *pAllocator) {
+VKAPI_ATTR void VKAPI_CALL debug_utils_DestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT messenger,
+                                                                     const VkAllocationCallbacks *pAllocator) {
     struct loader_instance *inst = loader_get_instance(instance);
     loader_platform_thread_lock_mutex(&loader_lock);
 
@@ -308,9 +310,10 @@ VkResult util_CreateDebugReportCallback(struct loader_instance *inst, const VkDe
     return VK_SUCCESS;
 }
 
-static VKAPI_ATTR VkResult VKAPI_CALL
-debug_utils_CreateDebugReportCallbackEXT(VkInstance instance, const VkDebugReportCallbackCreateInfoEXT *pCreateInfo,
-                                         const VkAllocationCallbacks *pAllocator, VkDebugReportCallbackEXT *pCallback) {
+VKAPI_ATTR VkResult VKAPI_CALL debug_utils_CreateDebugReportCallbackEXT(VkInstance instance,
+                                                                        const VkDebugReportCallbackCreateInfoEXT *pCreateInfo,
+                                                                        const VkAllocationCallbacks *pAllocator,
+                                                                        VkDebugReportCallbackEXT *pCallback) {
     struct loader_instance *inst = loader_get_instance(instance);
     loader_platform_thread_lock_mutex(&loader_lock);
     VkResult result = inst->disp->layer_inst_disp.CreateDebugReportCallbackEXT(inst->instance, pCreateInfo, pAllocator, pCallback);
@@ -399,8 +402,8 @@ VkResult util_CreateDebugReportCallbacks(struct loader_instance *inst, const voi
     return VK_SUCCESS;
 }
 
-static VKAPI_ATTR void VKAPI_CALL debug_utils_DestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCallbackEXT callback,
-                                                                            const VkAllocationCallbacks *pAllocator) {
+VKAPI_ATTR void VKAPI_CALL debug_utils_DestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCallbackEXT callback,
+                                                                     const VkAllocationCallbacks *pAllocator) {
     struct loader_instance *inst = loader_get_instance(instance);
     loader_platform_thread_lock_mutex(&loader_lock);
 
@@ -409,10 +412,9 @@ static VKAPI_ATTR void VKAPI_CALL debug_utils_DestroyDebugReportCallbackEXT(VkIn
     loader_platform_thread_unlock_mutex(&loader_lock);
 }
 
-static VKAPI_ATTR void VKAPI_CALL debug_utils_DebugReportMessageEXT(VkInstance instance, VkDebugReportFlagsEXT flags,
-                                                                    VkDebugReportObjectTypeEXT objType, uint64_t object,
-                                                                    size_t location, int32_t msgCode, const char *pLayerPrefix,
-                                                                    const char *pMsg) {
+VKAPI_ATTR void VKAPI_CALL debug_utils_DebugReportMessageEXT(VkInstance instance, VkDebugReportFlagsEXT flags,
+                                                             VkDebugReportObjectTypeEXT objType, uint64_t object, size_t location,
+                                                             int32_t msgCode, const char *pLayerPrefix, const char *pMsg) {
     struct loader_instance *inst = loader_get_instance(instance);
 
     inst->disp->layer_inst_disp.DebugReportMessageEXT(inst->instance, flags, objType, object, location, msgCode, pLayerPrefix,
@@ -548,7 +550,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_DebugReportMessageEXT(VkInstance instance,
 
 // General utilities
 
-static const VkExtensionProperties debug_utils_extension_info[] = {
+const VkExtensionProperties debug_utils_extension_info[] = {
     {VK_EXT_DEBUG_REPORT_EXTENSION_NAME, VK_EXT_DEBUG_REPORT_SPEC_VERSION},
     {VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_SPEC_VERSION},
 };

--- a/loader/loader_linux.c
+++ b/loader/loader_linux.c
@@ -35,7 +35,7 @@
 #include "log.h"
 
 // Determine a priority based on device type with the higher value being higher priority.
-static uint32_t determine_priority_type_value(VkPhysicalDeviceType type) {
+uint32_t determine_priority_type_value(VkPhysicalDeviceType type) {
     switch (type) {
         case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
             return 10;
@@ -55,7 +55,7 @@ static uint32_t determine_priority_type_value(VkPhysicalDeviceType type) {
 
 // Compare the two device types.
 // This behaves similar to a qsort compare.
-static int32_t device_type_compare(VkPhysicalDeviceType a, VkPhysicalDeviceType b) {
+int32_t device_type_compare(VkPhysicalDeviceType a, VkPhysicalDeviceType b) {
     uint32_t a_value = determine_priority_type_value(a);
     uint32_t b_value = determine_priority_type_value(b);
     if (a_value > b_value) {
@@ -204,8 +204,8 @@ int32_t compare_device_groups(const void *a, const void *b) {
 }
 
 // Search for the default device using the loader environment variable.
-static void linux_env_var_default_device(struct loader_instance *inst, uint32_t device_count,
-                                         struct LinuxSortedDeviceInfo *sorted_device_info) {
+void linux_env_var_default_device(struct loader_instance *inst, uint32_t device_count,
+                                  struct LinuxSortedDeviceInfo *sorted_device_info) {
     char *selection = loader_getenv("VK_LOADER_DEVICE_SELECT", inst);
     if (NULL != selection) {
         loader_log(inst, VULKAN_LOADER_DEBUG_BIT | VULKAN_LOADER_DRIVER_BIT, 0,

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -61,7 +61,7 @@
 #endif
 
 typedef HRESULT(APIENTRY *PFN_CreateDXGIFactory1)(REFIID riid, void **ppFactory);
-static PFN_CreateDXGIFactory1 fpCreateDXGIFactory1;
+PFN_CreateDXGIFactory1 fpCreateDXGIFactory1;
 
 void windows_initialization(void) {
     char dll_location[MAX_PATH];
@@ -227,8 +227,8 @@ out:
 
 VkResult windows_get_device_registry_files(const struct loader_instance *inst, uint32_t log_target_flag, char **reg_data,
                                            PDWORD reg_data_size, LPCSTR value_name) {
-    static const wchar_t *softwareComponentGUID = L"{5c4c3332-344d-483c-8739-259e934c9cc8}";
-    static const wchar_t *displayGUID = L"{4d36e968-e325-11ce-bfc1-08002be10318}";
+    const wchar_t *softwareComponentGUID = L"{5c4c3332-344d-483c-8739-259e934c9cc8}";
+    const wchar_t *displayGUID = L"{4d36e968-e325-11ce-bfc1-08002be10318}";
 #ifdef CM_GETIDLIST_FILTER_PRESENT
     const ULONG flags = CM_GETIDLIST_FILTER_CLASS | CM_GETIDLIST_FILTER_PRESENT;
 #else
@@ -348,7 +348,7 @@ VkResult windows_get_registry_files(const struct loader_instance *inst, char *lo
                                     PDWORD reg_data_size) {
     // This list contains all of the allowed ICDs. This allows us to verify that a device is actually present from the vendor
     // specified. This does disallow other vendors, but any new driver should use the device-specific registries anyway.
-    static const struct {
+    const struct {
         const char *filename;
         unsigned int vendor_id;
     } known_drivers[] = {

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -550,7 +550,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkQueuePresentKHR(VkQueue queue, co
     return disp->QueuePresentKHR(queue, pPresentInfo);
 }
 
-static VkIcdSurface *AllocateIcdSurfaceStruct(struct loader_instance *instance, size_t base_size, size_t platform_size) {
+VkIcdSurface *AllocateIcdSurfaceStruct(struct loader_instance *instance, size_t base_size, size_t platform_size) {
     // Next, if so, proceed with the implementation of this function:
     VkIcdSurface *pIcdSurface = loader_instance_heap_alloc(instance, sizeof(VkIcdSurface), VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
     if (pIcdSurface != NULL) {

--- a/tests/framework/layer/wrap_objects.cpp
+++ b/tests/framework/layer/wrap_objects.cpp
@@ -132,7 +132,7 @@ VkLayerDeviceCreateInfo *get_chain_info(const VkDeviceCreateInfo *pCreateInfo, V
 
 namespace wrap_objects {
 
-static const VkLayerProperties global_layer = {
+const VkLayerProperties global_layer = {
     "VK_LAYER_LUNARG_wrap_objects",
     VK_HEADER_VERSION_COMPLETE,
     1,

--- a/tests/framework/shim/unix_shim.cpp
+++ b/tests/framework/shim/unix_shim.cpp
@@ -33,7 +33,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
-static PlatformShim platform_shim;
+PlatformShim platform_shim;
 extern "C" {
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 PlatformShim* get_platform_shim(std::vector<fs::FolderManager>* folders) {
@@ -104,18 +104,18 @@ using PFN_SEC_GETENV = char* (*)(const char* name);
 #define real__secure_getenv __secure_getenv
 #endif
 #else
-static PFN_OPENDIR real_opendir = nullptr;
-static PFN_READDIR real_readdir = nullptr;
-static PFN_CLOSEDIR real_closedir = nullptr;
-static PFN_ACCESS real_access = nullptr;
-static PFN_FOPEN real_fopen = nullptr;
-static PFN_GETEUID real_geteuid = nullptr;
-static PFN_GETEGID real_getegid = nullptr;
+PFN_OPENDIR real_opendir = nullptr;
+PFN_READDIR real_readdir = nullptr;
+PFN_CLOSEDIR real_closedir = nullptr;
+PFN_ACCESS real_access = nullptr;
+PFN_FOPEN real_fopen = nullptr;
+PFN_GETEUID real_geteuid = nullptr;
+PFN_GETEGID real_getegid = nullptr;
 #if defined(HAVE_SECURE_GETENV)
-static PFN_SEC_GETENV real_secure_getenv = nullptr;
+PFN_SEC_GETENV real_secure_getenv = nullptr;
 #endif
 #if defined(HAVE___SECURE_GETENV)
-static PFN_SEC_GETENV real__secure_getenv = nullptr;
+PFN_SEC_GETENV real__secure_getenv = nullptr;
 #endif
 #endif
 

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -272,7 +272,7 @@ std::wstring widen(const std::string& utf8);
 
 #if defined(WIN32)
 typedef HMODULE loader_platform_dl_handle;
-static loader_platform_dl_handle loader_platform_open_library(const char* lib_path) {
+inline loader_platform_dl_handle loader_platform_open_library(const char* lib_path) {
     std::wstring lib_path_utf16 = widen(lib_path);
     // Try loading the library the original way first.
     loader_platform_dl_handle lib_handle = LoadLibraryW(lib_path_utf16.c_str());
@@ -770,7 +770,7 @@ inline bool contains(std::vector<VkLayerProperties> const& vec, const char* name
 #if defined(__linux__)
 
 // find application path + name. Path cannot be longer than 1024, returns NULL if it is greater than that.
-static inline std::string test_platform_executable_path() {
+inline std::string test_platform_executable_path() {
     std::string buffer;
     buffer.resize(1024);
     ssize_t count = readlink("/proc/self/exe", &buffer[0], buffer.size());
@@ -782,7 +782,7 @@ static inline std::string test_platform_executable_path() {
 }
 #elif defined(__APPLE__)  // defined(__linux__)
 #include <libproc.h>
-static inline std::string test_platform_executable_path() {
+inline std::string test_platform_executable_path() {
     std::string buffer;
     buffer.resize(1024);
     pid_t pid = getpid();
@@ -794,7 +794,7 @@ static inline std::string test_platform_executable_path() {
 }
 #elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #include <sys/sysctl.h>
-static inline std::string test_platform_executable_path() {
+inline std::string test_platform_executable_path() {
     int mib[] = {
         CTL_KERN,
 #if defined(__NetBSD__)
@@ -818,7 +818,7 @@ static inline std::string test_platform_executable_path() {
     return buffer;
 }
 #elif defined(__Fuchsia__) || defined(__OpenBSD__)
-static inline std::string test_platform_executable_path() { return {}; }
+inline std::string test_platform_executable_path() { return {}; }
 #elif defined(__QNXNTO__)
 
 #define SYSCONFDIR "/etc"
@@ -826,7 +826,7 @@ static inline std::string test_platform_executable_path() { return {}; }
 #include <fcntl.h>
 #include <sys/stat.h>
 
-static inline std::string test_platform_executable_path() {
+inline std::string test_platform_executable_path() {
     std::string buffer;
     buffer.resize(1024);
     int fd = open("/proc/self/exefile", O_RDONLY);
@@ -848,7 +848,7 @@ static inline std::string test_platform_executable_path() {
 }
 #endif  // defined (__QNXNTO__)
 #if defined(WIN32)
-static inline std::string test_platform_executable_path() {
+inline std::string test_platform_executable_path() {
     std::string buffer;
     buffer.resize(1024);
     DWORD ret = GetModuleFileName(NULL, static_cast<LPSTR>(&buffer[0]), (DWORD)buffer.size());

--- a/tests/loader_debug_ext_tests.cpp
+++ b/tests/loader_debug_ext_tests.cpp
@@ -34,9 +34,9 @@
 //
 
 // Prototype declaration for callback so we can use it in class utility methods
-static VkBool32 VKAPI_CALL test_DebugReportCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType,
-                                                    uint64_t object, size_t location, int32_t messageCode, const char* pLayerPrefix,
-                                                    const char* pMessage, void* pUserData);
+VkBool32 VKAPI_CALL test_DebugReportCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType, uint64_t object,
+                                             size_t location, int32_t messageCode, const char* pLayerPrefix, const char* pMessage,
+                                             void* pUserData);
 
 class DebugReportTest : public ::testing::Test {
    public:
@@ -121,9 +121,9 @@ class DebugReportTest : public ::testing::Test {
 };
 
 // This is the actual callback prototyped above.
-static VkBool32 VKAPI_CALL test_DebugReportCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType,
-                                                    uint64_t object, size_t location, int32_t messageCode, const char* pLayerPrefix,
-                                                    const char* pMessage, void* pUserData) {
+VkBool32 VKAPI_CALL test_DebugReportCallback(VkDebugReportFlagsEXT flags, VkDebugReportObjectTypeEXT objectType, uint64_t object,
+                                             size_t location, int32_t messageCode, const char* pLayerPrefix, const char* pMessage,
+                                             void* pUserData) {
     DebugReportTest* debug_report_test = reinterpret_cast<DebugReportTest*>(pUserData);
     debug_report_test->VerifyExpected(flags, objectType, pMessage);
     return VK_FALSE;
@@ -360,9 +360,9 @@ TEST_F(ManualReport, InfoMessage) {
 //
 
 // Prototype declaration for callback so we can use it in class utility methods
-static VkBool32 VKAPI_CALL test_DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
-                                                   VkDebugUtilsMessageTypeFlagsEXT message_types,
-                                                   const VkDebugUtilsMessengerCallbackDataEXT* callback_data, void* user_data);
+VkBool32 VKAPI_CALL test_DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                            VkDebugUtilsMessageTypeFlagsEXT message_types,
+                                            const VkDebugUtilsMessengerCallbackDataEXT* callback_data, void* user_data);
 
 class DebugUtilTest : public ::testing::Test {
    public:
@@ -461,9 +461,9 @@ class DebugUtilTest : public ::testing::Test {
 
 // This is the actual callback prototyped above.
 
-static VkBool32 VKAPI_CALL test_DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
-                                                   VkDebugUtilsMessageTypeFlagsEXT message_types,
-                                                   const VkDebugUtilsMessengerCallbackDataEXT* callback_data, void* user_data) {
+VkBool32 VKAPI_CALL test_DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                            VkDebugUtilsMessageTypeFlagsEXT message_types,
+                                            const VkDebugUtilsMessengerCallbackDataEXT* callback_data, void* user_data) {
     DebugUtilTest* debug_util_test = reinterpret_cast<DebugUtilTest*>(user_data);
     debug_util_test->VerifyExpected(message_types, message_severity, callback_data->pMessage, callback_data);
     return VK_FALSE;

--- a/tests/loader_handle_validation_tests.cpp
+++ b/tests/loader_handle_validation_tests.cpp
@@ -2018,10 +2018,9 @@ TEST(LoaderHandleValidTests, VerifyHandleWrappingXlibSurf) {
 }
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
-static VKAPI_ATTR VkBool32 VKAPI_CALL JunkDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
-                                                             VkDebugUtilsMessageTypeFlagsEXT messageTypes,
-                                                             const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData,
-                                                             void* pUserData) {
+VKAPI_ATTR VkBool32 VKAPI_CALL JunkDebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+                                                      VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+                                                      const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData) {
     // This is just a stub callback in case the loader or any other layer triggers it.
     (void)messageSeverity;
     (void)messageTypes;

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -5366,7 +5366,7 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
     ASSERT_EQ(found_added_count, 3U);
 }
 
-static bool GroupsAreTheSame(VkPhysicalDeviceGroupProperties a, VkPhysicalDeviceGroupProperties b) {
+bool GroupsAreTheSame(VkPhysicalDeviceGroupProperties a, VkPhysicalDeviceGroupProperties b) {
     if (a.physicalDeviceCount != b.physicalDeviceCount) {
         return false;
     }

--- a/tests/loader_phys_dev_inst_ext_tests.cpp
+++ b/tests/loader_phys_dev_inst_ext_tests.cpp
@@ -35,13 +35,13 @@
 // validation.
 
 // Fill in random but valid data into the device properties struct for the current physical device
-static void FillInRandomICDInfo(uint32_t& vendor_id, uint32_t& driver_vers) {
+void FillInRandomICDInfo(uint32_t& vendor_id, uint32_t& driver_vers) {
     vendor_id = VK_MAKE_API_VERSION(0, rand() % 64, rand() % 255, rand() % 255);
     driver_vers = VK_MAKE_API_VERSION(0, rand() % 64, rand() % 255, rand() % 255);
 }
 
 // Fill in random but valid data into the device properties struct for the current physical device
-static void FillInRandomDeviceProps(VkPhysicalDeviceProperties& props, uint32_t api_vers, uint32_t vendor, uint32_t driver_vers) {
+void FillInRandomDeviceProps(VkPhysicalDeviceProperties& props, uint32_t api_vers, uint32_t vendor, uint32_t driver_vers) {
     props.apiVersion = api_vers;
     props.driverVersion = driver_vers;
     props.vendorID = vendor;
@@ -364,7 +364,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2Mixed) {
 }
 
 // Fill in random but valid data into the features struct for the current physical device
-static void FillInRandomFeatures(VkPhysicalDeviceFeatures& feats) {
+void FillInRandomFeatures(VkPhysicalDeviceFeatures& feats) {
     feats.robustBufferAccess = (rand() % 2) == 0 ? VK_FALSE : VK_TRUE;
     feats.fullDrawIndexUint32 = (rand() % 2) == 0 ? VK_FALSE : VK_TRUE;
     feats.imageCubeArray = (rand() % 2) == 0 ? VK_FALSE : VK_TRUE;
@@ -423,7 +423,7 @@ static void FillInRandomFeatures(VkPhysicalDeviceFeatures& feats) {
 }
 
 // Compare the contents of the feature structs
-static bool CompareFeatures(const VkPhysicalDeviceFeatures& feats1, const VkPhysicalDeviceFeatures2& feats2) {
+bool CompareFeatures(const VkPhysicalDeviceFeatures& feats1, const VkPhysicalDeviceFeatures2& feats2) {
     return feats1.robustBufferAccess == feats2.features.robustBufferAccess &&
            feats1.fullDrawIndexUint32 == feats2.features.fullDrawIndexUint32 &&
            feats1.imageCubeArray == feats2.features.imageCubeArray && feats1.independentBlend == feats2.features.independentBlend &&
@@ -737,7 +737,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeatsMixed) {
 }
 
 // Fill in random but valid data into the format properties struct for the current physical device
-static void FillInRandomFormatProperties(std::vector<VkFormatProperties>& props) {
+void FillInRandomFormatProperties(std::vector<VkFormatProperties>& props) {
     props.resize(5);
     for (uint8_t form = 0; form < 5; ++form) {
         props[form].bufferFeatures = static_cast<VkFormatFeatureFlags>(rand());
@@ -1031,7 +1031,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatPropsMixed) {
 }
 
 // Fill in random but valid data into the image format data struct for the current physical device
-static void FillInRandomImageFormatData(VkImageFormatProperties& props) {
+void FillInRandomImageFormatData(VkImageFormatProperties& props) {
     props.maxExtent = {static_cast<uint32_t>(rand() % 512), static_cast<uint32_t>(rand() % 512),
                        static_cast<uint32_t>(rand() % 512)};
     props.maxMipLevels = static_cast<uint32_t>(1 << (rand() % 16));
@@ -1455,7 +1455,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryPropsKHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the memory data struct for the current physical device
-static void FillInRandomMemoryData(VkPhysicalDeviceMemoryProperties& props) {
+void FillInRandomMemoryData(VkPhysicalDeviceMemoryProperties& props) {
     props.memoryTypeCount = (rand() % 7) + 1;
     props.memoryHeapCount = (rand() % 7) + 1;
     for (uint32_t i = 0; i < props.memoryHeapCount; ++i) {
@@ -1469,7 +1469,7 @@ static void FillInRandomMemoryData(VkPhysicalDeviceMemoryProperties& props) {
 }
 
 // Compare the memory structs
-static bool CompareMemoryData(const VkPhysicalDeviceMemoryProperties& props1, const VkPhysicalDeviceMemoryProperties2& props2) {
+bool CompareMemoryData(const VkPhysicalDeviceMemoryProperties& props1, const VkPhysicalDeviceMemoryProperties2& props2) {
     bool equal = true;
     equal = equal && props1.memoryTypeCount == props2.memoryProperties.memoryTypeCount;
     equal = equal && props1.memoryHeapCount == props2.memoryProperties.memoryHeapCount;
@@ -1750,7 +1750,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyPropsKHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the queue family data struct for the current physical device
-static uint32_t FillInRandomQueueFamilyData(std::vector<MockQueueFamilyProperties>& props) {
+uint32_t FillInRandomQueueFamilyData(std::vector<MockQueueFamilyProperties>& props) {
     props.resize((rand() % 4) + 1);
     for (uint32_t i = 0; i < props.size(); ++i) {
         props[i].properties.queueFlags = (rand() % 30) + 1;
@@ -1765,8 +1765,8 @@ static uint32_t FillInRandomQueueFamilyData(std::vector<MockQueueFamilyPropertie
 }
 
 // Compare the queue family structs
-static bool CompareQueueFamilyData(const std::vector<VkQueueFamilyProperties>& props1,
-                                   const std::vector<VkQueueFamilyProperties2>& props2) {
+bool CompareQueueFamilyData(const std::vector<VkQueueFamilyProperties>& props1,
+                            const std::vector<VkQueueFamilyProperties2>& props2) {
     if (props1.size() != props2.size()) return false;
     bool equal = true;
     for (uint32_t i = 0; i < props1.size(); ++i) {
@@ -2106,7 +2106,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatPropsKHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the sparse image format data struct for the current physical device
-static void FillInRandomSparseImageFormatData(std::vector<VkSparseImageFormatProperties>& props) {
+void FillInRandomSparseImageFormatData(std::vector<VkSparseImageFormatProperties>& props) {
     props.resize((rand() % 4) + 1);
     for (uint32_t i = 0; i < props.size(); ++i) {
         props[i].aspectMask = static_cast<VkImageAspectFlags>((rand() % 0x7FE) + 1);
@@ -2117,8 +2117,8 @@ static void FillInRandomSparseImageFormatData(std::vector<VkSparseImageFormatPro
 }
 
 // Compare the sparse image format structs
-static bool CompareSparseImageFormatData(const std::vector<VkSparseImageFormatProperties>& props1,
-                                         const std::vector<VkSparseImageFormatProperties2>& props2) {
+bool CompareSparseImageFormatData(const std::vector<VkSparseImageFormatProperties>& props1,
+                                  const std::vector<VkSparseImageFormatProperties2>& props2) {
     if (props1.size() != props2.size()) return false;
     bool equal = true;
     for (uint32_t i = 0; i < props1.size(); ++i) {
@@ -2545,15 +2545,15 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsKHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the external memorydata struct for the current physical device
-static void FillInRandomExtMemoryData(VkExternalMemoryProperties& props) {
+void FillInRandomExtMemoryData(VkExternalMemoryProperties& props) {
     props.externalMemoryFeatures = static_cast<VkExternalMemoryFeatureFlags>((rand() % 6) + 1);
     props.exportFromImportedHandleTypes = static_cast<VkExternalMemoryHandleTypeFlags>((rand() % 0x1FFE) + 1);
     props.compatibleHandleTypes = static_cast<VkExternalMemoryHandleTypeFlags>((rand() % 0x1FFE) + 1);
 }
 
 // Compare the external memory data structs
-static bool CompareExtMemoryData(const VkExternalMemoryProperties& props1, const VkExternalMemoryProperties& props2,
-                                 bool supported = true) {
+bool CompareExtMemoryData(const VkExternalMemoryProperties& props1, const VkExternalMemoryProperties& props2,
+                          bool supported = true) {
     bool equal = true;
     if (supported) {
         equal = equal && props1.externalMemoryFeatures == props2.externalMemoryFeatures;
@@ -2810,7 +2810,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsKHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the external semaphore data struct for the current physical device
-static void FillInRandomExtSemData(VkExternalSemaphoreProperties& props) {
+void FillInRandomExtSemData(VkExternalSemaphoreProperties& props) {
     props.sType = VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES;
     props.pNext = nullptr;
     props.exportFromImportedHandleTypes = static_cast<VkExternalSemaphoreHandleTypeFlags>((rand() % 0xFFF) + 1);
@@ -2819,8 +2819,8 @@ static void FillInRandomExtSemData(VkExternalSemaphoreProperties& props) {
 }
 
 // Compare the external semaphore data structs
-static bool CompareExtSemaphoreData(const VkExternalSemaphoreProperties& props1, const VkExternalSemaphoreProperties& props2,
-                                    bool supported = true) {
+bool CompareExtSemaphoreData(const VkExternalSemaphoreProperties& props1, const VkExternalSemaphoreProperties& props2,
+                             bool supported = true) {
     bool equal = true;
     if (supported) {
         equal = equal && props1.externalSemaphoreFeatures == props2.externalSemaphoreFeatures;
@@ -3072,7 +3072,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsKHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the external fence data struct for the current physical device
-static void FillInRandomExtFenceData(VkExternalFenceProperties& props) {
+void FillInRandomExtFenceData(VkExternalFenceProperties& props) {
     props.sType = VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES;
     props.pNext = nullptr;
     props.exportFromImportedHandleTypes = static_cast<VkExternalFenceHandleTypeFlags>((rand() % 0xFFF) + 1);
@@ -3081,8 +3081,7 @@ static void FillInRandomExtFenceData(VkExternalFenceProperties& props) {
 }
 
 // Compare the external fence data structs
-static bool CompareExtFenceData(const VkExternalFenceProperties& props1, const VkExternalFenceProperties& props2,
-                                bool supported = true) {
+bool CompareExtFenceData(const VkExternalFenceProperties& props1, const VkExternalFenceProperties& props2, bool supported = true) {
     bool equal = true;
     if (supported) {
         equal = equal && props1.externalFenceFeatures == props2.externalFenceFeatures;
@@ -3334,7 +3333,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the surface capability data struct for the current physical device
-static void FillInRandomSurfaceCapsData(VkSurfaceCapabilitiesKHR& props) {
+void FillInRandomSurfaceCapsData(VkSurfaceCapabilitiesKHR& props) {
     props.minImageCount = (rand() % 0xFFF) + 1;
     props.maxImageCount = (rand() % 0xFFF) + 1;
     props.currentExtent.width = (rand() % 0xFFF) + 1;
@@ -3351,8 +3350,7 @@ static void FillInRandomSurfaceCapsData(VkSurfaceCapabilitiesKHR& props) {
 }
 
 // Compare the surface capability data structs
-static bool CompareSurfaceCapsData(const VkSurfaceCapabilitiesKHR& props1, const VkSurfaceCapabilitiesKHR& props2,
-                                   bool supported = true) {
+bool CompareSurfaceCapsData(const VkSurfaceCapabilitiesKHR& props1, const VkSurfaceCapabilitiesKHR& props2, bool supported = true) {
     bool equal = true;
     if (supported) {
         equal = equal && props1.minImageCount == props2.minImageCount;
@@ -3567,7 +3565,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the surface formats data struct for the current physical device
-static void FillInRandomSurfaceFormatsData(std::vector<VkSurfaceFormatKHR>& props) {
+void FillInRandomSurfaceFormatsData(std::vector<VkSurfaceFormatKHR>& props) {
     props.resize((rand() % 5) + 1);
     for (uint32_t i = 0; i < props.size(); ++i) {
         props[i].format = static_cast<VkFormat>((rand() % 0xFFF) + 1);
@@ -3576,8 +3574,8 @@ static void FillInRandomSurfaceFormatsData(std::vector<VkSurfaceFormatKHR>& prop
 }
 
 // Compare the surface formats data structs
-static bool CompareSurfaceFormatsData(const std::vector<VkSurfaceFormatKHR>& props1, const std::vector<VkSurfaceFormat2KHR>& props2,
-                                      bool supported = true) {
+bool CompareSurfaceFormatsData(const std::vector<VkSurfaceFormatKHR>& props1, const std::vector<VkSurfaceFormat2KHR>& props2,
+                               bool supported = true) {
     if (props1.size() != props2.size()) return false;
     bool equal = true;
     for (uint32_t i = 0; i < props1.size(); ++i) {
@@ -3802,7 +3800,7 @@ VkDisplayModeKHR CreateRandomDisplayMode() {
 }
 
 // Fill in random but valid data into the display property data struct for the current physical device
-static void FillInRandomDisplayPropData(std::vector<VkDisplayPropertiesKHR>& props) {
+void FillInRandomDisplayPropData(std::vector<VkDisplayPropertiesKHR>& props) {
     props.resize((rand() % 5) + 1);
     for (uint32_t i = 0; i < props.size(); ++i) {
         props[i].display = CreateRandomDisplay();
@@ -3817,8 +3815,7 @@ static void FillInRandomDisplayPropData(std::vector<VkDisplayPropertiesKHR>& pro
 }
 
 // Compare the display property data structs
-static bool CompareDisplayPropData(const std::vector<VkDisplayPropertiesKHR>& props1,
-                                   const std::vector<VkDisplayPropertiesKHR>& props2) {
+bool CompareDisplayPropData(const std::vector<VkDisplayPropertiesKHR>& props1, const std::vector<VkDisplayPropertiesKHR>& props2) {
     if (props1.size() != props2.size()) return false;
     bool equal = true;
     for (uint32_t i = 0; i < props1.size(); ++i) {
@@ -4001,7 +3998,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the display plane property data struct for the current physical device
-static void FillInRandomDisplayPlanePropData(std::vector<VkDisplayPlanePropertiesKHR>& props) {
+void FillInRandomDisplayPlanePropData(std::vector<VkDisplayPlanePropertiesKHR>& props) {
     props.resize((rand() % 5) + 1);
     for (uint32_t i = 0; i < props.size(); ++i) {
         props[i].currentDisplay = CreateRandomDisplay();
@@ -4010,8 +4007,8 @@ static void FillInRandomDisplayPlanePropData(std::vector<VkDisplayPlanePropertie
 }
 
 // Compare the display plane property data structs
-static bool CompareDisplayPlanePropData(const std::vector<VkDisplayPlanePropertiesKHR>& props1,
-                                        const std::vector<VkDisplayPlanePropertiesKHR>& props2) {
+bool CompareDisplayPlanePropData(const std::vector<VkDisplayPlanePropertiesKHR>& props1,
+                                 const std::vector<VkDisplayPlanePropertiesKHR>& props2) {
     if (props1.size() != props2.size()) return false;
     bool equal = true;
     for (uint32_t i = 0; i < props1.size(); ++i) {
@@ -4189,7 +4186,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the display plane property data struct for the current physical device
-static void GenerateRandomDisplays(std::vector<VkDisplayKHR>& disps) {
+void GenerateRandomDisplays(std::vector<VkDisplayKHR>& disps) {
     disps.resize((rand() % 5) + 1);
     for (uint32_t i = 0; i < disps.size(); ++i) {
         disps[i] = CreateRandomDisplay();
@@ -4197,7 +4194,7 @@ static void GenerateRandomDisplays(std::vector<VkDisplayKHR>& disps) {
 }
 
 // Compare the display plane property data structs
-static bool CompareDisplays(const std::vector<VkDisplayKHR>& disps1, const std::vector<VkDisplayKHR>& disps2) {
+bool CompareDisplays(const std::vector<VkDisplayKHR>& disps1, const std::vector<VkDisplayKHR>& disps2) {
     if (disps1.size() != disps2.size()) return false;
     bool equal = true;
     for (uint32_t i = 0; i < disps1.size(); ++i) {
@@ -4374,7 +4371,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the display mode properties data struct for the current physical device
-static void GenerateRandomDisplayModeProps(std::vector<VkDisplayModePropertiesKHR>& disps) {
+void GenerateRandomDisplayModeProps(std::vector<VkDisplayModePropertiesKHR>& disps) {
     disps.resize((rand() % 5) + 1);
     for (uint32_t i = 0; i < disps.size(); ++i) {
         disps[i].displayMode = CreateRandomDisplayMode();
@@ -4385,8 +4382,8 @@ static void GenerateRandomDisplayModeProps(std::vector<VkDisplayModePropertiesKH
 }
 
 // Compare the display mode properties data structs
-static bool CompareDisplayModeProps(const std::vector<VkDisplayModePropertiesKHR>& disps1,
-                                    const std::vector<VkDisplayModePropertiesKHR>& disps2) {
+bool CompareDisplayModeProps(const std::vector<VkDisplayModePropertiesKHR>& disps1,
+                             const std::vector<VkDisplayModePropertiesKHR>& disps2) {
     if (disps1.size() != disps2.size()) return false;
     bool equal = true;
     for (uint32_t i = 0; i < disps1.size(); ++i) {
@@ -4566,7 +4563,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRNoICDSupport) {
 }
 
 // Compare the display modes
-static bool CompareDisplayModes(const VkDisplayModeKHR& disps1, VkDisplayModeKHR& disps2) { return disps1 == disps2; }
+bool CompareDisplayModes(const VkDisplayModeKHR& disps1, VkDisplayModeKHR& disps2) { return disps1 == disps2; }
 
 // Test vkCreateDisplayModeKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDispModesKHRInstanceAndICDSupport) {
@@ -4726,7 +4723,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRNoICDSupport) {
 }
 
 // Fill in random but valid data into the display plane caps for the current physical device
-static void GenerateRandomDisplayPlaneCaps(VkDisplayPlaneCapabilitiesKHR& caps) {
+void GenerateRandomDisplayPlaneCaps(VkDisplayPlaneCapabilitiesKHR& caps) {
     caps.supportedAlpha = static_cast<VkDisplayPlaneAlphaFlagsKHR>((rand() % 0xFFFFFFF) + 1);
     caps.minSrcPosition.x = static_cast<uint32_t>((rand() % 0xFFFFFFF) + 1);
     caps.minSrcPosition.y = static_cast<uint32_t>((rand() % 0xFFFFFFF) + 1);
@@ -4747,8 +4744,8 @@ static void GenerateRandomDisplayPlaneCaps(VkDisplayPlaneCapabilitiesKHR& caps) 
 }
 
 // Compare the display plane caps
-static bool CompareDisplayPlaneCaps(const VkDisplayPlaneCapabilitiesKHR& caps1, VkDisplayPlaneCapabilitiesKHR& caps2,
-                                    bool supported = true) {
+bool CompareDisplayPlaneCaps(const VkDisplayPlaneCapabilitiesKHR& caps1, VkDisplayPlaneCapabilitiesKHR& caps2,
+                             bool supported = true) {
     bool equal = true;
     if (supported) {
         equal = equal && caps1.supportedAlpha == caps2.supportedAlpha;
@@ -4943,8 +4940,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRNoICDSupport) {
 }
 
 // Compare the display property data structs
-static bool CompareDisplayPropData(const std::vector<VkDisplayPropertiesKHR>& props1,
-                                   const std::vector<VkDisplayProperties2KHR>& props2) {
+bool CompareDisplayPropData(const std::vector<VkDisplayPropertiesKHR>& props1, const std::vector<VkDisplayProperties2KHR>& props2) {
     if (props1.size() != props2.size()) return false;
     bool equal = true;
     for (uint32_t i = 0; i < props1.size(); ++i) {
@@ -5123,8 +5119,8 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRNoICDSupport) {
 }
 
 // Compare the display plane property data structs
-static bool CompareDisplayPlanePropData(const std::vector<VkDisplayPlanePropertiesKHR>& props1,
-                                        const std::vector<VkDisplayPlaneProperties2KHR>& props2) {
+bool CompareDisplayPlanePropData(const std::vector<VkDisplayPlanePropertiesKHR>& props1,
+                                 const std::vector<VkDisplayPlaneProperties2KHR>& props2) {
     if (props1.size() != props2.size()) return false;
     bool equal = true;
     for (uint32_t i = 0; i < props1.size(); ++i) {
@@ -5295,8 +5291,8 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRNoICDSupport) {
 }
 
 // Compare the display mode properties data structs
-static bool CompareDisplayModeProps(const std::vector<VkDisplayModePropertiesKHR>& disps1,
-                                    const std::vector<VkDisplayModeProperties2KHR>& disps2) {
+bool CompareDisplayModeProps(const std::vector<VkDisplayModePropertiesKHR>& disps1,
+                             const std::vector<VkDisplayModeProperties2KHR>& disps2) {
     if (disps1.size() != disps2.size()) return false;
 
     bool equal = true;
@@ -5471,7 +5467,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRNoICDSupport) {
 }
 
 // Compare the display plane caps
-static bool CompareDisplayPlaneCaps(const VkDisplayPlaneCapabilitiesKHR& caps1, VkDisplayPlaneCapabilities2KHR& caps2) {
+bool CompareDisplayPlaneCaps(const VkDisplayPlaneCapabilitiesKHR& caps1, VkDisplayPlaneCapabilities2KHR& caps2) {
     bool equal = true;
     equal = equal && caps1.supportedAlpha == caps2.capabilities.supportedAlpha;
     equal = equal && caps1.minSrcPosition.x == caps2.capabilities.minSrcPosition.x;

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -2654,7 +2654,7 @@ TEST(EnumeratePhysicalDeviceGroups, MultipleAddRemoves) {
 }
 
 // Fill in random but valid data into the device properties struct for the current physical device
-static void FillInRandomDeviceProps(VkPhysicalDeviceProperties& props, VkPhysicalDeviceType dev_type, uint32_t api_vers,
+void FillInRandomDeviceProps(VkPhysicalDeviceProperties& props, VkPhysicalDeviceType dev_type, uint32_t api_vers,
                                     uint32_t vendor, uint32_t device) {
     props.apiVersion = api_vers;
     props.vendorID = vendor;


### PR DESCRIPTION
The `static` specifier is used inconsistently throughout the codebase. This commit removes it from most places where it is unnecessary. Static's purpose is to make any function defined inside of a translation unit unuseable from other translation units. But because we use header files to define which functions are exposed, we can simply omit static for functions private in a translation unit.

This commit also removes static in a couple of places where it isn't needed, such as local variables that do not act as storage beyond the scope of the function, and for global variables defined inside of implenetation files.

Uses of static in header files, such as vk_loader_platform.h, is left as is because those functions need static to prevent multiple definition errors.

Resolves #1158 