### PR TITLE
Enhance warning messages for portability enumeration

### DIFF
--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -311,6 +311,8 @@ struct loader_instance {
     loader_settings settings;
 
     bool portability_enumeration_enabled;
+    bool portability_enumeration_flag_bit_set;
+    bool portability_enumeration_extension_enabled;
 
     bool wsi_surface_enabled;
 #if defined(VK_USE_PLATFORM_WIN32_KHR)


### PR DESCRIPTION
There are three different ways for applications to fail to enumerate portability drivers, not enabling the flag bit, not enabling the extension, and both. These were all reported as the same error, which isn't as helpful as it printing a separate message for each case.

This also makes it possible to emit a VUID for the case of setting the flag bit but not the extension.

Fixes #1254 