### PR TITLE
Prevent /W3 from being added to MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@
 # ~~~
 cmake_minimum_required(VERSION 3.17.2)
 
+# prevents /W3 from being added to MSVC builds by default
+cmake_policy(SET CMP0092 NEW)
+
 project(VULKAN_LOADER VERSION 1.3.248)
 
 add_subdirectory(scripts)


### PR DESCRIPTION
CMake 3.15 added a new policy which prevents the /W3 flag from being added to MSVC builds. To enable it, we need to set the CMake policy CMP0092 to the 'new' behavior. Note: To see the effect, I had to delete my CMakeCache.