### PR TITLE
Fix incorrect handling of Debug Marker functions

### DIFF
--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -1429,38 +1429,38 @@ void init_extension_device_proc_terminator_dispatch(struct loader_device *dev) {
     struct loader_device_terminator_dispatch* dispatch = &dev->loader_dispatch.extension_terminator_dispatch;
     PFN_vkGetDeviceProcAddr gpda = (PFN_vkGetDeviceProcAddr)dev->phys_dev_term->this_icd_term->dispatch.GetDeviceProcAddr;
     // ---- VK_KHR_swapchain extension commands
-    if (dev->extensions.khr_swapchain_enabled)
+    if (dev->driver_extensions.khr_swapchain_enabled)
        dispatch->CreateSwapchainKHR = (PFN_vkCreateSwapchainKHR)gpda(dev->icd_device, "vkCreateSwapchainKHR");
-    if (dev->extensions.khr_swapchain_enabled)
+    if (dev->driver_extensions.khr_swapchain_enabled)
        dispatch->GetDeviceGroupSurfacePresentModesKHR = (PFN_vkGetDeviceGroupSurfacePresentModesKHR)gpda(dev->icd_device, "vkGetDeviceGroupSurfacePresentModesKHR");
     // ---- VK_KHR_display_swapchain extension commands
-    if (dev->extensions.khr_display_swapchain_enabled)
+    if (dev->driver_extensions.khr_display_swapchain_enabled)
        dispatch->CreateSharedSwapchainsKHR = (PFN_vkCreateSharedSwapchainsKHR)gpda(dev->icd_device, "vkCreateSharedSwapchainsKHR");
     // ---- VK_EXT_debug_marker extension commands
-    if (dev->extensions.ext_debug_marker_enabled)
+    if (dev->driver_extensions.ext_debug_marker_enabled)
        dispatch->DebugMarkerSetObjectTagEXT = (PFN_vkDebugMarkerSetObjectTagEXT)gpda(dev->icd_device, "vkDebugMarkerSetObjectTagEXT");
-    if (dev->extensions.ext_debug_marker_enabled)
+    if (dev->driver_extensions.ext_debug_marker_enabled)
        dispatch->DebugMarkerSetObjectNameEXT = (PFN_vkDebugMarkerSetObjectNameEXT)gpda(dev->icd_device, "vkDebugMarkerSetObjectNameEXT");
     // ---- VK_EXT_debug_utils extension commands
-    if (dev->extensions.ext_debug_utils_enabled)
+    if (dev->driver_extensions.ext_debug_utils_enabled)
        dispatch->SetDebugUtilsObjectNameEXT = (PFN_vkSetDebugUtilsObjectNameEXT)gpda(dev->icd_device, "vkSetDebugUtilsObjectNameEXT");
-    if (dev->extensions.ext_debug_utils_enabled)
+    if (dev->driver_extensions.ext_debug_utils_enabled)
        dispatch->SetDebugUtilsObjectTagEXT = (PFN_vkSetDebugUtilsObjectTagEXT)gpda(dev->icd_device, "vkSetDebugUtilsObjectTagEXT");
-    if (dev->extensions.ext_debug_utils_enabled)
+    if (dev->driver_extensions.ext_debug_utils_enabled)
        dispatch->QueueBeginDebugUtilsLabelEXT = (PFN_vkQueueBeginDebugUtilsLabelEXT)gpda(dev->icd_device, "vkQueueBeginDebugUtilsLabelEXT");
-    if (dev->extensions.ext_debug_utils_enabled)
+    if (dev->driver_extensions.ext_debug_utils_enabled)
        dispatch->QueueEndDebugUtilsLabelEXT = (PFN_vkQueueEndDebugUtilsLabelEXT)gpda(dev->icd_device, "vkQueueEndDebugUtilsLabelEXT");
-    if (dev->extensions.ext_debug_utils_enabled)
+    if (dev->driver_extensions.ext_debug_utils_enabled)
        dispatch->QueueInsertDebugUtilsLabelEXT = (PFN_vkQueueInsertDebugUtilsLabelEXT)gpda(dev->icd_device, "vkQueueInsertDebugUtilsLabelEXT");
-    if (dev->extensions.ext_debug_utils_enabled)
+    if (dev->driver_extensions.ext_debug_utils_enabled)
        dispatch->CmdBeginDebugUtilsLabelEXT = (PFN_vkCmdBeginDebugUtilsLabelEXT)gpda(dev->icd_device, "vkCmdBeginDebugUtilsLabelEXT");
-    if (dev->extensions.ext_debug_utils_enabled)
+    if (dev->driver_extensions.ext_debug_utils_enabled)
        dispatch->CmdEndDebugUtilsLabelEXT = (PFN_vkCmdEndDebugUtilsLabelEXT)gpda(dev->icd_device, "vkCmdEndDebugUtilsLabelEXT");
-    if (dev->extensions.ext_debug_utils_enabled)
+    if (dev->driver_extensions.ext_debug_utils_enabled)
        dispatch->CmdInsertDebugUtilsLabelEXT = (PFN_vkCmdInsertDebugUtilsLabelEXT)gpda(dev->icd_device, "vkCmdInsertDebugUtilsLabelEXT");
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     // ---- VK_EXT_full_screen_exclusive extension commands
-    if (dev->extensions.ext_full_screen_exclusive_enabled && dev->extensions.khr_device_group_enabled)
+    if (dev->driver_extensions.ext_full_screen_exclusive_enabled && dev->driver_extensions.khr_device_group_enabled)
        dispatch->GetDeviceGroupSurfacePresentModes2EXT = (PFN_vkGetDeviceGroupSurfacePresentModes2EXT)gpda(dev->icd_device, "vkGetDeviceGroupSurfacePresentModes2EXT");
 #endif // VK_USE_PLATFORM_WIN32_KHR
 }
@@ -2439,8 +2439,8 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
     if (!strcmp(name, "GetImageSubresourceLayout2KHR")) return (void *)table->GetImageSubresourceLayout2KHR;
 
     // ---- VK_EXT_debug_marker extension commands
-    if (!strcmp(name, "DebugMarkerSetObjectTagEXT")) return dev->extensions.ext_debug_marker_enabled ? (void *)DebugMarkerSetObjectTagEXT : NULL;
-    if (!strcmp(name, "DebugMarkerSetObjectNameEXT")) return dev->extensions.ext_debug_marker_enabled ? (void *)DebugMarkerSetObjectNameEXT : NULL;
+    if (!strcmp(name, "DebugMarkerSetObjectTagEXT")) return dev->layer_extensions.ext_debug_marker_enabled ? (void *)DebugMarkerSetObjectTagEXT : NULL;
+    if (!strcmp(name, "DebugMarkerSetObjectNameEXT")) return dev->layer_extensions.ext_debug_marker_enabled ? (void *)DebugMarkerSetObjectNameEXT : NULL;
     if (!strcmp(name, "CmdDebugMarkerBeginEXT")) return (void *)table->CmdDebugMarkerBeginEXT;
     if (!strcmp(name, "CmdDebugMarkerEndEXT")) return (void *)table->CmdDebugMarkerEndEXT;
     if (!strcmp(name, "CmdDebugMarkerInsertEXT")) return (void *)table->CmdDebugMarkerInsertEXT;
@@ -2502,8 +2502,8 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
     if (!strcmp(name, "SetHdrMetadataEXT")) return (void *)table->SetHdrMetadataEXT;
 
     // ---- VK_EXT_debug_utils extension commands
-    if (!strcmp(name, "SetDebugUtilsObjectNameEXT")) return dev->extensions.ext_debug_utils_enabled ? (void *)SetDebugUtilsObjectNameEXT : NULL;
-    if (!strcmp(name, "SetDebugUtilsObjectTagEXT")) return dev->extensions.ext_debug_utils_enabled ? (void *)SetDebugUtilsObjectTagEXT : NULL;
+    if (!strcmp(name, "SetDebugUtilsObjectNameEXT")) return dev->layer_extensions.ext_debug_utils_enabled ? (void *)SetDebugUtilsObjectNameEXT : NULL;
+    if (!strcmp(name, "SetDebugUtilsObjectTagEXT")) return dev->layer_extensions.ext_debug_utils_enabled ? (void *)SetDebugUtilsObjectTagEXT : NULL;
     if (!strcmp(name, "QueueBeginDebugUtilsLabelEXT")) return (void *)table->QueueBeginDebugUtilsLabelEXT;
     if (!strcmp(name, "QueueEndDebugUtilsLabelEXT")) return (void *)table->QueueEndDebugUtilsLabelEXT;
     if (!strcmp(name, "QueueInsertDebugUtilsLabelEXT")) return (void *)table->QueueInsertDebugUtilsLabelEXT;
@@ -11385,77 +11385,77 @@ PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *de
     // ---- VK_KHR_swapchain extension commands
     if (!strcmp(name, "CreateSwapchainKHR")) {
         *found_name = true;
-        return dev->extensions.khr_swapchain_enabled ?
+        return dev->driver_extensions.khr_swapchain_enabled ?
             (PFN_vkVoidFunction)terminator_CreateSwapchainKHR : NULL;
     }
     if (!strcmp(name, "GetDeviceGroupSurfacePresentModesKHR")) {
         *found_name = true;
-        return dev->extensions.khr_swapchain_enabled ?
+        return dev->driver_extensions.khr_swapchain_enabled ?
             (PFN_vkVoidFunction)terminator_GetDeviceGroupSurfacePresentModesKHR : NULL;
     }
     // ---- VK_KHR_display_swapchain extension commands
     if (!strcmp(name, "CreateSharedSwapchainsKHR")) {
         *found_name = true;
-        return dev->extensions.khr_display_swapchain_enabled ?
+        return dev->driver_extensions.khr_display_swapchain_enabled ?
             (PFN_vkVoidFunction)terminator_CreateSharedSwapchainsKHR : NULL;
     }
     // ---- VK_EXT_debug_marker extension commands
     if (!strcmp(name, "DebugMarkerSetObjectTagEXT")) {
         *found_name = true;
-        return dev->extensions.ext_debug_marker_enabled ?
+        return dev->driver_extensions.ext_debug_marker_enabled ?
             (PFN_vkVoidFunction)terminator_DebugMarkerSetObjectTagEXT : NULL;
     }
     if (!strcmp(name, "DebugMarkerSetObjectNameEXT")) {
         *found_name = true;
-        return dev->extensions.ext_debug_marker_enabled ?
+        return dev->driver_extensions.ext_debug_marker_enabled ?
             (PFN_vkVoidFunction)terminator_DebugMarkerSetObjectNameEXT : NULL;
     }
     // ---- VK_EXT_debug_utils extension commands
     if (!strcmp(name, "SetDebugUtilsObjectNameEXT")) {
         *found_name = true;
-        return dev->extensions.ext_debug_utils_enabled ?
+        return dev->driver_extensions.ext_debug_utils_enabled ?
             (PFN_vkVoidFunction)terminator_SetDebugUtilsObjectNameEXT : NULL;
     }
     if (!strcmp(name, "SetDebugUtilsObjectTagEXT")) {
         *found_name = true;
-        return dev->extensions.ext_debug_utils_enabled ?
+        return dev->driver_extensions.ext_debug_utils_enabled ?
             (PFN_vkVoidFunction)terminator_SetDebugUtilsObjectTagEXT : NULL;
     }
     if (!strcmp(name, "QueueBeginDebugUtilsLabelEXT")) {
         *found_name = true;
-        return dev->extensions.ext_debug_utils_enabled ?
+        return dev->driver_extensions.ext_debug_utils_enabled ?
             (PFN_vkVoidFunction)terminator_QueueBeginDebugUtilsLabelEXT : NULL;
     }
     if (!strcmp(name, "QueueEndDebugUtilsLabelEXT")) {
         *found_name = true;
-        return dev->extensions.ext_debug_utils_enabled ?
+        return dev->driver_extensions.ext_debug_utils_enabled ?
             (PFN_vkVoidFunction)terminator_QueueEndDebugUtilsLabelEXT : NULL;
     }
     if (!strcmp(name, "QueueInsertDebugUtilsLabelEXT")) {
         *found_name = true;
-        return dev->extensions.ext_debug_utils_enabled ?
+        return dev->driver_extensions.ext_debug_utils_enabled ?
             (PFN_vkVoidFunction)terminator_QueueInsertDebugUtilsLabelEXT : NULL;
     }
     if (!strcmp(name, "CmdBeginDebugUtilsLabelEXT")) {
         *found_name = true;
-        return dev->extensions.ext_debug_utils_enabled ?
+        return dev->driver_extensions.ext_debug_utils_enabled ?
             (PFN_vkVoidFunction)terminator_CmdBeginDebugUtilsLabelEXT : NULL;
     }
     if (!strcmp(name, "CmdEndDebugUtilsLabelEXT")) {
         *found_name = true;
-        return dev->extensions.ext_debug_utils_enabled ?
+        return dev->driver_extensions.ext_debug_utils_enabled ?
             (PFN_vkVoidFunction)terminator_CmdEndDebugUtilsLabelEXT : NULL;
     }
     if (!strcmp(name, "CmdInsertDebugUtilsLabelEXT")) {
         *found_name = true;
-        return dev->extensions.ext_debug_utils_enabled ?
+        return dev->driver_extensions.ext_debug_utils_enabled ?
             (PFN_vkVoidFunction)terminator_CmdInsertDebugUtilsLabelEXT : NULL;
     }
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     // ---- VK_EXT_full_screen_exclusive extension commands
     if (!strcmp(name, "GetDeviceGroupSurfacePresentModes2EXT")) {
         *found_name = true;
-        return dev->extensions.ext_full_screen_exclusive_enabled && dev->extensions.khr_device_group_enabled ?
+        return dev->driver_extensions.ext_full_screen_exclusive_enabled && dev->driver_extensions.khr_device_group_enabled ?
             (PFN_vkVoidFunction)terminator_GetDeviceGroupSurfacePresentModes2EXT : NULL;
     }
 #endif // VK_USE_PLATFORM_WIN32_KHR

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -189,6 +189,14 @@ struct loader_device {
 
     VkAllocationCallbacks alloc_callbacks;
 
+    // List of activated device extensions that layers support (but not necessarily the driver which have functions that require
+    // trampolines to work correctly. EX - vkDebugMarkerSetObjectNameEXT can name wrapped handles like instance, physical device,
+    // or surface
+    struct {
+        bool ext_debug_marker_enabled;
+        bool ext_debug_utils_enabled;
+    } layer_extensions;
+
     // List of activated device extensions that have terminators implemented in the loader
     struct {
         bool khr_swapchain_enabled;
@@ -197,7 +205,7 @@ struct loader_device {
         bool ext_debug_marker_enabled;
         bool ext_debug_utils_enabled;
         bool ext_full_screen_exclusive_enabled;
-    } extensions;
+    } driver_extensions;
 
     struct loader_device *next;
 

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -936,9 +936,9 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                         tables += f'    if (!strcmp(name, "{base_name}")) '
                         if cur_cmd.name in DEVICE_CMDS_MUST_USE_TRAMP:
                             if version_check != '':
-                                tables += f'{{\n{version_check}        return dev->extensions.{cur_cmd.ext_name[3:].lower()}_enabled ? (void *){base_name} : NULL;\n    }}\n'
+                                tables += f'{{\n{version_check}        return dev->layer_extensions.{cur_cmd.ext_name[3:].lower()}_enabled ? (void *){base_name} : NULL;\n    }}\n'
                             else:
-                                tables += f'return dev->extensions.{cur_cmd.ext_name[3:].lower()}_enabled ? (void *){base_name} : NULL;\n'
+                                tables += f'return dev->layer_extensions.{cur_cmd.ext_name[3:].lower()}_enabled ? (void *){base_name} : NULL;\n'
 
                         else:
                             if version_check != '':
@@ -1501,9 +1501,9 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 term_func += f'    if (!strcmp(name, "{ext_cmd.name[2:]}")) {{\n'
                 term_func += f'        *found_name = true;\n'
                 if ext_cmd.require:
-                    term_func += f'        return dev->extensions.{ext_cmd.ext_name[3:].lower()}_enabled && dev->extensions.{ext_cmd.require[3:].lower()}_enabled ?\n'
+                    term_func += f'        return dev->driver_extensions.{ext_cmd.ext_name[3:].lower()}_enabled && dev->driver_extensions.{ext_cmd.require[3:].lower()}_enabled ?\n'
                 else:
-                    term_func += f'        return dev->extensions.{ext_cmd.ext_name[3:].lower()}_enabled ?\n'
+                    term_func += f'        return dev->driver_extensions.{ext_cmd.ext_name[3:].lower()}_enabled ?\n'
                 term_func += f'            (PFN_vkVoidFunction)terminator_{(ext_cmd.name[2:])} : NULL;\n'
                 term_func += f'    }}\n'
 
@@ -1598,10 +1598,10 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
 
 
                 if ext_cmd.require:
-                    term_func += f'    if (dev->extensions.{ext_cmd.ext_name[3:].lower()}_enabled && dev->extensions.{ext_cmd.require[3:].lower()}_enabled)\n'
+                    term_func += f'    if (dev->driver_extensions.{ext_cmd.ext_name[3:].lower()}_enabled && dev->driver_extensions.{ext_cmd.require[3:].lower()}_enabled)\n'
                     term_func += f'       dispatch->{ext_cmd.name[2:]} = (PFN_{(ext_cmd.name)})gpda(dev->icd_device, "{(ext_cmd.name)}");\n'
                 else:
-                    term_func += f'    if (dev->extensions.{ext_cmd.ext_name[3:].lower()}_enabled)\n'
+                    term_func += f'    if (dev->driver_extensions.{ext_cmd.ext_name[3:].lower()}_enabled)\n'
                     term_func += f'       dispatch->{ext_cmd.name[2:]} = (PFN_{(ext_cmd.name)})gpda(dev->icd_device, "{(ext_cmd.name)}");\n'
 
         if last_protect is not None:

--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -654,11 +654,11 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroyDevice(VkDevice device, const VkAllocat
                                        layer.second_device_created_during_create_device.dispatch_table.DestroyDevice);
     }
 
-    for (auto& created_device : layer.created_devices) {
-        if (created_device.device_handle == device) {
-            created_device.dispatch_table.DestroyDevice(device, pAllocator);
-            break;
-        }
+    auto it = std::find_if(std::begin(layer.created_devices), std::end(layer.created_devices),
+                           [device](const TestLayer::Device& dev) { return device == dev.device_handle; });
+    if (it != std::end(layer.created_devices)) {
+        it->dispatch_table.DestroyDevice(device, pAllocator);
+        layer.created_devices.erase(it);
     }
 }
 

--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -87,6 +87,30 @@ FRAMEWORK_EXPORT TestLayer* reset_layer_func() {
 }
 }
 
+bool IsInstanceExtensionSupported(const char* extension_name) {
+    return layer.instance_extensions.end() !=
+           std::find_if(layer.instance_extensions.begin(), layer.instance_extensions.end(),
+                        [extension_name](Extension const& ext) { return string_eq(&ext.extensionName[0], extension_name); });
+}
+
+bool IsInstanceExtensionEnabled(const char* extension_name) {
+    return layer.enabled_instance_extensions.end() !=
+           std::find_if(layer.enabled_instance_extensions.begin(), layer.enabled_instance_extensions.end(),
+                        [extension_name](Extension const& ext) { return string_eq(&ext.extensionName[0], extension_name); });
+}
+
+bool IsDeviceExtensionAvailable(VkDevice dev, const char* extension_name) {
+    for (auto& device : layer.created_devices) {
+        if ((dev == VK_NULL_HANDLE || device.device_handle == dev) &&
+            device.enabled_extensions.end() !=
+                std::find_if(device.enabled_extensions.begin(), device.enabled_extensions.end(),
+                             [extension_name](Extension const& ext) { return ext.extensionName == extension_name; })) {
+            return true;
+        }
+    }
+    return false;
+}
+
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL get_instance_func(VkInstance instance, const char* pName);
 
 VkLayerInstanceCreateInfo* get_chain_info(const VkInstanceCreateInfo* pCreateInfo, VkLayerFunction func) {
@@ -111,11 +135,48 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceLayerProperties(uint32_t*
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount,
                                                                            VkExtensionProperties* pProperties) {
+    if (pPropertyCount == nullptr) {
+        return VK_INCOMPLETE;
+    }
     if (pLayerName && string_eq(pLayerName, TEST_LAYER_NAME)) {
-        *pPropertyCount = 0;
+        if (pProperties) {
+            if (*pPropertyCount < layer.injected_instance_extensions.size()) {
+                return VK_INCOMPLETE;
+            }
+            for (size_t i = 0; i < layer.injected_instance_extensions.size(); i++) {
+                pProperties[i] = layer.injected_instance_extensions.at(i).get();
+            }
+            *pPropertyCount = static_cast<uint32_t>(layer.injected_instance_extensions.size());
+        } else {
+            *pPropertyCount = static_cast<uint32_t>(layer.injected_instance_extensions.size());
+        }
         return VK_SUCCESS;
     }
-    return layer.instance_dispatch_table.EnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties);
+
+    uint32_t hardware_prop_count = 0;
+    if (pProperties) {
+        hardware_prop_count = *pPropertyCount - static_cast<uint32_t>(layer.injected_instance_extensions.size());
+    }
+
+    VkResult res =
+        layer.instance_dispatch_table.EnumerateInstanceExtensionProperties(pLayerName, &hardware_prop_count, pProperties);
+    if (res < 0) {
+        return res;
+    }
+
+    if (pProperties == nullptr) {
+        *pPropertyCount = hardware_prop_count + static_cast<uint32_t>(layer.injected_instance_extensions.size());
+    } else {
+        if (hardware_prop_count + layer.injected_instance_extensions.size() > *pPropertyCount) {
+            *pPropertyCount = hardware_prop_count;
+            return VK_INCOMPLETE;
+        }
+        for (size_t i = 0; i < layer.injected_instance_extensions.size(); i++) {
+            pProperties[hardware_prop_count + i] = layer.injected_instance_extensions.at(i).get();
+        }
+        *pPropertyCount = hardware_prop_count + static_cast<uint32_t>(layer.injected_instance_extensions.size());
+    }
+    return res;
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateDeviceLayerProperties(VkPhysicalDevice, uint32_t*, VkLayerProperties*) {
@@ -125,12 +186,49 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateDeviceLayerProperties(VkPhysicalD
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char* pLayerName,
                                                                          uint32_t* pPropertyCount,
                                                                          VkExtensionProperties* pProperties) {
+    if (pPropertyCount == nullptr) {
+        return VK_INCOMPLETE;
+    }
+
     if (pLayerName && string_eq(pLayerName, TEST_LAYER_NAME)) {
-        *pPropertyCount = 0;
+        if (pProperties) {
+            if (*pPropertyCount < static_cast<uint32_t>(layer.injected_device_extensions.size())) {
+                return VK_INCOMPLETE;
+            }
+            for (size_t i = 0; i < layer.injected_device_extensions.size(); i++) {
+                pProperties[i] = layer.injected_device_extensions.at(i).get();
+            }
+            *pPropertyCount = static_cast<uint32_t>(layer.injected_device_extensions.size());
+        } else {
+            *pPropertyCount = static_cast<uint32_t>(layer.injected_device_extensions.size());
+        }
         return VK_SUCCESS;
     }
-    return layer.instance_dispatch_table.EnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount,
-                                                                            pProperties);
+
+    uint32_t hardware_prop_count = 0;
+    if (pProperties) {
+        hardware_prop_count = *pPropertyCount - static_cast<uint32_t>(layer.injected_device_extensions.size());
+    }
+
+    VkResult res = layer.instance_dispatch_table.EnumerateDeviceExtensionProperties(physicalDevice, pLayerName,
+                                                                                    &hardware_prop_count, pProperties);
+    if (res < 0) {
+        return res;
+    }
+
+    if (pProperties == nullptr) {
+        *pPropertyCount = hardware_prop_count + static_cast<uint32_t>(layer.injected_device_extensions.size());
+    } else {
+        if (hardware_prop_count + layer.injected_device_extensions.size() > *pPropertyCount) {
+            *pPropertyCount = hardware_prop_count;
+            return VK_INCOMPLETE;
+        }
+        for (size_t i = 0; i < layer.injected_device_extensions.size(); i++) {
+            pProperties[hardware_prop_count + i] = layer.injected_device_extensions.at(i).get();
+        }
+        *pPropertyCount = hardware_prop_count + static_cast<uint32_t>(layer.injected_device_extensions.size());
+    }
+    return res;
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceVersion(uint32_t* pApiVersion) {
@@ -194,6 +292,10 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo*
     // Init layer's dispatch table using GetInstanceProcAddr of
     // next layer in the chain.
     layer_init_instance_dispatch_table(layer.instance_handle, &layer.instance_dispatch_table, fpGetInstanceProcAddr);
+
+    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
+        layer.enabled_instance_extensions.push_back({pCreateInfo->ppEnabledExtensionNames[i]});
+    }
 
     if (layer.create_instance_callback) result = layer.create_instance_callback(layer);
 
@@ -308,6 +410,10 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevi
 
     // initialize layer's dispatch table
     layer_init_device_dispatch_table(device.device_handle, &device.dispatch_table, fpGetDeviceProcAddr);
+
+    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
+        device.enabled_extensions.push_back({pCreateInfo->ppEnabledExtensionNames[i]});
+    }
 
     for (auto& func : layer.custom_device_interception_functions) {
         auto next_func = layer.next_vkGetDeviceProcAddr(*pDevice, func.name.c_str());
@@ -555,6 +661,120 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroyDevice(VkDevice device, const VkAllocat
         }
     }
 }
+
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDebugUtilsMessengerEXT(VkInstance instance,
+                                                                   const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
+                                                                   const VkAllocationCallbacks* pAllocator,
+                                                                   VkDebugUtilsMessengerEXT* pMessenger) {
+    if (layer.instance_dispatch_table.CreateDebugUtilsMessengerEXT) {
+        return layer.instance_dispatch_table.CreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger);
+    } else {
+        return VK_SUCCESS;
+    }
+}
+
+VKAPI_ATTR void VKAPI_CALL test_vkDestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT messenger,
+                                                                const VkAllocationCallbacks* pAllocator) {
+    if (layer.instance_dispatch_table.DestroyDebugUtilsMessengerEXT)
+        return layer.instance_dispatch_table.DestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
+}
+
+// Debug utils & debug marker ext stubs
+VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectTagEXT(VkDevice dev, const VkDebugMarkerObjectTagInfoEXT* pTagInfo) {
+    for (const auto& d : layer.created_devices) {
+        if (d.device_handle == dev) {
+            if (d.dispatch_table.DebugMarkerSetObjectTagEXT) {
+                return d.dispatch_table.DebugMarkerSetObjectTagEXT(dev, pTagInfo);
+            } else {
+                return VK_SUCCESS;
+            }
+        }
+    }
+    return VK_SUCCESS;
+}
+VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectNameEXT(VkDevice dev, const VkDebugMarkerObjectNameInfoEXT* pNameInfo) {
+    for (const auto& d : layer.created_devices) {
+        if (d.device_handle == dev) {
+            if (d.dispatch_table.DebugMarkerSetObjectNameEXT) {
+                return d.dispatch_table.DebugMarkerSetObjectNameEXT(dev, pNameInfo);
+            } else {
+                return VK_SUCCESS;
+            }
+        }
+    }
+    return VK_SUCCESS;
+}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerBeginEXT(VkCommandBuffer cmd_buf, const VkDebugMarkerMarkerInfoEXT* marker_info) {
+    // Just call the first device -
+    if (layer.created_devices[0].dispatch_table.CmdDebugMarkerBeginEXT)
+        layer.created_devices[0].dispatch_table.CmdDebugMarkerBeginEXT(cmd_buf, marker_info);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerEndEXT(VkCommandBuffer cmd_buf) {
+    // Just call the first device -
+    if (layer.created_devices[0].dispatch_table.CmdDebugMarkerEndEXT)
+        layer.created_devices[0].dispatch_table.CmdDebugMarkerEndEXT(cmd_buf);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerInsertEXT(VkCommandBuffer cmd_buf, const VkDebugMarkerMarkerInfoEXT* marker_info) {
+    // Just call the first device -
+    if (layer.created_devices[0].dispatch_table.CmdDebugMarkerInsertEXT)
+        layer.created_devices[0].dispatch_table.CmdDebugMarkerInsertEXT(cmd_buf, marker_info);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectNameEXT(VkDevice dev, const VkDebugUtilsObjectNameInfoEXT* pNameInfo) {
+    for (const auto& d : layer.created_devices) {
+        if (d.device_handle == dev) {
+            if (d.dispatch_table.SetDebugUtilsObjectNameEXT) {
+                return d.dispatch_table.SetDebugUtilsObjectNameEXT(dev, pNameInfo);
+            } else {
+                return VK_SUCCESS;
+            }
+        }
+    }
+    return VK_SUCCESS;
+}
+VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectTagEXT(VkDevice dev, const VkDebugUtilsObjectTagInfoEXT* pTagInfo) {
+    for (const auto& d : layer.created_devices) {
+        if (d.device_handle == dev) {
+            if (d.dispatch_table.SetDebugUtilsObjectTagEXT) {
+                return d.dispatch_table.SetDebugUtilsObjectTagEXT(dev, pTagInfo);
+            } else {
+                return VK_SUCCESS;
+            }
+        }
+    }
+    return VK_SUCCESS;
+}
+VKAPI_ATTR void VKAPI_CALL test_vkQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* label) {
+    // Just call the first device -
+    if (layer.created_devices[0].dispatch_table.QueueBeginDebugUtilsLabelEXT)
+        layer.created_devices[0].dispatch_table.QueueBeginDebugUtilsLabelEXT(queue, label);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkQueueEndDebugUtilsLabelEXT(VkQueue queue) {
+    // Just call the first device -
+    if (layer.created_devices[0].dispatch_table.QueueEndDebugUtilsLabelEXT)
+        layer.created_devices[0].dispatch_table.QueueEndDebugUtilsLabelEXT(queue);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkQueueInsertDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* label) {
+    // Just call the first device -
+    if (layer.created_devices[0].dispatch_table.QueueInsertDebugUtilsLabelEXT)
+        layer.created_devices[0].dispatch_table.QueueInsertDebugUtilsLabelEXT(queue, label);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdBeginDebugUtilsLabelEXT(VkCommandBuffer cmd_buf, const VkDebugUtilsLabelEXT* label) {
+    // Just call the first device -
+    if (layer.created_devices[0].dispatch_table.CmdBeginDebugUtilsLabelEXT)
+        layer.created_devices[0].dispatch_table.CmdBeginDebugUtilsLabelEXT(cmd_buf, label);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdEndDebugUtilsLabelEXT(VkCommandBuffer cmd_buf) {
+    // Just call the first device -
+    if (layer.created_devices[0].dispatch_table.CmdEndDebugUtilsLabelEXT)
+        layer.created_devices[0].dispatch_table.CmdEndDebugUtilsLabelEXT(cmd_buf);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdInsertDebugUtilsLabelEXT(VkCommandBuffer cmd_buf, const VkDebugUtilsLabelEXT* label) {
+    // Just call the first device -
+    if (layer.created_devices[0].dispatch_table.CmdInsertDebugUtilsLabelEXT)
+        layer.created_devices[0].dispatch_table.CmdInsertDebugUtilsLabelEXT(cmd_buf, label);
+}
+
 // forward declarations needed for trampolines
 #if TEST_LAYER_EXPORT_GET_PHYSICAL_DEVICE_PROC_ADDR
 extern "C" {
@@ -567,6 +787,24 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL get_device_func(VkDevice device, const 
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL get_device_func_impl([[maybe_unused]] VkDevice device, const char* pName) {
     if (string_eq(pName, "vkGetDeviceProcAddr")) return to_vkVoidFunction(get_device_func);
     if (string_eq(pName, "vkDestroyDevice")) return to_vkVoidFunction(test_vkDestroyDevice);
+
+    if (IsDeviceExtensionAvailable(device, VK_EXT_DEBUG_MARKER_EXTENSION_NAME)) {
+        if (string_eq(pName, "vkDebugMarkerSetObjectTagEXT")) return to_vkVoidFunction(test_vkDebugMarkerSetObjectTagEXT);
+        if (string_eq(pName, "vkDebugMarkerSetObjectNameEXT")) return to_vkVoidFunction(test_vkDebugMarkerSetObjectNameEXT);
+        if (string_eq(pName, "vkCmdDebugMarkerBeginEXT")) return to_vkVoidFunction(test_vkCmdDebugMarkerBeginEXT);
+        if (string_eq(pName, "vkCmdDebugMarkerEndEXT")) return to_vkVoidFunction(test_vkCmdDebugMarkerEndEXT);
+        if (string_eq(pName, "vkCmdDebugMarkerInsertEXT")) return to_vkVoidFunction(test_vkCmdDebugMarkerInsertEXT);
+    }
+    if (IsInstanceExtensionEnabled(VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        if (string_eq(pName, "vkSetDebugUtilsObjectNameEXT")) return to_vkVoidFunction(test_vkSetDebugUtilsObjectNameEXT);
+        if (string_eq(pName, "vkSetDebugUtilsObjectTagEXT")) return to_vkVoidFunction(test_vkSetDebugUtilsObjectTagEXT);
+        if (string_eq(pName, "vkQueueBeginDebugUtilsLabelEXT")) return to_vkVoidFunction(test_vkQueueBeginDebugUtilsLabelEXT);
+        if (string_eq(pName, "vkQueueEndDebugUtilsLabelEXT")) return to_vkVoidFunction(test_vkQueueEndDebugUtilsLabelEXT);
+        if (string_eq(pName, "vkQueueInsertDebugUtilsLabelEXT")) return to_vkVoidFunction(test_vkQueueInsertDebugUtilsLabelEXT);
+        if (string_eq(pName, "vkCmdBeginDebugUtilsLabelEXT")) return to_vkVoidFunction(test_vkCmdBeginDebugUtilsLabelEXT);
+        if (string_eq(pName, "vkCmdEndDebugUtilsLabelEXT")) return to_vkVoidFunction(test_vkCmdEndDebugUtilsLabelEXT);
+        if (string_eq(pName, "vkCmdInsertDebugUtilsLabelEXT")) return to_vkVoidFunction(test_vkCmdInsertDebugUtilsLabelEXT);
+    }
 
     for (auto& func : layer.custom_device_interception_functions) {
         if (func.name == pName) {

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -108,10 +108,17 @@ struct TestLayer {
     BUILDER_VECTOR(TestLayer, std::string, alternative_function_names, alternative_function_name)
 
     BUILDER_VECTOR(TestLayer, Extension, instance_extensions, instance_extension)
+    std::vector<Extension> enabled_instance_extensions;
+
     BUILDER_VECTOR(TestLayer, Extension, device_extensions, device_extension)
 
     BUILDER_VALUE(TestLayer, std::string, enable_environment, {});
     BUILDER_VALUE(TestLayer, std::string, disable_environment, {});
+
+    // Modifies the extension list returned by vkEnumerateInstanceExtensionProperties to include what is in this vector
+    BUILDER_VECTOR(TestLayer, Extension, injected_instance_extensions, injected_instance_extension)
+    // Modifies the extension list returned by  vkEnumerateDeviceExtensionProperties to include what is in this vector
+    BUILDER_VECTOR(TestLayer, Extension, injected_device_extensions, injected_device_extension)
 
     BUILDER_VECTOR(TestLayer, LayerDefinition, meta_component_layers, meta_component_layer);
 
@@ -193,6 +200,7 @@ struct TestLayer {
     struct Device {
         VkDevice device_handle = VK_NULL_HANDLE;
         VkLayerDispatchTable dispatch_table{};
+        std::vector<Extension> enabled_extensions;
     };
     std::vector<Device> created_devices;
 

--- a/tests/loader_debug_ext_tests.cpp
+++ b/tests/loader_debug_ext_tests.cpp
@@ -1074,11 +1074,11 @@ TEST(GetProcAddr, DebugFuncsWithTrampoline) {
     driver.physical_devices.at(0).add_extensions({"VK_KHR_swapchain"});
     // Hardware doesn't support the debug extensions
 
-    // // Use getDeviceProcAddr & vary enabling the debug extensions
+    // Use getDeviceProcAddr & vary enabling the debug extensions
     ASSERT_NO_FATAL_FAILURE(CheckDeviceFunctions(env, false, false, false));
     ASSERT_NO_FATAL_FAILURE(CheckDeviceFunctions(env, false, true, false));
 
-    // // Use getInstanceProcAddr & vary enabling the debug extensions
+    // Use getInstanceProcAddr & vary enabling the debug extensions
     ASSERT_NO_FATAL_FAILURE(CheckDeviceFunctions(env, true, false, false));
     ASSERT_NO_FATAL_FAILURE(CheckDeviceFunctions(env, true, true, false));
 
@@ -1108,11 +1108,11 @@ TEST(GetProcAddr, DebugFuncsWithDebugExtsForceAdded) {
     driver.physical_devices.at(0).add_extensions({"VK_KHR_swapchain"});
     // Hardware doesn't support the debug extensions
 
-    // // Use getDeviceProcAddr & vary enabling the debug extensions
+    // Use getDeviceProcAddr & vary enabling the debug extensions
     ASSERT_NO_FATAL_FAILURE(CheckDeviceFunctions(env, false, false, false));
     ASSERT_NO_FATAL_FAILURE(CheckDeviceFunctions(env, false, true, false));
 
-    // // Use getInstanceProcAddr & vary enabling the debug extensions
+    // Use getInstanceProcAddr & vary enabling the debug extensions
     ASSERT_NO_FATAL_FAILURE(CheckDeviceFunctions(env, true, false, false));
     ASSERT_NO_FATAL_FAILURE(CheckDeviceFunctions(env, true, true, false));
 
@@ -1126,7 +1126,7 @@ TEST(GetProcAddr, DebugFuncsWithDebugExtsForceAdded) {
         .add_injected_instance_extensions({{VK_EXT_DEBUG_REPORT_EXTENSION_NAME}, {VK_EXT_DEBUG_UTILS_EXTENSION_NAME}})
         .add_injected_device_extension({VK_EXT_DEBUG_MARKER_EXTENSION_NAME});
 
-    // // Use getDeviceProcAddr & vary enabling the debug extensions
+    // Use getDeviceProcAddr & vary enabling the debug extensions
     ASSERT_NO_FATAL_FAILURE(CheckDeviceFunctions(env, false, false, true));
     ASSERT_NO_FATAL_FAILURE(CheckDeviceFunctions(env, false, true, true));
 


### PR DESCRIPTION
The implementation for VK_KHR_maintenance_5 exposed a bug in how the function
for debug_marker functions were gotten. The bug was to only check if a
driver supports a physical device when querying for device function pointers,
which ignores the possibility of a layer supporting a device extension. This
is an issue for VK_EXT_debug_marker, which requires trampoline functions to
properly unwrap data passed in, resulting in the various debug marker functions
returning NULL instead of a valid function pointer.