### PR TITLE
Add relative path support to test harness

### DIFF
--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -519,6 +519,12 @@ enum class ManifestDiscoveryType {
     macos_bundle,         // place it in a location only accessible to macos bundles
 };
 
+enum class LibraryPathType {
+    absolute,              // default for testing - the exact path of the binary
+    relative,              // Relative to the manifest file
+    default_search_paths,  // Dont add any path information to the library_path - force the use of the default search paths
+};
+
 struct TestICDDetails {
     TestICDDetails(ManifestICD icd_manifest) noexcept : icd_manifest(icd_manifest) {}
     TestICDDetails(fs::path icd_binary_path, uint32_t api_version = VK_API_VERSION_1_0) noexcept {
@@ -531,7 +537,7 @@ struct TestICDDetails {
     BUILDER_VALUE(TestICDDetails, ManifestDiscoveryType, discovery_type, ManifestDiscoveryType::generic);
     BUILDER_VALUE(TestICDDetails, bool, is_fake, false);
     // Dont add any path information to the library_path - force the use of the default search paths
-    BUILDER_VALUE(TestICDDetails, bool, use_dynamic_library_default_search_paths, false);
+    BUILDER_VALUE(TestICDDetails, LibraryPathType, library_path_type, LibraryPathType::absolute);
 };
 
 struct TestLayerDetails {
@@ -543,8 +549,7 @@ struct TestLayerDetails {
     BUILDER_VALUE(TestLayerDetails, bool, is_fake, false);
     // If discovery type is env-var, is_dir controls whether the env-var has the full name to the manifest or just the folder
     BUILDER_VALUE(TestLayerDetails, bool, is_dir, true);
-    // Dont add any path information to the library_path - force the use of the default search paths
-    BUILDER_VALUE(TestLayerDetails, bool, use_dynamic_library_default_search_paths, false);
+    BUILDER_VALUE(TestLayerDetails, LibraryPathType, library_path_type, LibraryPathType::absolute);
 };
 
 // Locations manifests can go in the test framework

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -126,7 +126,7 @@ std::string ManifestICD::get_manifest_str() const {
     writer.StartObject();
     writer.AddKeyedString("file_format_version", file_format_version.get_version_str());
     writer.StartKeyedObject("ICD");
-    writer.AddKeyedString("library_path", fs::fixup_backslashes_in_path(lib_path));
+    writer.AddKeyedString("library_path", fs::fixup_backslashes_in_path(lib_path).str());
     writer.AddKeyedString("api_version", version_to_string(api_version));
     writer.AddKeyedBool("is_portability_driver", is_portability_driver);
     if (!library_arch.empty()) writer.AddKeyedString("library_arch", library_arch);

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -216,11 +216,11 @@ struct path {
     path operator/(const char* in) const;
 
     // accessors
-    path parent_path() const;
-    bool has_parent_path() const;
-    path filename() const;
-    path extension() const;
-    path stem() const;
+    path parent_path() const;      // Everything before the last path separator, if there is one.
+    bool has_parent_path() const;  // True if the path contains more than just a filename.
+    path filename() const;         // Everything after the last path separator.
+    path extension() const;        // The file extension, if it has one.
+    path stem() const;             // The filename minus the extension.
 
     // modifiers
     path& replace_filename(path const& replacement);
@@ -595,7 +595,7 @@ struct ManifestVersion {
 struct ManifestICD {
     BUILDER_VALUE(ManifestICD, ManifestVersion, file_format_version, {})
     BUILDER_VALUE(ManifestICD, uint32_t, api_version, 0)
-    BUILDER_VALUE(ManifestICD, std::string, lib_path, {})
+    BUILDER_VALUE(ManifestICD, fs::path, lib_path, {})
     BUILDER_VALUE(ManifestICD, bool, is_portability_driver, false)
     BUILDER_VALUE(ManifestICD, std::string, library_arch, "")
     std::string get_manifest_str() const;


### PR DESCRIPTION
Makes sure the loader test framework can create relative paths in the library_path fields. Adds a test to insure those paths still work.

Since the contents of "library_path" is mututally exclusive with the existing use_dynamic_library_default_search_paths, a new enum was added to allow tests to choose which of the three content types a given ICD or Layer manifest should use.