### PR TITLE
loader/cJSON: Prefix/mark static/remove symbols

### DIFF
--- a/loader/cJSON.h
+++ b/loader/cJSON.h
@@ -62,91 +62,22 @@ typedef struct cJSON {
     VkAllocationCallbacks *pAllocator;
 } cJSON;
 
-/* Supply a block of JSON, and this returns a cJSON object you can interrogate.
- * Call cJSON_Delete when finished. */
-cJSON *cJSON_Parse(const VkAllocationCallbacks *pAllocator, const char *value);
 /* Render a cJSON entity to text for transfer/storage. Free the char* when
  * finished. */
-char *cJSON_Print(cJSON *item);
+char *loader_cJSON_Print(cJSON *item);
 /* Render a cJSON entity to text for transfer/storage without any formatting.
  * Free the char* when finished. */
-char *cJSON_PrintUnformatted(cJSON *item);
-/* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess
- * at the final size. guessing well reduces reallocation. fmt=0 gives
- * unformatted, =1 gives formatted */
-char *cJSON_PrintBuffered(cJSON *item, int prebuffer, int fmt);
+char *loader_cJSON_PrintUnformatted(cJSON *item);
 /* Delete a cJSON entity and all subentities. */
-void cJSON_Delete(cJSON *c);
-/* Delete an item allocated inside the JSON parser*/
-void cJSON_Free(const VkAllocationCallbacks *pAllocator, void *p);
+void loader_cJSON_Delete(cJSON *c);
 
 /* Returns the number of items in an array (or object). */
-int cJSON_GetArraySize(cJSON *array);
+int loader_cJSON_GetArraySize(cJSON *array);
 /* Retrieve item number "item" from array "array". Returns NULL if unsuccessful.
  */
-cJSON *cJSON_GetArrayItem(cJSON *array, int item);
+cJSON *loader_cJSON_GetArrayItem(cJSON *array, int item);
 /* Get item "string" from object. Case insensitive. */
-cJSON *cJSON_GetObjectItem(cJSON *object, const char *string);
-
-/* For analysing failed parses. This returns a pointer to the parse error.
- * You'll probably need to look a few chars back to make sense of it. Defined
- * when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
-// commented out as its unused and required external locks to work correctly
-// const char *cJSON_GetErrorPtr(void);
-
-/* These calls create a cJSON item of the appropriate type. */
-cJSON *cJSON_CreateNull(const VkAllocationCallbacks *pAllocator);
-cJSON *cJSON_CreateTrue(const VkAllocationCallbacks *pAllocator);
-cJSON *cJSON_CreateFalse(const VkAllocationCallbacks *pAllocator);
-cJSON *cJSON_CreateBool(const VkAllocationCallbacks *pAllocator, int b);
-cJSON *cJSON_CreateNumber(const VkAllocationCallbacks *pAllocator, double num);
-cJSON *cJSON_CreateString(const VkAllocationCallbacks *pAllocator, const char *string);
-cJSON *cJSON_CreateArray(const VkAllocationCallbacks *pAllocator);
-cJSON *cJSON_CreateObject(const VkAllocationCallbacks *pAllocator);
-
-/* These utilities create an Array of count items. */
-cJSON *cJSON_CreateIntArray(const VkAllocationCallbacks *pAllocator, const int *numbers, int count);
-cJSON *cJSON_CreateFloatArray(const VkAllocationCallbacks *pAllocator, const float *numbers, int count);
-cJSON *cJSON_CreateDoubleArray(const VkAllocationCallbacks *pAllocator, const double *numbers, int count);
-cJSON *cJSON_CreateStringArray(const VkAllocationCallbacks *pAllocator, const char **strings, int count);
-
-/* Append item to the specified array/object. */
-void cJSON_AddItemToArray(cJSON *array, cJSON *item);
-void cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item);
-/* Use this when string is definitely const  (i.e. a literal, or as good as), and
- * will definitely survive the cJSON object */
-void cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item);
-/* Append reference to item to the specified array/object. Use this when you
- * want to add an existing cJSON to a new cJSON, but don't want to corrupt your
- * existing cJSON. */
-void cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
-void cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item);
-
-/* Remove/Detach items from Arrays/Objects. */
-cJSON *cJSON_DetachItemFromArray(cJSON *array, int which);
-void cJSON_DeleteItemFromArray(cJSON *array, int which);
-cJSON *cJSON_DetachItemFromObject(cJSON *object, const char *string);
-void cJSON_DeleteItemFromObject(cJSON *object, const char *string);
-
-/* Update array items. */
-void cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem); /* Shifts pre-existing items to the right. */
-void cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem);
-void cJSON_ReplaceItemInObject(cJSON *object, const char *string, cJSON *newitem);
-
-/* Duplicate a cJSON item */
-cJSON *cJSON_Duplicate(cJSON *item, int recurse);
-/* Duplicate will create a new, identical cJSON item to the one you pass, in new
-memory that will
-need to be released. With recurse!=0, it will duplicate any children connected
-to the item.
-The item->next and ->prev pointers are always zero on return from Duplicate. */
-
-/* ParseWithOpts allows you to require (and check) that the JSON is null
- * terminated, and to retrieve the pointer to the final byte parsed. */
-cJSON *cJSON_ParseWithOpts(const VkAllocationCallbacks *pAllocator, const char *value, const char **return_parse_end,
-                           int require_null_terminated);
-
-void cJSON_Minify(char *json);
+cJSON *loader_cJSON_GetObjectItem(cJSON *object, const char *string);
 
 /* When assigning an integer value, it needs to be propagated to valuedouble
  * too. */


### PR DESCRIPTION
Prefixes the symbols that are used outside the file with `loader_` to match the others. Marks symbols that are not used outside as static.
Removes the symbols that are not used at all.
    
Prevents conflicts with other libraries that might also use cjson.
This may cause issues if the internal checkout of cJSON is updated, in that case, it may be simpler to just prefix all of cJSON's symbols with `loader_cJSON_`.

Please let me know if the suggested alternative of prefixing all the symbols instead if preferable or not.