### PR TITLE
Fix warning message refering to layers instead of ICDs

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3654,7 +3654,7 @@ VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_t
                                icd_details[i].full_library_path);
                     break;
                 case LOADER_LAYER_LIB_ERROR_WRONG_BIT_TYPE: {
-                    loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "Requested layer %s was wrong bit-type. Ignoring this JSON",
+                    loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "Requested ICD %s was wrong bit-type. Ignoring this JSON",
                                icd_details[i].full_library_path);
                     break;
                 }


### PR DESCRIPTION
The warning message about the binary having the wrong bitness for ICD's was wrongly stating it was about layers having the wrong bitness.