### PR TITLE
Replace strok with threadsafe functions

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -375,21 +375,21 @@ size_t loader_platform_combine_path(char *dest, size_t len, ...) {
 uint32_t loader_parse_version_string(char *vers_str) {
     uint32_t variant = 0, major = 0, minor = 0, patch = 0;
     char *vers_tok;
-
+    char *context = NULL;
     if (!vers_str) {
         return 0;
     }
 
-    vers_tok = strtok(vers_str, ".\"\n\r");
+    vers_tok = thread_safe_strtok(vers_str, ".\"\n\r", &context);
     if (NULL != vers_tok) {
         major = (uint16_t)atoi(vers_tok);
-        vers_tok = strtok(NULL, ".\"\n\r");
+        vers_tok = thread_safe_strtok(NULL, ".\"\n\r", &context);
         if (NULL != vers_tok) {
             minor = (uint16_t)atoi(vers_tok);
-            vers_tok = strtok(NULL, ".\"\n\r");
+            vers_tok = thread_safe_strtok(NULL, ".\"\n\r", &context);
             if (NULL != vers_tok) {
                 patch = (uint16_t)atoi(vers_tok);
-                vers_tok = strtok(NULL, ".\"\n\r");
+                vers_tok = thread_safe_strtok(NULL, ".\"\n\r", &context);
                 // check that we are using a 4 part version string
                 if (NULL != vers_tok) {
                     // if we are, move the values over into the correct place

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -382,6 +382,8 @@ static inline void loader_platform_thread_lock_mutex(loader_platform_thread_mute
 static inline void loader_platform_thread_unlock_mutex(loader_platform_thread_mutex *pMutex) { pthread_mutex_unlock(pMutex); }
 static inline void loader_platform_thread_delete_mutex(loader_platform_thread_mutex *pMutex) { pthread_mutex_destroy(pMutex); }
 
+static void *thread_safe_strtok(char *str, const char *delim, char **saveptr) { return strtok_r(str, delim, saveptr); }
+
 #elif defined(_WIN32)
 
 // Get the key for the plug n play driver registry
@@ -536,6 +538,8 @@ static void loader_platform_thread_create_mutex(loader_platform_thread_mutex *pM
 static void loader_platform_thread_lock_mutex(loader_platform_thread_mutex *pMutex) { EnterCriticalSection(pMutex); }
 static void loader_platform_thread_unlock_mutex(loader_platform_thread_mutex *pMutex) { LeaveCriticalSection(pMutex); }
 static void loader_platform_thread_delete_mutex(loader_platform_thread_mutex *pMutex) { DeleteCriticalSection(pMutex); }
+
+static void *thread_safe_strtok(char *str, const char *delimiters, char **context) { return strtok_s(str, delimiters, context); }
 
 #else  // defined(_WIN32)
 

--- a/tests/loader_testing_main.cpp
+++ b/tests/loader_testing_main.cpp
@@ -80,18 +80,6 @@ int main(int argc, char** argv) {
     EnvVarWrapper vk_loader_layers_disable_env_var{"VK_LOADER_LAYERS_DISABLE"};
     EnvVarWrapper vk_loader_debug_env_var{"VK_LOADER_DEBUG"};
     EnvVarWrapper vk_loader_disable_inst_ext_filter_env_var{"VK_LOADER_DISABLE_INST_EXT_FILTER"};
-    vk_icd_filenames_env_var.remove_value();
-    vk_driver_files_env_var.remove_value();
-    vk_add_driver_files_env_var.remove_value();
-    vk_layer_path_env_var.remove_value();
-    vk_add_layer_path_env_var.remove_value();
-    vk_instance_layers_env_var.remove_value();
-    vk_loader_drivers_select_env_var.remove_value();
-    vk_loader_drivers_disable_env_var.remove_value();
-    vk_loader_layers_enable_env_var.remove_value();
-    vk_loader_layers_disable_env_var.remove_value();
-    vk_loader_debug_env_var.remove_value();
-    vk_loader_disable_inst_ext_filter_env_var.remove_value();
 
 #if COMMON_UNIX_PLATFORMS
     // Set only one of the 4 XDG variables to /etc, let everything else be empty

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -923,6 +923,22 @@ TEST(DriverManifest, UnknownManifestVersion) {
     ASSERT_TRUE(log.find("has unknown icd manifest file version 3.2.1. May cause errors."));
 }
 
+TEST(DriverManifest, LargeUnknownManifestVersion) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(
+        ManifestICD{}.set_lib_path(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA).set_file_format_version({100, 222, 111})));
+    env.get_test_icd().physical_devices.push_back({});
+
+    DebugUtilsLogger log;
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0));
+    FillDebugUtilsCreateDetails(inst.create_info, log);
+    inst.CheckCreate();
+    ASSERT_TRUE(log.find("loader_parse_icd_manifest: "));
+    // log prints the path to the file, don't look for it since it is hard to determine inside the test what the path should be.
+    ASSERT_TRUE(log.find("has unknown icd manifest file version 100.222.111. May cause errors."));
+}
+
 TEST(LayerManifest, UnknownManifestVersion) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
@@ -932,7 +948,7 @@ TEST(LayerManifest, UnknownManifestVersion) {
     env.add_implicit_layer(ManifestLayer{}
                                .add_layer(ManifestLayer::LayerDescription{}
                                               .set_name(implicit_layer_name)
-                                              .set_api_version(VK_MAKE_API_VERSION(1, 1, 0, 0))
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0))
                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                               .set_disable_environment("DISABLE_ME"))
                                .set_file_format_version({3, 2, 1}),
@@ -946,6 +962,31 @@ TEST(LayerManifest, UnknownManifestVersion) {
     ASSERT_TRUE(log.find("loader_add_layer_properties: "));
     // log prints the path to the file, don't look for it since it is hard to determine inside the test what the path should be.
     ASSERT_TRUE(log.find("has unknown layer manifest file version 3.2.1.  May cause errors."));
+}
+
+TEST(LayerManifest, LargeUnknownManifestVersion) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    env.get_test_icd().physical_devices.push_back({});
+
+    const char* implicit_layer_name = "ImplicitTestLayer";
+    env.add_implicit_layer(ManifestLayer{}
+                               .add_layer(ManifestLayer::LayerDescription{}
+                                              .set_name(implicit_layer_name)
+                                              .set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0))
+                                              .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                              .set_disable_environment("DISABLE_ME"))
+                               .set_file_format_version({100, 222, 111}),
+                           "implicit_test_layer.json");
+
+    DebugUtilsLogger log;
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.set_api_version(VK_MAKE_API_VERSION(0, 1, 0, 0));
+    FillDebugUtilsCreateDetails(inst.create_info, log);
+    inst.CheckCreate();
+    ASSERT_TRUE(log.find("loader_add_layer_properties: "));
+    // log prints the path to the file, don't look for it since it is hard to determine inside the test what the path should be.
+    ASSERT_TRUE(log.find("has unknown layer manifest file version 100.222.111.  May cause errors."));
 }
 
 struct DriverInfo {


### PR DESCRIPTION
strtok is not threadsafe, which was previously not a problem thanks to the
'read json' mutex. But since that was removed, it left strtok potentially
corrupting data as multiple threads try to use it. While there are
platform specific versions of strtok that are thread safe, the parsing
logic is simple enough that replacement functions were devised for the
handful of places it was used.

Fixes #1224 

Looking at the fixes I have here, I am not sold on replacing the code with bespoke functions when strtok_r/strtok_s exists. It makes the changes simpler and doesn't introduce new one-off code that is potentially full of bugs.