### PR TITLE
cmake: Add find_package support

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -435,6 +435,13 @@ if(PKG_CONFIG_FOUND)
 endif()
 
 target_link_libraries(vulkan PRIVATE Vulkan::Headers)
-add_library(Vulkan::Vulkan ALIAS vulkan)
+add_library(Vulkan::Loader ALIAS vulkan)
 
-install(TARGETS vulkan)
+if (APPLE AND BUILD_STATIC_LOADER)
+    # When exporting a static library all linked libraries - private or not - need to be exported.
+    return()
+endif()
+
+install(TARGETS vulkan EXPORT VulkanLoaderConfig)
+set_target_properties(vulkan PROPERTIES EXPORT_NAME "Loader")
+install(EXPORT VulkanLoaderConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanLoader NAMESPACE Vulkan::)


### PR DESCRIPTION
Now CMake config files are installed.

```
PS D:\projects\loader> cmake --install .\build\ --prefix .\build\install
-- Install configuration: "Debug"
-- Up-to-date: D:/projects/loader/.\build\install/lib/vulkan-1.lib
-- Up-to-date: D:/projects/loader/.\build\install/bin/vulkan-1.dll
-- Up-to-date: D:/projects/loader/.\build\install/lib/cmake/VulkanLoader/VulkanLoaderConfig.cmake
-- Up-to-date: D:/projects/loader/.\build\install/lib/cmake/VulkanLoader/VulkanLoaderConfig-debug.cmake
```

This allows find_package to work.

```
find_package(VulkanLoader)

target_link_libraries(foobar PRIVATE Vulkan::Loader)
```