### PR TITLE
Add 4th component to version in loader.rc

### DIFF
--- a/loader/loader.rc
+++ b/loader/loader.rc
@@ -22,7 +22,7 @@
 #include "winres.h"
 
 // All set through CMake
-#define VER_FILE_VERSION 1, 3, 245
+#define VER_FILE_VERSION 1, 3, 245, 0
 #define VER_FILE_DESCRIPTION_STR "1.3.245.Dev Build"
 #define VER_FILE_VERSION_STR "Vulkan Loader - Dev Build"
 #define VER_COPYRIGHT_STR "Copyright (C) 2015-2023"

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -120,7 +120,7 @@ def main(argv):
 
         with open(common_codegen.repo_relative('loader/loader.rc.in'), "r") as rc_file:
             rc_file_contents = rc_file.read()
-        rc_ver = ', '.join(args.generated_version.split('.'))
+        rc_ver = ', '.join(args.generated_version.split('.') + ['0'])
         rc_file_contents = rc_file_contents.replace('${LOADER_VER_FILE_VERSION}', f'{rc_ver}')
         rc_file_contents = rc_file_contents.replace('${LOADER_VER_FILE_DESCRIPTION_STR}', f'"{args.generated_version}.Dev Build"')
         rc_file_contents = rc_file_contents.replace('${LOADER_VER_FILE_VERSION_STR}', f'"Vulkan Loader - Dev Build"')


### PR DESCRIPTION
FILVERSION is supposed to be a 4 component field. The previous commit to make loader.rc be generated did not account for that and so requires this fix to make sure it has four components. Thankfully, this issue is not present in SDK released loaders thanks to the SDK specifying its own version string that has 4 components.

Fixes #1164 