### PR TITLE
loader: add support for GNU/Hurd

### DIFF
--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -40,7 +40,7 @@
 
 // Set of platforms with a common set of functionality which is queried throughout the program
 #if defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNXNTO__) || defined(__FreeBSD__) || \
-    defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+    defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__GNU__)
 #define COMMON_UNIX_PLATFORMS 1
 #else
 #define COMMON_UNIX_PLATFORMS 0
@@ -260,7 +260,7 @@ static inline char *loader_platform_dirname(char *path) { return dirname(path); 
 
 // loader_platform_executable_path finds application path + name.
 // Path cannot be longer than 1024, returns NULL if it is greater than that.
-#if defined(__linux__)
+#if defined(__linux__) || defined(__GNU__)
 static inline char *loader_platform_executable_path(char *buffer, size_t size) {
     ssize_t count = readlink("/proc/self/exe", buffer, size);
     if (count == -1) return NULL;

--- a/tests/framework/framework_config.h.in
+++ b/tests/framework/framework_config.h.in
@@ -77,7 +77,7 @@
 #define BAD_DUMMY_BINARY_WINDOWS_64 "${CMAKE_CURRENT_SOURCE_DIR}/data/binaries/libdummy_library_elf_64.dll"
 #define BAD_DUMMY_BINARY_WINDOWS_32 "${CMAKE_CURRENT_SOURCE_DIR}/data/binaries/libdummy_library_elf_32.dll"
 #endif
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__GNU__)
 #define DUMMY_BINARY_LINUX_64 "${CMAKE_CURRENT_SOURCE_DIR}/data/binaries/libdummy_library_elf_64.so"
 #define DUMMY_BINARY_LINUX_32 "${CMAKE_CURRENT_SOURCE_DIR}/data/binaries/libdummy_library_elf_32.so"
 #define BAD_DUMMY_BINARY_LINUX_64 "${CMAKE_CURRENT_SOURCE_DIR}/data/binaries/dummy_library_pe_64.so"
@@ -94,7 +94,7 @@
 #define CURRENT_PLATFORM_DUMMY_BINARY_BAD BAD_DUMMY_BINARY_WINDOWS_32
 #endif
 #endif
-#if defined(__linux__)
+#if defined(__linux__) || defined(__GNU__)
 #if __x86_64__ || __ppc64__
 #define CURRENT_PLATFORM_DUMMY_BINARY_WRONG_TYPE DUMMY_BINARY_LINUX_32
 #define CURRENT_PLATFORM_DUMMY_BINARY_BAD BAD_DUMMY_BINARY_LINUX_64

--- a/tests/framework/shim/shim.h
+++ b/tests/framework/shim/shim.h
@@ -227,7 +227,7 @@ extern "C" {
 using PFN_get_platform_shim = PlatformShim* (*)(std::vector<fs::FolderManager>* folders);
 #define GET_PLATFORM_SHIM_STR "get_platform_shim"
 
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__GNU__)
 // statically link on linux
 PlatformShim* get_platform_shim(std::vector<fs::FolderManager>* folders);
 #endif

--- a/tests/framework/shim/unix_shim.cpp
+++ b/tests/framework/shim/unix_shim.cpp
@@ -35,7 +35,7 @@
 
 PlatformShim platform_shim;
 extern "C" {
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__GNU__)
 PlatformShim* get_platform_shim(std::vector<fs::FolderManager>* folders) {
     platform_shim = PlatformShim(folders);
     return &platform_shim;
@@ -48,7 +48,7 @@ FRAMEWORK_EXPORT PlatformShim* get_platform_shim(std::vector<fs::FolderManager>*
 #endif
 
 // Necessary for MacOS function shimming
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__GNU__)
 #define OPENDIR_FUNC_NAME opendir
 #define READDIR_FUNC_NAME readdir
 #define CLOSEDIR_FUNC_NAME closedir

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -334,7 +334,7 @@ PlatformShimWrapper::PlatformShimWrapper(std::vector<fs::FolderManager>* folders
     PFN_get_platform_shim get_platform_shim_func = shim_library.get_symbol(GET_PLATFORM_SHIM_STR);
     assert(get_platform_shim_func != NULL && "Must be able to get \"platform_shim\"");
     platform_shim = get_platform_shim_func(folders);
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__GNU__)
     platform_shim = get_platform_shim(folders);
 #endif
     platform_shim->reset();

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -63,7 +63,7 @@
 
 // Set of platforms with a common set of functionality which is queried throughout the program
 #if defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNXNTO__) || defined(__FreeBSD__) || \
-    defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+    defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__GNU__)
 #define COMMON_UNIX_PLATFORMS 1
 #else
 #define COMMON_UNIX_PLATFORMS 0
@@ -784,7 +784,7 @@ inline bool contains(std::vector<VkLayerProperties> const& vec, const char* name
                        [name](VkLayerProperties const& elem) { return string_eq(name, elem.layerName); });
 }
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__GNU__)
 
 // find application path + name. Path cannot be longer than 1024, returns NULL if it is greater than that.
 inline std::string test_platform_executable_path() {

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -134,7 +134,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyDriverEnvVar) {
     env.platform_shim->set_elevated_privilege(false);
 }
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__GNU__)
 // Make sure the loader reports the correct message based on if LOADER_USE_UNSAFE_FILE_SEARCH is set or not
 TEST(EnvVarICDOverrideSetup, NonSecureEnvVarLookup) {
     FrameworkEnvironment env{};
@@ -244,7 +244,7 @@ TEST(EnvVarICDOverrideSetup, TestBothDriverEnvVars) {
     ASSERT_EQ(phys_dev_count, 3U);
 }
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__GNU__)
 // Test VK_LAYER_PATH environment variable
 TEST(EnvVarICDOverrideSetup, TestOnlyLayerEnvVar) {
     FrameworkEnvironment env{};

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -1301,7 +1301,7 @@ TEST(TryLoadWrongBinaries, WrongICD) {
 #if _WIN32 || _WIN64
     ASSERT_TRUE(log.find("Failed to open dynamic library"));
 #endif
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__GNU__)
 #if defined(__x86_64__)
     ASSERT_TRUE(log.find("wrong ELF class: ELFCLASS32"));
 #else
@@ -2699,7 +2699,7 @@ TEST(CreateInstance, InstanceNullExtensionPtr) {
     ASSERT_EQ(env.vulkan_functions.vkCreateInstance(&info, VK_NULL_HANDLE, &inst), VK_ERROR_EXTENSION_NOT_PRESENT);
 }
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__GNU__)
 // NOTE: Sort order only affects Linux
 TEST(SortedPhysicalDevices, DevicesSortEnabled10NoAppExt) {
     FrameworkEnvironment env{};
@@ -3529,7 +3529,7 @@ TEST(SortedPhysicalDevices, DeviceGroupsSortedDisabled) {
     }
 }
 
-#endif  // __linux__ || __FreeBSD__ || __OpenBSD__
+#endif  // __linux__ || __FreeBSD__ || __OpenBSD__ || __GNU__
 
 const char* portability_driver_warning =
     "vkCreateInstance: Found drivers that contain devices which support the portability subset, but the "


### PR DESCRIPTION
* add the Hurd to `COMMON_UNIX_PLATFORMS`, as it is a POSIX OS
* use the Linux paths for getting the executable path (i.e. using `/proc/self/exe`): the Linux procfs provides both `self` and `<pid>/exe`
* follow the Linux behaviour in tests w.r.t. the platform shim behaviour, the test dummy binaries, and few more other bits

It builds fine, and almost the tests pass with the exception of `ImplicitLayers.DuplicateLayers`, which I have not figured out yet (`env.GetLayerProperties(2)` finds only 1 property and not 2 as expected).

In case of doubts: yes, `__GNU__` the official define for GNU/Hurd, see https://github.com/cpredef/predef/blob/master/OperatingSystems.md#gnu-aka-gnuhurd.