### PR TITLE
Fix ordering regression for VK_INSTANCE_LAYERS

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4450,9 +4450,8 @@ VkResult loader_enable_instance_layers(struct loader_instance *inst, const VkIns
     }
 
     // Add any layers specified via environment variable next
-    res = loader_add_environment_layers(inst, VK_LAYER_TYPE_FLAG_EXPLICIT_LAYER, "VK_INSTANCE_LAYERS", &layers_enable_filter,
-                                        &layers_disable_filter, &inst->app_activated_layer_list,
-                                        &inst->expanded_activated_layer_list, instance_layers);
+    res = loader_add_environment_layers(inst, VK_LAYER_TYPE_FLAG_EXPLICIT_LAYER, &layers_enable_filter, &layers_disable_filter,
+                                        &inst->app_activated_layer_list, &inst->expanded_activated_layer_list, instance_layers);
     if (res != VK_SUCCESS) {
         goto out;
     }
@@ -5343,8 +5342,8 @@ VkResult loader_validate_instance_extensions(struct loader_instance *inst, const
     if (res != VK_SUCCESS) {
         goto out;
     }
-    res = loader_add_environment_layers(inst, VK_LAYER_TYPE_FLAG_EXPLICIT_LAYER, ENABLED_LAYERS_ENV, &layers_enable_filter,
-                                        &layers_disable_filter, &active_layers, &expanded_layers, instance_layers);
+    res = loader_add_environment_layers(inst, VK_LAYER_TYPE_FLAG_EXPLICIT_LAYER, &layers_enable_filter, &layers_disable_filter,
+                                        &active_layers, &expanded_layers, instance_layers);
     if (res != VK_SUCCESS) {
         goto out;
     }

--- a/loader/loader_environment.h
+++ b/loader/loader_environment.h
@@ -50,7 +50,7 @@ VkResult parse_layers_disable_filter_environment_var(const struct loader_instanc
                                                      struct loader_envvar_disable_layers_filter *disable_struct);
 bool check_name_matches_filter_environment_var(const struct loader_instance *inst, const char *name,
                                                const struct loader_envvar_filter *filter_struct);
-VkResult loader_add_environment_layers(struct loader_instance *inst, const enum layer_type_flags type_flags, const char *env_name,
+VkResult loader_add_environment_layers(struct loader_instance *inst, const enum layer_type_flags type_flags,
                                        const struct loader_envvar_filter *enable_filter,
                                        const struct loader_envvar_disable_layers_filter *disable_filter,
                                        struct loader_layer_list *target_list, struct loader_layer_list *expanded_target_list,

--- a/tests/framework/shim/shim_common.cpp
+++ b/tests/framework/shim/shim_common.cpp
@@ -103,7 +103,8 @@ void PlatformShim::reset() {
     hkey_local_machine_drivers.clear();
 }
 
-void PlatformShim::set_path(ManifestCategory category, fs::path const& path) {}
+void PlatformShim::set_fake_path(ManifestCategory category, fs::path const& path) {}
+void PlatformShim::add_known_path(fs::path const& path) {}
 
 void PlatformShim::add_manifest(ManifestCategory category, fs::path const& path) {
     if (category == ManifestCategory::implicit_layer)
@@ -161,10 +162,14 @@ std::string category_path_name(ManifestCategory category) {
 
 void PlatformShim::reset() { redirection_map.clear(); }
 
-void PlatformShim::redirect_path(fs::path const& path, fs::path const& new_path) { redirection_map[path.str()] = new_path; }
-void PlatformShim::remove_redirect(fs::path const& path) { redirection_map.erase(path.str()); }
 bool PlatformShim::is_fake_path(fs::path const& path) { return redirection_map.count(path.str()) > 0; }
 fs::path const& PlatformShim::get_fake_path(fs::path const& path) { return redirection_map.at(path.str()); }
+void PlatformShim::redirect_path(fs::path const& path, fs::path const& new_path) { redirection_map[path.str()] = new_path; }
+void PlatformShim::remove_redirect(fs::path const& path) { redirection_map.erase(path.str()); }
+
+bool PlatformShim::is_known_path(fs::path const& path) { return known_path_set.count(path.str()) > 0; }
+void PlatformShim::add_known_path(fs::path const& path) { known_path_set.insert(path.str()); }
+void PlatformShim::remove_known_path(fs::path const& path) { known_path_set.erase(path.str()); }
 
 void PlatformShim::add_manifest(ManifestCategory category, fs::path const& path) {}
 
@@ -215,7 +220,7 @@ void PlatformShim::redirect_category(fs::path const& new_path, ManifestCategory 
     }
 }
 
-void PlatformShim::set_path(ManifestCategory category, fs::path const& path) {
+void PlatformShim::set_fake_path(ManifestCategory category, fs::path const& path) {
     // use /etc as the 'redirection path' by default since its always searched
     redirect_path(fs::path(SYSCONFDIR) / "vulkan" / category_path_name(category), path);
 }

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -503,6 +503,7 @@ struct FrameworkEnvironment {
     FrameworkEnvironment() noexcept;  // default is to enable VK_LOADER_DEBUG=all and enable the default search paths
     FrameworkEnvironment(bool enable_log) noexcept;
     FrameworkEnvironment(bool enable_log, bool enable_default_search_paths) noexcept;
+    ~FrameworkEnvironment();
 
     TestICDHandle& add_icd(TestICDDetails icd_details) noexcept;
     void add_implicit_layer(ManifestLayer layer_manifest, const std::string& json_name) noexcept;

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -3991,7 +3991,7 @@ TEST(ManifestDiscovery, ValidSymlink) {
     int res = symlink(driver_path.c_str(), symlink_path.c_str());
     ASSERT_EQ(res, 0);
 
-    env.platform_shim->set_path(ManifestCategory::icd, env.get_folder(ManifestLocation::driver_env_var).location());
+    env.platform_shim->set_fake_path(ManifestCategory::icd, env.get_folder(ManifestLocation::driver_env_var).location());
 
     InstWrapper inst{env.vulkan_functions};
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
@@ -4025,7 +4025,7 @@ TEST(ManifestDiscovery, InvalidSymlink) {
     ASSERT_EQ(res, 0);
     env.get_folder(ManifestLocation::driver).add_existing_file(symlink_name);
 
-    env.platform_shim->set_path(ManifestCategory::icd, env.get_folder(ManifestLocation::driver_env_var).location());
+    env.platform_shim->set_fake_path(ManifestCategory::icd, env.get_folder(ManifestLocation::driver_env_var).location());
 
     InstWrapper inst{env.vulkan_functions};
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);


### PR DESCRIPTION
The commit to add VK_LOADER_LAYERS_ENABLE/DISABLE inadvertently broke the ordering guarantees of VK_INSTANCE_LAYERS. This commit restores that order. If both VK_INSTANCE_LAYERS and VK_LOADER_LAYERS_ENABLE add layers, the order will be VK_INSTANCE_LAYERS enabled layers, in the order specified by the env-var, followed by any layers enabled by VK_LOADER_LAYERS_ENABLED enabled in the order they are found on the system.

In addition to this, the test framework receieved two changes:
* Make env-var folders report their contents in a deterministic order (aka the order the items were added to the framework). This mirrors existing behavior for redirected folders.
* Make platform shim resilient to shutdown ordering issues. Namely, set a flag during shutdown so that any interception functions go straight to the real version of the functoin. This works around an issue during the destruction of the FolderManagers for the environment variables, where the readdir shim function was trying to use the FolderManager's data but Address Sanitizer declared that such a use was 'heap use after free'.

Fixes #1168 