### PR TITLE
Add JSON Schemas for Driver and Layer Manifests

### DIFF
--- a/docs/LoaderDriverInterface.md
+++ b/docs/LoaderDriverInterface.md
@@ -42,6 +42,7 @@
   - [Using Pre-Production ICDs or Software Drivers](#using-pre-production-icds-or-software-drivers)
   - [Driver Discovery on Android](#driver-discovery-on-android)
 - [Driver Manifest File Format](#driver-manifest-file-format)
+  - [JSON Schema for Driver Manifest Files](#json-schema-for-driver-manifest-files)
   - [Driver Manifest File Versions](#driver-manifest-file-versions)
     - [Driver Manifest File Version 1.0.0](#driver-manifest-file-version-100)
     - [Driver Manifest File Version 1.0.1](#driver-manifest-file-version-101)
@@ -715,15 +716,36 @@ Here is an example driver JSON Manifest file:
 }
 ```
 
+### JSON Schema for Driver Manifest Files
+
+The Driver Manifest file can be validated against the provided JSON Schema files.
+This offers a quick way to check that the manifest file matches the format the
+loader expects.
+
+While the schema files are located in the repo, it is best to reference the web
+URL `https://schema.khronos.org/vulkan/driver_manifest_X_Y_Z.json`
+where `X`, `Y`, and `Z` correspond to the file_format_version used by the manifest.
+
+For example, a manifest of version 1.0.1 should use the following:
+
+```json
+{
+    "$schema":"https://schema.khronos.org/vulkan/driver_manifest_1_0_1.json",
+    "file_format_version" : "1.0.1",
+    ...
+```
+
 <table style="width:100%">
   <tr>
     <th>Field Name</th>
     <th>Field Value</th>
+    <th>JSON Type</th>
   </tr>
   <tr>
     <td>"file_format_version"</td>
     <td>The JSON format major.minor.patch version number of this file.<br/>
         Supported versions are: 1.0.0 and 1.0.1.</td>
+    <td>string</td>
   </tr>
   <tr>
     <td>"ICD"</td>
@@ -731,6 +753,7 @@ Here is an example driver JSON Manifest file:
         <br/>
         <b>NOTE:</b> Even though this is labelled <i>ICD</i> it is historical
         and just as accurate to use for other drivers.</td>
+    <td>object</td>
   </tr>
   <tr>
     <td>"library_path"</td>
@@ -743,6 +766,7 @@ Here is an example driver JSON Manifest file:
         There are no rules about the name of the driver's shared library file
         other than it should end with the appropriate suffix (".DLL" on
         Windows, ".so" on Linux and ".dylib" on macOS).</td>
+    <td>string</td>
   </tr>
   <tr>
     <td>"library_arch"</td>
@@ -751,6 +775,7 @@ Here is an example driver JSON Manifest file:
         Allows the loader to quickly determine if the architecture of the driver
         matches that of the running application. <br />
         The only valid values are "32" and "64".</td>
+    <td>string</td>
   </tr>
   <tr>
     <td>"api_version" </td>
@@ -763,12 +788,14 @@ Here is an example driver JSON Manifest file:
         queried by the user using the <i>vkGetPhysicalDeviceProperties</i> API
         call.<br/>
         For example: 1.0.33.</td>
+    <td>string</td>
   </tr>
   <tr>
     <td>"is_portability_driver" </td>
     <td>Defines whether the driver contains any VkPhysicalDevices which
         implement the VK_KHR_portability_subset extension.<br/>
     </td>
+    <td>boolean</td>
   </tr>
 </table>
 
@@ -798,7 +825,7 @@ they contain VkPhysicalDevices which support the VK_KHR_portability_subset
 extension. This is an optional field. Omitting the field has the same effect as
 setting the field to `false`.
 
-Added the "library\_arch" field to the driver manifest to allow the loader to
+Added the `library_arch` field to the driver manifest to allow the loader to
 quickly determine if the driver matches the architecture of the current running
 application. This field is optional.
 

--- a/docs/LoaderLayerInterface.md
+++ b/docs/LoaderLayerInterface.md
@@ -53,8 +53,9 @@
   - [Creating New Dispatchable Objects](#creating-new-dispatchable-objects)
   - [Versioning and Activation Interactions](#versioning-and-activation-interactions)
 - [Layer Manifest File Format](#layer-manifest-file-format)
+  - [JSON Schema for Layer Manifest Files](#json-schema-for-layer-manifest-files)
   - [Layer Manifest File Version History](#layer-manifest-file-version-history)
-  - [Layer Manifest File Version 1.2.1](#layer-manifest-file-version-121)
+    - [Layer Manifest File Version 1.2.1](#layer-manifest-file-version-121)
     - [Layer Manifest File Version 1.2.0](#layer-manifest-file-version-120)
     - [Layer Manifest File Version 1.1.2](#layer-manifest-file-version-112)
     - [Layer Manifest File Version 1.1.1](#layer-manifest-file-version-111)
@@ -1629,12 +1630,31 @@ Here's an example of a meta-layer manifest file:
 }
 ```
 
+### JSON Schema for Layer Manifest Files
+
+The Layer Manifest file can be validated against the provided JSON Schema files.
+This offers a quick way to check that the manifest file matches the format the
+loader expects.
+
+While the schema files are located in the repo, it is best to reference the web
+URL `https://schema.khronos.org/vulkan/layer_manifest_X_Y_Z.json`
+where `X`, `Y`, and `Z` correspond to the file_format_version used by the manifest.
+
+For example, a manifest of version 1.2.1 should use the following:
+
+```json
+{
+    "$schema":"https://schema.khronos.org/vulkan/layer_manifest_1_2_1.json",
+    "file_format_version" : "1.2.1",
+    ...
+```
 
 <table style="width:100%">
   <tr>
     <th>JSON Node</th>
     <th>Description and Notes</th>
     <th>Restrictions</th>
+    <th>JSON Type</th>
     <th>Parent</th>
     <th>Introspection Query</th>
   </tr>
@@ -1648,6 +1668,7 @@ Here's an example of a meta-layer manifest file:
         For example: 1.0.33.
     </td>
     <td>None</td>
+    <td>string</td>
     <td>"layer"/"layers"</td>
     <td><small>vkEnumerateInstanceLayerProperties</small></td>
   </tr>
@@ -1656,6 +1677,7 @@ Here's an example of a meta-layer manifest file:
     <td>List of paths to executables that the meta-layer applies to.
     </td>
     <td><b>Meta-layers Only</b></td>
+    <td>array of strings</td>
     <td>"layer"/"layers"</td>
     <td><small>N/A</small></td>
   </tr>
@@ -1665,6 +1687,7 @@ Here's an example of a meta-layer manifest file:
         requested by the application.
     </td>
     <td><b>Meta-layers Only</b></td>
+    <td>array of strings</td>
     <td>"layer"/"layers"</td>
     <td><small>N/A</small></td>
   </tr>
@@ -1680,6 +1703,7 @@ Here's an example of a meta-layer manifest file:
         <b>This field must not be present if "library_path" is defined</b>.
     </td>
     <td><b>Meta-layers Only</b></td>
+    <td>array of strings</td>
     <td>"layer"/"layers"</td>
     <td><small>N/A</small></td>
   </tr>
@@ -1687,6 +1711,7 @@ Here's an example of a meta-layer manifest file:
     <td>"description"</td>
     <td>A high-level description of the layer and its intended use.</td>
     <td>None</td>
+    <td>string</td>
     <td>"layer"/"layers"</td>
     <td><small>vkEnumerateInstanceLayerProperties</small></td>
   </tr>
@@ -1706,6 +1731,7 @@ Here's an example of a meta-layer manifest file:
         by the supported extension.
     </td>
     <td>None</td>
+    <td>array</td>
     <td>"layer"/"layers"</td>
     <td><small>vkEnumerateDeviceExtensionProperties</small></td>
   </tr>
@@ -1722,6 +1748,7 @@ Here's an example of a meta-layer manifest file:
         set, the implicit layer is disabled.
     </td>
     <td><b>Implicit Layers Only</b></td>
+    <td>object</td>
     <td>"layer"/"layers"</td>
     <td><small>N/A</small></td>
   </tr>
@@ -1738,6 +1765,7 @@ Here's an example of a meta-layer manifest file:
         implicit layer(s).
     </td>
     <td><b>Implicit Layers Only</b></td>
+    <td>object</td>
     <td>"layer"/"layers"</td>
     <td><small>N/A</small></td>
   </tr>
@@ -1747,6 +1775,7 @@ Here's an example of a meta-layer manifest file:
         Supported versions are: 1.0.0, 1.0.1, 1.1.0, 1.1.1, 1.1.2 and 1.2.0.
     </td>
     <td>None</td>
+    <td>string</td>
     <td>None</td>
     <td><small>N/A</small></td>
   </tr>
@@ -1759,6 +1788,7 @@ Here's an example of a meta-layer manifest file:
         name for `vkNegotiateLoaderLayerInterfaceVersion`.
     </td>
     <td>None</td>
+    <td>object</td>
     <td>"layer"/"layers"</td>
     <td><small>vkGet*ProcAddr</small></td>
   </tr>
@@ -1769,6 +1799,7 @@ Here's an example of a meta-layer manifest file:
         the loader and/or application can identify it properly.
     </td>
     <td>None</td>
+    <td>string</td>
     <td>"layer"/"layers"</td>
     <td><small>vkEnumerateInstanceLayerProperties</small></td>
   </tr>
@@ -1784,6 +1815,7 @@ Here's an example of a meta-layer manifest file:
         "specVersion" respectively.
     </td>
     <td>None</td>
+    <td>array</td>
     <td>"layer"/"layers"</td>
     <td><small>vkEnumerateInstanceExtensionProperties</small></td>
   </tr>
@@ -1792,6 +1824,7 @@ Here's an example of a meta-layer manifest file:
     <td>The identifier used to group a single layer's information together.
     </td>
     <td>None</td>
+    <td>object</td>
     <td>None</td>
     <td><small>vkEnumerateInstanceLayerProperties</small></td>
   </tr>
@@ -1801,6 +1834,7 @@ Here's an example of a meta-layer manifest file:
         This requires a minimum Manifest file format version of 1.0.1.
     </td>
     <td>None</td>
+    <td>object</td>
     <td>None</td>
     <td><small>vkEnumerateInstanceLayerProperties</small></td>
   </tr>
@@ -1820,6 +1854,7 @@ Here's an example of a meta-layer manifest file:
         <b>This field must not be present if "component_layers" is defined</b>.
     </td>
     <td><b>Not Valid For Meta-layers</b></td>
+    <td>string</td>
     <td>"layer"/"layers"</td>
     <td><small>N/A</small></td>
   </tr>
@@ -1829,6 +1864,9 @@ Here's an example of a meta-layer manifest file:
         Allows the loader to quickly determine if the architecture of the layer
         matches that of the running application. <br />
         The only valid values are "32" and "64".</td>
+    <td><b>Not Valid For Meta-layers</b></td>
+    <td>string</td>
+        <td>"layer"/"layers"</td>
     <td><small>N/A</small></td>
   </tr>
   <tr>
@@ -1836,6 +1874,7 @@ Here's an example of a meta-layer manifest file:
     <td>"name"</td>
     <td>The string used to uniquely identify this layer to applications.</td>
     <td>None</td>
+    <td>string</td>
     <td>"layer"/"layers"</td>
     <td><small>vkEnumerateInstanceLayerProperties</small></td>
   </tr>
@@ -1845,6 +1884,7 @@ Here's an example of a meta-layer manifest file:
         layers.
     </td>
     <td><b>Meta-layers Only</b></td>
+    <td>array of strings</td>
     <td>"layer"/"layers"</td>
     <td><small>N/A</small></td>
   </tr>
@@ -1861,6 +1901,7 @@ Here's an example of a meta-layer manifest file:
         more information.
     </td>
     <td><b>Implicit Layers Only</b></td>
+    <td>object</td>
     <td>"layer"/"layers"</td>
     <td><small>vkEnumerateInstance*Properties</small></td>
   </tr>
@@ -1878,6 +1919,7 @@ Here's an example of a meta-layer manifest file:
         not found.
     </td>
     <td>None</td>
+    <td>string</td>
     <td>"layer"/"layers"</td>
     <td><small>vkEnumerate*LayerProperties</small></td>
   </tr>
@@ -1885,10 +1927,10 @@ Here's an example of a meta-layer manifest file:
 
 ### Layer Manifest File Version History
 
-The current highest supported Layer Manifest file format supported is 1.2.0.
+The current highest supported Layer Manifest file format supported is 1.2.1.
 Information about each version is detailed in the following sub-sections:
 
-### Layer Manifest File Version 1.2.1
+#### Layer Manifest File Version 1.2.1
 
 Added the "library\_arch" field to the layer manifest to allow the loader to
 quickly determine if the layer matches the architecture of the current running

--- a/schemas/driver_manifest_1_0_0.json
+++ b/schemas/driver_manifest_1_0_0.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "https://schema.khronos.org/vulkan/driver_manifest_1_0_0.json",
+    "title": "Vulkan Driver Manifest Version 1.0.0",
+    "description": "JSON Schema for Driver Manifest files for the Vulkan Loader",
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+        "file_format_version": {
+            "type": "string",
+            "pattern": "^1.0.0$"
+        },
+        "ICD": {
+            "type": "object",
+            "properties": {
+                "library_path": {
+                    "type": "string",
+                    "description": "Path validation is not feasible to validate with regex since valid paths are different per platform"
+                },
+                "api_version": {
+                    "type": "string",
+                    "pattern": "^[0-9]*\\.[0-9]*\\.[0-9]*$|^[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*$",
+                    "description": "Matches 3 and 4 component versions"
+                },
+                "library_arch": false,
+                "is_portability_driver": false
+            },
+            "required": [
+                "library_path",
+                "api_version"
+            ]
+        }
+    },
+    "required": [
+        "file_format_version",
+        "ICD"
+    ]
+}

--- a/schemas/driver_manifest_1_0_1.json
+++ b/schemas/driver_manifest_1_0_1.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "https://schema.khronos.org/vulkan/driver_manifest_1_0_1.json",
+    "title": "Vulkan Driver Manifest Version 1.0.1",
+    "description": "JSON Schema for Driver Manifest files for the Vulkan Loader",
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+        "file_format_version": {
+            "type": "string",
+            "pattern": "^1.0.1$"
+        },
+        "ICD": {
+            "type": "object",
+            "properties": {
+                "library_path": {
+                    "type": "string",
+                    "description": "Path validation is not feasible to validate with regex since valid paths are different per platform"
+                },
+                "api_version": {
+                    "type": "string",
+                    "pattern": "^[0-9]*\\.[0-9]*\\.[0-9]*$|^[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*$",
+                    "description": "Matches 3 and 4 component versions"
+                },
+                "library_arch": {
+                    "enum": [
+                        "32",
+                        "64"
+                    ]
+                },
+                "is_portability_driver": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "library_path",
+                "api_version"
+            ]
+        }
+    },
+    "required": [
+        "file_format_version",
+        "ICD"
+    ]
+}

--- a/schemas/layer_manifest_1_0_0.json
+++ b/schemas/layer_manifest_1_0_0.json
@@ -1,0 +1,215 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "https://schema.khronos.org/vulkan/layer_manifest_1_0_0.json",
+    "title": "Vulkan Layer Manifest Version 1.0.0",
+    "description": "JSON Schema for Layer Manifest files for the Vulkan Loader",
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+        "file_format_version": {
+            "$ref": "#/$defs/file_version"
+        },
+        "layer": {
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/explicit_layer"
+                },
+                {
+                    "$ref": "#/$defs/implicit_layer"
+                }
+            ]
+        },
+        "layers": false
+    },
+    "$defs": {
+        "file_version": {
+            "type": "string",
+            "pattern": "^1.0.0$"
+        },
+        "regular_string": {
+            "type": "string"
+        },
+        "vulkan_string": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Vulkan API strings may not exceed 256 characters in length"
+        },
+        "supported_path_types": {
+            "type": "string",
+            "description": "Path validation is not feasible to validate with regex since valid paths are different per platform"
+        },
+        "vulkan_api_version": {
+            "type": "string",
+            "pattern": "^[0-9]*\\.[0-9]*\\.[0-9]*$|^[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*$",
+            "description": "Matches 3 and 4 component versions"
+        },
+        "extension_array": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "$ref": "#/$defs/vulkan_string"
+                    },
+                    "spec_version": {
+                        "type": "string"
+                    },
+                    "entrypoints": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "spec_version"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "layer_type": {
+            "enum": [
+                "INSTANCE",
+                "GLOBAL"
+            ]
+        },
+        "architecture": {
+            "enum": [
+                "32",
+                "64"
+            ]
+        },
+        "environment_variable": {
+            "type": "object",
+            "patternProperties": {
+                "": {
+                    "type": "string"
+                }
+            },
+            "maxProperties": 1,
+            "additionalProperties": false
+        },
+        "function_definitions": {
+            "type": "object",
+            "patternProperties": {
+                "": {
+                    "type": "string"
+                }
+            }
+        },
+        "vulkan_string_array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/vulkan_string"
+            }
+        },
+        "string_array": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "explicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": false,
+                "disable_environment": false,
+                "pre_instance_functions": false,
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "api_version",
+                "library_path",
+                "implementation_version",
+                "description"
+            ]
+        },
+        "implicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "disable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "pre_instance_functions": false,
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "library_path",
+                "api_version",
+                "implementation_version",
+                "description",
+                "disable_environment"
+            ]
+        }
+    }
+}

--- a/schemas/layer_manifest_1_0_1.json
+++ b/schemas/layer_manifest_1_0_1.json
@@ -1,0 +1,256 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "https://schema.khronos.org/vulkan/layer_manifest_1_0_1.json",
+    "title": "Vulkan Layer Manifest Version 1.0.1",
+    "description": "JSON Schema for Layer Manifest files for the Vulkan Loader",
+    "type": "object",
+    "additionalProperties": true,
+    "oneOf": [
+        {
+            "$ref": "#/$defs/single_layer"
+        },
+        {
+            "$ref": "#/$defs/layer_array"
+        }
+    ],
+    "$defs": {
+        "file_version": {
+            "type": "string",
+            "pattern": "^1.0.1$"
+        },
+        "regular_string": {
+            "type": "string"
+        },
+        "vulkan_string": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Vulkan API strings may not exceed 256 characters in length"
+        },
+        "supported_path_types": {
+            "type": "string",
+            "description": "Path validation is not feasible to validate with regex since valid paths are different per platform"
+        },
+        "vulkan_api_version": {
+            "type": "string",
+            "pattern": "^[0-9]*\\.[0-9]*\\.[0-9]*$|^[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*$",
+            "description": "Matches 3 and 4 component versions"
+        },
+        "extension_array": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "$ref": "#/$defs/vulkan_string"
+                    },
+                    "spec_version": {
+                        "type": "string"
+                    },
+                    "entrypoints": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "spec_version"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "layer_type": {
+            "enum": [
+                "INSTANCE",
+                "GLOBAL"
+            ]
+        },
+        "architecture": {
+            "enum": [
+                "32",
+                "64"
+            ]
+        },
+        "environment_variable": {
+            "type": "object",
+            "patternProperties": {
+                "": {
+                    "type": "string"
+                }
+            },
+            "maxProperties": 1,
+            "additionalProperties": false
+        },
+        "function_definitions": {
+            "type": "object",
+            "patternProperties": {
+                "^$": {
+                    "type": "string"
+                }
+            }
+        },
+        "vulkan_string_array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/vulkan_string"
+            }
+        },
+        "string_array": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "explicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": false,
+                "disable_environment": false,
+                "pre_instance_functions": false,
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "api_version",
+                "library_path",
+                "implementation_version",
+                "description"
+            ]
+        },
+        "implicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "disable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "pre_instance_functions": false,
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "library_path",
+                "api_version",
+                "implementation_version",
+                "description",
+                "disable_environment"
+            ]
+        },
+        "single_layer": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layer": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/explicit_layer"
+                        },
+                        {
+                            "$ref": "#/$defs/implicit_layer"
+                        }
+                    ]
+                },
+                "layers": false
+            },
+            "required": [
+                "file_format_version",
+                "layer"
+            ]
+        },
+        "layer_array": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layers": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/$defs/explicit_layer"
+                            },
+                            {
+                                "$ref": "#/$defs/implicit_layer"
+                            }
+                        ]
+                    }
+                },
+                "layer": false
+            },
+            "required": [
+                "file_format_version",
+                "layers"
+            ]
+        }
+    }
+}

--- a/schemas/layer_manifest_1_1_0.json
+++ b/schemas/layer_manifest_1_1_0.json
@@ -1,0 +1,256 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "https://schema.khronos.org/vulkan/layer_manifest_1_1_0.json",
+    "title": "Vulkan Layer Manifest Version 1.1.0",
+    "description": "JSON Schema for Layer Manifest files for the Vulkan Loader",
+    "type": "object",
+    "additionalProperties": true,
+    "oneOf": [
+        {
+            "$ref": "#/$defs/single_layer"
+        },
+        {
+            "$ref": "#/$defs/layer_array"
+        }
+    ],
+    "$defs": {
+        "file_version": {
+            "type": "string",
+            "pattern": "^1.1.0$"
+        },
+        "regular_string": {
+            "type": "string"
+        },
+        "vulkan_string": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Vulkan API strings may not exceed 256 characters in length"
+        },
+        "supported_path_types": {
+            "type": "string",
+            "description": "Path validation is not feasible to validate with regex since valid paths are different per platform"
+        },
+        "vulkan_api_version": {
+            "type": "string",
+            "pattern": "^[0-9]*\\.[0-9]*\\.[0-9]*$|^[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*$",
+            "description": "Matches 3 and 4 component versions"
+        },
+        "extension_array": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "$ref": "#/$defs/vulkan_string"
+                    },
+                    "spec_version": {
+                        "type": "string"
+                    },
+                    "entrypoints": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "spec_version"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "layer_type": {
+            "enum": [
+                "INSTANCE",
+                "GLOBAL"
+            ]
+        },
+        "architecture": {
+            "enum": [
+                "32",
+                "64"
+            ]
+        },
+        "environment_variable": {
+            "type": "object",
+            "patternProperties": {
+                "": {
+                    "type": "string"
+                }
+            },
+            "maxProperties": 1,
+            "additionalProperties": false
+        },
+        "function_definitions": {
+            "type": "object",
+            "patternProperties": {
+                "^$": {
+                    "type": "string"
+                }
+            }
+        },
+        "vulkan_string_array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/vulkan_string"
+            }
+        },
+        "string_array": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "explicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": false,
+                "disable_environment": false,
+                "pre_instance_functions": false,
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "api_version",
+                "library_path",
+                "implementation_version",
+                "description"
+            ]
+        },
+        "implicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "disable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "pre_instance_functions": false,
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "library_path",
+                "api_version",
+                "implementation_version",
+                "description",
+                "disable_environment"
+            ]
+        },
+        "single_layer": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layer": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/explicit_layer"
+                        },
+                        {
+                            "$ref": "#/$defs/implicit_layer"
+                        }
+                    ]
+                },
+                "layers": false
+            },
+            "required": [
+                "file_format_version",
+                "layer"
+            ]
+        },
+        "layer_array": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layers": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/$defs/explicit_layer"
+                            },
+                            {
+                                "$ref": "#/$defs/implicit_layer"
+                            }
+                        ]
+                    }
+                },
+                "layer": false
+            },
+            "required": [
+                "file_format_version",
+                "layers"
+            ]
+        }
+    }
+}

--- a/schemas/layer_manifest_1_1_1.json
+++ b/schemas/layer_manifest_1_1_1.json
@@ -1,0 +1,317 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "https://schema.khronos.org/vulkan/layer_manifest_1_1_1.json",
+    "title": "Vulkan Layer Manifest Version 1.1.1",
+    "description": "JSON Schema for Layer Manifest files for the Vulkan Loader",
+    "type": "object",
+    "additionalProperties": true,
+    "oneOf": [
+        {
+            "$ref": "#/$defs/single_layer"
+        },
+        {
+            "$ref": "#/$defs/layer_array"
+        }
+    ],
+    "$defs": {
+        "file_version": {
+            "type": "string",
+            "pattern": "^1.1.1$"
+        },
+        "regular_string": {
+            "type": "string"
+        },
+        "vulkan_string": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Vulkan API strings may not exceed 256 characters in length"
+        },
+        "supported_path_types": {
+            "type": "string",
+            "description": "Path validation is not feasible to validate with regex since valid paths are different per platform"
+        },
+        "vulkan_api_version": {
+            "type": "string",
+            "pattern": "^[0-9]*\\.[0-9]*\\.[0-9]*$|^[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*$",
+            "description": "Matches 3 and 4 component versions"
+        },
+        "extension_array": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "$ref": "#/$defs/vulkan_string"
+                    },
+                    "spec_version": {
+                        "type": "string"
+                    },
+                    "entrypoints": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "spec_version"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "layer_type": {
+            "enum": [
+                "INSTANCE",
+                "GLOBAL"
+            ]
+        },
+        "architecture": {
+            "enum": [
+                "32",
+                "64"
+            ]
+        },
+        "environment_variable": {
+            "type": "object",
+            "patternProperties": {
+                "": {
+                    "type": "string"
+                }
+            },
+            "maxProperties": 1,
+            "additionalProperties": false
+        },
+        "function_definitions": {
+            "type": "object",
+            "patternProperties": {
+                "^$": {
+                    "type": "string"
+                }
+            }
+        },
+        "vulkan_string_array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/vulkan_string"
+            }
+        },
+        "string_array": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "explicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": false,
+                "disable_environment": false,
+                "pre_instance_functions": false,
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "api_version",
+                "library_path",
+                "implementation_version",
+                "description"
+            ]
+        },
+        "implicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "disable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "pre_instance_functions": false,
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "library_path",
+                "api_version",
+                "implementation_version",
+                "description",
+                "disable_environment"
+            ]
+        },
+        "meta_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "enable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "disable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "component_layers": {
+                    "$ref": "#/$defs/vulkan_string_array"
+                },
+                "blacklisted_layers": {
+                    "$ref": "#/$defs/vulkan_string_array"
+                },
+                "app_keys": {
+                    "$ref": "#/$defs/string_array"
+                },
+                "override_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "library_path": false,
+                "pre_instance_functions": false,
+                "functions": false,
+                "instance_extensions": false,
+                "device_extensions": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "api_version",
+                "implementation_version",
+                "description",
+                "component_layers"
+            ]
+        },
+        "single_layer": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layer": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/explicit_layer"
+                        },
+                        {
+                            "$ref": "#/$defs/implicit_layer"
+                        },
+                        {
+                            "$ref": "#/$defs/meta_layer"
+                        }
+                    ]
+                },
+                "layers": false
+            },
+            "required": [
+                "file_format_version",
+                "layer"
+            ]
+        },
+        "layer_array": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layers": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/$defs/explicit_layer"
+                            },
+                            {
+                                "$ref": "#/$defs/implicit_layer"
+                            },
+                            {
+                                "$ref": "#/$defs/meta_layer"
+                            }
+                        ]
+                    }
+                },
+                "layer": false
+            },
+            "required": [
+                "file_format_version",
+                "layers"
+            ]
+        }
+    }
+}

--- a/schemas/layer_manifest_1_1_2.json
+++ b/schemas/layer_manifest_1_1_2.json
@@ -1,0 +1,330 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "https://schema.khronos.org/vulkan/layer_manifest_1_1_2.json",
+    "title": "Vulkan Layer Manifest Version 1.1.2",
+    "description": "JSON Schema for Layer Manifest files for the Vulkan Loader",
+    "type": "object",
+    "additionalProperties": true,
+    "oneOf": [
+        {
+            "$ref": "#/$defs/single_layer"
+        },
+        {
+            "$ref": "#/$defs/layer_array"
+        }
+    ],
+    "$defs": {
+        "file_version": {
+            "type": "string",
+            "pattern": "^1.1.2$"
+        },
+        "regular_string": {
+            "type": "string"
+        },
+        "vulkan_string": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Vulkan API strings may not exceed 256 characters in length"
+        },
+        "supported_path_types": {
+            "type": "string",
+            "description": "Path validation is not feasible to validate with regex since valid paths are different per platform"
+        },
+        "vulkan_api_version": {
+            "type": "string",
+            "pattern": "^[0-9]*\\.[0-9]*\\.[0-9]*$|^[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*$",
+            "description": "Matches 3 and 4 component versions"
+        },
+        "extension_array": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "$ref": "#/$defs/vulkan_string"
+                    },
+                    "spec_version": {
+                        "type": "string"
+                    },
+                    "entrypoints": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "spec_version"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "layer_type": {
+            "enum": [
+                "INSTANCE",
+                "GLOBAL"
+            ]
+        },
+        "architecture": {
+            "enum": [
+                "32",
+                "64"
+            ]
+        },
+        "environment_variable": {
+            "type": "object",
+            "patternProperties": {
+                "": {
+                    "type": "string"
+                }
+            },
+            "maxProperties": 1,
+            "additionalProperties": false
+        },
+        "function_definitions": {
+            "type": "object",
+            "patternProperties": {
+                "^$": {
+                    "type": "string"
+                }
+            }
+        },
+        "vulkan_string_array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/vulkan_string"
+            }
+        },
+        "string_array": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "explicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": false,
+                "disable_environment": false,
+                "pre_instance_functions": false,
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "api_version",
+                "library_path",
+                "implementation_version",
+                "description"
+            ]
+        },
+        "implicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "disable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "pre_instance_functions": {
+                    "type": "object",
+                    "properties": {
+                        "vkEnumerateInstanceExtensionProperties": {
+                            "type": "string"
+                        },
+                        "vkEnumerateInstanceLayerProperties": {
+                            "type": "string"
+                        },
+                        "vkEnumerateInstanceVersion": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "library_path",
+                "api_version",
+                "implementation_version",
+                "description",
+                "disable_environment"
+            ]
+        },
+        "meta_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "enable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "disable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "component_layers": {
+                    "$ref": "#/$defs/vulkan_string_array"
+                },
+                "blacklisted_layers": {
+                    "$ref": "#/$defs/vulkan_string_array"
+                },
+                "app_keys": {
+                    "$ref": "#/$defs/string_array"
+                },
+                "override_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "library_path": false,
+                "pre_instance_functions": false,
+                "functions": false,
+                "instance_extensions": false,
+                "device_extensions": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "api_version",
+                "implementation_version",
+                "description",
+                "component_layers"
+            ]
+        },
+        "single_layer": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layer": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/explicit_layer"
+                        },
+                        {
+                            "$ref": "#/$defs/implicit_layer"
+                        },
+                        {
+                            "$ref": "#/$defs/meta_layer"
+                        }
+                    ]
+                },
+                "layers": false
+            },
+            "required": [
+                "file_format_version",
+                "layer"
+            ]
+        },
+        "layer_array": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layers": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/$defs/explicit_layer"
+                            },
+                            {
+                                "$ref": "#/$defs/implicit_layer"
+                            },
+                            {
+                                "$ref": "#/$defs/meta_layer"
+                            }
+                        ]
+                    }
+                },
+                "layer": false
+            },
+            "required": [
+                "file_format_version",
+                "layers"
+            ]
+        }
+    }
+}

--- a/schemas/layer_manifest_1_2_0.json
+++ b/schemas/layer_manifest_1_2_0.json
@@ -1,0 +1,377 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "https://schema.khronos.org/vulkan/layer_manifest_1_2_0.json",
+    "title": "Vulkan Layer Manifest Version 1.2.0",
+    "description": "JSON Schema for Layer Manifest files for the Vulkan Loader",
+    "type": "object",
+    "additionalProperties": true,
+    "oneOf": [
+        {
+            "$ref": "#/$defs/single_layer"
+        },
+        {
+            "$ref": "#/$defs/layer_array"
+        }
+    ],
+    "$defs": {
+        "file_version": {
+            "type": "string",
+            "pattern": "^1.2.0$"
+        },
+        "regular_string": {
+            "type": "string"
+        },
+        "vulkan_string": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Vulkan API strings may not exceed 256 characters in length"
+        },
+        "supported_path_types": {
+            "type": "string",
+            "description": "Path validation is not feasible to validate with regex since valid paths are different per platform"
+        },
+        "vulkan_api_version": {
+            "type": "string",
+            "pattern": "^[0-9]*\\.[0-9]*\\.[0-9]*$|^[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*$",
+            "description": "Matches 3 and 4 component versions"
+        },
+        "extension_array": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "$ref": "#/$defs/vulkan_string"
+                    },
+                    "spec_version": {
+                        "type": "string"
+                    },
+                    "entrypoints": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "spec_version"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "layer_type": {
+            "enum": [
+                "INSTANCE",
+                "GLOBAL"
+            ]
+        },
+        "architecture": {
+            "enum": [
+                "32",
+                "64"
+            ]
+        },
+        "environment_variable": {
+            "type": "object",
+            "patternProperties": {
+                "": {
+                    "type": "string"
+                }
+            },
+            "maxProperties": 1,
+            "additionalProperties": false
+        },
+        "function_definitions": {
+            "type": "object",
+            "patternProperties": {
+                "^$": {
+                    "type": "string"
+                }
+            }
+        },
+        "vulkan_string_array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/vulkan_string"
+            }
+        },
+        "string_array": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "development_status": {
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "explicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "introduction": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "platforms": {
+                    "$ref": "#/$defs/string_array"
+                },
+                "status": {
+                    "$ref": "#/$defs/development_status"
+                },
+                "enable_environment": false,
+                "disable_environment": false,
+                "pre_instance_functions": false,
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "api_version",
+                "library_path",
+                "implementation_version",
+                "description"
+            ]
+        },
+        "implicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "disable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "pre_instance_functions": {
+                    "type": "object",
+                    "properties": {
+                        "vkEnumerateInstanceExtensionProperties": {
+                            "type": "string"
+                        },
+                        "vkEnumerateInstanceLayerProperties": {
+                            "type": "string"
+                        },
+                        "vkEnumerateInstanceVersion": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "introduction": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "platforms": {
+                    "$ref": "#/$defs/string_array"
+                },
+                "status": {
+                    "$ref": "#/$defs/development_status"
+                },
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "library_path",
+                "api_version",
+                "implementation_version",
+                "description",
+                "disable_environment"
+            ]
+        },
+        "meta_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "enable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "disable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "component_layers": {
+                    "$ref": "#/$defs/vulkan_string_array"
+                },
+                "blacklisted_layers": {
+                    "$ref": "#/$defs/vulkan_string_array"
+                },
+                "app_keys": {
+                    "$ref": "#/$defs/string_array"
+                },
+                "override_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "introduction": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "platforms": {
+                    "$ref": "#/$defs/string_array"
+                },
+                "status": {
+                    "$ref": "#/$defs/development_status"
+                },
+                "library_path": false,
+                "pre_instance_functions": false,
+                "functions": false,
+                "instance_extensions": false,
+                "device_extensions": false,
+                "library_arch": false
+            },
+            "required": [
+                "name",
+                "type",
+                "api_version",
+                "implementation_version",
+                "description",
+                "component_layers"
+            ]
+        },
+        "single_layer": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layer": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/explicit_layer"
+                        },
+                        {
+                            "$ref": "#/$defs/implicit_layer"
+                        },
+                        {
+                            "$ref": "#/$defs/meta_layer"
+                        }
+                    ]
+                },
+                "layers": false
+            },
+            "required": [
+                "file_format_version",
+                "layer"
+            ]
+        },
+        "layer_array": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layers": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/$defs/explicit_layer"
+                            },
+                            {
+                                "$ref": "#/$defs/implicit_layer"
+                            },
+                            {
+                                "$ref": "#/$defs/meta_layer"
+                            }
+                        ]
+                    }
+                },
+                "layer": false
+            },
+            "required": [
+                "file_format_version",
+                "layers"
+            ]
+        }
+    }
+}

--- a/schemas/layer_manifest_1_2_1.json
+++ b/schemas/layer_manifest_1_2_1.json
@@ -1,0 +1,383 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "id": "https://schema.khronos.org/vulkan/layer_manifest_1_2_1.json",
+    "title": "Vulkan Layer Manifest Version 1.2.1",
+    "description": "JSON Schema for Layer Manifest files for the Vulkan Loader",
+    "type": "object",
+    "additionalProperties": true,
+    "oneOf": [
+        {
+            "$ref": "#/$defs/single_layer"
+        },
+        {
+            "$ref": "#/$defs/layer_array"
+        }
+    ],
+    "$defs": {
+        "file_version": {
+            "type": "string",
+            "pattern": "^1.2.1$"
+        },
+        "regular_string": {
+            "type": "string"
+        },
+        "vulkan_string": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Vulkan API strings may not exceed 256 characters in length"
+        },
+        "supported_path_types": {
+            "type": "string",
+            "description": "Path validation is not feasible to validate with regex since valid paths are different per platform"
+        },
+        "vulkan_api_version": {
+            "type": "string",
+            "pattern": "^[0-9]*\\.[0-9]*\\.[0-9]*$|^[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*$",
+            "description": "Matches 3 and 4 component versions"
+        },
+        "extension_array": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "$ref": "#/$defs/vulkan_string"
+                    },
+                    "spec_version": {
+                        "type": "string"
+                    },
+                    "entrypoints": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "spec_version"
+                ],
+                "additionalProperties": false
+            }
+        },
+        "layer_type": {
+            "enum": [
+                "INSTANCE",
+                "GLOBAL"
+            ]
+        },
+        "architecture": {
+            "enum": [
+                "32",
+                "64"
+            ]
+        },
+        "environment_variable": {
+            "type": "object",
+            "patternProperties": {
+                "": {
+                    "type": "string"
+                }
+            },
+            "maxProperties": 1,
+            "additionalProperties": false
+        },
+        "function_definitions": {
+            "type": "object",
+            "patternProperties": {
+                "^$": {
+                    "type": "string"
+                }
+            }
+        },
+        "vulkan_string_array": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/vulkan_string"
+            }
+        },
+        "string_array": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "development_status": {
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "explicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "library_arch": {
+                    "$ref": "#/$defs/architecture"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "introduction": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "platforms": {
+                    "$ref": "#/$defs/string_array"
+                },
+                "status": {
+                    "$ref": "#/$defs/development_status"
+                },
+                "enable_environment": false,
+                "disable_environment": false,
+                "pre_instance_functions": false,
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false
+            },
+            "required": [
+                "name",
+                "type",
+                "api_version",
+                "library_path",
+                "implementation_version",
+                "description"
+            ]
+        },
+        "implicit_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_path": {
+                    "$ref": "#/$defs/supported_path_types"
+                },
+                "library_arch": {
+                    "$ref": "#/$defs/architecture"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "functions": {
+                    "$ref": "#/$defs/function_definitions"
+                },
+                "instance_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "device_extensions": {
+                    "$ref": "#/$defs/extension_array"
+                },
+                "enable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "disable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "pre_instance_functions": {
+                    "type": "object",
+                    "properties": {
+                        "vkEnumerateInstanceExtensionProperties": {
+                            "type": "string"
+                        },
+                        "vkEnumerateInstanceLayerProperties": {
+                            "type": "string"
+                        },
+                        "vkEnumerateInstanceVersion": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "introduction": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "platforms": {
+                    "$ref": "#/$defs/string_array"
+                },
+                "status": {
+                    "$ref": "#/$defs/development_status"
+                },
+                "component_layers": false,
+                "blacklisted_layers": false,
+                "app_keys": false,
+                "override_paths": false
+            },
+            "required": [
+                "name",
+                "type",
+                "library_path",
+                "api_version",
+                "implementation_version",
+                "description",
+                "disable_environment"
+            ]
+        },
+        "meta_layer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "type": {
+                    "$ref": "#/$defs/layer_type"
+                },
+                "library_arch": {
+                    "$ref": "#/$defs/architecture"
+                },
+                "api_version": {
+                    "$ref": "#/$defs/vulkan_api_version"
+                },
+                "implementation_version": {
+                    "type": "string"
+                },
+                "description": {
+                    "$ref": "#/$defs/vulkan_string"
+                },
+                "enable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "disable_environment": {
+                    "$ref": "#/$defs/environment_variable"
+                },
+                "component_layers": {
+                    "$ref": "#/$defs/vulkan_string_array"
+                },
+                "blacklisted_layers": {
+                    "$ref": "#/$defs/vulkan_string_array"
+                },
+                "app_keys": {
+                    "$ref": "#/$defs/string_array"
+                },
+                "override_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "introduction": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "platforms": {
+                    "$ref": "#/$defs/string_array"
+                },
+                "status": {
+                    "$ref": "#/$defs/development_status"
+                },
+                "library_path": false,
+                "pre_instance_functions": false,
+                "functions": false,
+                "instance_extensions": false,
+                "device_extensions": false
+            },
+            "required": [
+                "name",
+                "type",
+                "api_version",
+                "implementation_version",
+                "description",
+                "component_layers"
+            ]
+        },
+        "single_layer": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layer": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/explicit_layer"
+                        },
+                        {
+                            "$ref": "#/$defs/implicit_layer"
+                        },
+                        {
+                            "$ref": "#/$defs/meta_layer"
+                        }
+                    ]
+                },
+                "layers": false
+            },
+            "required": [
+                "file_format_version",
+                "layer"
+            ]
+        },
+        "layer_array": {
+            "type": "object",
+            "properties": {
+                "file_format_version": {
+                    "$ref": "#/$defs/file_version"
+                },
+                "layers": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/$defs/explicit_layer"
+                            },
+                            {
+                                "$ref": "#/$defs/implicit_layer"
+                            },
+                            {
+                                "$ref": "#/$defs/meta_layer"
+                            }
+                        ]
+                    }
+                },
+                "layer": false
+            },
+            "required": [
+                "file_format_version",
+                "layers"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
The JSON Schema format allows for automatic validation of a given manifest file. This enhances the ability for layer and driver developers to check that their manifest files are correct, as well as clarifying the exact format that the loader expects manifest files to be in.

These files will be available inside the repo for reference, but the primary location they will be made available from is:
https://schema.khornos.org/vulkan/

Each version of the Driver and Layer Manifest formats have their own schema, allowing verification of whichever version the driver or layer intends to use.