### PR TITLE
Remove foward declaration of VkResult and VkFlags

### DIFF
--- a/loader/log.h
+++ b/loader/log.h
@@ -31,8 +31,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "vulkan/vulkan_core.h"
+
 struct loader_instance;
-typedef uint32_t VkFlags;
 
 enum vulkan_loader_debug_flags {
     VULKAN_LOADER_INFO_BIT = 0x01,

--- a/loader/settings.h
+++ b/loader/settings.h
@@ -28,9 +28,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "vulkan/vulkan_core.h"
+
 #include "log.h"
 
-typedef enum VkResult VkResult;
 struct loader_instance;
 struct loader_layer_list;
 struct loader_pointer_layer_list;


### PR DESCRIPTION
While it is nice to forward declare the 1 type needed, it is better to include vulkan.h since the enum forward declaration is a microsoft specific extension.