### PR TITLE
Unwrap VkInstance in set name/tag debug functions

### DIFF
--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -4708,6 +4708,10 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
         struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pTagInfo->object;
         local_tag_info.object = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;
     }
+    if (pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {
+        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pTagInfo->object;
+        local_tag_info.object = (uint64_t)(uintptr_t)instance->instance;
+    }
     return disp->DebugMarkerSetObjectTagEXT(device, &local_tag_info);
 }
 
@@ -4762,6 +4766,10 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(
     if (pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {
         struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pNameInfo->object;
         local_name_info.object = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;
+    }
+    if (pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {
+        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pNameInfo->object;
+        local_name_info.object = (uint64_t)(uintptr_t)instance->instance;
     }
     return disp->DebugMarkerSetObjectNameEXT(device, &local_name_info);
 }
@@ -5346,6 +5354,10 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
         struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pNameInfo->objectHandle;
         local_name_info.objectHandle = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;
     }
+    if (pNameInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {
+        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pNameInfo->objectHandle;
+        local_name_info.objectHandle = (uint64_t)(uintptr_t)instance->instance;
+    }
     if (disp->SetDebugUtilsObjectNameEXT != NULL) {
         return disp->SetDebugUtilsObjectNameEXT(device, &local_name_info);
     } else {
@@ -5404,6 +5416,10 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectTagEXT(
     if (pTagInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {
         struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pTagInfo->objectHandle;
         local_tag_info.objectHandle = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;
+    }
+    if (pTagInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {
+        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pTagInfo->objectHandle;
+        local_tag_info.objectHandle = (uint64_t)(uintptr_t)instance->instance;
     }
     if (disp->SetDebugUtilsObjectTagEXT != NULL) {
         return disp->SetDebugUtilsObjectTagEXT(device, &local_tag_info);

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -935,13 +935,13 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
 
                         tables += f'    if (!strcmp(name, "{base_name}")) '
                         if cur_cmd.name in DEVICE_CMDS_MUST_USE_TRAMP:
-                            if version_check is not '':
+                            if version_check != '':
                                 tables += f'{{\n{version_check}        return dev->extensions.{cur_cmd.ext_name[3:].lower()}_enabled ? (void *){base_name} : NULL;\n    }}\n'
                             else:
                                 tables += f'return dev->extensions.{cur_cmd.ext_name[3:].lower()}_enabled ? (void *){base_name} : NULL;\n'
 
                         else:
-                            if version_check is not '':
+                            if version_check != '':
                                 tables += f'{{\n{version_check}        return (void *)table->{base_name};\n    }}\n'
                             else:
                                 tables += f'return (void *)table->{base_name};\n'
@@ -1105,6 +1105,10 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     funcs += '        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pNameInfo->object;\n'
                     funcs += '        local_name_info.object = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n'
                     funcs += '    }\n'
+                    funcs += '    if (pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {\n'
+                    funcs += '        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pNameInfo->object;\n'
+                    funcs += '        local_name_info.object = (uint64_t)(uintptr_t)instance->instance;\n'
+                    funcs += '    }\n'
                 elif 'DebugMarkerSetObjectTag' in ext_cmd.name:
                     funcs += '    VkDebugMarkerObjectTagInfoEXT local_tag_info;\n'
                     funcs += '    memcpy(&local_tag_info, pTagInfo, sizeof(VkDebugMarkerObjectTagInfoEXT));\n'
@@ -1112,6 +1116,10 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     funcs += '    if (pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {\n'
                     funcs += '        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pTagInfo->object;\n'
                     funcs += '        local_tag_info.object = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n'
+                    funcs += '    }\n'
+                    funcs += '    if (pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {\n'
+                    funcs += '        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pTagInfo->object;\n'
+                    funcs += '        local_tag_info.object = (uint64_t)(uintptr_t)instance->instance;\n'
                     funcs += '    }\n'
                 elif 'SetDebugUtilsObjectName' in ext_cmd.name:
                     funcs += '    VkDebugUtilsObjectNameInfoEXT local_name_info;\n'
@@ -1121,6 +1129,10 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     funcs += '        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pNameInfo->objectHandle;\n'
                     funcs += '        local_name_info.objectHandle = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n'
                     funcs += '    }\n'
+                    funcs += '    if (pNameInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {\n'
+                    funcs += '        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pNameInfo->objectHandle;\n'
+                    funcs += '        local_name_info.objectHandle = (uint64_t)(uintptr_t)instance->instance;\n'
+                    funcs += '    }\n'
                 elif 'SetDebugUtilsObjectTag' in ext_cmd.name:
                     funcs += '    VkDebugUtilsObjectTagInfoEXT local_tag_info;\n'
                     funcs += '    memcpy(&local_tag_info, pTagInfo, sizeof(VkDebugUtilsObjectTagInfoEXT));\n'
@@ -1128,6 +1140,10 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     funcs += '    if (pTagInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {\n'
                     funcs += '        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pTagInfo->objectHandle;\n'
                     funcs += '        local_tag_info.objectHandle = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n'
+                    funcs += '    }\n'
+                    funcs += '    if (pTagInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {\n'
+                    funcs += '        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pTagInfo->objectHandle;\n'
+                    funcs += '        local_tag_info.objectHandle = (uint64_t)(uintptr_t)instance->instance;\n'
                     funcs += '    }\n'
 
                 if ext_cmd.ext_name in NULL_CHECK_EXT_NAMES:


### PR DESCRIPTION
It is possible for a layer to wrap the instance handle, and when the various Set Name/Tag debug functions are called, the passed structure may contain an instance handle which was previously not being unwrapped before calling down the chain. This caused renderdoc to crash, as the instance handle was not known to it.

Fixes #1266 