### PR TITLE
Enable CRT Warnings and fix them

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -30,7 +30,6 @@ if(WIN32)
         set(CMAKE_C_STANDARD_LIBRARIES ${CMAKE_CXX_STANDARD_LIBRARIES})
     endif()
 
-    target_compile_options(loader_specific_options INTERFACE -D_CRT_SECURE_NO_WARNINGS)
     # ~~~
     # Build dev_ext_trampoline.c and unknown_ext_chain.c with /O2 to allow tail-call optimization.
     # Setup two CMake targets (loader-norm and loader-opt) for the different compilation flags.

--- a/loader/asm_offset.c
+++ b/loader/asm_offset.c
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
         // clang-format on
     };
 
-    FILE *file = fopen("gen_defines.asm", "w");
+    FILE *file = loader_fopen("gen_defines.asm", "w");
     fprintf(file, "\n");
     if (!strcmp(assembler, "MASM")) {
         for (size_t i = 0; i < sizeof(values) / sizeof(values[0]); ++i) {

--- a/loader/dirent_on_windows.c
+++ b/loader/dirent_on_windows.c
@@ -36,11 +36,12 @@ DIR *opendir(const VkAllocationCallbacks *pAllocator, const char *name) {
         size_t base_length = strlen(name);
         const char *all = /* search pattern must end with suitable wildcard */
             strchr("/\\", name[base_length - 1]) ? "*" : "/*";
+        size_t full_length = base_length + strlen(all) + 1;
 
         if ((dir = (DIR *)loader_alloc(pAllocator, sizeof *dir, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND)) != 0 &&
-            (dir->name = (char *)loader_alloc(pAllocator, base_length + strlen(all) + 1, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND)) !=
-                0) {
-            strcat(strcpy(dir->name, name), all);
+            (dir->name = (char *)loader_calloc(pAllocator, full_length, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND)) != 0) {
+            loader_strncpy(dir->name, full_length, name, base_length);
+            loader_strncat(dir->name, full_length, all, strlen(all));
 
             if ((dir->handle = (handle_type)_findfirst(dir->name, &dir->info)) != -1) {
                 dir->result.d_name = 0;

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -110,6 +110,7 @@ VkResult append_str_to_string_list(const struct loader_instance *inst, struct lo
 // Resize if there isn't enough space, then copy the string str to a new string the end of the loader_string_list
 // This function does not take ownership of the string, it merely copies it.
 // This function appends a null terminator to the string automatically
+// The str_len parameter does not include the null terminator
 VkResult copy_str_to_string_list(const struct loader_instance *inst, struct loader_string_list *string_list, const char *str,
                                  size_t str_len);
 

--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -275,9 +275,11 @@ VkResult parse_generic_filter_environment_var(const struct loader_instance *inst
         size_t actual_len;
         determine_filter_type(token, &cur_filter_type, &actual_start, &actual_len);
         if (actual_len > VK_MAX_EXTENSION_NAME_SIZE) {
-            strncpy(filter_struct->filters[filter_struct->count].value, actual_start, VK_MAX_EXTENSION_NAME_SIZE);
+            loader_strncpy(filter_struct->filters[filter_struct->count].value, VK_MAX_EXTENSION_NAME_SIZE, actual_start,
+                           VK_MAX_EXTENSION_NAME_SIZE);
         } else {
-            strncpy(filter_struct->filters[filter_struct->count].value, actual_start, actual_len);
+            loader_strncpy(filter_struct->filters[filter_struct->count].value, VK_MAX_EXTENSION_NAME_SIZE, actual_start,
+                           actual_len);
         }
         filter_struct->filters[filter_struct->count].length = actual_len;
         filter_struct->filters[filter_struct->count++].type = cur_filter_type;
@@ -344,9 +346,11 @@ VkResult parse_layers_disable_filter_environment_var(const struct loader_instanc
             }
         } else {
             if (actual_len > VK_MAX_EXTENSION_NAME_SIZE) {
-                strncpy(disable_struct->additional_filters.filters[cur_count].value, actual_start, VK_MAX_EXTENSION_NAME_SIZE);
+                loader_strncpy(disable_struct->additional_filters.filters[cur_count].value, VK_MAX_EXTENSION_NAME_SIZE,
+                               actual_start, VK_MAX_EXTENSION_NAME_SIZE);
             } else {
-                strncpy(disable_struct->additional_filters.filters[cur_count].value, actual_start, actual_len);
+                loader_strncpy(disable_struct->additional_filters.filters[cur_count].value, VK_MAX_EXTENSION_NAME_SIZE,
+                               actual_start, actual_len);
             }
             disable_struct->additional_filters.filters[cur_count].length = actual_len;
             disable_struct->additional_filters.filters[cur_count].type = cur_filter_type;
@@ -440,7 +444,7 @@ VkResult loader_add_environment_layers(struct loader_instance *inst, const enum 
         size_t layer_env_len = strlen(layer_env) + 1;
         char *name = loader_stack_alloc(layer_env_len);
         if (name != NULL) {
-            strncpy(name, layer_env, layer_env_len);
+            loader_strncpy(name, layer_env_len, layer_env, layer_env_len);
 
             loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0, "env var \'%s\' defined and adding layers \"%s\"",
                        ENABLED_LAYERS_ENV, name);

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -622,7 +622,8 @@ VkResult windows_read_manifest_from_d3d_adapters(const struct loader_instance *i
             .value_type = REG_MULTI_SZ,
             .physical_adapter_index = 0,
         };
-        wcsncpy(filename_info.value_name, value_name, sizeof(filename_info.value_name) / sizeof(WCHAR));
+        size_t value_name_size = wcslen(value_name);
+        wcsncpy_s(filename_info.value_name, MAX_PATH, value_name, value_name_size);
         LoaderQueryAdapterInfo query_info;
         query_info.handle = adapters.adapters[i].handle;
         query_info.type = LOADER_QUERY_TYPE_REGISTRY;
@@ -1105,11 +1106,12 @@ VkResult get_settings_path_if_exists_in_registry_key(const struct loader_instanc
         }
 
         if (strcmp(VK_LOADER_SETTINGS_FILENAME, &(name[start_of_path_filename])) == 0) {
-            *out_path = loader_instance_heap_alloc(inst, name_size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            *out_path = loader_instance_heap_calloc(inst, name_size + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
             if (*out_path == NULL) {
                 return VK_ERROR_OUT_OF_HOST_MEMORY;
             }
-            strcpy(*out_path, name);
+            loader_strncpy(*out_path, name_size + 1, name, name_size);
+            (*out_path)[name_size] = '\0';
             result = VK_SUCCESS;
             break;
         }

--- a/loader/log.c
+++ b/loader/log.c
@@ -167,7 +167,7 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
     // Also use the same header for all output
     char cmd_line_msg[64];
     size_t cmd_line_size = sizeof(cmd_line_msg);
-    size_t num_used = 1;
+    size_t num_used = 0;
 
     cmd_line_msg[0] = '\0';
 
@@ -175,8 +175,8 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
 // Assumes that we haven't used the entire buffer - must manually check this when adding new filter types
 // We concat at the end of cmd_line_msg, so that strncat isn't a victim of Schlemiel the Painter
 // We write to the end - 1 of cmd_line_msg, as the end is actually a null terminator
-#define STRNCAT_TO_BUFFER(string_literal_to_cat)                                             \
-    strncat(cmd_line_msg + (num_used - 1), string_literal_to_cat, cmd_line_size - num_used); \
+#define STRNCAT_TO_BUFFER(string_literal_to_cat)                                                                             \
+    loader_strncat(cmd_line_msg + num_used, cmd_line_size - num_used, string_literal_to_cat, sizeof(string_literal_to_cat)); \
     num_used += sizeof(string_literal_to_cat) - 1;  // subtract one to remove the null terminator in the string literal
 
     if ((msg_type & VULKAN_LOADER_ERROR_BIT) != 0) {
@@ -216,8 +216,8 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
     if (num_used < 19) {
         const char *space_buffer = "                   ";
         // Only write (19 - num_used) spaces
-        strncat(cmd_line_msg + (num_used - 1), space_buffer, 19 - num_used);
-        num_used += sizeof(space_buffer) - (num_used - 1);
+        loader_strncat(cmd_line_msg + num_used, cmd_line_size - num_used, space_buffer, 19 - num_used);
+        num_used += sizeof(space_buffer) - 1 - num_used;
     }
     // Assert that we didn't write more than what is available in cmd_line_msg
     assert(cmd_line_size > num_used);

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -208,13 +208,15 @@ VkResult check_if_settings_path_exists(const struct loader_instance* inst, char*
     if (NULL == base || NULL == suffix) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
-
-    *settings_file_path = loader_instance_heap_calloc(inst, strlen(base) + strlen(suffix) + 1, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
+    size_t base_len = strlen(base);
+    size_t suffix_len = strlen(suffix);
+    size_t path_len = base_len + suffix_len + 1;
+    *settings_file_path = loader_instance_heap_calloc(inst, path_len, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
     if (NULL == *settings_file_path) {
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
-    strncpy(*settings_file_path, base, strlen(base));
-    strncat(*settings_file_path, suffix, strlen(suffix));
+    loader_strncpy(*settings_file_path, path_len, base, base_len);
+    loader_strncat(*settings_file_path, path_len, suffix, suffix_len);
 
     if (!loader_platform_file_exists(*settings_file_path)) {
         loader_instance_heap_free(inst, *settings_file_path);
@@ -532,7 +534,7 @@ VkResult get_settings_layers(const struct loader_instance* inst, struct loader_l
         if (layer_config->control == LOADER_SETTINGS_LAYER_CONTROL_OFF) {
             struct loader_layer_properties props = {0};
             props.settings_control_value = LOADER_SETTINGS_LAYER_CONTROL_OFF;
-            strncpy(props.info.layerName, layer_config->name, VK_MAX_EXTENSION_NAME_SIZE);
+            loader_strncpy(props.info.layerName, VK_MAX_EXTENSION_NAME_SIZE, layer_config->name, VK_MAX_EXTENSION_NAME_SIZE);
             props.info.layerName[VK_MAX_EXTENSION_NAME_SIZE - 1] = '\0';
             res = loader_copy_to_new_str(inst, layer_config->path, &props.manifest_file_name);
             if (VK_ERROR_OUT_OF_HOST_MEMORY == res) {
@@ -748,7 +750,7 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
             size_t vk_instance_layers_env_len = strlen(vk_instance_layers_env) + 1;
             char* name = loader_stack_alloc(vk_instance_layers_env_len);
             if (name != NULL) {
-                strncpy(name, vk_instance_layers_env, vk_instance_layers_env_len);
+                loader_strncpy(name, vk_instance_layers_env_len, vk_instance_layers_env, vk_instance_layers_env_len);
                 // First look for the old-fashion layers forced on with VK_INSTANCE_LAYERS
                 while (name && *name) {
                     char* next = loader_get_next_path(name);

--- a/loader/unknown_function_handling.c
+++ b/loader/unknown_function_handling.c
@@ -164,7 +164,7 @@ void *loader_dev_ext_gpa_impl(struct loader_instance *inst, const char *funcName
         // failed to allocate memory, return NULL
         return NULL;
     }
-    strncpy(inst->dev_ext_disp_functions[inst->dev_ext_disp_function_count], funcName, funcName_len);
+    loader_strncpy(inst->dev_ext_disp_functions[inst->dev_ext_disp_function_count], funcName_len, funcName, funcName_len);
     // init any dev dispatch table entries as needed
     loader_init_dispatch_dev_ext_entry(inst, NULL, inst->dev_ext_disp_function_count, funcName);
     void *out_function = loader_get_dev_ext_trampoline(inst->dev_ext_disp_function_count);
@@ -276,7 +276,8 @@ void *loader_phys_dev_ext_gpa_impl(struct loader_instance *inst, const char *fun
             // failed to allocate memory, return NULL
             return NULL;
         }
-        strncpy(inst->phys_dev_ext_disp_functions[inst->phys_dev_ext_disp_function_count], funcName, funcName_len);
+        loader_strncpy(inst->phys_dev_ext_disp_functions[inst->phys_dev_ext_disp_function_count], funcName_len, funcName,
+                       funcName_len);
 
         new_function_index = inst->phys_dev_ext_disp_function_count;
         // increment the count so that the subsequent logic includes the newly added entry point when searching for functions

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -30,9 +30,11 @@
 #endif
 
 #include <assert.h>
-#include <string.h>
+#include <float.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 
 #if defined(__Fuchsia__)
 #include "dlopen_fuchsia.h"
@@ -390,6 +392,16 @@ static inline void loader_platform_thread_delete_mutex(loader_platform_thread_mu
 
 static inline void *thread_safe_strtok(char *str, const char *delim, char **saveptr) { return strtok_r(str, delim, saveptr); }
 
+static inline FILE *loader_fopen(const char *fileName, const char *mode) { return fopen(fileName, mode); }
+static inline char *loader_strncat(char *dest, size_t dest_sz, const char *src, size_t count) {
+    (void)dest_sz;
+    return strncat(dest, src, count);
+}
+static inline char *loader_strncpy(char *dest, size_t dest_sz, const char *src, size_t count) {
+    (void)dest_sz;
+    return strncpy(dest, src, count);
+}
+
 #elif defined(_WIN32)
 
 // Get the key for the plug n play driver registry
@@ -546,6 +558,25 @@ static inline void loader_platform_thread_delete_mutex(loader_platform_thread_mu
 
 static inline void *thread_safe_strtok(char *str, const char *delimiters, char **context) {
     return strtok_s(str, delimiters, context);
+}
+
+static inline FILE *loader_fopen(const char *fileName, const char *mode) {
+    FILE *file = NULL;
+    errno_t err = fopen_s(&file, fileName, mode);
+    if (err != 0) return NULL;
+    return file;
+}
+
+static inline char *loader_strncat(char *dest, size_t dest_sz, const char *src, size_t count) {
+    errno_t err = strncat_s(dest, dest_sz, src, count);
+    if (err != 0) return NULL;
+    return dest;
+}
+
+static inline char *loader_strncpy(char *dest, size_t dest_sz, const char *src, size_t count) {
+    errno_t err = strncpy_s(dest, dest_sz, src, count);
+    if (err != 0) return NULL;
+    return dest;
 }
 
 #else  // defined(_WIN32)


### PR DESCRIPTION
CRT_SECURE_NO_WARNINGS disables warnings from using strcpy & strcat as well as strncpy and strncat. This isn't likely a huge concern, but the more warnings the better typically. 

This commit introduces loader_strncpy and loader_strncat which are platform generic versions. C11 added strncpy_s and strncat_s which are analogs to the win32 functions. But because this is a C99 project, these functions are not used.
