### PR TITLE
Enable VK_KHR_maintenance_5 support

### DIFF
--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -1498,753 +1498,753 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
 
     // ---- Core 1_0 commands
     if (!strcmp(name, "GetDeviceProcAddr")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetDeviceProcAddr;
     }
     if (!strcmp(name, "DestroyDevice")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyDevice;
     }
     if (!strcmp(name, "GetDeviceQueue")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetDeviceQueue;
     }
     if (!strcmp(name, "QueueSubmit")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->QueueSubmit;
     }
     if (!strcmp(name, "QueueWaitIdle")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->QueueWaitIdle;
     }
     if (!strcmp(name, "DeviceWaitIdle")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DeviceWaitIdle;
     }
     if (!strcmp(name, "AllocateMemory")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->AllocateMemory;
     }
     if (!strcmp(name, "FreeMemory")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->FreeMemory;
     }
     if (!strcmp(name, "MapMemory")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->MapMemory;
     }
     if (!strcmp(name, "UnmapMemory")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->UnmapMemory;
     }
     if (!strcmp(name, "FlushMappedMemoryRanges")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->FlushMappedMemoryRanges;
     }
     if (!strcmp(name, "InvalidateMappedMemoryRanges")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->InvalidateMappedMemoryRanges;
     }
     if (!strcmp(name, "GetDeviceMemoryCommitment")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetDeviceMemoryCommitment;
     }
     if (!strcmp(name, "BindBufferMemory")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->BindBufferMemory;
     }
     if (!strcmp(name, "BindImageMemory")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->BindImageMemory;
     }
     if (!strcmp(name, "GetBufferMemoryRequirements")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetBufferMemoryRequirements;
     }
     if (!strcmp(name, "GetImageMemoryRequirements")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetImageMemoryRequirements;
     }
     if (!strcmp(name, "GetImageSparseMemoryRequirements")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetImageSparseMemoryRequirements;
     }
     if (!strcmp(name, "QueueBindSparse")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->QueueBindSparse;
     }
     if (!strcmp(name, "CreateFence")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateFence;
     }
     if (!strcmp(name, "DestroyFence")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyFence;
     }
     if (!strcmp(name, "ResetFences")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->ResetFences;
     }
     if (!strcmp(name, "GetFenceStatus")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetFenceStatus;
     }
     if (!strcmp(name, "WaitForFences")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->WaitForFences;
     }
     if (!strcmp(name, "CreateSemaphore")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateSemaphore;
     }
     if (!strcmp(name, "DestroySemaphore")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroySemaphore;
     }
     if (!strcmp(name, "CreateEvent")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateEvent;
     }
     if (!strcmp(name, "DestroyEvent")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyEvent;
     }
     if (!strcmp(name, "GetEventStatus")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetEventStatus;
     }
     if (!strcmp(name, "SetEvent")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->SetEvent;
     }
     if (!strcmp(name, "ResetEvent")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->ResetEvent;
     }
     if (!strcmp(name, "CreateQueryPool")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateQueryPool;
     }
     if (!strcmp(name, "DestroyQueryPool")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyQueryPool;
     }
     if (!strcmp(name, "GetQueryPoolResults")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetQueryPoolResults;
     }
     if (!strcmp(name, "CreateBuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateBuffer;
     }
     if (!strcmp(name, "DestroyBuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyBuffer;
     }
     if (!strcmp(name, "CreateBufferView")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateBufferView;
     }
     if (!strcmp(name, "DestroyBufferView")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyBufferView;
     }
     if (!strcmp(name, "CreateImage")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateImage;
     }
     if (!strcmp(name, "DestroyImage")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyImage;
     }
     if (!strcmp(name, "GetImageSubresourceLayout")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetImageSubresourceLayout;
     }
     if (!strcmp(name, "CreateImageView")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateImageView;
     }
     if (!strcmp(name, "DestroyImageView")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyImageView;
     }
     if (!strcmp(name, "CreateShaderModule")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateShaderModule;
     }
     if (!strcmp(name, "DestroyShaderModule")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyShaderModule;
     }
     if (!strcmp(name, "CreatePipelineCache")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreatePipelineCache;
     }
     if (!strcmp(name, "DestroyPipelineCache")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyPipelineCache;
     }
     if (!strcmp(name, "GetPipelineCacheData")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetPipelineCacheData;
     }
     if (!strcmp(name, "MergePipelineCaches")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->MergePipelineCaches;
     }
     if (!strcmp(name, "CreateGraphicsPipelines")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateGraphicsPipelines;
     }
     if (!strcmp(name, "CreateComputePipelines")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateComputePipelines;
     }
     if (!strcmp(name, "DestroyPipeline")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyPipeline;
     }
     if (!strcmp(name, "CreatePipelineLayout")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreatePipelineLayout;
     }
     if (!strcmp(name, "DestroyPipelineLayout")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyPipelineLayout;
     }
     if (!strcmp(name, "CreateSampler")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateSampler;
     }
     if (!strcmp(name, "DestroySampler")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroySampler;
     }
     if (!strcmp(name, "CreateDescriptorSetLayout")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateDescriptorSetLayout;
     }
     if (!strcmp(name, "DestroyDescriptorSetLayout")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyDescriptorSetLayout;
     }
     if (!strcmp(name, "CreateDescriptorPool")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateDescriptorPool;
     }
     if (!strcmp(name, "DestroyDescriptorPool")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyDescriptorPool;
     }
     if (!strcmp(name, "ResetDescriptorPool")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->ResetDescriptorPool;
     }
     if (!strcmp(name, "AllocateDescriptorSets")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->AllocateDescriptorSets;
     }
     if (!strcmp(name, "FreeDescriptorSets")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->FreeDescriptorSets;
     }
     if (!strcmp(name, "UpdateDescriptorSets")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->UpdateDescriptorSets;
     }
     if (!strcmp(name, "CreateFramebuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateFramebuffer;
     }
     if (!strcmp(name, "DestroyFramebuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyFramebuffer;
     }
     if (!strcmp(name, "CreateRenderPass")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateRenderPass;
     }
     if (!strcmp(name, "DestroyRenderPass")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyRenderPass;
     }
     if (!strcmp(name, "GetRenderAreaGranularity")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->GetRenderAreaGranularity;
     }
     if (!strcmp(name, "CreateCommandPool")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CreateCommandPool;
     }
     if (!strcmp(name, "DestroyCommandPool")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->DestroyCommandPool;
     }
     if (!strcmp(name, "ResetCommandPool")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->ResetCommandPool;
     }
     if (!strcmp(name, "AllocateCommandBuffers")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->AllocateCommandBuffers;
     }
     if (!strcmp(name, "FreeCommandBuffers")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->FreeCommandBuffers;
     }
     if (!strcmp(name, "BeginCommandBuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->BeginCommandBuffer;
     }
     if (!strcmp(name, "EndCommandBuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->EndCommandBuffer;
     }
     if (!strcmp(name, "ResetCommandBuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->ResetCommandBuffer;
     }
     if (!strcmp(name, "CmdBindPipeline")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdBindPipeline;
     }
     if (!strcmp(name, "CmdSetViewport")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdSetViewport;
     }
     if (!strcmp(name, "CmdSetScissor")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdSetScissor;
     }
     if (!strcmp(name, "CmdSetLineWidth")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdSetLineWidth;
     }
     if (!strcmp(name, "CmdSetDepthBias")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdSetDepthBias;
     }
     if (!strcmp(name, "CmdSetBlendConstants")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdSetBlendConstants;
     }
     if (!strcmp(name, "CmdSetDepthBounds")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdSetDepthBounds;
     }
     if (!strcmp(name, "CmdSetStencilCompareMask")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdSetStencilCompareMask;
     }
     if (!strcmp(name, "CmdSetStencilWriteMask")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdSetStencilWriteMask;
     }
     if (!strcmp(name, "CmdSetStencilReference")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdSetStencilReference;
     }
     if (!strcmp(name, "CmdBindDescriptorSets")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdBindDescriptorSets;
     }
     if (!strcmp(name, "CmdBindIndexBuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdBindIndexBuffer;
     }
     if (!strcmp(name, "CmdBindVertexBuffers")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdBindVertexBuffers;
     }
     if (!strcmp(name, "CmdDraw")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdDraw;
     }
     if (!strcmp(name, "CmdDrawIndexed")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdDrawIndexed;
     }
     if (!strcmp(name, "CmdDrawIndirect")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdDrawIndirect;
     }
     if (!strcmp(name, "CmdDrawIndexedIndirect")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdDrawIndexedIndirect;
     }
     if (!strcmp(name, "CmdDispatch")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdDispatch;
     }
     if (!strcmp(name, "CmdDispatchIndirect")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdDispatchIndirect;
     }
     if (!strcmp(name, "CmdCopyBuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdCopyBuffer;
     }
     if (!strcmp(name, "CmdCopyImage")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdCopyImage;
     }
     if (!strcmp(name, "CmdBlitImage")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdBlitImage;
     }
     if (!strcmp(name, "CmdCopyBufferToImage")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdCopyBufferToImage;
     }
     if (!strcmp(name, "CmdCopyImageToBuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdCopyImageToBuffer;
     }
     if (!strcmp(name, "CmdUpdateBuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdUpdateBuffer;
     }
     if (!strcmp(name, "CmdFillBuffer")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdFillBuffer;
     }
     if (!strcmp(name, "CmdClearColorImage")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdClearColorImage;
     }
     if (!strcmp(name, "CmdClearDepthStencilImage")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdClearDepthStencilImage;
     }
     if (!strcmp(name, "CmdClearAttachments")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdClearAttachments;
     }
     if (!strcmp(name, "CmdResolveImage")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdResolveImage;
     }
     if (!strcmp(name, "CmdSetEvent")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdSetEvent;
     }
     if (!strcmp(name, "CmdResetEvent")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdResetEvent;
     }
     if (!strcmp(name, "CmdWaitEvents")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdWaitEvents;
     }
     if (!strcmp(name, "CmdPipelineBarrier")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdPipelineBarrier;
     }
     if (!strcmp(name, "CmdBeginQuery")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdBeginQuery;
     }
     if (!strcmp(name, "CmdEndQuery")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdEndQuery;
     }
     if (!strcmp(name, "CmdResetQueryPool")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdResetQueryPool;
     }
     if (!strcmp(name, "CmdWriteTimestamp")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdWriteTimestamp;
     }
     if (!strcmp(name, "CmdCopyQueryPoolResults")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdCopyQueryPoolResults;
     }
     if (!strcmp(name, "CmdPushConstants")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdPushConstants;
     }
     if (!strcmp(name, "CmdBeginRenderPass")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdBeginRenderPass;
     }
     if (!strcmp(name, "CmdNextSubpass")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdNextSubpass;
     }
     if (!strcmp(name, "CmdEndRenderPass")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdEndRenderPass;
     }
     if (!strcmp(name, "CmdExecuteCommands")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_0) return NULL;
         return (void *)table->CmdExecuteCommands;
     }
 
     // ---- Core 1_1 commands
     if (!strcmp(name, "BindBufferMemory2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->BindBufferMemory2;
     }
     if (!strcmp(name, "BindImageMemory2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->BindImageMemory2;
     }
     if (!strcmp(name, "GetDeviceGroupPeerMemoryFeatures")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->GetDeviceGroupPeerMemoryFeatures;
     }
     if (!strcmp(name, "CmdSetDeviceMask")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->CmdSetDeviceMask;
     }
     if (!strcmp(name, "CmdDispatchBase")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->CmdDispatchBase;
     }
     if (!strcmp(name, "GetImageMemoryRequirements2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->GetImageMemoryRequirements2;
     }
     if (!strcmp(name, "GetBufferMemoryRequirements2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->GetBufferMemoryRequirements2;
     }
     if (!strcmp(name, "GetImageSparseMemoryRequirements2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->GetImageSparseMemoryRequirements2;
     }
     if (!strcmp(name, "TrimCommandPool")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->TrimCommandPool;
     }
     if (!strcmp(name, "GetDeviceQueue2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->GetDeviceQueue2;
     }
     if (!strcmp(name, "CreateSamplerYcbcrConversion")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->CreateSamplerYcbcrConversion;
     }
     if (!strcmp(name, "DestroySamplerYcbcrConversion")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->DestroySamplerYcbcrConversion;
     }
     if (!strcmp(name, "CreateDescriptorUpdateTemplate")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->CreateDescriptorUpdateTemplate;
     }
     if (!strcmp(name, "DestroyDescriptorUpdateTemplate")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->DestroyDescriptorUpdateTemplate;
     }
     if (!strcmp(name, "UpdateDescriptorSetWithTemplate")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->UpdateDescriptorSetWithTemplate;
     }
     if (!strcmp(name, "GetDescriptorSetLayoutSupport")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1) return NULL;
         return (void *)table->GetDescriptorSetLayoutSupport;
     }
 
     // ---- Core 1_2 commands
     if (!strcmp(name, "CmdDrawIndirectCount")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->CmdDrawIndirectCount;
     }
     if (!strcmp(name, "CmdDrawIndexedIndirectCount")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->CmdDrawIndexedIndirectCount;
     }
     if (!strcmp(name, "CreateRenderPass2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->CreateRenderPass2;
     }
     if (!strcmp(name, "CmdBeginRenderPass2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->CmdBeginRenderPass2;
     }
     if (!strcmp(name, "CmdNextSubpass2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->CmdNextSubpass2;
     }
     if (!strcmp(name, "CmdEndRenderPass2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->CmdEndRenderPass2;
     }
     if (!strcmp(name, "ResetQueryPool")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->ResetQueryPool;
     }
     if (!strcmp(name, "GetSemaphoreCounterValue")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->GetSemaphoreCounterValue;
     }
     if (!strcmp(name, "WaitSemaphores")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->WaitSemaphores;
     }
     if (!strcmp(name, "SignalSemaphore")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->SignalSemaphore;
     }
     if (!strcmp(name, "GetBufferDeviceAddress")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->GetBufferDeviceAddress;
     }
     if (!strcmp(name, "GetBufferOpaqueCaptureAddress")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->GetBufferOpaqueCaptureAddress;
     }
     if (!strcmp(name, "GetDeviceMemoryOpaqueCaptureAddress")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_2) return NULL;
         return (void *)table->GetDeviceMemoryOpaqueCaptureAddress;
     }
 
     // ---- Core 1_3 commands
     if (!strcmp(name, "CreatePrivateDataSlot")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CreatePrivateDataSlot;
     }
     if (!strcmp(name, "DestroyPrivateDataSlot")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->DestroyPrivateDataSlot;
     }
     if (!strcmp(name, "SetPrivateData")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->SetPrivateData;
     }
     if (!strcmp(name, "GetPrivateData")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->GetPrivateData;
     }
     if (!strcmp(name, "CmdSetEvent2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetEvent2;
     }
     if (!strcmp(name, "CmdResetEvent2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdResetEvent2;
     }
     if (!strcmp(name, "CmdWaitEvents2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdWaitEvents2;
     }
     if (!strcmp(name, "CmdPipelineBarrier2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdPipelineBarrier2;
     }
     if (!strcmp(name, "CmdWriteTimestamp2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdWriteTimestamp2;
     }
     if (!strcmp(name, "QueueSubmit2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->QueueSubmit2;
     }
     if (!strcmp(name, "CmdCopyBuffer2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdCopyBuffer2;
     }
     if (!strcmp(name, "CmdCopyImage2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdCopyImage2;
     }
     if (!strcmp(name, "CmdCopyBufferToImage2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdCopyBufferToImage2;
     }
     if (!strcmp(name, "CmdCopyImageToBuffer2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdCopyImageToBuffer2;
     }
     if (!strcmp(name, "CmdBlitImage2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdBlitImage2;
     }
     if (!strcmp(name, "CmdResolveImage2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdResolveImage2;
     }
     if (!strcmp(name, "CmdBeginRendering")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdBeginRendering;
     }
     if (!strcmp(name, "CmdEndRendering")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdEndRendering;
     }
     if (!strcmp(name, "CmdSetCullMode")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetCullMode;
     }
     if (!strcmp(name, "CmdSetFrontFace")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetFrontFace;
     }
     if (!strcmp(name, "CmdSetPrimitiveTopology")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetPrimitiveTopology;
     }
     if (!strcmp(name, "CmdSetViewportWithCount")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetViewportWithCount;
     }
     if (!strcmp(name, "CmdSetScissorWithCount")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetScissorWithCount;
     }
     if (!strcmp(name, "CmdBindVertexBuffers2")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdBindVertexBuffers2;
     }
     if (!strcmp(name, "CmdSetDepthTestEnable")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetDepthTestEnable;
     }
     if (!strcmp(name, "CmdSetDepthWriteEnable")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetDepthWriteEnable;
     }
     if (!strcmp(name, "CmdSetDepthCompareOp")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetDepthCompareOp;
     }
     if (!strcmp(name, "CmdSetDepthBoundsTestEnable")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetDepthBoundsTestEnable;
     }
     if (!strcmp(name, "CmdSetStencilTestEnable")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetStencilTestEnable;
     }
     if (!strcmp(name, "CmdSetStencilOp")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetStencilOp;
     }
     if (!strcmp(name, "CmdSetRasterizerDiscardEnable")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetRasterizerDiscardEnable;
     }
     if (!strcmp(name, "CmdSetDepthBiasEnable")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetDepthBiasEnable;
     }
     if (!strcmp(name, "CmdSetPrimitiveRestartEnable")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->CmdSetPrimitiveRestartEnable;
     }
     if (!strcmp(name, "GetDeviceBufferMemoryRequirements")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->GetDeviceBufferMemoryRequirements;
     }
     if (!strcmp(name, "GetDeviceImageMemoryRequirements")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->GetDeviceImageMemoryRequirements;
     }
     if (!strcmp(name, "GetDeviceImageSparseMemoryRequirements")) {
-        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
+        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_3) return NULL;
         return (void *)table->GetDeviceImageSparseMemoryRequirements;
     }
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5850,6 +5850,8 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
             dev->extensions.ext_debug_marker_enabled = true;
         } else if (!strcmp(localCreateInfo.ppEnabledExtensionNames[i], "VK_EXT_full_screen_exclusive")) {
             dev->extensions.ext_full_screen_exclusive_enabled = true;
+        } else if (!strcmp(localCreateInfo.ppEnabledExtensionNames[i], VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+            dev->should_ignore_device_commands_from_newer_version = true;
         }
     }
     dev->extensions.ext_debug_utils_enabled = icd_term->this_instance->enabled_known_extensions.ext_debug_utils;

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -200,6 +200,10 @@ struct loader_device {
     } extensions;
 
     struct loader_device *next;
+
+    // Makes vkGetDeviceProcAddr check if core functions are supported by the current app_api_version.
+    // Only set to true if VK_KHR_maintenance5 is enabled.
+    bool should_ignore_device_commands_from_newer_version;
 };
 
 // Per ICD information
@@ -359,10 +363,6 @@ struct loader_instance {
     bool wsi_display_props2_enabled;
     bool create_terminator_invalid_extension;
     bool supports_get_dev_prop_2;
-
-    // Makes vkGetDeviceProcAddr check if core functions are supported by the current app_api_version
-    // Currently unused
-    bool should_ignore_device_commands_from_newer_version;
 };
 
 // VkPhysicalDevice requires special treatment by loader.  Firstly, terminator

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -143,7 +143,7 @@ LOADER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDev
             const struct loader_instance *inst = icd_term->this_instance;
             uint32_t api_version =
                 VK_MAKE_API_VERSION(0, inst->app_api_version.major, inst->app_api_version.minor, inst->app_api_version.patch);
-            return (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1)
+            return (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_1_1)
                        ? NULL
                        : (PFN_vkVoidFunction)vkGetDeviceQueue2;
         }

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -914,7 +914,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                             if 'VK_VERSION_' in cur_cmd.ext_name:
                                 tables += '\n    // ---- Core %s commands\n' % cur_cmd.ext_name[11:]
                                 if cur_type == 'device':
-                                    version_check = f'        if (inst->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_{cur_cmd.ext_name[11:]}) return NULL;\n'
+                                    version_check = f'        if (dev->should_ignore_device_commands_from_newer_version && api_version < VK_API_VERSION_{cur_cmd.ext_name[11:]}) return NULL;\n'
                             else:
 
                                 tables += '\n    // ---- %s extension commands\n' % cur_cmd.ext_name


### PR DESCRIPTION
The extension changes the behavior of vkGetDeviceProcAddr to no longer allow querying of core functions beyond the version specified in VkApplicationInfo. Thus, a check is needed to ensure that if the extension is enabled, the apiVersion is sufficient for the function to be returned.