### PR TITLE
Fix layer querying of instance functions after create instance

### DIFF
--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -235,6 +235,9 @@ struct loader_instance {
     struct loader_instance_dispatch_table *disp;  // must be first entry in structure
     uint64_t magic;                               // Should be LOADER_MAGIC_NUMBER
 
+    // Store all the terminators for instance functions in case a layer queries one *after* vkCreateInstance
+    VkLayerInstanceDispatchTable terminator_dispatch;
+
     // Vulkan API version the app is intending to use.
     loader_api_version app_api_version;
 
@@ -294,6 +297,9 @@ struct loader_instance {
     VkLayerDbgFunctionNode *InstanceCreationDeletionDebugFunctionHead;
 
     VkAllocationCallbacks alloc_callbacks;
+
+    // Set to true after vkCreateInstance has returned - necessary for loader_gpa_instance_terminator()
+    bool instance_finished_creation;
 
     bool portability_enumeration_enabled;
 

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -600,6 +600,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         // GetInstanceProcAddr functions to return valid extension functions
         // if enabled.
         loader_activate_instance_layer_extensions(ptr_instance, created_instance);
+        ptr_instance->instance_finished_creation = true;
     } else if (VK_ERROR_EXTENSION_NOT_PRESENT == res && !ptr_instance->create_terminator_invalid_extension) {
         loader_log(ptr_instance, VULKAN_LOADER_WARN_BIT, 0,
                    "vkCreateInstance: Layer returning invalid extension error not triggered by ICD/Loader (Policy #LLP_LAYER_17).");

--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -253,6 +253,14 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo*
         }
     }
 
+    if (layer.check_if_EnumDevExtProps_is_same_as_queried_function) {
+        auto chain_info_EnumDeviceExtProps = reinterpret_cast<PFN_vkEnumerateDeviceExtensionProperties>(
+            fpGetInstanceProcAddr(layer.instance_handle, "vkEnumerateDeviceExtensionProperties"));
+        if (chain_info_EnumDeviceExtProps != layer.instance_dispatch_table.EnumerateDeviceExtensionProperties) {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+    }
+
     return result;
 }
 
@@ -284,6 +292,13 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevi
 
     layer.next_vkGetDeviceProcAddr = fpGetDeviceProcAddr;
 
+    if (layer.check_if_EnumDevExtProps_is_same_as_queried_function) {
+        auto chain_info_EnumDeviceExtProps = reinterpret_cast<PFN_vkEnumerateDeviceExtensionProperties>(
+            fpGetInstanceProcAddr(layer.instance_handle, "vkEnumerateDeviceExtensionProperties"));
+        if (chain_info_EnumDeviceExtProps != layer.instance_dispatch_table.EnumerateDeviceExtensionProperties) {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+    }
     // Advance the link info for the next element on the chain
     chain_info->u.pLayerInfo = chain_info->u.pLayerInfo->pNext;
 

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -181,6 +181,8 @@ struct TestLayer {
     BUILDER_VALUE(TestLayer, bool, call_create_device_while_create_device_is_called, false)
     BUILDER_VALUE(TestLayer, uint32_t, physical_device_index_to_use_during_create_device, 0)
 
+    BUILDER_VALUE(TestLayer, bool, check_if_EnumDevExtProps_is_same_as_queried_function, false)
+
     PFN_vkGetInstanceProcAddr next_vkGetInstanceProcAddr = VK_NULL_HANDLE;
     PFN_GetPhysicalDeviceProcAddr next_GetPhysicalDeviceProcAddr = VK_NULL_HANDLE;
     PFN_vkGetDeviceProcAddr next_vkGetDeviceProcAddr = VK_NULL_HANDLE;

--- a/tests/framework/layer/wrap_objects.cpp
+++ b/tests/framework/layer/wrap_objects.cpp
@@ -170,7 +170,7 @@ VKAPI_ATTR VkResult VKAPI_CALL wrap_vkCreateInstance(const VkInstanceCreateInfo 
         inst->pfn_inst_init = NULL;
         inst->loader_disp = *(reinterpret_cast<VkLayerInstanceDispatchTable **>(inst->obj));
     }
-    layer_init_instance_dispatch_table(*pInstance, &inst->layer_disp, fpGetInstanceProcAddr);
+    layer_init_instance_dispatch_table(inst->obj, &inst->layer_disp, fpGetInstanceProcAddr);
     bool found = false;
     for (uint32_t layer = 0; layer < pCreateInfo->enabledLayerCount; ++layer) {
         std::string layer_name = pCreateInfo->ppEnabledLayerNames[layer];

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -515,9 +515,10 @@ void FrameworkEnvironment::add_layer_impl(TestLayerDetails layer_details, Manife
     size_t new_layers_start = layers.size();
     for (auto& layer : layer_details.layer_manifest.layers) {
         if (!layer.lib_path.str().empty()) {
-            std::string layer_binary_name = layer.lib_path.filename().str() + "_" + std::to_string(layers.size());
+            fs::path layer_binary_name =
+                layer.lib_path.filename().stem() + "_" + std::to_string(layers.size()) + layer.lib_path.filename().extension();
 
-            auto new_layer_location = folder.copy_file(layer.lib_path, layer_binary_name);
+            auto new_layer_location = folder.copy_file(layer.lib_path, layer_binary_name.str());
 
             // Don't load the layer binary if using any of the wrap objects layers, since it doesn't export the same interface
             // functions


### PR DESCRIPTION
Layers are given chainInfo during instance and device creation. This contains
vkGetInstanceProcAddr (GIPA) that corresponds to the next layer in the chain,
and if there is none, the loader's GIPA terminator. During vkCreateInstance
the instance dispatch table contains the terminators for instance functions.
After vkCreateInstance returns up the call chain, these terminators get
overwritten by calling GIPA on the first layer in the chain.

The problem is that after vkCreateInstance, the instance dispatch table
is being used by loader_gpa_instance_terminator, resulting in the wrong
function being returned to a layer who calls it.

This problem typically only shows up during vkCreateDevice, because the
chainInfo is given to each layer and that chainInfo contains a "nextGIPA".
Except, only the last layer gets a pointer to loader_gpa_instance_terminator,
as every other layer gets the GIPA of the next layer in the chain. Still,
this last layer should not be getting a pointer to the first function in
the chain.

The solution is to stash the terminator dispatch table after returning up
the vkCreateInstance chain but before overwriting the dispatch table with
the first layer in each function chain. Then, inside of
loader_gpa_instance_terminator check if we are still inside of
vkCreateInstance or not.

Fixes #1200 