### PR TITLE
Move vk_dispatch_table_helper.h to tests

### DIFF
--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -132,7 +132,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
         preamble += '#include <vulkan/vulkan.h>\n'
         preamble += '#include <vulkan/vk_layer.h>\n'
         preamble += '#include <string.h>\n'
-        preamble += '#include "vk_layer_dispatch_table.h"\n'
+        preamble += '#include "loader/generated/vk_layer_dispatch_table.h"\n'
 
         write(copyright, file=self.outFile)
         write(preamble, file=self.outFile)

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -44,8 +44,7 @@ def main(argv):
     gen_cmds = [[common_codegen.repo_relative('scripts/loader_genvk.py'),
                  '-registry', os.path.abspath(os.path.join(args.registry,  'vk.xml')),
                  '-quiet',
-                 filename] for filename in ['vk_dispatch_table_helper.h',
-                                            'vk_layer_dispatch_table.h',
+                 filename] for filename in ['vk_layer_dispatch_table.h',
                                             'vk_loader_extensions.h',
                                             'vk_loader_extensions.c',
                                             'vk_object_types.h']]

--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -27,7 +27,7 @@
 
 #include "test_layer.h"
 
-#include "loader/generated/vk_dispatch_table_helper.h"
+#include "vk_dispatch_table_helper.h"
 
 // export the enumeration functions instance|device+layer|extension
 #ifndef TEST_LAYER_EXPORT_ENUMERATE_FUNCTIONS

--- a/tests/framework/layer/vk_dispatch_table_helper.h
+++ b/tests/framework/layer/vk_dispatch_table_helper.h
@@ -27,7 +27,7 @@
 #include <vulkan/vulkan.h>
 #include <vulkan/vk_layer.h>
 #include <string.h>
-#include "vk_layer_dispatch_table.h"
+#include "loader/generated/vk_layer_dispatch_table.h"
 
 static VKAPI_ATTR VkResult VKAPI_CALL StubCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain) { return VK_SUCCESS; }
 static VKAPI_ATTR void VKAPI_CALL StubDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator) {  }

--- a/tests/framework/layer/wrap_objects.cpp
+++ b/tests/framework/layer/wrap_objects.cpp
@@ -27,7 +27,7 @@
 #include <memory>
 
 #include "vulkan/vk_layer.h"
-#include "loader/generated/vk_dispatch_table_helper.h"
+#include "vk_dispatch_table_helper.h"
 #include "loader/vk_loader_layer.h"
 
 // Export full support of instance extension VK_EXT_direct_mode_display extension


### PR DESCRIPTION
vk_dispatch_table_helper.h will no longer be generated for every new header version because it is not used in the loader source. Rather, it was only being used for the tests. This commit moves it to tests/framework/layer where it is being used. While the python generation code could have been updated to write it into a different folder, due to the difficulty of that change, it is simpler to just move the file and stop autogenerating it. The code to generate it is left as is in case there is a need to update it in the future.