### PR TITLE
Don't export Vulkan functions when building the loader statically

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -62,6 +62,9 @@ config("vulkan_internal_config") {
       "FALLBACK_DATA_DIRS=\"/usr/local/share:/usr/share\"",
     ]
   }
+  if (!vulkan_loader_shared) {
+    defines += [ "BUILD_STATIC_LOADER" ]
+  }
 }
 
 # Vulkan loader

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -76,7 +76,9 @@
 
 #include "stack_allocation.h"
 
-#if defined(__GNUC__) && __GNUC__ >= 4
+#if defined(BUILD_STATIC_LOADER)
+#define LOADER_EXPORT
+#elif defined(__GNUC__) && __GNUC__ >= 4
 #define LOADER_EXPORT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
 #define LOADER_EXPORT __attribute__((visibility("default")))


### PR DESCRIPTION
If the loader is linked statically, there is no need to export all vulkan functions from the linking application. This issue showed up in ANGLE which would export all GLES and Vulkan functions on Mac.