### PR TITLE
Warn when ICD Manifest version differs from VkPhysicalDevice

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5419,7 +5419,17 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateInstance(const VkInstanceCreateI
                                "terminator_CreateInstance: ICD \"%s\" vkEnumerateInstanceVersion returned error. The ICD will be "
                                "treated as a 1.0 ICD",
                                icd_term->scanned_icd->lib_name);
+                } else if (VK_API_VERSION_MINOR(icd_version) == 0) {
+                    loader_log(ptr_instance, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                               "terminator_CreateInstance: Manifest ICD for \"%s\" contained a 1.1 or greater API version, but "
+                               "vkEnumerateInstanceVersion returned 1.0, treating as a 1.0 ICD",
+                               icd_term->scanned_icd->lib_name);
                 }
+            } else {
+                loader_log(ptr_instance, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                           "terminator_CreateInstance: Manifest ICD for \"%s\" contained a 1.1 or greater API version, but does "
+                           "not support vkEnumerateInstanceVersion, treating as a 1.0 ICD",
+                           icd_term->scanned_icd->lib_name);
             }
         }
 

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -173,7 +173,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceLayerProperties(uint32_t*
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceVersion(uint32_t* pApiVersion) {
     if (pApiVersion != nullptr) {
-        *pApiVersion = VK_API_VERSION_1_0;
+        *pApiVersion = icd.icd_api_version;
     }
     return VK_SUCCESS;
 }
@@ -1162,7 +1162,7 @@ FRAMEWORK_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vk_icdEnumerateAdapterPhysicalDe
 PFN_vkVoidFunction get_instance_func_ver_1_1([[maybe_unused]] VkInstance instance, const char* pName) {
     if (icd.icd_api_version >= VK_API_VERSION_1_1) {
         if (string_eq(pName, "test_vkEnumerateInstanceVersion")) {
-            return to_vkVoidFunction(test_vkEnumerateInstanceVersion);
+            return icd.can_query_vkEnumerateInstanceVersion ? to_vkVoidFunction(test_vkEnumerateInstanceVersion) : nullptr;
         }
         if (string_eq(pName, "vkEnumeratePhysicalDeviceGroups")) {
             return to_vkVoidFunction(test_vkEnumeratePhysicalDeviceGroups);
@@ -1549,7 +1549,8 @@ PFN_vkVoidFunction base_get_instance_proc_addr(VkInstance instance, const char* 
                        : NULL;
         if (string_eq(pName, "vkEnumerateInstanceLayerProperties"))
             return to_vkVoidFunction(test_vkEnumerateInstanceLayerProperties);
-        if (string_eq(pName, "vkEnumerateInstanceVersion")) return to_vkVoidFunction(test_vkEnumerateInstanceVersion);
+        if (string_eq(pName, "vkEnumerateInstanceVersion"))
+            return icd.can_query_vkEnumerateInstanceVersion ? to_vkVoidFunction(test_vkEnumerateInstanceVersion) : nullptr;
         if (string_eq(pName, "vkCreateInstance")) return to_vkVoidFunction(test_vkCreateInstance);
     }
     if (string_eq(pName, "vkGetDeviceProcAddr")) return to_vkVoidFunction(test_vkGetDeviceProcAddr);

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -267,6 +267,9 @@ test_vkEnumeratePhysicalDeviceGroups([[maybe_unused]] VkInstance instance, uint3
                 pPhysicalDeviceGroupProperties[device_group].physicalDeviceCount = 1;
                 pPhysicalDeviceGroupProperties[device_group].physicalDevices[0] =
                     icd.physical_devices[device_group].vk_physical_device.handle;
+                for (size_t i = 1; i < VK_MAX_DEVICE_GROUP_SIZE; i++) {
+                    pPhysicalDeviceGroupProperties[device_group].physicalDevices[i] = {};
+                }
             }
         } else {
             group_count = static_cast<uint32_t>(icd.physical_device_groups.size());
@@ -283,6 +286,9 @@ test_vkEnumeratePhysicalDeviceGroups([[maybe_unused]] VkInstance instance, uint3
                     handles_written++;
                     pPhysicalDeviceGroupProperties[device_group].physicalDevices[i] =
                         icd.physical_device_groups[device_group].physical_device_handles[i]->vk_physical_device.handle;
+                }
+                for (size_t i = handles_written; i < VK_MAX_DEVICE_GROUP_SIZE; i++) {
+                    pPhysicalDeviceGroupProperties[device_group].physicalDevices[i] = {};
                 }
                 pPhysicalDeviceGroupProperties[device_group].physicalDeviceCount = handles_written;
             }

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -120,6 +120,8 @@ struct TestICD {
     std::vector<uint64_t> messenger_handles;
     std::vector<uint64_t> swapchain_handles;
 
+    BUILDER_VALUE(TestICD, bool, can_query_vkEnumerateInstanceVersion, true);
+
     // Unknown instance functions Add a `VulkanFunction` to this list which will be searched in
     // vkGetInstanceProcAddr for custom_instance_functions and vk_icdGetPhysicalDeviceProcAddr for
     // custom_physical_device_functions. To add unknown device functions, add it to the PhysicalDevice directly (in the

--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -457,10 +457,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDeviceGroups(
             //       underneath us when using this test.
             uint32_t icd_group_count = 0;
             layer.instance_dispatch_table.EnumeratePhysicalDeviceGroups(instance, &icd_group_count, nullptr);
-            std::vector<VkPhysicalDeviceGroupProperties> tmp_vector(icd_group_count);
-            for (uint32_t group = 0; group < icd_group_count; ++group) {
-                tmp_vector[group].sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES;
-            }
+            std::vector<VkPhysicalDeviceGroupProperties> tmp_vector(icd_group_count,
+                                                                    {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
             layer.instance_dispatch_table.EnumeratePhysicalDeviceGroups(instance, &icd_group_count, tmp_vector.data());
             layer.complete_physical_device_groups.clear();
 

--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -75,7 +75,7 @@
 #endif
 
 #if !defined(TEST_LAYER_NAME)
-#define TEST_LAYER_NAME "VkLayer_LunarG_test_layer"
+#define TEST_LAYER_NAME "VK_LAYER_LunarG_test_layer"
 #endif
 
 TestLayer layer;

--- a/tests/loader_alloc_callback_tests.cpp
+++ b/tests/loader_alloc_callback_tests.cpp
@@ -701,7 +701,7 @@ TEST(Allocation, CreateInstanceDeviceIntentionalAllocFail) {
     custom_json_file_contents << custom_json_file.rdbuf();
 
     fs::path new_path = env.get_folder(ManifestLocation::explicit_layer)
-                            .write_manifest("VkLayer_complex_file.json", custom_json_file_contents.str());
+                            .write_manifest("VK_LAYER_complex_file.json", custom_json_file_contents.str());
     env.platform_shim->add_manifest(ManifestCategory::explicit_layer, new_path);
 
     size_t fail_index = 0;

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -4643,18 +4643,16 @@ TEST(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &grp_count, nullptr));
     ASSERT_GT(grp_count, icd_groups);
 
-    auto not_exp_phys_dev_groups = std::vector<VkPhysicalDeviceGroupProperties>(icd_groups);
-    for (uint32_t group = 0; group < icd_groups; ++group) {
-        not_exp_phys_dev_groups[group].sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES;
-    }
+    auto not_exp_phys_dev_groups =
+        std::vector<VkPhysicalDeviceGroupProperties>(icd_groups, {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
+
     uint32_t returned_group_count = icd_groups;
     ASSERT_EQ(VK_INCOMPLETE, inst->vkEnumeratePhysicalDeviceGroups(inst, &returned_group_count, not_exp_phys_dev_groups.data()));
     ASSERT_EQ(icd_groups, returned_group_count);
 
-    auto phys_dev_groups = std::vector<VkPhysicalDeviceGroupProperties>(grp_count);
-    for (uint32_t group = 0; group < grp_count; ++group) {
-        phys_dev_groups[group].sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES;
-    }
+    auto phys_dev_groups =
+        std::vector<VkPhysicalDeviceGroupProperties>(grp_count, {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
+
     returned_group_count = grp_count;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &returned_group_count, phys_dev_groups.data()));
     ASSERT_EQ(grp_count, returned_group_count);
@@ -4731,10 +4729,9 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &grp_count, nullptr));
     ASSERT_LT(grp_count, icd_groups);
 
-    auto phys_dev_groups = std::vector<VkPhysicalDeviceGroupProperties>(grp_count);
-    for (uint32_t group = 0; group < grp_count; ++group) {
-        phys_dev_groups[group].sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES;
-    }
+    auto phys_dev_groups =
+        std::vector<VkPhysicalDeviceGroupProperties>(grp_count, {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
+
     uint32_t returned_group_count = grp_count;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &returned_group_count, phys_dev_groups.data()));
     ASSERT_EQ(grp_count, returned_group_count);
@@ -4784,10 +4781,9 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &grp_count, nullptr));
     ASSERT_EQ(grp_count, icd_groups);
 
-    auto phys_dev_groups = std::vector<VkPhysicalDeviceGroupProperties>(grp_count);
-    for (uint32_t group = 0; group < grp_count; ++group) {
-        phys_dev_groups[group].sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES;
-    }
+    auto phys_dev_groups =
+        std::vector<VkPhysicalDeviceGroupProperties>(grp_count, {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
+
     uint32_t returned_group_count = grp_count;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &returned_group_count, phys_dev_groups.data()));
     ASSERT_EQ(grp_count, returned_group_count);
@@ -4837,10 +4833,9 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &grp_count, nullptr));
     ASSERT_GT(grp_count, icd_groups);
 
-    auto phys_dev_groups = std::vector<VkPhysicalDeviceGroupProperties>(grp_count);
-    for (uint32_t group = 0; group < grp_count; ++group) {
-        phys_dev_groups[group].sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES;
-    }
+    auto phys_dev_groups =
+        std::vector<VkPhysicalDeviceGroupProperties>(grp_count, {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
+
     uint32_t returned_group_count = grp_count;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &returned_group_count, phys_dev_groups.data()));
     ASSERT_EQ(grp_count, returned_group_count);

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -3213,10 +3213,10 @@ TEST(TestLayers, ImplicitLayerPre10APIVersion) {
         auto layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         ASSERT_TRUE(string_eq(regular_layer_name, layer_props.at(0).layerName));
     }
-    {  // application doesn't state its API version
+    {  // application sets its API version to 0
         DebugUtilsLogger log;
         InstWrapper inst{env.vulkan_functions};
-        inst.create_info.set_fill_in_application_info(false);
+        inst.create_info.set_api_version(0);
         FillDebugUtilsCreateDetails(inst.create_info, log);
         inst.CheckCreate();
         EXPECT_TRUE(log.find(std::string("Insert instance layer \"") + regular_layer_name));

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -92,7 +92,7 @@ TEST(ImplicitLayers, WithEnableAndDisableEnvVar) {
 TEST(ImplicitLayers, OnlyDisableEnvVar) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    const char* implicit_layer_name = "ImplicitTestLayer";
+    const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
     EnvVarWrapper disable_env_var{"DISABLE_ME"};
 
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -127,7 +127,7 @@ TEST(ImplicitLayers, OnlyDisableEnvVar) {
 TEST(ImplicitLayers, PreInstanceEnumInstLayerProps) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    const char* implicit_layer_name = "ImplicitTestLayer";
+    const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
     EnvVarWrapper disable_env_var{"DISABLE_ME"};
 
     env.add_implicit_layer(
@@ -161,7 +161,7 @@ TEST(ImplicitLayers, PreInstanceEnumInstLayerProps) {
 TEST(ImplicitLayers, PreInstanceEnumInstExtProps) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    const char* implicit_layer_name = "ImplicitTestLayer";
+    const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
     EnvVarWrapper disable_env_var{"DISABLE_ME"};
 
     env.add_implicit_layer(
@@ -198,7 +198,7 @@ TEST(ImplicitLayers, PreInstanceVersion) {
         .add_physical_device({})
         .set_icd_api_version(VK_MAKE_API_VERSION(0, 1, 2, 3));
 
-    const char* implicit_layer_name = "ImplicitTestLayer";
+    const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
     EnvVarWrapper disable_env_var{"DISABLE_ME"};
 
     env.add_implicit_layer(ManifestLayer{}.set_file_format_version({1, 1, 2}).add_layer(
@@ -237,7 +237,7 @@ TEST(ImplicitLayers, OverrideGetInstanceProcAddr) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).add_physical_device({});
 
-    const char* implicit_layer_name = "ImplicitTestLayer";
+    const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
     EnvVarWrapper disable_env_var{"DISABLE_ME"};
 
     env.add_implicit_layer(ManifestLayer{}.set_file_format_version({1, 0, 0}).add_layer(
@@ -1873,7 +1873,7 @@ TEST(LayerCreateInstance, GetPhysicalDeviceProperties2) {
         .add_physical_device({})
         .set_icd_api_version(VK_API_VERSION_1_1);
 
-    const char* regular_layer_name = "TestLayer";
+    const char* regular_layer_name = "VK_LAYER_TestLayer";
     env.add_explicit_layer(
         ManifestLayer{}.set_file_format_version({1, 1, 2}).add_layer(
             ManifestLayer::LayerDescription{}.set_name(regular_layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
@@ -1973,13 +1973,13 @@ TEST(ExplicitLayers, WrapObjects) {
                                ManifestLayer::LayerDescription{}.set_name(wrap_objects_name).set_lib_path(TEST_LAYER_WRAP_OBJECTS)),
                            "wrap_objects_layer.json");
 
-    const char* regular_layer_name_1 = "RegularLayer1";
+    const char* regular_layer_name_1 = "VK_LAYER_RegularLayer1";
     env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(regular_layer_name_1).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
         "regular_layer_1.json");
 
-    const char* regular_layer_name_2 = "RegularLayer2";
+    const char* regular_layer_name_2 = "VK_LAYER_RegularLayer2";
     env.add_explicit_layer(
         ManifestLayer{}.add_layer(
             ManifestLayer::LayerDescription{}.set_name(regular_layer_name_2).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
@@ -2029,7 +2029,7 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
 
     {
         // verify layer loads successfully when setting VK_LAYER_PATH to a full filepath
-        const char* regular_layer_name_1 = "RegularLayer1";
+        const char* regular_layer_name_1 = "VK_LAYER_RegularLayer1";
         env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                                               .set_name(regular_layer_name_1)
                                                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
@@ -2045,7 +2045,7 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
     }
     {
         // verify layers load successfully when setting VK_LAYER_PATH to multiple full filepaths
-        const char* regular_layer_name_1 = "RegularLayer1";
+        const char* regular_layer_name_1 = "VK_LAYER_RegularLayer1";
         env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                                               .set_name(regular_layer_name_1)
                                                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
@@ -2053,7 +2053,7 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
                                    .set_discovery_type(ManifestDiscoveryType::env_var)
                                    .set_is_dir(false));
 
-        const char* regular_layer_name_2 = "RegularLayer2";
+        const char* regular_layer_name_2 = "VK_LAYER_RegularLayer2";
         env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                                               .set_name(regular_layer_name_2)
                                                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
@@ -2070,14 +2070,14 @@ TEST(ExplicitLayers, VkLayerPathEnvVar) {
     }
     {
         // verify layers load successfully when setting VK_LAYER_PATH to a directory
-        const char* regular_layer_name_1 = "RegularLayer1";
+        const char* regular_layer_name_1 = "VK_LAYER_RegularLayer1";
         env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                                               .set_name(regular_layer_name_1)
                                                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
                                                 "regular_layer_1.json")
                                    .set_discovery_type(ManifestDiscoveryType::env_var));
 
-        const char* regular_layer_name_2 = "RegularLayer2";
+        const char* regular_layer_name_2 = "VK_LAYER_RegularLayer2";
         env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                                               .set_name(regular_layer_name_2)
                                                                               .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
@@ -4350,7 +4350,7 @@ TEST(LayerPhysDeviceMod, AddPhysicalDevices) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                         .set_name("VkLayer_LunarG_add_phys_dev")
+                                                         .set_name("VK_LAYER_LunarG_add_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                          .set_api_version(VK_API_VERSION_1_1)
                                                          .set_disable_environment("TEST_DISABLE_ADD_PHYS_DEV")),
@@ -4427,7 +4427,7 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDevices) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                         .set_name("VkLayer_LunarG_remove_phys_dev")
+                                                         .set_name("VK_LAYER_LunarG_remove_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                          .set_api_version(VK_API_VERSION_1_1)
                                                          .set_disable_environment("TEST_DISABLE_REMOVE_PHYS_DEV")),
@@ -4477,7 +4477,7 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDevices) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                         .set_name("VkLayer_LunarG_reorder_phys_dev")
+                                                         .set_name("VK_LAYER_LunarG_reorder_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                          .set_api_version(VK_API_VERSION_1_1)
                                                          .set_disable_environment("TEST_DISABLE_REORDER_PHYS_DEV")),
@@ -4527,7 +4527,7 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                         .set_name("VkLayer_LunarG_all_phys_dev")
+                                                         .set_name("VK_LAYER_LunarG_all_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                          .set_api_version(VK_API_VERSION_1_1)
                                                          .set_disable_environment("TEST_DISABLE_ALL_PHYS_DEV")),
@@ -4603,7 +4603,7 @@ TEST(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                         .set_name("VkLayer_LunarG_add_phys_dev")
+                                                         .set_name("VK_LAYER_LunarG_add_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                          .set_api_version(VK_API_VERSION_1_1)
                                                          .set_disable_environment("TEST_DISABLE_ADD_PHYS_DEV")),
@@ -4691,7 +4691,7 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                         .set_name("VkLayer_LunarG_remove_phys_dev")
+                                                         .set_name("VK_LAYER_LunarG_remove_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                          .set_api_version(VK_API_VERSION_1_1)
                                                          .set_disable_environment("TEST_DISABLE_REMOVE_PHYS_DEV")),
@@ -4744,7 +4744,7 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                         .set_name("VkLayer_LunarG_reorder_phys_dev")
+                                                         .set_name("VK_LAYER_LunarG_reorder_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                          .set_api_version(VK_API_VERSION_1_1)
                                                          .set_disable_environment("TEST_DISABLE_REORDER_PHYS_DEV")),
@@ -4797,7 +4797,7 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
     FrameworkEnvironment env;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
-                                                         .set_name("VkLayer_LunarG_all_phys_dev")
+                                                         .set_name("VK_LAYER_LunarG_all_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                          .set_api_version(VK_API_VERSION_1_1)
                                                          .set_disable_environment("TEST_DISABLE_ALL_PHYS_DEV")),

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -4348,7 +4348,6 @@ TEST(TestLayers, DeviceLayerNotPresent) {
 
 TEST(LayerPhysDeviceMod, AddPhysicalDevices) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VK_LAYER_LunarG_add_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -4360,7 +4359,8 @@ TEST(LayerPhysDeviceMod, AddPhysicalDevices) {
     layer.set_add_phys_devs(true);
 
     for (uint32_t icd = 0; icd < 2; ++icd) {
-        auto& cur_icd = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_icd_api_version(VK_API_VERSION_1_2);
+        auto& cur_icd =
+            env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_2)).set_icd_api_version(VK_API_VERSION_1_2);
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
@@ -4425,7 +4425,6 @@ TEST(LayerPhysDeviceMod, AddPhysicalDevices) {
 
 TEST(LayerPhysDeviceMod, RemovePhysicalDevices) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VK_LAYER_LunarG_remove_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -4437,7 +4436,8 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDevices) {
     layer.set_remove_phys_devs(true);
 
     for (uint32_t icd = 0; icd < 2; ++icd) {
-        auto& cur_icd = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_icd_api_version(VK_API_VERSION_1_2);
+        auto& cur_icd =
+            env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_2)).set_icd_api_version(VK_API_VERSION_1_2);
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
@@ -4475,7 +4475,6 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDevices) {
 
 TEST(LayerPhysDeviceMod, ReorderPhysicalDevices) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VK_LAYER_LunarG_reorder_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -4487,7 +4486,8 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDevices) {
     layer.set_reorder_phys_devs(true);
 
     for (uint32_t icd = 0; icd < 2; ++icd) {
-        auto& cur_icd = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_icd_api_version(VK_API_VERSION_1_2);
+        auto& cur_icd =
+            env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_2)).set_icd_api_version(VK_API_VERSION_1_2);
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
@@ -4525,7 +4525,6 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDevices) {
 
 TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VK_LAYER_LunarG_all_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -4537,7 +4536,8 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
     layer.set_add_phys_devs(true).set_remove_phys_devs(true).set_reorder_phys_devs(true);
 
     for (uint32_t icd = 0; icd < 2; ++icd) {
-        auto& cur_icd = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_icd_api_version(VK_API_VERSION_1_2);
+        auto& cur_icd =
+            env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_2)).set_icd_api_version(VK_API_VERSION_1_2);
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
@@ -4601,7 +4601,6 @@ bool GroupsAreTheSame(VkPhysicalDeviceGroupProperties a, VkPhysicalDeviceGroupPr
 
 TEST(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VK_LAYER_LunarG_add_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -4613,7 +4612,8 @@ TEST(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
     layer.set_add_phys_devs(true);
 
     for (uint32_t icd = 0; icd < 2; ++icd) {
-        auto& cur_icd = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_icd_api_version(VK_API_VERSION_1_2);
+        auto& cur_icd =
+            env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_2)).set_icd_api_version(VK_API_VERSION_1_2);
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
@@ -4687,7 +4687,7 @@ TEST(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
 
 TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    EnvVarWrapper disable_linux_sort("VK_LOADER_DISABLE_SELECT", "1");
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VK_LAYER_LunarG_remove_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -4699,7 +4699,8 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
     layer.set_remove_phys_devs(true);
 
     for (uint32_t icd = 0; icd < 2; ++icd) {
-        auto& cur_icd = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_icd_api_version(VK_API_VERSION_1_2);
+        auto& cur_icd =
+            env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_2)).set_icd_api_version(VK_API_VERSION_1_2);
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
@@ -4719,7 +4720,7 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
         cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[1]);
         cur_icd.physical_device_groups.back().use_physical_device(cur_icd.physical_devices[2]);
     }
-    const uint32_t icd_groups = 4;
+    const uint32_t icd_groups = 3;
 
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -4727,7 +4728,7 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
 
     uint32_t grp_count = 0;
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &grp_count, nullptr));
-    ASSERT_LT(grp_count, icd_groups);
+    ASSERT_EQ(grp_count, icd_groups);
 
     auto phys_dev_groups =
         std::vector<VkPhysicalDeviceGroupProperties>(grp_count, {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
@@ -4739,7 +4740,6 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
 
 TEST(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VK_LAYER_LunarG_reorder_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -4751,7 +4751,8 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
     layer.set_reorder_phys_devs(true);
 
     for (uint32_t icd = 0; icd < 2; ++icd) {
-        auto& cur_icd = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_icd_api_version(VK_API_VERSION_1_2);
+        auto& cur_icd =
+            env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_2)).set_icd_api_version(VK_API_VERSION_1_2);
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
@@ -4791,7 +4792,6 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
 
 TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
     FrameworkEnvironment env;
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VK_LAYER_LunarG_all_phys_dev")
                                                          .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
@@ -4803,7 +4803,8 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
     layer.set_add_phys_devs(true).set_remove_phys_devs(true).set_reorder_phys_devs(true);
 
     for (uint32_t icd = 0; icd < 2; ++icd) {
-        auto& cur_icd = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_icd_api_version(VK_API_VERSION_1_2);
+        auto& cur_icd =
+            env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_2)).set_icd_api_version(VK_API_VERSION_1_2);
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
@@ -4820,8 +4821,8 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
             cur_icd.physical_devices.back().set_properties(properties);
         }
         cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[0]);
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(cur_icd.physical_devices[2]);
+        cur_icd.physical_device_groups.back().use_physical_device(cur_icd.physical_devices[1]);
+        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[2]);
     }
     const uint32_t icd_groups = 4;
 

--- a/tests/loader_phys_dev_inst_ext_tests.cpp
+++ b/tests/loader_phys_dev_inst_ext_tests.cpp
@@ -122,7 +122,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2KHRInstanceAndICDSupport) {
 // Also check if the application didn't enable 1.1 and when a layer 'upgrades' the api version to 1.1
 TEST(LoaderInstPhysDevExts, PhysDevProps2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_1));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
@@ -297,7 +297,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2Mixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -521,11 +521,12 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRInstanceAndICDSupport) {
 // Also check if the application didn't enable 1.1 and when a layer 'upgrades' the api version to 1.1
 TEST(LoaderInstPhysDevExts, PhysDevFeats2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_1));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    env.get_test_icd(0).physical_devices.back().set_api_version(VK_API_VERSION_1_1);
     FillInRandomFeatures(env.get_test_icd(0).physical_devices.back().features);
     {
         InstWrapper instance(env.vulkan_functions);
@@ -663,7 +664,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeatsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -792,11 +793,12 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRInstanceAndICDSupport) {
 // Also check if the application didn't enable 1.1 and when a layer 'upgrades' the api version to 1.1
 TEST(LoaderInstPhysDevExts, PhysDevFormatProps2Simple) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_1));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
     env.get_test_icd(0).physical_devices.push_back({});
     env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    env.get_test_icd(0).physical_devices.back().set_api_version(VK_API_VERSION_1_1);
     FillInRandomFormatProperties(env.get_test_icd(0).physical_devices.back().format_properties);
     {
         InstWrapper instance(env.vulkan_functions);
@@ -946,7 +948,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -1323,7 +1325,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -1630,7 +1632,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -1976,7 +1978,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -2393,7 +2395,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -2658,7 +2660,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -2918,7 +2920,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -3177,7 +3179,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
 
         // ICD 1 should not have 1.1
@@ -3409,7 +3411,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRMixed) {
     Extension third_ext{VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME};
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.min_icd_interface_version = 3;
@@ -3620,7 +3622,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRMixed) {
     Extension third_ext{VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME};
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.enable_icd_wsi = true;
@@ -3827,7 +3829,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -4015,7 +4017,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -4200,7 +4202,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -4389,7 +4391,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -4551,7 +4553,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -4768,7 +4770,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
 
@@ -4954,7 +4956,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -5127,7 +5129,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -5299,7 +5301,7 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -5467,7 +5469,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -5601,7 +5603,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -5754,7 +5756,7 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTMixed) {
     const uint32_t max_phys_devs = 7;
 
     for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, icd != 1 ? VK_API_VERSION_1_1 : VK_API_VERSION_1_0));
         auto& cur_icd = env.get_test_icd(icd);
         cur_icd.icd_api_version = VK_API_VERSION_1_0;
         cur_icd.add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});

--- a/tests/loader_phys_dev_inst_ext_tests.cpp
+++ b/tests/loader_phys_dev_inst_ext_tests.cpp
@@ -304,8 +304,6 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2Mixed) {
         if (icd != 1) {
             cur_icd.icd_api_version = VK_API_VERSION_1_1;
             cur_icd.add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-        } else {
-            cur_icd.icd_api_version = VK_API_VERSION_1_0;
         }
 
         uint32_t rand_vendor_id;
@@ -672,8 +670,6 @@ TEST(LoaderInstPhysDevExts, PhysDevFeatsMixed) {
         if (icd != 1) {
             cur_icd.icd_api_version = VK_API_VERSION_1_1;
             cur_icd.add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-        } else {
-            cur_icd.icd_api_version = VK_API_VERSION_1_0;
         }
 
         uint32_t rand_vendor_id;
@@ -957,8 +953,6 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatPropsMixed) {
         if (icd != 1) {
             cur_icd.icd_api_version = VK_API_VERSION_1_1;
             cur_icd.add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-        } else {
-            cur_icd.icd_api_version = VK_API_VERSION_1_0;
         }
 
         uint32_t rand_vendor_id;
@@ -1336,8 +1330,6 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatPropsMixed) {
         if (icd != 1) {
             cur_icd.icd_api_version = VK_API_VERSION_1_1;
             cur_icd.add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-        } else {
-            cur_icd.icd_api_version = VK_API_VERSION_1_0;
         }
 
         uint32_t rand_vendor_id;
@@ -1645,8 +1637,6 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryPropsMixed) {
         if (icd != 1) {
             cur_icd.icd_api_version = VK_API_VERSION_1_1;
             cur_icd.add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-        } else {
-            cur_icd.icd_api_version = VK_API_VERSION_1_0;
         }
 
         uint32_t rand_vendor_id;
@@ -1993,8 +1983,6 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyPropsMixed) {
         if (icd != 1) {
             cur_icd.icd_api_version = VK_API_VERSION_1_1;
             cur_icd.add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-        } else {
-            cur_icd.icd_api_version = VK_API_VERSION_1_0;
         }
 
         uint32_t rand_vendor_id;
@@ -2412,8 +2400,6 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatPropsMixed) {
         if (icd != 1) {
             cur_icd.icd_api_version = VK_API_VERSION_1_1;
             cur_icd.add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-        } else {
-            cur_icd.icd_api_version = VK_API_VERSION_1_0;
         }
 
         uint32_t rand_vendor_id;
@@ -2679,8 +2665,6 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsMixed) {
         if (icd != 1) {
             cur_icd.icd_api_version = VK_API_VERSION_1_1;
             cur_icd.add_instance_extension({VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME});
-        } else {
-            cur_icd.icd_api_version = VK_API_VERSION_1_0;
         }
 
         uint32_t rand_vendor_id;
@@ -2941,8 +2925,6 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsMixed) {
         if (icd != 1) {
             cur_icd.icd_api_version = VK_API_VERSION_1_1;
             cur_icd.add_instance_extension({VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME});
-        } else {
-            cur_icd.icd_api_version = VK_API_VERSION_1_0;
         }
 
         uint32_t rand_vendor_id;
@@ -3202,8 +3184,6 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsMixed) {
         if (icd != 1) {
             cur_icd.icd_api_version = VK_API_VERSION_1_1;
             cur_icd.add_instance_extension({VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME});
-        } else {
-            cur_icd.icd_api_version = VK_API_VERSION_1_0;
         }
 
         uint32_t rand_vendor_id;

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -783,7 +783,7 @@ TEST(EnumeratePhysicalDevices, ZeroPhysicalDevices) {
 
 TEST(EnumeratePhysicalDevices, ZeroPhysicalDevicesAfterCreateInstance) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_min_icd_interface_version(5);
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1)).set_min_icd_interface_version(5);
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.set_api_version(VK_API_VERSION_1_1);
     inst.CheckCreate();
@@ -1572,7 +1572,7 @@ TEST(TryLoadWrongBinaries, WrongArchLayer) {
 
 TEST(EnumeratePhysicalDeviceGroups, OneCall) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1))
                        .set_min_icd_interface_version(5)
                        .set_icd_api_version(VK_API_VERSION_1_1)
                        .add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
@@ -1581,6 +1581,7 @@ TEST(EnumeratePhysicalDeviceGroups, OneCall) {
     for (size_t i = 0; i < 3; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
         driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
     }
     driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
     driver.physical_device_groups.back().use_physical_device(driver.physical_devices[1]);
@@ -1705,7 +1706,7 @@ TEST(EnumeratePhysicalDeviceGroups, OneCall) {
 
 TEST(EnumeratePhysicalDeviceGroups, TwoCall) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1))
                        .set_min_icd_interface_version(5)
                        .set_icd_api_version(VK_API_VERSION_1_1)
                        .add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
@@ -1714,6 +1715,7 @@ TEST(EnumeratePhysicalDeviceGroups, TwoCall) {
     for (size_t i = 0; i < 3; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
         driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
     }
     driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
     driver.physical_device_groups.back().use_physical_device(driver.physical_devices[1]);
@@ -1821,7 +1823,7 @@ TEST(EnumeratePhysicalDeviceGroups, TwoCall) {
 
 TEST(EnumeratePhysicalDeviceGroups, TwoCallIncomplete) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1))
                        .set_min_icd_interface_version(5)
                        .set_icd_api_version(VK_API_VERSION_1_1)
                        .add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
@@ -1830,6 +1832,7 @@ TEST(EnumeratePhysicalDeviceGroups, TwoCallIncomplete) {
     for (size_t i = 0; i < 3; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
         driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
     }
     driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
     driver.physical_device_groups.back().use_physical_device(driver.physical_devices[1]);
@@ -1938,7 +1941,7 @@ TEST(EnumeratePhysicalDeviceGroups, TwoCallIncomplete) {
 // vkEnumeratePhysicalDeviceGroupsKHR, and make sure they return the same info.
 TEST(EnumeratePhysicalDeviceGroups, TestCoreVersusExtensionSameReturns) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1))
                        .set_min_icd_interface_version(5)
                        .set_icd_api_version(VK_API_VERSION_1_1)
                        .add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME})
@@ -1947,6 +1950,7 @@ TEST(EnumeratePhysicalDeviceGroups, TestCoreVersusExtensionSameReturns) {
     // Generate the devices
     for (size_t i = 0; i < 6; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
+        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
     }
 
     // Generate the starting groups
@@ -2027,13 +2031,14 @@ TEST(EnumeratePhysicalDeviceGroups, TestCoreVersusExtensionSameReturns) {
 // querying vkEnumeratePhysicalDeviceGroups before and after the add.
 TEST(EnumeratePhysicalDeviceGroups, CallThriceAddGroupInBetween) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1))
                        .set_min_icd_interface_version(5)
                        .set_icd_api_version(VK_API_VERSION_1_1);
 
     // Generate the devices
     for (size_t i = 0; i < 7; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
+        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
     }
 
     // Generate the starting groups
@@ -2121,13 +2126,14 @@ TEST(EnumeratePhysicalDeviceGroups, CallThriceAddGroupInBetween) {
 // querying vkEnumeratePhysicalDeviceGroups before and after the remove.
 TEST(EnumeratePhysicalDeviceGroups, CallTwiceRemoveGroupInBetween) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1))
                        .set_min_icd_interface_version(5)
                        .set_icd_api_version(VK_API_VERSION_1_1);
 
     // Generate the devices
     for (size_t i = 0; i < 7; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
+        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
     }
 
     // Generate the starting groups
@@ -2207,13 +2213,14 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceRemoveGroupInBetween) {
 // querying vkEnumeratePhysicalDeviceGroups before and after the add.
 TEST(EnumeratePhysicalDeviceGroups, CallTwiceAddDeviceInBetween) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1))
                        .set_min_icd_interface_version(5)
                        .set_icd_api_version(VK_API_VERSION_1_1);
 
     // Generate the devices
     for (size_t i = 0; i < 7; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
+        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
     }
 
     // Generate the starting groups
@@ -2292,13 +2299,14 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceAddDeviceInBetween) {
 // querying vkEnumeratePhysicalDeviceGroups before and after the remove.
 TEST(EnumeratePhysicalDeviceGroups, CallTwiceRemoveDeviceInBetween) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1))
                        .set_min_icd_interface_version(5)
                        .set_icd_api_version(VK_API_VERSION_1_1);
 
     // Generate the devices
     for (size_t i = 0; i < 6; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
+        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
     }
 
     // Generate the starting groups
@@ -2388,13 +2396,14 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceRemoveDeviceInBetween) {
 // various devices and groups while querying in between.
 TEST(EnumeratePhysicalDeviceGroups, MultipleAddRemoves) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1))
                        .set_min_icd_interface_version(5)
                        .set_icd_api_version(VK_API_VERSION_1_1);
 
     // Generate the devices
     for (size_t i = 0; i < 9; i++) {
         driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
+        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
     }
 
     // Generate the starting groups
@@ -2529,7 +2538,7 @@ TEST(EnumeratePhysicalDeviceGroups, FakePNext) {
     //   PhysDev 6: pd6, Discrete, Vulkan 1.1, Bus 2
     //   Group 0: PhysDev 5, PhysDev 6
     //   Group 1: PhysDev 4
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_1));
     auto& cur_icd_0 = env.get_test_icd(0);
     cur_icd_0.set_icd_api_version(VK_API_VERSION_1_1);
     cur_icd_0.physical_devices.push_back({"pd0"});
@@ -2550,7 +2559,7 @@ TEST(EnumeratePhysicalDeviceGroups, FakePNext) {
         .use_physical_device(cur_icd_0.physical_devices[2]);
     cur_icd_0.physical_device_groups.push_back({cur_icd_0.physical_devices[1]});
 
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_1));
     auto& cur_icd_1 = env.get_test_icd(1);
     cur_icd_1.set_icd_api_version(VK_API_VERSION_1_1);
     cur_icd_1.physical_devices.push_back({"pd4"});
@@ -2655,7 +2664,7 @@ TEST(ExtensionManual, ToolingProperties) {
     }
     {  // core
         FrameworkEnvironment env{};
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA))
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_3))
             .add_physical_device({})
             .set_supports_tooling_info_core(true)
             .add_tooling_property(icd_tool_props)

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -206,8 +206,8 @@ TEST(ICDInterfaceVersion2, EnumAdapters2) {
 TEST(ICDInterfaceVersion2PlusEnumerateAdapterPhysicalDevices, VerifyPhysDevResults) {
     FrameworkEnvironment env{};
     auto& driver =
-        env.add_icd(TestICDDetails{TEST_ICD_PATH_VERSION_2_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES}.set_discovery_type(
-                        ManifestDiscoveryType::null_dir))
+        env.add_icd(TestICDDetails{TEST_ICD_PATH_VERSION_2_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES, VK_API_VERSION_1_1}
+                        .set_discovery_type(ManifestDiscoveryType::null_dir))
             .set_min_icd_interface_version(6)
             .set_icd_api_version(VK_API_VERSION_1_1);
     const std::vector<std::string> physical_device_names = {"physical_device_4", "physical_device_3", "physical_device_2",
@@ -250,8 +250,8 @@ TEST(ICDInterfaceVersion2PlusEnumerateAdapterPhysicalDevices, VerifyPhysDevResul
 TEST(ICDInterfaceVersion2PlusEnumerateAdapterPhysicalDevices, VerifyGroupResults) {
     FrameworkEnvironment env{};
     auto& driver =
-        env.add_icd(TestICDDetails{TEST_ICD_PATH_VERSION_2_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES}.set_discovery_type(
-                        ManifestDiscoveryType::null_dir))
+        env.add_icd(TestICDDetails{TEST_ICD_PATH_VERSION_2_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES, VK_API_VERSION_1_1}
+                        .set_discovery_type(ManifestDiscoveryType::null_dir))
             .set_min_icd_interface_version(6)
             .set_icd_api_version(VK_API_VERSION_1_1);
     const std::vector<std::string> physical_device_names = {"physical_device_4", "physical_device_3", "physical_device_2",
@@ -415,7 +415,7 @@ TEST(MultipleDriverConfig, DifferentICDsWithDevices) {
 TEST(MultipleDriverConfig, DifferentICDsWithDevicesAndGroups) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_EXPORT_ICD_GIPA));
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
 
     // The loader has to be able to handle drivers that support device groups in combination
@@ -433,8 +433,8 @@ TEST(MultipleDriverConfig, DifferentICDsWithDevicesAndGroups) {
 
     // ICD 1 :  1.1 support (with 1 group with 2 devices)
     TestICD& icd1 = env.get_test_icd(1);
-    icd1.physical_devices.emplace_back("physical_device_1");
-    icd1.physical_devices.emplace_back("physical_device_2");
+    icd1.physical_devices.emplace_back("physical_device_1").set_api_version(VK_API_VERSION_1_1);
+    icd1.physical_devices.emplace_back("physical_device_2").set_api_version(VK_API_VERSION_1_1);
     icd1.physical_device_groups.emplace_back(icd1.physical_devices[0]);
     icd1.physical_device_groups.back().use_physical_device(icd1.physical_devices[1]);
     icd1.min_icd_interface_version = 5;

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -37,7 +37,6 @@ TEST(WsiTests, CreateSurfaceWin32NoICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
 
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extensions({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
@@ -55,7 +54,6 @@ TEST(WsiTests, CreateSurfaceWin32NoICDCreateSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
     cur_icd.enable_icd_wsi = false;
@@ -78,7 +76,6 @@ TEST(WsiTests, CreateSurfaceWin32ICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
     cur_icd.enable_icd_wsi = true;
@@ -128,7 +125,6 @@ TEST(WsiTests, GetPhysicalDeviceWin32PresentNoICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
     cur_icd.physical_devices.emplace_back("physical_device_0");
@@ -156,7 +152,6 @@ TEST(WsiTests, GetPhysicalDeviceWin32PresentICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
     cur_icd.physical_devices.emplace_back("physical_device_0");
@@ -221,7 +216,6 @@ TEST(WsiTests, CreateSurfaceXCBNoICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.enable_icd_wsi = false;
 
     InstWrapper inst{env.vulkan_functions};
@@ -240,7 +234,6 @@ TEST(WsiTests, CreateSurfaceXCBNoICDCreateSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
     cur_icd.enable_icd_wsi = false;
@@ -264,7 +257,6 @@ TEST(WsiTests, CreateSurfaceXCBICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
     cur_icd.enable_icd_wsi = true;
@@ -316,7 +308,6 @@ TEST(WsiTests, GetPhysicalDeviceXcbPresentNoICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
     cur_icd.physical_devices.emplace_back("physical_device_0");
@@ -344,7 +335,6 @@ TEST(WsiTests, GetPhysicalDeviceXcbPresentICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
     cur_icd.physical_devices.emplace_back("physical_device_0");
@@ -409,7 +399,6 @@ TEST(WsiTests, CreateSurfaceXLIBNoICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.enable_icd_wsi = false;
 
     InstWrapper inst{env.vulkan_functions};
@@ -428,7 +417,6 @@ TEST(WsiTests, CreateSurfaceXLIBNoICDCreateSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
     cur_icd.enable_icd_wsi = false;
@@ -452,7 +440,6 @@ TEST(WsiTests, CreateSurfaceXLIBICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
     cur_icd.enable_icd_wsi = true;
@@ -504,7 +491,6 @@ TEST(WsiTests, GetPhysicalDeviceXlibPresentNoICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
     cur_icd.physical_devices.emplace_back("physical_device_0");
@@ -532,7 +518,6 @@ TEST(WsiTests, GetPhysicalDeviceXlibPresentICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
     cur_icd.physical_devices.emplace_back("physical_device_0");
@@ -597,7 +582,6 @@ TEST(WsiTests, CreateSurfaceWaylandNoICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.enable_icd_wsi = false;
 
     InstWrapper inst{env.vulkan_functions};
@@ -616,7 +600,6 @@ TEST(WsiTests, CreateSurfaceWaylandNoICDCreateSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
     cur_icd.enable_icd_wsi = false;
@@ -640,7 +623,6 @@ TEST(WsiTests, CreateSurfaceWaylandICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
     cur_icd.enable_icd_wsi = true;
@@ -692,7 +674,6 @@ TEST(WsiTests, GetPhysicalDeviceWaylandPresentNoICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
     cur_icd.physical_devices.emplace_back("physical_device_0");
@@ -720,7 +701,6 @@ TEST(WsiTests, GetPhysicalDeviceWaylandPresentICDSupport) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.set_min_icd_interface_version(5);
-    cur_icd.set_icd_api_version(VK_API_VERSION_1_0);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
     cur_icd.physical_devices.emplace_back("physical_device_0");


### PR DESCRIPTION
The apiVersion of a VkPhysicalDevice is not guaranteed to be identical to the
api_version specified by the ICD Manifest JSON file. While there is nothing
inherently wrong with a different version, it is unusual for these versions
to not match, and so this commit adds logic to check & emit a warning whenever
these versions are different.

This warning is in response to a real issue due to behavioral differences in
the loader between 1.0 and 1.1 drivers, as the manifest file reported 1.1
while the VkPhysicalDeviceProperties::apiVersion reported 1.0.

This PR also cleans up tests a fair bit - including setting the API version in a lot of places where they may be relevant.

Fixes #1242 