### PR TITLE
Change settings file location

### DIFF
--- a/loader/loader_windows.h
+++ b/loader/loader_windows.h
@@ -118,8 +118,8 @@ VkLoaderFeatureFlags windows_initialize_dxgi(void);
 char *windows_get_app_package_manifest_path(const struct loader_instance *inst);
 
 // Gets the path to the loader settings file, if it exists. If it doesn't exists, writes NULL to out_path.
-// The path is located through the registry as an entry in HKEY_CURRENT_USER/SOFTWARE/Khronos/Vulkan/Settings
-// and if nothing is there, will try to look in HKEY_LOCAL_MACHINE/SOFTWARE/Khronos/Vulkan/Settings.
+// The path is located through the registry as an entry in HKEY_CURRENT_USER/SOFTWARE/Khronos/Vulkan/LoaderSettings
+// and if nothing is there, will try to look in HKEY_LOCAL_MACHINE/SOFTWARE/Khronos/Vulkan/LoaderSettings.
 // If running with elevated privileges, this function only looks in HKEY_LOCAL_MACHINE.
 VkResult windows_get_loader_settings_file_path(const struct loader_instance *inst, char **out_path);
 #endif  // WIN32

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -226,19 +226,20 @@ VkResult check_if_settings_path_exists(const struct loader_instance* inst, char*
 VkResult get_unix_settings_path(const struct loader_instance* inst, char** settings_file_path) {
     VkResult res =
         check_if_settings_path_exists(inst, loader_secure_getenv("HOME", inst),
-                                      "/.local/share/vulkan/settings.d/" VK_LOADER_SETTINGS_FILENAME, settings_file_path);
+                                      "/.local/share/vulkan/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME, settings_file_path);
     if (res == VK_SUCCESS) {
         return res;
     }
     // If HOME isn't set, fallback to XDG_DATA_HOME
     res = check_if_settings_path_exists(inst, loader_secure_getenv("XDG_DATA_HOME", inst),
-                                        "/vulkan/settings.d/" VK_LOADER_SETTINGS_FILENAME, settings_file_path);
+                                        "/vulkan/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME, settings_file_path);
     if (res == VK_SUCCESS) {
         return res;
     }
     // if XDG_DATA_HOME isn't set, fallback to /etc.
     // note that the settings_fil_path_suffix stays the same since its the same layout as for XDG_DATA_HOME
-    return check_if_settings_path_exists(inst, "/etc", "/vulkan/settings.d/" VK_LOADER_SETTINGS_FILENAME, settings_file_path);
+    return check_if_settings_path_exists(inst, "/etc", "/vulkan/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
+                                         settings_file_path);
 }
 
 bool check_if_settings_are_equal(loader_settings* a, loader_settings* b) {

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -137,9 +137,9 @@
 #define VK_ILAYERS_INFO_RELATIVE_DIR VULKAN_DIR VULKAN_ILAYERCONF_DIR
 
 #define VK_DRIVERS_INFO_REGISTRY_LOC ""
-#define VK_SETTINGS_INFO_REGISTRY_LOC ""
 #define VK_ELAYERS_INFO_REGISTRY_LOC ""
 #define VK_ILAYERS_INFO_REGISTRY_LOC ""
+#define VK_SETTINGS_INFO_REGISTRY_LOC ""
 
 #if defined(__QNXNTO__)
 #define SYSCONFDIR "/etc"
@@ -183,9 +183,9 @@ typedef pthread_cond_t loader_platform_thread_cond;
 #define HKR_VK_DRIVER_NAME API_NAME "DriverNameWow"
 #endif
 #define VK_DRIVERS_INFO_REGISTRY_LOC "SOFTWARE\\Khronos\\" API_NAME "\\Drivers"
-#define VK_SETTINGS_INFO_REGISTRY_LOC "SOFTWARE\\Khronos\\" API_NAME "\\Settings"
 #define VK_ELAYERS_INFO_REGISTRY_LOC "SOFTWARE\\Khronos\\" API_NAME "\\ExplicitLayers"
 #define VK_ILAYERS_INFO_REGISTRY_LOC "SOFTWARE\\Khronos\\" API_NAME "\\ImplicitLayers"
+#define VK_SETTINGS_INFO_REGISTRY_LOC "SOFTWARE\\Khronos\\" API_NAME "\\LoaderSettings"
 
 #define PRINTF_SIZE_T_SPECIFIER "%Iu"
 

--- a/tests/framework/shim/windows_shim.cpp
+++ b/tests/framework/shim/windows_shim.cpp
@@ -341,8 +341,8 @@ std::vector<RegistryEntry> *get_registry_vector(std::string const &path) {
         return &platform_shim.hkey_current_user_explicit_layers;
     if (path == "HKEY_CURRENT_USER\\SOFTWARE\\Khronos\\Vulkan\\ImplicitLayers")
         return &platform_shim.hkey_current_user_implicit_layers;
-    if (path == "HKEY_LOCAL_MACHINE\\SOFTWARE\\Khronos\\Vulkan\\Settings") return &platform_shim.hkey_local_machine_settings;
-    if (path == "HKEY_CURRENT_USER\\SOFTWARE\\Khronos\\Vulkan\\Settings") return &platform_shim.hkey_current_user_settings;
+    if (path == "HKEY_LOCAL_MACHINE\\SOFTWARE\\Khronos\\Vulkan\\LoaderSettings") return &platform_shim.hkey_local_machine_settings;
+    if (path == "HKEY_CURRENT_USER\\SOFTWARE\\Khronos\\Vulkan\\LoaderSettings") return &platform_shim.hkey_current_user_settings;
     return nullptr;
 }
 LSTATUS __stdcall ShimRegQueryValueExA(HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType, LPBYTE lpData,

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -399,9 +399,9 @@ FrameworkEnvironment::FrameworkEnvironment(FrameworkSettings const& settings) no
     }
 #if COMMON_UNIX_PLATFORMS
     if (settings.secure_loader_settings) {
-        platform_shim->redirect_path("/etc/vulkan/settings.d", get_folder(ManifestLocation::settings_location).location());
+        platform_shim->redirect_path("/etc/vulkan/loader_settings.d", get_folder(ManifestLocation::settings_location).location());
     } else {
-        platform_shim->redirect_path(get_env_var("HOME") + "/.local/share/vulkan/settings.d",
+        platform_shim->redirect_path(get_env_var("HOME") + "/.local/share/vulkan/loader_settings.d",
                                      get_folder(ManifestLocation::settings_location).location());
     }
 #endif

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -33,9 +33,9 @@ std::string get_settings_location_log_message(FrameworkEnvironment const& env, b
     return s + env.get_folder(ManifestLocation::settings_location).location().str() + "\\vk_loader_settings.json";
 #elif COMMON_UNIX_PLATFORMS
     if (use_secure)
-        return s + "/etc/vulkan/settings.d/vk_loader_settings.json";
+        return s + "/etc/vulkan/loader_settings.d/vk_loader_settings.json";
     else
-        return s + "/home/fake_home/.local/share/vulkan/settings.d/vk_loader_settings.json";
+        return s + "/home/fake_home/.local/share/vulkan/loader_settings.d/vk_loader_settings.json";
 #endif
 }
 


### PR DESCRIPTION
Move the settings registry to "LoaderSettings" and the unix location to "loader_settings.d".

The  validation layers looks for the settings file on windows in "SOFTWARE/Khronos/Vulkan/Settings" but doesn't check the file name. To maintain compatibility, the loader's settings file needs to be in a different location.

Fixes #1219 