### PR TITLE
Fix wrong pointer usage & Fix tests not using SYSCONFDIR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
                 sudo apt install --yes --no-install-recommends gcc-multilib g++-multilib libc6:i386 libc6-dev-i386 libgcc-s1:i386 libwayland-dev:i386 libxrandr-dev:i386
 
             - name: Generate build files
-              run: cmake -S. -B build -D CMAKE_BUILD_TYPE=${{matrix.config}} -D BUILD_TESTS=ON -D UPDATE_DEPS=ON -D ENABLE_WERROR=ON
+              run: cmake -S. -B build -D CMAKE_BUILD_TYPE=${{matrix.config}} -D BUILD_TESTS=ON -D UPDATE_DEPS=ON -D ENABLE_WERROR=ON -D SYSCONFDIR=/etc/not_vulkan
               env:
                 CFLAGS: -m32
                 CXXFLAGS: -m32

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3790,8 +3790,8 @@ VkResult get_override_layer_override_paths(struct loader_instance *inst, struct 
         --cur_write_ptr;
         assert(cur_write_ptr - (*override_paths) < (ptrdiff_t)override_path_size);
         *cur_write_ptr = '\0';
-        loader_log(NULL, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0, "Override layer has override paths set to %s",
-                   override_paths);
+        loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0, "Override layer has override paths set to %s",
+                   *override_paths);
     }
     return VK_SUCCESS;
 }

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -72,6 +72,13 @@
 
 #include "layer/test_layer.h"
 
+// Useful defines
+#if COMMON_UNIX_PLATFORMS
+#define HOME_DIR "/home/fake_home"
+#define USER_LOCAL_SHARE_DIR HOME_DIR "/.local/share"
+#define ETC_DIR "/etc"
+#endif
+
 // handle checking
 template <typename T>
 void handle_assert_has_value(T const& handle) {

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -1363,6 +1363,7 @@ TEST(OverrideMetaLayer, NewerComponentLayerInMetaLayer) {
                                                                          .add_component_layers({regular_layer_name})
                                                                          .set_disable_environment("DisableMeIfYouCan")),
         "meta_test_layer.json");
+
     {  // global functions
         auto layer_props = env.GetLayerProperties(2);
         // Expect the explicit layer to still be found
@@ -1376,10 +1377,10 @@ TEST(OverrideMetaLayer, NewerComponentLayerInMetaLayer) {
         inst.CheckCreate();
         // Newer component is allowed now
         EXPECT_TRUE(env.debug_log.find(std::string("Insert instance layer \"") + regular_layer_name));
-        env.debug_log.clear();
         auto layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 2);
         EXPECT_TRUE(check_permutation({regular_layer_name, lunarg_meta_layer_name}, layer_props));
     }
+    env.debug_log.clear();
 
     {
         // 1.3 instance
@@ -1389,7 +1390,6 @@ TEST(OverrideMetaLayer, NewerComponentLayerInMetaLayer) {
         inst.CheckCreate();
         // Newer component is allowed now
         EXPECT_TRUE(env.debug_log.find(std::string("Insert instance layer \"") + regular_layer_name));
-        env.debug_log.clear();
         auto layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 2);
 
         EXPECT_TRUE(check_permutation({regular_layer_name, lunarg_meta_layer_name}, layer_props));
@@ -1603,6 +1603,8 @@ TEST(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
                                    .add_override_path(env.get_folder(ManifestLocation::override_layer).location().str())),
                            "meta_test_layer.json");
 
+    auto meta_layer_path = env.get_folder(ManifestLocation::override_layer).location();
+
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.set_api_version(1, 1, 0);
     inst.create_info.add_layer(env_var_layer_name);
@@ -1613,6 +1615,7 @@ TEST(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
         std::string("Ignoring VK_LAYER_PATH. The Override layer is active and has override paths set, which takes priority. "
                     "VK_LAYER_PATH is set to ") +
         env.env_var_vk_layer_paths.value()));
+    ASSERT_TRUE(env.debug_log.find("Override layer has override paths set to " + meta_layer_path.str()));
 
     env.layers.clear();
 }

--- a/tests/loader_testing_main.cpp
+++ b/tests/loader_testing_main.cpp
@@ -83,11 +83,11 @@ int main(int argc, char** argv) {
 
 #if COMMON_UNIX_PLATFORMS
     // Set only one of the 4 XDG variables to /etc, let everything else be empty
-    EnvVarWrapper xdg_config_home_env_var{"XDG_CONFIG_HOME", "/etc"};
+    EnvVarWrapper xdg_config_home_env_var{"XDG_CONFIG_HOME", ETC_DIR};
     EnvVarWrapper xdg_config_dirs_env_var{"XDG_CONFIG_DIRS"};
     EnvVarWrapper xdg_data_home_env_var{"XDG_DATA_HOME"};
     EnvVarWrapper xdg_data_dirs_env_var{"XDG_DATA_DIRS"};
-    EnvVarWrapper home_env_var{"HOME", "/home/fake_home"};
+    EnvVarWrapper home_env_var{"HOME", HOME_DIR};
 #endif
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::UnitTest::GetInstance()->listeners().Append(new ThrowListener);


### PR DESCRIPTION
get_override_layer_override_paths logs the path used, but during the refactor it
failed to dereference the double pointer properly, leading to the loader_log
message reading garbage. This was not caught on x64 address sanitizer builds, but
was on the 32 bit build.