### PR TITLE
cmake: Fix LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
               arch: ${{ matrix.arch }}
 
           - name: Configure
-            run: cmake -S. -B build -DUPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=${{matrix.config}} -G "Ninja"
+            run: cmake -S. -B build -DUPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=${{matrix.config}} -G "Ninja" -D LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING=ON
 
           - name: Build
             run: cmake --build ./build

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -258,11 +258,6 @@ else() # i.e.: Linux
     endif()
 endif()
 
-option(LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING "Causes the loader to not unload dynamic libraries.")
-if (LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING)
-    target_compile_definitions(vulkan PRIVATE LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING)
-endif()
-
 if(WIN32)
     add_library(loader-opt STATIC ${OPT_LOADER_SRCS})
     target_link_libraries(loader-opt PUBLIC loader_specific_options)
@@ -370,6 +365,11 @@ else()
         )
 # cmake-format: on
     endif()
+endif()
+
+option(LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING "Causes the loader to not unload dynamic libraries.")
+if (LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING)
+    target_compile_definitions(vulkan PRIVATE LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING)
 endif()
 
 # common attributes of the vulkan library

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -363,9 +363,11 @@ static inline const char *loader_platform_open_library_error(const char *libPath
 }
 static inline void loader_platform_close_library(loader_platform_dl_handle library) {
 #if defined(LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING)
+    (void)library;
     return;
-#endif
+#else
     dlclose(library);
+#endif
 }
 static inline void *loader_platform_get_proc_address(loader_platform_dl_handle library, const char *name) {
     assert(library);
@@ -512,9 +514,11 @@ static const char *loader_platform_open_library_error(const char *libPath) {
 }
 static void loader_platform_close_library(loader_platform_dl_handle library) {
 #if defined(LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING)
+    (void)library;
     return;
-#endif
+#else
     FreeLibrary(library);
+#endif
 }
 static void *loader_platform_get_proc_address(loader_platform_dl_handle library, const char *name) {
     assert(library);


### PR DESCRIPTION
Fixes this error:

```
CMake Error at loader/CMakeLists.txt:263 (target_compile_definitions):
  Cannot specify compile definitions for target "vulkan" which is not built
  by this project.
```