### PR TITLE
LOADER_CODEGEN

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -23,7 +23,6 @@ Instructions for building this repository on Linux, Windows, and MacOS.
         - [Notes About the Automatic Option](#notes-about-the-automatic-option)
     - [Generated source code](#generated-source-code)
     - [Build Options](#build-options)
-    - [CCACHE](#ccache)
   - [Building On Windows](#building-on-windows)
     - [Windows Development Environment Requirements](#windows-development-environment-requirements)
     - [Windows Build - Microsoft Visual Studio](#windows-build---microsoft-visual-studio)
@@ -103,8 +102,7 @@ This repository attempts to resolve some of its dependencies by using
 components found from the following places, in this order:
 
 1. CMake or Environment variable overrides (e.g., -DVULKAN_HEADERS_INSTALL_DIR)
-1. LunarG Vulkan SDK, located by the `VULKAN_SDK` environment variable
-1. System-installed packages, mostly applicable on Linux
+2. System-installed packages, mostly applicable on Linux
 
 Dependencies that cannot be resolved by the SDK or installed packages must be
 resolved with the "install directory" override and are listed below. The
@@ -222,14 +220,17 @@ heavy-lifting, you may just trigger the following CMake commands:
 This repository contains generated source code in the `loader/generated`
 directory which is not intended to be modified directly. Instead, changes should be
 made to the corresponding generator in the `scripts` directory. The source files can
-then be regenerated using `scripts/generate_source.py`:
+then be regenerated using `scripts/generate_source.py`.
 
-    python3 scripts/generate_source.py PATH_TO_VULKAN_HEADERS_REGISTRY_DIR
+Run `python scripts/generate_source.py --help` to see how to invoke it.
 
-A helper CMake target `VulkanLoader_generated_source` is also provided to simplify
-the invocation of `scripts/generate_source.py` from the build directory:
+A helper CMake target `loader_codegen` is also provided to simplify the invocation of `scripts/generate_source.py`.
 
-    cmake --build . --target VulkanLoader_generated_source
+```
+# Note by default this helper target is disabled
+cmake -S . -B build -D LOADER_CODEGEN=ON
+cmake --build . --target loader_codegen
+```
 
 ### Build Options
 
@@ -254,6 +255,7 @@ on/off options currently supported by this repository:
 | LOADER_ENABLE_THREAD_SANITIZER           | Linux & macOS | `OFF`   | Enables Thread Sanitizer in the loader and tests.                                                                                                                                 |
 | LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING | All           | `OFF`   | Causes the loader to not unload dynamic libraries. Example use case. This option allows leak sanitizers to have full stack traces.       |
 | LOADER_USE_UNSAFE_FILE_SEARCH            | All           | `OFF`   | Disables security policies that prevent unsecure locations from being used when running with elevated permissions.  |
+| LOADER_CODEGEN                           | All           | `OFF`   | Creates a helper CMake target to generate code. |
 
 NOTE: `LOADER_USE_UNSAFE_FILE_SEARCH` should NOT be enabled except in very specific contexts (like isolated test environments)!
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,6 @@ project(VULKAN_LOADER VERSION 1.3.250)
 
 add_subdirectory(scripts)
 
-find_package(PythonInterp 3 QUIET)
-
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
@@ -229,15 +227,13 @@ if(NOT MSVC AND NOT (HAVE_SECURE_GETENV OR HAVE___SECURE_GETENV))
     message(WARNING "Using non-secure environmental lookups. This loader will not properly disable environent variables when run with elevated permissions.")
 endif()
 
-# Optional codegen target
-if(PYTHONINTERP_FOUND)
-    add_custom_target(VulkanLoader_generated_source
-                      COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/generate_source.py
-                              ${VULKAN_HEADERS_REGISTRY_DIRECTORY}
-                              --generated-version ${VulkanHeaders_VERSION}
-                              --incremental)
-else()
-    message(WARNING "VulkanLoader_generated_source target requires python 3")
+option(LOADER_CODEGEN "Enable vulkan loader code generation")
+if(LOADER_CODEGEN)
+    find_package(Python3 REQUIRED)
+    add_custom_target(loader_codegen
+        COMMAND Python3::Interpreter ${PROJECT_SOURCE_DIR}/scripts/generate_source.py ${VULKAN_HEADERS_REGISTRY_DIRECTORY}
+                --generated-version ${VulkanHeaders_VERSION} --incremental
+    )
 endif()
 
 if(UNIX)

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -161,13 +161,13 @@ if(WIN32)
             # Force off optimization so that the output assembly includes all the necessary info - optimizer would get rid of it otherwise.
             target_compile_options(asm_offset PRIVATE /Od)
 
-            find_package(PythonInterp REQUIRED)
+            find_package(Python3 REQUIRED QUIET)
             # Run parse_asm_values.py on asm_offset's assembly file to generate the gen_defines.asm, which the asm code depends on
             add_custom_command(TARGET asm_offset POST_BUILD
-                COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/parse_asm_values.py "${CMAKE_CURRENT_BINARY_DIR}/gen_defines.asm"
+                COMMAND Python3::Interpreter ${PROJECT_SOURCE_DIR}/scripts/parse_asm_values.py "${CMAKE_CURRENT_BINARY_DIR}/gen_defines.asm"
                     "$<TARGET_FILE_DIR:asm_offset>/asm_offset.asm" "MASM" "${CMAKE_CXX_COMPILER_ID}" "${CMAKE_SYSTEM_PROCESSOR}"
                 BYPRODUCTS gen_defines.asm
-                )
+            )
         endif()
         add_custom_target(loader_asm_gen_files DEPENDS gen_defines.asm)
         set_target_properties(loader_asm_gen_files PROPERTIES FOLDER ${LOADER_HELPER_FOLDER})
@@ -238,13 +238,13 @@ else() # i.e.: Linux
                 set(ASM_OFFSET_INTERMEDIATE_LOCATION "$<TARGET_FILE_DIR:asm_offset>/CMakeFiles/asm_offset.dir/asm_offset.s")
             endif()
 
-            find_package(PythonInterp REQUIRED)
+            find_package(Python3 REQUIRED QUIET)
             # Run parse_asm_values.py on asm_offset's assembly file to generate the gen_defines.asm, which the asm code depends on
             add_custom_command(TARGET asm_offset POST_BUILD
-                COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/parse_asm_values.py "$<TARGET_FILE_DIR:asm_offset>/gen_defines.asm"
+                COMMAND Python3::Interpreter ${PROJECT_SOURCE_DIR}/scripts/parse_asm_values.py "$<TARGET_FILE_DIR:asm_offset>/gen_defines.asm"
                     "${ASM_OFFSET_INTERMEDIATE_LOCATION}" "GAS" "${CMAKE_CXX_COMPILER_ID}" "${ASM_OFFSET_SYSTEM_PROCESSOR}"
                 BYPRODUCTS gen_defines.asm
-                )
+            )
         endif()
         add_custom_target(loader_asm_gen_files DEPENDS gen_defines.asm)
     else()

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -54,7 +54,7 @@ def main(argv):
     # get directory where generators will run
     if args.verify or args.incremental:
         # generate in temp directory so we can compare or copy later
-        temp_obj = tempfile.TemporaryDirectory(prefix='VulkanLoader_generated_source_')
+        temp_obj = tempfile.TemporaryDirectory(prefix='loader_codegen_')
         temp_dir = temp_obj.name
         gen_dir = temp_dir
     else:


### PR DESCRIPTION
There are a couple things at play here.

Only enable codegen helper target for users who request it. Avoids issues with package managers.

Also avoid usage of `find_package(PythonInterp 3)` which has been deprecated since 3.12