### PR TITLE
Make correct layer be used when duplicates are present

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -101,6 +101,7 @@ bool has_vk_extension_property_array(const VkExtensionProperties *vk_ext_prop, c
                                      const VkExtensionProperties *ext_array);
 bool has_vk_extension_property(const VkExtensionProperties *vk_ext_prop, const struct loader_extension_list *ext_list);
 
+bool loader_find_layer_name_in_list(const char *name, const struct loader_layer_list *layer_list);
 VkResult loader_add_layer_properties_to_list(const struct loader_instance *inst, struct loader_layer_list *list,
                                              uint32_t prop_list_count, const struct loader_layer_properties *props);
 void loader_free_layer_properties(const struct loader_instance *inst, struct loader_layer_properties *layer_properties);

--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -497,7 +497,9 @@ VkResult loader_add_environment_layers(struct loader_instance *inst, const enum 
 
         // If we are supposed to filter through all layers, we need to compare the layer name against the filter.
         // This can override the disable above, so we want to do it second.
-        if (check_name_matches_filter_environment_var(inst, source_prop->info.layerName, enable_filter)) {
+        // Also make sure the layer isn't already in the output_list, skip adding it if it is.
+        if (check_name_matches_filter_environment_var(inst, source_prop->info.layerName, enable_filter) &&
+            !loader_find_layer_name_in_list(source_prop->info.layerName, target_list)) {
             adding = true;
             // Only way is_substring is true is if there are enable variables.  If that's the case, and we're past the
             // above, we should indicate that it was forced on in this way.
@@ -506,9 +508,11 @@ VkResult loader_add_environment_layers(struct loader_instance *inst, const enum 
         } else {
             adding = false;
             // If it's not in the enable filter, check the environment variable if it exists
+            // Also make sure the layer isn't already in the output_list, skip adding it if it is.
             if (vk_inst_layer_count > 0) {
                 for (uint32_t cur_layer = 0; cur_layer < vk_inst_layer_count; ++cur_layer) {
-                    if (!strcmp(vk_inst_layers[cur_layer], source_prop->info.layerName)) {
+                    if (!strcmp(vk_inst_layers[cur_layer], source_prop->info.layerName) &&
+                        !loader_find_layer_name_in_list(source_prop->info.layerName, target_list)) {
                         adding = true;
                         break;
                     }

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -264,6 +264,11 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
 
     // Prepend layers onto the chain if they implement this entry point
     for (uint32_t i = 0; i < layers.count; ++i) {
+        // Skip this layer if it doesn't expose the entry-point
+        if (layers.list[i].pre_instance_functions.enumerate_instance_layer_properties[0] == '\0') {
+            continue;
+        }
+
         loader_platform_dl_handle layer_lib = loader_platform_open_library(layers.list[i].lib_name);
         if (layer_lib == NULL) {
             loader_log(NULL, VULKAN_LOADER_WARN_BIT, 0, "%s: Unable to load implicit layer library \"%s\"", __FUNCTION__,

--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -210,6 +210,22 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo*
         }
     }
 
+    if (!layer.make_spurious_log_in_create_instance.empty()) {
+        auto* chain = reinterpret_cast<const VkBaseInStructure*>(pCreateInfo->pNext);
+        while (chain) {
+            if (chain->sType == VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT) {
+                auto* debug_messenger = reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT*>(chain);
+                VkDebugUtilsMessengerCallbackDataEXT data{};
+                data.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT;
+                data.pMessage = layer.make_spurious_log_in_create_instance.c_str();
+                debug_messenger->pfnUserCallback(VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT,
+                                                 VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT, &data, debug_messenger->pUserData);
+            }
+
+            chain = chain->pNext;
+        }
+    }
+
     return result;
 }
 

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -160,6 +160,8 @@ struct TestLayer {
         return nullptr;
     }
 
+    // Allows distinguishing different layers (that use the same binary)
+    BUILDER_VALUE(TestLayer, std::string, make_spurious_log_in_create_instance, "")
     BUILDER_VALUE(TestLayer, bool, do_spurious_allocations_in_create_instance, false)
     void* spurious_instance_memory_allocation = nullptr;
     BUILDER_VALUE(TestLayer, bool, do_spurious_allocations_in_create_device, false)

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -470,6 +470,7 @@ struct TestICDDetails {
     }
     BUILDER_VALUE(TestICDDetails, ManifestICD, icd_manifest, {});
     BUILDER_VALUE(TestICDDetails, std::string, json_name, "test_icd");
+    // Uses the json_name without modification - default is to append _1 in the json file to distinguish drivers
     BUILDER_VALUE(TestICDDetails, bool, disable_icd_inc, false);
     BUILDER_VALUE(TestICDDetails, ManifestDiscoveryType, discovery_type, ManifestDiscoveryType::generic);
     BUILDER_VALUE(TestICDDetails, bool, is_fake, false);

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -203,10 +203,10 @@ std::string ManifestLayer::get_manifest_str() const {
         out += "\t\"layer\": ";
         out += layers.at(0).get_manifest_str() + "\n";
     } else {
-        out += "\"\tlayers\": [";
+        out += "\t\"layers\": [";
         for (size_t i = 0; i < layers.size(); i++) {
             if (i > 0) out += ",";
-            out += "\n" + layers.at(0).get_manifest_str();
+            out += "\n" + layers.at(i).get_manifest_str();
         }
         out += "\n]";
     }

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -131,15 +131,12 @@ struct EnvVarWrapper {
     std::string name;
     std::string cur_value;
 
-#if defined(WIN32)
     void set_env_var();
     void remove_env_var() const;
+#if defined(WIN32)
     // Environment variable list separator - not for filesystem paths
     const char OS_ENV_VAR_LIST_SEPARATOR = ';';
-
 #elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-    void set_env_var();
-    void remove_env_var() const;
     // Environment variable list separator - not for filesystem paths
     const char OS_ENV_VAR_LIST_SEPARATOR = ':';
 #endif
@@ -148,11 +145,7 @@ struct EnvVarWrapper {
 // get_env_var() - returns a std::string of `name`. if report_failure is true, then it will log to stderr that it didn't find the
 //     env-var
 // NOTE: This is only intended for test framework code, all test code MUST use EnvVarWrapper
-#if defined(WIN32)
 std::string get_env_var(std::string const& name, bool report_failure = true);
-#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-std::string get_env_var(std::string const& name, bool report_failure = true);
-#endif
 
 // Windows specific error handling logic
 #if defined(WIN32)

--- a/tests/loader_testing_main.cpp
+++ b/tests/loader_testing_main.cpp
@@ -88,13 +88,12 @@ int main(int argc, char** argv) {
     vk_loader_debug_env_var.remove_value();
     vk_loader_disable_inst_ext_filter_env_var.remove_value();
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-    EnvVarWrapper xdg_config_home_env_var{"XDG_CONFIG_HOME", "/etc"};
-    EnvVarWrapper xdg_config_dirs_env_var{"XDG_CONFIG_DIRS", "/etc"};
-    EnvVarWrapper xdg_data_home_env_var{"XDG_DATA_HOME", "/etc"};
-    EnvVarWrapper xdg_data_dirs_env_var{"XDG_DATA_DIRS", "/etc"};
-#endif
 #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+    // Set only one of the 4 XDG variables to /etc, let everything else be empty
+    EnvVarWrapper xdg_config_home_env_var{"XDG_CONFIG_HOME", "/etc"};
+    EnvVarWrapper xdg_config_dirs_env_var{"XDG_CONFIG_DIRS", ""};
+    EnvVarWrapper xdg_data_home_env_var{"XDG_DATA_HOME", ""};
+    EnvVarWrapper xdg_data_dirs_env_var{"XDG_DATA_DIRS", ""};
     EnvVarWrapper home_env_var{"HOME", "/home/fake_home"};
 #endif
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
When there are multiple versions of the same layer found through environment variables or from implicit layer locations, the loader would use the *last* one that appeared rather than the first, causing surprising behavior. This commit fixes that by checking to make sure that layers do not already exist in the list of layers to be enabled before adding a layer to the list, preventing duplicates from appearing in the list.

Fixes #1153 