### PR TITLE
Document VK_DRIVER_FILES ability to look in folders

### DIFF
--- a/docs/LoaderDriverInterface.md
+++ b/docs/LoaderDriverInterface.md
@@ -120,8 +120,9 @@ If both `VK_DRIVER_FILES` and `VK_ICD_FILENAMES` environment variables are
 present, then the newer `VK_DRIVER_FILES` will be used, and the values in
 `VK_ICD_FILENAMES` will be ignored.
 
-The `VK_DRIVER_FILES` environment variable is a list of Driver Manifest
-files, containing the full path to the driver JSON Manifest file.
+The `VK_DRIVER_FILES` environment variable is a list of paths to Driver Manifest
+files, containing the full path to the driver JSON Manifest file, and/or paths
+to folders containing Driver Manifest files.
 This list is colon-separated on Linux and macOS, and semicolon-separated on
 Windows.
 Typically, `VK_DRIVER_FILES` will only contain a full pathname to one info
@@ -135,7 +136,7 @@ Driver in addition to the standard drivers (without replacing the standard
 search paths.
 The `VK_ADD_DRIVER_FILES` environment variable can be used to add a list of
 Driver Manifest files, containing the full path to the driver JSON Manifest
-file.
+file, and/or paths to folders containing Driver Manifest files.
 This list is colon-separated on Linux and macOS, and semicolon-separated on
 Windows.
 It will be added prior to the standard driver search files.

--- a/docs/LoaderInterfaceArchitecture.md
+++ b/docs/LoaderInterfaceArchitecture.md
@@ -632,14 +632,15 @@ discovery.
     <td><small>
         Force the loader to use the specific driver JSON files.
         The value contains a list of delimited full path listings to
-        driver JSON Manifest files.<br/>
+        driver JSON Manifest files and/or
+        paths to folders containing driver JSON files.<br/>
         <br/>
         This has replaced the older deprecated environment variable
         <i>VK_ICD_FILENAMES</i>, however the older environment variable will
-        continue to work for some time.
+        continue to work.
     </small></td>
     <td><small>
-        If a global path to the JSON file is not used, issues may be encountered.
+        If a relative path not used, issues may be encountered.
         <br/> <br/>
         <a href="#elevated-privilege-caveats">
             Ignored when running Vulkan application with elevated privileges.

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -508,11 +508,19 @@ TestICD& FrameworkEnvironment::add_icd(TestICDDetails icd_details) noexcept {
 #endif
                 break;
             case (ManifestDiscoveryType::env_var):
-                env_var_vk_icd_filenames.add_to_list((folder->location() / full_json_name).str());
+                if (icd_details.is_dir) {
+                    env_var_vk_icd_filenames.add_to_list(folder->location().str());
+                } else {
+                    env_var_vk_icd_filenames.add_to_list((folder->location() / full_json_name).str());
+                }
                 platform_shim->add_known_path(folder->location());
                 break;
             case (ManifestDiscoveryType::add_env_var):
-                add_env_var_vk_icd_filenames.add_to_list((folder->location() / full_json_name).str());
+                if (icd_details.is_dir) {
+                    add_env_var_vk_icd_filenames.add_to_list(folder->location().str());
+                } else {
+                    add_env_var_vk_icd_filenames.add_to_list((folder->location() / full_json_name).str());
+                }
                 platform_shim->add_known_path(folder->location());
                 break;
             case (ManifestDiscoveryType::macos_bundle):

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -536,7 +536,8 @@ struct TestICDDetails {
     BUILDER_VALUE(TestICDDetails, bool, disable_icd_inc, false);
     BUILDER_VALUE(TestICDDetails, ManifestDiscoveryType, discovery_type, ManifestDiscoveryType::generic);
     BUILDER_VALUE(TestICDDetails, bool, is_fake, false);
-    // Dont add any path information to the library_path - force the use of the default search paths
+    // If discovery type is env-var, is_dir controls whether to use the path to the file or folder the manifest is in
+    BUILDER_VALUE(TestICDDetails, bool, is_dir, false);
     BUILDER_VALUE(TestICDDetails, LibraryPathType, library_path_type, LibraryPathType::absolute);
 };
 
@@ -547,7 +548,7 @@ struct TestLayerDetails {
     BUILDER_VALUE(TestLayerDetails, std::string, json_name, "test_layer");
     BUILDER_VALUE(TestLayerDetails, ManifestDiscoveryType, discovery_type, ManifestDiscoveryType::generic);
     BUILDER_VALUE(TestLayerDetails, bool, is_fake, false);
-    // If discovery type is env-var, is_dir controls whether the env-var has the full name to the manifest or just the folder
+    // If discovery type is env-var, is_dir controls whether to use the path to the file or folder the manifest is in
     BUILDER_VALUE(TestLayerDetails, bool, is_dir, true);
     BUILDER_VALUE(TestLayerDetails, LibraryPathType, library_path_type, LibraryPathType::absolute);
 };


### PR DESCRIPTION
Orinigally VK_ICD_FILENAMES was documented to only be able to use full paths to ICD Manifest files. This is untrue, as VK_ICD_FILENAMES, and its replacement VK_DRIVER_FILES is able to find drivers using full paths as well as paths to folders containing manifest files. This commit amends the documentation to reflect that capability as well as adding a test for that use case.

Fixes #613 