### PR TITLE
Fix crash from layers creating devices on different physical devices

### DIFF
--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -308,7 +308,7 @@ VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_icd_term *icd_t
 VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_dispatch_table *dev_table, PFN_vkGetDeviceProcAddr gpa,
                                                              VkDevice dev) {
     VkLayerDispatchTable *table = &dev_table->core_dispatch;
-    table->magic = DEVICE_DISP_TABLE_MAGIC_NUMBER;
+    assert(table->magic == DEVICE_DISP_TABLE_MAGIC_NUMBER);
     for (uint32_t i = 0; i < MAX_NUM_UNKNOWN_EXTS; i++) dev_table->ext_dispatch[i] = (PFN_vkDevExt)vkDevExtError;
 
     // ---- Core 1_0 commands

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1238,6 +1238,8 @@ struct loader_device *loader_create_logical_device(const struct loader_instance 
         return NULL;
     }
 
+    new_dev->loader_dispatch.core_dispatch.magic = DEVICE_DISP_TABLE_MAGIC_NUMBER;
+
     if (pAllocator) {
         new_dev->alloc_callbacks = *pAllocator;
     }

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -780,7 +780,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 tables += 'VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_dispatch_table *dev_table, PFN_vkGetDeviceProcAddr gpa,\n'
                 tables += '                                                             VkDevice dev) {\n'
                 tables += '    VkLayerDispatchTable *table = &dev_table->core_dispatch;\n'
-                tables += '    table->magic = DEVICE_DISP_TABLE_MAGIC_NUMBER;\n'
+                tables += '    assert(table->magic == DEVICE_DISP_TABLE_MAGIC_NUMBER);\n'
                 tables += '    for (uint32_t i = 0; i < MAX_NUM_UNKNOWN_EXTS; i++) dev_table->ext_dispatch[i] = (PFN_vkDevExt)vkDevExtError;\n'
 
             elif x == 1:

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -177,6 +177,10 @@ struct TestLayer {
     // Have a layer query for vkCreateDevice with a NULL instance handle
     BUILDER_VALUE(TestLayer, bool, buggy_query_of_vkCreateDevice, false)
 
+    // Makes the layer try to create a device using the loader provided function in the layer chain
+    BUILDER_VALUE(TestLayer, bool, call_create_device_while_create_device_is_called, false)
+    BUILDER_VALUE(TestLayer, uint32_t, physical_device_index_to_use_during_create_device, 0)
+
     PFN_vkGetInstanceProcAddr next_vkGetInstanceProcAddr = VK_NULL_HANDLE;
     PFN_GetPhysicalDeviceProcAddr next_GetPhysicalDeviceProcAddr = VK_NULL_HANDLE;
     PFN_vkGetDeviceProcAddr next_vkGetDeviceProcAddr = VK_NULL_HANDLE;
@@ -189,6 +193,12 @@ struct TestLayer {
         VkLayerDispatchTable dispatch_table{};
     };
     std::vector<Device> created_devices;
+
+    // Stores the callback that allows layers to create devices on their own
+    PFN_vkLayerCreateDevice callback_vkCreateDevice{};
+    PFN_vkLayerDestroyDevice callback_vkDestroyDevice{};
+    std::vector<VkPhysicalDevice> queried_physical_devices;
+    Device second_device_created_during_create_device{};
 };
 
 using GetTestLayerFunc = TestLayer* (*)();


### PR DESCRIPTION
The magic value for the device dispatch table was being set after calling down the layer chain rather than before. This is wrong because of the situation when layers create devices from different physical devices, the magic value using the default value of zero means that loader_get_icd_and_device will return the wrong loader_icd_term, leading to crashes elsewhere.

The fix is to set the magic value right after the dispatch table is allocated.

This commit adds tests for both drivers being created from the same physical device and from different physical devices.

Fixes #1198 