### PR TITLE
Remove inclusion of winsock2.h

### DIFF
--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -29,11 +29,6 @@
 #include <sys/select.h>
 #endif
 
-#if defined(_WIN32)
-// WinSock2.h must be included *BEFORE* windows.h
-#include <winsock2.h>
-#endif  // _WIN32
-
 #include <assert.h>
 #include <string.h>
 #include <stdbool.h>


### PR DESCRIPTION
The header is unused and causes compilation issues due to the header needing to be included before windows.h