### PR TITLE
LOADER_USE_UNSAFE_FILE_SEARCH

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
               arch: ${{ matrix.arch }}
 
           - name: Configure
-            run: cmake -S. -B build -DUPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=${{matrix.config}} -G "Ninja" -D LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING=ON
+            run: cmake -S. -B build -DUPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=${{matrix.config}} -G "Ninja" -D LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING=ON -D LOADER_USE_UNSAFE_FILE_SEARCH=ON
 
           - name: Build
             run: cmake --build ./build

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2019 The ANGLE Project Authors.
-# Copyright (C) 2019 LunarG, Inc.
+# Copyright (C) 2019-2023 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ config("vulkan_loader_config") {
   ]
   defines = [
     "API_NAME=\"Vulkan\"",
-    "USE_UNSAFE_FILE_SEARCH=1",
+    "LOADER_USE_UNSAFE_FILE_SEARCH=1",
   ]
 
   if (is_win) {

--- a/BUILD.md
+++ b/BUILD.md
@@ -253,6 +253,9 @@ on/off options currently supported by this repository:
 | LOADER_ENABLE_ADDRESS_SANITIZER          | Linux & macOS | `OFF`   | Enables Address Sanitizer in the loader and tests.                                                                                                                                |
 | LOADER_ENABLE_THREAD_SANITIZER           | Linux & macOS | `OFF`   | Enables Thread Sanitizer in the loader and tests.                                                                                                                                 |
 | LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING | All           | `OFF`   | Causes the loader to not unload dynamic libraries. Example use case. This option allows leak sanitizers to have full stack traces.       |
+| LOADER_USE_UNSAFE_FILE_SEARCH            | All           | `OFF`   | Disables security policies that prevent unsecure locations from being used when running with elevated permissions.  |
+
+NOTE: `LOADER_USE_UNSAFE_FILE_SEARCH` should NOT be enabled except in very specific contexts (like isolated test environments)!
 
 The following is a table of all string options currently supported by this repository:
 
@@ -263,26 +266,6 @@ The following is a table of all string options currently supported by this repos
 | BUILD_DLL_VERSIONINFO | Windows     | `""` (empty string)           | Allows setting the Windows specific version information for the Loader DLL. Format is "major.minor.patch.build".                                     |
 
 These variables should be set using the `-D` option when invoking CMake to generate the native platform files.
-
-### CCACHE
-
-There are 2 methods to enable CCACHE:
-
-1.) Set environment variables
-
-```bash
-# Requires CMake 3.17 (https://cmake.org/cmake/help/latest/envvar/CMAKE_LANG_COMPILER_LAUNCHER.html)
-export CMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache
-export CMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
-```
-
-2.) Pass in cache variables
-
-```
-cmake ... -D CMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache -D CMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
-```
-
-
 
 ## Building On Windows
 

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -367,6 +367,11 @@ else()
     endif()
 endif()
 
+option(LOADER_USE_UNSAFE_FILE_SEARCH "Allows the loader to search in unsafe locations")
+if (LOADER_USE_UNSAFE_FILE_SEARCH)
+    target_compile_definitions(vulkan PRIVATE LOADER_USE_UNSAFE_FILE_SEARCH)
+endif()
+
 option(LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING "Causes the loader to not unload dynamic libraries.")
 if (LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING)
     target_compile_definitions(vulkan PRIVATE LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING)

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1815,6 +1815,10 @@ void loader_initialize(void) {
 #if defined(LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING)
     loader_log(NULL, VULKAN_LOADER_WARN_BIT, 0, "Vulkan Loader: library unloading is disabled");
 #endif
+
+#if defined(LOADER_USE_UNSAFE_FILE_SEARCH)
+    loader_log(NULL, VULKAN_LOADER_WARN_BIT, 0, "Vulkan Loader: unsafe searching is enabled");
+#endif
 }
 
 void loader_release() {

--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -1,8 +1,8 @@
 /*
  *
- * Copyright (c) 2014-2022 The Khronos Group Inc.
- * Copyright (c) 2014-2022 Valve Corporation
- * Copyright (c) 2014-2022 LunarG, Inc.
+ * Copyright (c) 2014-2023 The Khronos Group Inc.
+ * Copyright (c) 2014-2023 Valve Corporation
+ * Copyright (c) 2014-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,15 +61,15 @@ char *loader_secure_getenv(const char *name, const struct loader_instance *inst)
 #else
     // Linux
     char *out;
-#if defined(HAVE_SECURE_GETENV) && !defined(USE_UNSAFE_FILE_SEARCH)
+#if defined(HAVE_SECURE_GETENV) && !defined(LOADER_USE_UNSAFE_FILE_SEARCH)
     (void)inst;
     out = secure_getenv(name);
-#elif defined(HAVE___SECURE_GETENV) && !defined(USE_UNSAFE_FILE_SEARCH)
+#elif defined(HAVE___SECURE_GETENV) && !defined(LOADER_USE_UNSAFE_FILE_SEARCH)
     (void)inst;
     out = __secure_getenv(name);
 #else
     out = loader_getenv(name, inst);
-#if !defined(USE_UNSAFE_FILE_SEARCH)
+#if !defined(LOADER_USE_UNSAFE_FILE_SEARCH)
     loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "Loader is using non-secure environment variable lookup for %s", name);
 #endif
 #endif
@@ -146,7 +146,7 @@ char *loader_getenv(const char *name, const struct loader_instance *inst) {
 }
 
 char *loader_secure_getenv(const char *name, const struct loader_instance *inst) {
-#if !defined(USE_UNSAFE_FILE_SEARCH)
+#if !defined(LOADER_USE_UNSAFE_FILE_SEARCH)
     if (is_high_integrity()) {
         loader_log(inst, VULKAN_LOADER_INFO_BIT, 0,
                    "Loader is running with elevated permissions. Environment variable %s will be ignored", name);

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -135,7 +135,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyDriverEnvVar) {
 }
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-// Make sure the loader reports the correct message based on if USE_UNSAFE_FILE_SEARCH is set or not
+// Make sure the loader reports the correct message based on if LOADER_USE_UNSAFE_FILE_SEARCH is set or not
 TEST(EnvVarICDOverrideSetup, NonSecureEnvVarLookup) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
@@ -146,7 +146,7 @@ TEST(EnvVarICDOverrideSetup, NonSecureEnvVarLookup) {
     FillDebugUtilsCreateDetails(inst.create_info, log);
     inst.CheckCreate();
 
-#if !defined(USE_UNSAFE_FILE_SEARCH)
+#if !defined(LOADER_USE_UNSAFE_FILE_SEARCH)
     ASSERT_FALSE(log.find("Loader is using non-secure environment variable lookup for"));
 #else
     ASSERT_TRUE(log.find("Loader is using non-secure environment variable lookup for"));


### PR DESCRIPTION
Make LOADER_USE_UNSAFE_FILE_SEARCH a CMake option.

Allows validation layers to disable safe search to work around permissions issues on Github Actions.