### PR TITLE
Update QNX build environment to make it buildable again.

### DIFF
--- a/build-qnx/common.mk
+++ b/build-qnx/common.mk
@@ -22,7 +22,9 @@ NAME=vulkan
 
 SRCS = cJSON.c debug_utils.c dev_ext_trampoline.c loader.c \
 	phys_dev_ext.c trampoline.c unknown_ext_chain.c wsi.c \
-	extension_manual.c unknown_function_handling.c
+	extension_manual.c unknown_function_handling.c settings.c \
+	log.c allocation.c loader_environment.c gpa_helper.c \
+	terminator.c
 
 LDFLAGS += -Wl,--unresolved-symbols=report-all -Wl,--no-undefined -Wl,-fPIC
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2964,7 +2964,7 @@ VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enu
     char *xdg_config_home = loader_secure_getenv("XDG_CONFIG_HOME", inst);
     char *xdg_config_dirs = loader_secure_getenv("XDG_CONFIG_DIRS", inst);
 
-#if !defined(__Fuchsia__) && !defined(__QNXNTO__)
+#if !defined(__Fuchsia__) && !defined(__QNX__)
     if (NULL == xdg_config_dirs || '\0' == xdg_config_dirs[0]) {
         xdg_config_dirs = FALLBACK_CONFIG_DIRS;
     }
@@ -2973,7 +2973,7 @@ VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enu
     char *xdg_data_home = loader_secure_getenv("XDG_DATA_HOME", inst);
     char *xdg_data_dirs = loader_secure_getenv("XDG_DATA_DIRS", inst);
 
-#if !defined(__Fuchsia__) && !defined(__QNXNTO__)
+#if !defined(__Fuchsia__) && !defined(__QNX__)
     if (NULL == xdg_data_dirs || '\0' == xdg_data_dirs[0]) {
         xdg_data_dirs = FALLBACK_DATA_DIRS;
     }

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -41,7 +41,7 @@
 #endif  // defined(__Fuchsia__)
 
 // Set of platforms with a common set of functionality which is queried throughout the program
-#if defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNXNTO__) || defined(__FreeBSD__) || \
+#if defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNX__) || defined(__FreeBSD__) || \
     defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__GNU__)
 #define COMMON_UNIX_PLATFORMS 1
 #else
@@ -144,7 +144,7 @@
 #define VK_ILAYERS_INFO_REGISTRY_LOC ""
 #define VK_SETTINGS_INFO_REGISTRY_LOC ""
 
-#if defined(__QNXNTO__)
+#if defined(__QNX__)
 #define SYSCONFDIR "/etc"
 #endif
 
@@ -306,7 +306,7 @@ static inline char *loader_platform_executable_path(char *buffer, size_t size) {
 }
 #elif defined(__Fuchsia__) || defined(__OpenBSD__)
 static inline char *loader_platform_executable_path(char *buffer, size_t size) { return NULL; }
-#elif defined(__QNXNTO__)
+#elif defined(__QNX__)
 
 #define SYSCONFDIR "/etc"
 
@@ -330,7 +330,7 @@ static inline char *loader_platform_executable_path(char *buffer, size_t size) {
 
     return buffer;
 }
-#endif  // defined (__QNXNTO__)
+#endif  // defined (__QNX__)
 
 // Compatability with compilers that don't support __has_feature
 #if !defined(__has_feature)

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -62,7 +62,7 @@
 #include <stdint.h>
 
 // Set of platforms with a common set of functionality which is queried throughout the program
-#if defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNXNTO__) || defined(__FreeBSD__) || \
+#if defined(__linux__) || defined(__APPLE__) || defined(__Fuchsia__) || defined(__QNX__) || defined(__FreeBSD__) || \
     defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__GNU__)
 #define COMMON_UNIX_PLATFORMS 1
 #else
@@ -836,7 +836,7 @@ inline std::string test_platform_executable_path() {
 }
 #elif defined(__Fuchsia__) || defined(__OpenBSD__)
 inline std::string test_platform_executable_path() { return {}; }
-#elif defined(__QNXNTO__)
+#elif defined(__QNX__)
 
 #define SYSCONFDIR "/etc"
 
@@ -863,7 +863,7 @@ inline std::string test_platform_executable_path() {
 
     return buffer;
 }
-#endif  // defined (__QNXNTO__)
+#endif  // defined (__QNX__)
 #if defined(WIN32)
 inline std::string test_platform_executable_path() {
     std::string buffer;


### PR DESCRIPTION
1. Update build-qnx content to make it buildable again.
2. Switch __QNXNTO__ macro check to __QNX__

During last 23 years the QNX Neutrino microkernel was active, __QNXNTO__ macro belongs to it. Now QNX Muon microkernel is under development, so __QNX__ macro covers both versions: Neutrino and Muon.

First public announce of QNX Muon was here: https://blogs.blackberry.com/en/2023/04/get-in-the-sdv-podcast-from-blackberry-season-2-episode-3