### PR TITLE
Check correct magic value in device dispatch table

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5597,9 +5597,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
         loader_log(icd_term->this_instance, VULKAN_LOADER_WARN_BIT, 0,
                    "terminator_CreateDevice: Loader device pointer null encountered.  Possibly set by active layer. (Policy "
                    "#LLP_LAYER_22)");
-    } else if (LOADER_MAGIC_NUMBER != dev->loader_dispatch.core_dispatch.magic) {
+    } else if (DEVICE_DISP_TABLE_MAGIC_NUMBER != dev->loader_dispatch.core_dispatch.magic) {
         loader_log(icd_term->this_instance, VULKAN_LOADER_WARN_BIT, 0,
-                   "terminator_CreateDevice: Device pointer (%p) has invalid MAGIC value 0x%08x. Device value possibly "
+                   "terminator_CreateDevice: Device pointer (%p) has invalid MAGIC value 0x%08lx. The expected value is "
+                   "0x10ADED040410ADED. Device value possibly "
                    "corrupted by active layer (Policy #LLP_LAYER_22).  ",
                    dev, dev->loader_dispatch.core_dispatch.magic);
     }

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -4130,19 +4130,20 @@ TEST(Layer, LLP_LAYER_22) {
     ASSERT_DEATH(
         dev.CheckCreate(inst.GetPhysDev()),
         testing::ContainsRegex(
-            R"(terminator_CreateDevice: Device pointer \(................\) has invalid MAGIC value 0x00000000. Device value )"
+            R"(terminator_CreateDevice: Device pointer \(................\) has invalid MAGIC value 0x00000000. The expected value is 0x10ADED040410ADED. Device value )"
             R"(possibly corrupted by active layer \(Policy #LLP_LAYER_22\))"));
 #else
-    ASSERT_DEATH(dev.CheckCreate(inst.GetPhysDev()),
-                 testing::ContainsRegex(
-                     R"(terminator_CreateDevice: Device pointer \(........\) has invalid MAGIC value 0x00000000. Device value )"
-                     R"(possibly corrupted by active layer \(Policy #LLP_LAYER_22\))"));
+    ASSERT_DEATH(
+        dev.CheckCreate(inst.GetPhysDev()),
+        testing::ContainsRegex(
+            R"(terminator_CreateDevice: Device pointer \(........\) has invalid MAGIC value 0x00000000. The expected value is 0x10ADED040410ADED. Device value )"
+            R"(possibly corrupted by active layer \(Policy #LLP_LAYER_22\))"));
 #endif
 #else
     ASSERT_DEATH(
         dev.CheckCreate(inst.GetPhysDev()),
         testing::ContainsRegex(
-            R"(terminator_CreateDevice: Device pointer \(0x[0-9A-Fa-f]+\) has invalid MAGIC value 0x00000000. Device value )"
+            R"(terminator_CreateDevice: Device pointer \(0x[0-9A-Fa-f]+\) has invalid MAGIC value 0x00000000. The expected value is 0x10ADED040410ADED. Device value )"
             R"(possibly corrupted by active layer \(Policy #LLP_LAYER_22\))"));
 #endif
 }


### PR DESCRIPTION
The check for a correct magic value in the device dispatch table used LOADER_MAGIC_NUMBER instead of DEVICE_DISP_TABLE_MAGIC_NUMBER. This causes every device creation to emit the 'invalid magic value' message, which is wrong. This commit fixes that, as well as adds the expected value to the log message.