### PR TITLE
Fix USE_MASM=OFF in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,7 @@ jobs:
                 python-version: '3.7'
 
             - name: Generate build files
-              run: cmake -S. -B build -DBUILD_TESTS=ON -DUPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Release -A ${{ matrix.arch }} -USE_MASM=OFF
+              run: cmake -S. -B build -DBUILD_TESTS=ON -DUPDATE_DEPS=ON -D USE_MASM=OFF -D CMAKE_BUILD_TYPE=Release -A ${{ matrix.arch }}
 
             - name: Build the loader
               run: cmake --build ./build --config Release


### PR DESCRIPTION
The windows_vs-no-asm was incorrectly setup, causing the assembler to be found when it should have used the fallback path.