### PR TITLE
XCode fix - warnings as errors and unused parameter triggers it

### DIFF
--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -277,6 +277,7 @@ static inline char *loader_platform_executable_path(char *buffer, size_t size) {
 #elif defined(__APPLE__)
 #if defined(__APPLE_EMBEDDED__)
 static inline char *loader_platform_executable_path(char *buffer, size_t size) {
+    (void)size;
     buffer[0] = '\0';
     return buffer;
 }


### PR DESCRIPTION
This should have been in the last update for iOS. The latest XCode flags an unused parameter as a warning, and warnings are treated as errors causes a failure in vk_loader_platform.h