### PR TITLE
Fixed the value of the FATAL_ERROR bit

### DIFF
--- a/loader/log.c
+++ b/loader/log.c
@@ -157,9 +157,9 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
         // Exit early if the current instance settings do not ask for logging to stderr
         if (inst && inst->settings.settings_active && 0 == (msg_type & inst->settings.debug_level)) {
             return;
-        } else {
             // Check the global settings and if that doesn't say to skip, check the environment variable
-            if (0 == (msg_type & g_loader_debug)) return;
+        } else if (0 == (msg_type & g_loader_debug)) {
+            return;
         }
     }
 

--- a/loader/log.h
+++ b/loader/log.h
@@ -44,7 +44,7 @@ enum vulkan_loader_debug_flags {
     VULKAN_LOADER_LAYER_BIT = 0x20,
     VULKAN_LOADER_DRIVER_BIT = 0x40,
     VULKAN_LOADER_VALIDATION_BIT = 0x80,
-    VULKAN_LOADER_FATAL_ERROR_BIT = 0x160,  // only forces the output to be printed to stderr, has no other effect
+    VULKAN_LOADER_FATAL_ERROR_BIT = 0x100,  // only forces the output to be printed to stderr, has no other effect
 };
 
 // Checks for the environment variable VK_LOADER_DEBUG and sets up the current debug level accordingly


### PR DESCRIPTION
0x160 is *not* the next highest power of two in hex after 0x80, it is in fact 0x100.

This error caused the log function to always log every message, rather than just fatal ones and whatever messages match the VK_LOADER_LOG environment variable.