### PR TITLE
Fix debug extension function loading

### DIFF
--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -362,6 +362,12 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectNameEXT(VkDevice dev, 
     }
     return VK_SUCCESS;
 }
+VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer,
+                                                         const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer) {}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer,
+                                                          const VkDebugMarkerMarkerInfoEXT* pMarkerInfo) {}
+
 VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectNameEXT(VkDevice dev, const VkDebugUtilsObjectNameInfoEXT* pNameInfo) {
     if (pNameInfo && pNameInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pNameInfo->objectHandle);
@@ -1490,6 +1496,9 @@ PFN_vkVoidFunction get_device_func(VkDevice device, const char* pName) {
     if (should_check(create_info.enabled_extensions, device, "VK_EXT_debug_marker")) {
         if (string_eq(pName, "vkDebugMarkerSetObjectTagEXT")) return to_vkVoidFunction(test_vkDebugMarkerSetObjectTagEXT);
         if (string_eq(pName, "vkDebugMarkerSetObjectNameEXT")) return to_vkVoidFunction(test_vkDebugMarkerSetObjectNameEXT);
+        if (string_eq(pName, "vkCmdDebugMarkerBeginEXT")) return to_vkVoidFunction(test_vkCmdDebugMarkerBeginEXT);
+        if (string_eq(pName, "vkCmdDebugMarkerEndEXT")) return to_vkVoidFunction(test_vkCmdDebugMarkerEndEXT);
+        if (string_eq(pName, "vkCmdDebugMarkerInsertEXT")) return to_vkVoidFunction(test_vkCmdDebugMarkerInsertEXT);
     }
     if (IsInstanceExtensionEnabled("VK_EXT_debug_utils")) {
         if (string_eq(pName, "vkSetDebugUtilsObjectNameEXT")) return to_vkVoidFunction(test_vkSetDebugUtilsObjectNameEXT);

--- a/tests/loader_debug_ext_tests.cpp
+++ b/tests/loader_debug_ext_tests.cpp
@@ -886,10 +886,19 @@ void CheckDeviceFunctions(FrameworkEnvironment& env, bool use_GIPA, bool enable_
     VkSwapchainKHR swapchain{};
     ASSERT_EQ(VK_SUCCESS, dev_funcs.vkCreateSwapchainKHR(dev.dev, &info, nullptr, &swapchain));
 
+    // Debug marker
     PFN_vkDebugMarkerSetObjectTagEXT DebugMarkerSetObjectTagEXT;
     DebugMarkerSetObjectTagEXT = use_GIPA ? inst.load("vkDebugMarkerSetObjectTagEXT") : dev.load("vkDebugMarkerSetObjectTagEXT");
     PFN_vkDebugMarkerSetObjectNameEXT DebugMarkerSetObjectNameEXT;
     DebugMarkerSetObjectNameEXT = use_GIPA ? inst.load("vkDebugMarkerSetObjectNameEXT") : dev.load("vkDebugMarkerSetObjectNameEXT");
+    PFN_vkCmdDebugMarkerBeginEXT CmdDebugMarkerBeginEXT =
+        use_GIPA ? inst.load("vkCmdDebugMarkerBeginEXT") : dev.load("vkCmdDebugMarkerBeginEXT");
+    PFN_vkCmdDebugMarkerEndEXT CmdDebugMarkerEndEXT =
+        use_GIPA ? inst.load("vkCmdDebugMarkerEndEXT") : dev.load("vkCmdDebugMarkerEndEXT");
+    PFN_vkCmdDebugMarkerInsertEXT CmdDebugMarkerInsertEXT =
+        use_GIPA ? inst.load("vkCmdDebugMarkerInsertEXT") : dev.load("vkCmdDebugMarkerInsertEXT");
+
+    // Debug utils
     PFN_vkSetDebugUtilsObjectNameEXT SetDebugUtilsObjectNameEXT;
     SetDebugUtilsObjectNameEXT = use_GIPA ? inst.load("vkSetDebugUtilsObjectNameEXT") : dev.load("vkSetDebugUtilsObjectNameEXT");
     PFN_vkSetDebugUtilsObjectTagEXT SetDebugUtilsObjectTagEXT;
@@ -909,33 +918,31 @@ void CheckDeviceFunctions(FrameworkEnvironment& env, bool use_GIPA, bool enable_
     PFN_vkCmdInsertDebugUtilsLabelEXT CmdInsertDebugUtilsLabelEXT;
     CmdInsertDebugUtilsLabelEXT = use_GIPA ? inst.load("vkCmdInsertDebugUtilsLabelEXT") : dev.load("vkCmdInsertDebugUtilsLabelEXT");
 
+    // Debug marker functions - should always be found when using GIPA but when using GDPA found only when the extension is enabled
     if (use_GIPA) {
-        // When querying from GIPA, these functions should always be found
         ASSERT_TRUE(nullptr != DebugMarkerSetObjectTagEXT);
         ASSERT_TRUE(nullptr != DebugMarkerSetObjectNameEXT);
-        // When querying from GIPA, these functions are found only if the extensions were enabled
-        ASSERT_EQ(enable_debug_extensions, nullptr != SetDebugUtilsObjectNameEXT);
-        ASSERT_EQ(enable_debug_extensions, nullptr != SetDebugUtilsObjectTagEXT);
-        ASSERT_EQ(enable_debug_extensions, nullptr != QueueBeginDebugUtilsLabelEXT);
-        ASSERT_EQ(enable_debug_extensions, nullptr != QueueEndDebugUtilsLabelEXT);
-        ASSERT_EQ(enable_debug_extensions, nullptr != QueueInsertDebugUtilsLabelEXT);
-        ASSERT_EQ(enable_debug_extensions, nullptr != CmdBeginDebugUtilsLabelEXT);
-        ASSERT_EQ(enable_debug_extensions, nullptr != CmdEndDebugUtilsLabelEXT);
-        ASSERT_EQ(enable_debug_extensions, nullptr != CmdInsertDebugUtilsLabelEXT);
+        ASSERT_TRUE(nullptr != CmdDebugMarkerBeginEXT);
+        ASSERT_TRUE(nullptr != CmdDebugMarkerEndEXT);
+        ASSERT_TRUE(nullptr != CmdDebugMarkerInsertEXT);
     } else {
-        // When querying from GDPA, these functions are found only if the extensions were enabled
         ASSERT_EQ(enable_debug_extensions, nullptr != DebugMarkerSetObjectTagEXT);
         ASSERT_EQ(enable_debug_extensions, nullptr != DebugMarkerSetObjectNameEXT);
-        ASSERT_EQ(enable_debug_extensions, nullptr != SetDebugUtilsObjectNameEXT);
-        ASSERT_EQ(enable_debug_extensions, nullptr != SetDebugUtilsObjectTagEXT);
-        // When querying from GDPA, these functions should always be found
-        ASSERT_TRUE(nullptr != QueueBeginDebugUtilsLabelEXT);
-        ASSERT_TRUE(nullptr != QueueEndDebugUtilsLabelEXT);
-        ASSERT_TRUE(nullptr != QueueInsertDebugUtilsLabelEXT);
-        ASSERT_TRUE(nullptr != CmdBeginDebugUtilsLabelEXT);
-        ASSERT_TRUE(nullptr != CmdEndDebugUtilsLabelEXT);
-        ASSERT_TRUE(nullptr != CmdInsertDebugUtilsLabelEXT);
+        ASSERT_EQ(enable_debug_extensions, nullptr != CmdDebugMarkerBeginEXT);
+        ASSERT_EQ(enable_debug_extensions, nullptr != CmdDebugMarkerEndEXT);
+        ASSERT_EQ(enable_debug_extensions, nullptr != CmdDebugMarkerInsertEXT);
     }
+
+    // Debug utils functions - should only be found if the extension was enabled (because its instance level)
+    ASSERT_EQ(enable_debug_extensions, nullptr != SetDebugUtilsObjectNameEXT);
+    ASSERT_EQ(enable_debug_extensions, nullptr != SetDebugUtilsObjectTagEXT);
+    ASSERT_EQ(enable_debug_extensions, nullptr != QueueBeginDebugUtilsLabelEXT);
+    ASSERT_EQ(enable_debug_extensions, nullptr != QueueEndDebugUtilsLabelEXT);
+    ASSERT_EQ(enable_debug_extensions, nullptr != QueueInsertDebugUtilsLabelEXT);
+    ASSERT_EQ(enable_debug_extensions, nullptr != CmdBeginDebugUtilsLabelEXT);
+    ASSERT_EQ(enable_debug_extensions, nullptr != CmdEndDebugUtilsLabelEXT);
+    ASSERT_EQ(enable_debug_extensions, nullptr != CmdInsertDebugUtilsLabelEXT);
+
     if (SetDebugUtilsObjectNameEXT) {
         VkDebugUtilsObjectNameInfoEXT obj_name_info{};
         obj_name_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;


### PR DESCRIPTION
This commit fixes the loader to check for the debug_utils extension being enabled before returning functions, fixes the tests to properly check for the functions when using both Get*ProcAddrs, and enhances the test framework to support querying for the debug marker extensions.

The debug_utils functions are special because they are from an instance level function. That means it is always possible to check if the extension that makes them available is enabled from both vkGetInstanceProcAddr and vkGetDeviceProcAddr. The loader was previously always returning valid functions for some of the debug_utils functions when the extension was not enabled, and this commit fixes that.

The debug_marker extension is a bit different, since it is a device level extension. Thus, querying the functions from vkGetInstanceProcAddr should always exceed - as we don't yet know if the extension was enabled or not.

Fixes #1177 