### PR TITLE
Fix fallback unknown function build logic & add no-asm CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,34 @@ jobs:
             - name: Verify commit message formatting
               run: ./scripts/check_commit_message_format.sh
 
+    linux-no-asm:
+        runs-on: ubuntu-22.04
+
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v3
+              with:
+                python-version: '3.7'
+            - uses: lukka/get-cmake@latest
+              with:
+                cmakeVersion: 3.17.2
+            - run: sudo apt update
+            - name: Install Dependencies
+              run: sudo apt install --yes --no-install-recommends libwayland-dev libxrandr-dev
+
+            - name: Generate build files
+              run: cmake -S. -B build -D CMAKE_BUILD_TYPE=Release -D BUILD_TESTS=ON -D UPDATE_DEPS=ON -DUSE_GAS=OFF
+              env:
+                CC: clang
+                CXX: clang++
+
+            - name: Build the loader
+              run: cmake --build build
+
+            - name: Run regression tests
+              working-directory: ./build
+              run: ctest --output-on-failure -E UnknownFunction
+
     linux-32:
         runs-on: ${{matrix.os}}
 
@@ -144,6 +172,42 @@ jobs:
               working-directory: ./build
               run: ctest --output-on-failure
 
+    linux-32-no-asm:
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v3
+              with:
+                python-version: '3.7'
+            - uses: lukka/get-cmake@latest
+              with:
+                cmakeVersion: 3.17.2
+
+            - name: Enable 32 bit
+              run: |-
+                sudo dpkg --add-architecture i386
+            - name: Update packages
+              run: |-
+                sudo apt-get update
+            - name: Install Dependencies
+              run: |-
+                sudo apt install --yes --no-install-recommends gcc-multilib g++-multilib libc6:i386 libc6-dev-i386 libgcc-s1:i386 libwayland-dev:i386 libxrandr-dev:i386
+
+            - name: Generate build files
+              run: cmake -S. -B build -D CMAKE_BUILD_TYPE=Release -D BUILD_TESTS=ON -D UPDATE_DEPS=ON -D USE_GAS=OFF
+              env:
+                CFLAGS: -m32
+                CXXFLAGS: -m32
+                LDFLAGS: -m32
+                ASFLAGS: --32
+
+            - name: Build the loader
+              run: cmake --build build
+
+            - name: Run regression tests
+              working-directory: ./build
+              run: ctest --output-on-failure -E UnknownFunction
+
     windows_vs:
         runs-on: windows-latest
         strategy:
@@ -169,6 +233,28 @@ jobs:
             - name: Run regression tests
               working-directory: ./build
               run: ctest --output-on-failure -C ${{matrix.config}}
+
+    windows_vs-no-asm:
+        runs-on: windows-latest
+        strategy:
+            matrix:
+                arch: [ Win32, x64 ]
+
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v3
+              with:
+                python-version: '3.7'
+
+            - name: Generate build files
+              run: cmake -S. -B build -DBUILD_TESTS=ON -DUPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Release -A ${{ matrix.arch }} -USE_MASM=OFF
+
+            - name: Build the loader
+              run: cmake --build ./build --config Release
+
+            - name: Run regression tests
+              working-directory: ./build
+              run: ctest --output-on-failure -C Release -E UnknownFunction
 
     # Something about Github Actions + Windows + Ninja + Unicode doesn't play nicely together.
     # https://github.com/KhronosGroup/Vulkan-Loader/pull/1188#issuecomment-1536659318
@@ -275,6 +361,34 @@ jobs:
               working-directory: ./build
               run: ctest --output-on-failure
 
+    mac-no-asm:
+        runs-on: macos-latest
+
+        strategy:
+            matrix:
+                static_build: [ BUILD_STATIC_LOADER=ON, BUILD_STATIC_LOADER=OFF ]
+
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v3
+              with:
+                python-version: '3.7'
+            - uses: lukka/get-cmake@latest
+            - name: Generate build files
+              run: cmake -S. -B build -D CMAKE_BUILD_TYPE=Release -D ${{matrix.static_build}} -D BUILD_TESTS=ON -D UPDATE_DEPS=ON -D USE_GAS=OFF -G "Ninja"
+              env:
+                # Specify the minimum version of macOS on which the target binaries are to be deployed.
+                # https://cmake.org/cmake/help/latest/envvar/MACOSX_DEPLOYMENT_TARGET.html
+                MACOSX_DEPLOYMENT_TARGET: 10.12
+
+            - name: Build the loader
+              run: cmake --build build
+
+            - name: Run regression tests
+              working-directory: ./build
+              run: ctest --output-on-failure -E UnknownFunction
+
+
     gn:
         runs-on: ubuntu-20.04
 
@@ -322,6 +436,37 @@ jobs:
           run: gcc --version # If this fails MINGW is not setup correctly
         - name: Configure
           run: cmake -S. -B build -D UPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Release
+          env:
+            LDFLAGS: -fuse-ld=lld # MINGW linking is very slow. Use llvm linker instead.
+            CMAKE_C_COMPILER_LAUNCHER: ccache
+            CMAKE_CXX_COMPILER_LAUNCHER: ccache
+            CMAKE_GENERATOR: Ninja
+        - name: Build
+          run: cmake --build build -- --quiet
+        - name: Install
+          run: cmake --install build --prefix build/install
+        - name: MinGW ccache stats # The Post Setup ccache doesn't work right on MinGW
+          run: ccache --show-stats
+
+    mingw-no-asm:
+      runs-on: windows-2022
+      defaults:
+        run:
+          shell: bash
+      steps:
+        - uses: actions/checkout@v3
+        - name: Setup ccache
+          uses: hendrikmuhs/ccache-action@v1.2
+          with:
+            key: mingw-ccache
+        - uses: actions/setup-python@v4
+          with:
+            python-version: '3.8'
+        - uses: lukka/get-cmake@latest
+        - name: GCC Version
+          run: gcc --version # If this fails MINGW is not setup correctly
+        - name: Configure
+          run: cmake -S. -B build -D UPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Release -D USE_MASM=OFF
           env:
             LDFLAGS: -fuse-ld=lld # MINGW linking is very slow. Use llvm linker instead.
             CMAKE_C_COMPILER_LAUNCHER: ccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,36 +417,38 @@ jobs:
             - name: Build the loader
               run: ninja -C out/${{matrix.config}}
 
-    mingw:
-      runs-on: windows-2022
-      defaults:
-        run:
-          shell: bash
-      steps:
-        - uses: actions/checkout@v3
-        - name: Setup ccache
-          uses: hendrikmuhs/ccache-action@v1.2
-          with:
-            key: mingw-ccache
-        - uses: actions/setup-python@v4
-          with:
-            python-version: '3.8'
-        - uses: lukka/get-cmake@latest
-        - name: GCC Version
-          run: gcc --version # If this fails MINGW is not setup correctly
-        - name: Configure
-          run: cmake -S. -B build -D UPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Release
-          env:
-            LDFLAGS: -fuse-ld=lld # MINGW linking is very slow. Use llvm linker instead.
-            CMAKE_C_COMPILER_LAUNCHER: ccache
-            CMAKE_CXX_COMPILER_LAUNCHER: ccache
-            CMAKE_GENERATOR: Ninja
-        - name: Build
-          run: cmake --build build -- --quiet
-        - name: Install
-          run: cmake --install build --prefix build/install
-        - name: MinGW ccache stats # The Post Setup ccache doesn't work right on MinGW
-          run: ccache --show-stats
+    # MinGW uses JWASM to compile the assembly code - since that isn't available on github actions, this run is disabled
+
+    # mingw:
+    #   runs-on: windows-2022
+    #   defaults:
+    #     run:
+    #       shell: bash
+    #   steps:
+    #     - uses: actions/checkout@v3
+    #     - name: Setup ccache
+    #       uses: hendrikmuhs/ccache-action@v1.2
+    #       with:
+    #         key: mingw-ccache
+    #     - uses: actions/setup-python@v4
+    #       with:
+    #         python-version: '3.8'
+    #     - uses: lukka/get-cmake@latest
+    #     - name: GCC Version
+    #       run: gcc --version # If this fails MINGW is not setup correctly
+    #     - name: Configure
+    #       run: cmake -S. -B build -D UPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Release
+    #       env:
+    #         LDFLAGS: -fuse-ld=lld # MINGW linking is very slow. Use llvm linker instead.
+    #         CMAKE_C_COMPILER_LAUNCHER: ccache
+    #         CMAKE_CXX_COMPILER_LAUNCHER: ccache
+    #         CMAKE_GENERATOR: Ninja
+    #     - name: Build
+    #       run: cmake --build build -- --quiet
+    #     - name: Install
+    #       run: cmake --install build --prefix build/install
+    #     - name: MinGW ccache stats # The Post Setup ccache doesn't work right on MinGW
+    #       run: ccache --show-stats
 
     mingw-no-asm:
       runs-on: windows-2022

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -189,11 +189,8 @@ if(WIN32)
         target_include_directories(loader-unknown-chain PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
         add_dependencies(loader-unknown-chain loader_asm_gen_files)
     else()
+        set(USE_ASSEMBLY_FALLBACK ON)
         message(WARNING "Could not find working MASM assembler\n${ASM_FAILURE_MSG}")
-        add_custom_target(loader_asm_gen_files)
-        add_library(loader-unknown-chain OBJECT unknown_ext_chain.c)
-        target_link_libraries(loader-unknown-chain loader_specific_options)
-        set_target_properties(loader-unknown-chain PROPERTIES CMAKE_C_FLAGS_DEBUG "${MODIFIED_C_FLAGS_DEBUG}")
     endif()
 elseif(UNIX) # i.e.: Linux & Apple
     option(USE_GAS "Use GAS" ON)
@@ -254,20 +251,30 @@ elseif(UNIX) # i.e.: Linux & Apple
             )
         endif()
         add_custom_target(loader_asm_gen_files DEPENDS gen_defines.asm)
+
+        if (APPLE)
+            set(MODIFY_UNKNOWN_FUNCTION_DECLS ON)
+        endif()
     else()
+        set(USE_ASSEMBLY_FALLBACK ON)
         if(USE_GAS)
             message(WARNING "Could not find working ${ASM_OFFSET_SYSTEM_PROCESSOR} GAS assembler\n${ASM_FAILURE_MSG}")
         else()
             message(WARNING "Assembly sources have been disabled\n${ASM_FAILURE_MSG}")
         endif()
-        set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain.c)
-        add_custom_target(loader_asm_gen_files)
     endif()
-else()
-    # For other platforms, use the C code and force the compiler's tail-call optimization instead of using assembly code.
-    set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain.c)
-    set_source_files_properties(${OPT_LOADER_SRCS} PROPERTIES COMPILE_FLAGS -O)
-    add_custom_target(loader_asm_gen_files) # This causes no assembly files to be generated.
+endif()
+
+if(USE_ASSEMBLY_FALLBACK)
+    add_custom_target(loader_asm_gen_files)
+    if (MSVC)
+        add_library(loader-unknown-chain OBJECT unknown_ext_chain.c)
+        target_link_libraries(loader-unknown-chain loader_specific_options)
+        set_target_properties(loader-unknown-chain PROPERTIES CMAKE_C_FLAGS_DEBUG "${MODIFIED_C_FLAGS_DEBUG}")
+    else()
+        set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain.c)
+        set_source_files_properties(${OPT_LOADER_SRCS} PROPERTIES COMPILE_FLAGS -O)
+    endif()
 endif()
 
 if(WIN32)
@@ -282,10 +289,16 @@ if(WIN32)
         set(RC_FILE_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/loader.rc)
     endif()
 
+    if (MSVC)
+        set(LOADER_UNKNOWN_CHAIN_LIBRARY $<TARGET_OBJECTS:loader-unknown-chain>)
+    else()
+        set(LOADER_UNKNOWN_CHAIN_LIBRARY "")
+    endif()
+
     add_library(vulkan
                 SHARED
                 ${NORMAL_LOADER_SRCS}
-                $<TARGET_OBJECTS:loader-unknown-chain>
+                ${LOADER_UNKNOWN_CHAIN_LIBRARY}
                 ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-1.def
                 ${RC_FILE_LOCATION})
 
@@ -355,6 +368,13 @@ else()
         add_dependencies(vulkan-framework loader_asm_gen_files)
         target_link_libraries(vulkan-framework ${CMAKE_DL_LIBS} Threads::Threads -lm "-framework CoreFoundation")
         target_link_libraries(vulkan-framework loader_specific_options)
+
+        if (MODIFY_UNKNOWN_FUNCTION_DECLS)
+            # Modifies the names of functions as they appearin the assembly code so that the
+            # unknown function handling will work
+            target_compile_definitions(vulkan PRIVATE MODIFY_UNKNOWN_FUNCTION_DECLS)
+            target_compile_definitions(vulkan-framework PRIVATE MODIFY_UNKNOWN_FUNCTION_DECLS)
+        endif()
 
         # The FRAMEWORK_VERSION needs to be "A" here so that Xcode code-signing works when a user adds their framework to an Xcode
         # project and does "Sign on Copy". It would have been nicer to use "1" to denote Vulkan 1. Although Apple docs say that a

--- a/loader/dev_ext_trampoline.c
+++ b/loader/dev_ext_trampoline.c
@@ -25,7 +25,7 @@
 #endif
 
 // The asm declaration prevents name mangling which is necessary for macOS
-#if defined(__GNUC__) && defined(__clang__)
+#if defined(MODIFY_UNKNOWN_FUNCTION_DECLS)
 #define ASM_NAME(name) __asm(name)
 #else
 #define ASM_NAME(name)

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -85,7 +85,8 @@ void windows_initialization(void) {
     GetSystemDirectoryW(systemPath, MAX_PATH);
     StringCchCatW(systemPath, MAX_PATH, L"\\dxgi.dll");
     HMODULE dxgi_module = LoadLibraryW(systemPath);
-    fpCreateDXGIFactory1 = dxgi_module == NULL ? NULL : (PFN_CreateDXGIFactory1)GetProcAddress(dxgi_module, "CreateDXGIFactory1");
+    fpCreateDXGIFactory1 =
+        dxgi_module == NULL ? NULL : (PFN_CreateDXGIFactory1)(void *)GetProcAddress(dxgi_module, "CreateDXGIFactory1");
 
 #if !defined(NDEBUG)
     _set_error_mode(_OUT_TO_STDERR);
@@ -585,9 +586,10 @@ VkResult windows_read_manifest_from_d3d_adapters(const struct loader_instance *i
         goto out;
     }
 
-    PFN_LoaderEnumAdapters2 fpLoaderEnumAdapters2 = (PFN_LoaderEnumAdapters2)GetProcAddress(gdi32_dll, "D3DKMTEnumAdapters2");
+    PFN_LoaderEnumAdapters2 fpLoaderEnumAdapters2 =
+        (PFN_LoaderEnumAdapters2)(void *)GetProcAddress(gdi32_dll, "D3DKMTEnumAdapters2");
     PFN_LoaderQueryAdapterInfo fpLoaderQueryAdapterInfo =
-        (PFN_LoaderQueryAdapterInfo)GetProcAddress(gdi32_dll, "D3DKMTQueryAdapterInfo");
+        (PFN_LoaderQueryAdapterInfo)(void *)GetProcAddress(gdi32_dll, "D3DKMTQueryAdapterInfo");
     if (fpLoaderEnumAdapters2 == NULL || fpLoaderQueryAdapterInfo == NULL) {
         result = VK_ERROR_INCOMPATIBLE_DRIVER;
         goto out;
@@ -999,13 +1001,13 @@ char *windows_get_app_package_manifest_path(const struct loader_instance *inst) 
     // These functions are only available on Windows 8 and above, load them dynamically for compatibility with Windows 7
     typedef LONG(WINAPI * PFN_GetPackagesByPackageFamily)(PCWSTR, UINT32 *, PWSTR *, UINT32 *, WCHAR *);
     PFN_GetPackagesByPackageFamily fpGetPackagesByPackageFamily =
-        (PFN_GetPackagesByPackageFamily)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "GetPackagesByPackageFamily");
+        (PFN_GetPackagesByPackageFamily)(void *)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "GetPackagesByPackageFamily");
     if (!fpGetPackagesByPackageFamily) {
         return NULL;
     }
     typedef LONG(WINAPI * PFN_GetPackagePathByFullName)(PCWSTR, UINT32 *, PWSTR);
     PFN_GetPackagePathByFullName fpGetPackagePathByFullName =
-        (PFN_GetPackagePathByFullName)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "GetPackagePathByFullName");
+        (PFN_GetPackagePathByFullName)(void *)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "GetPackagePathByFullName");
     if (!fpGetPackagePathByFullName) {
         return NULL;
     }

--- a/loader/log.h
+++ b/loader/log.h
@@ -57,7 +57,7 @@ void loader_set_global_debug_level(uint32_t new_loader_debug);
 uint32_t loader_get_global_debug_level(void);
 
 // The asm declaration prevents name mangling which is necessary for macOS
-#if defined(__GNUC__) && defined(__clang__)
+#if defined(MODIFY_UNKNOWN_FUNCTION_DECLS)
 #define ASM_NAME(name) __asm(name)
 #else
 #define ASM_NAME(name)

--- a/loader/phys_dev_ext.c
+++ b/loader/phys_dev_ext.c
@@ -35,7 +35,7 @@
 #endif
 
 // The asm declaration prevents name mangling which is necessary for macOS
-#if defined(__GNUC__) && defined(__clang__)
+#if defined(MODIFY_UNKNOWN_FUNCTION_DECLS)
 #define ASM_NAME(name) __asm(name)
 #else
 #define ASM_NAME(name)


### PR DESCRIPTION
The build logic for enabling the unknown function support when ASM code doesn't
work or is disabled was broken. This fixes it by consolidating the various code
paths as well as making sure it is enabled when it should be.

This also fixes the fallback path for macOS by making sure to only modify the
names of functions if and only if the corresponding assembly code is active.
