### PR TITLE
loader: Add check for working MASM compiler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -472,6 +472,38 @@ jobs:
         - name: GCC Version
           run: gcc --version # If this fails MINGW is not setup correctly
         - name: Configure
+          # Make sure this doesn't fail even without -D USE_MASM=OFF and without uasm
+          run: cmake -S. -B build -D UPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Release
+          env:
+            LDFLAGS: -fuse-ld=lld # MINGW linking is very slow. Use llvm linker instead.
+            CMAKE_C_COMPILER_LAUNCHER: ccache
+            CMAKE_CXX_COMPILER_LAUNCHER: ccache
+            CMAKE_GENERATOR: Ninja
+        - name: Build
+          run: cmake --build build -- --quiet
+        - name: Install
+          run: cmake --install build --prefix build/install
+        - name: MinGW ccache stats # The Post Setup ccache doesn't work right on MinGW
+          run: ccache --show-stats
+
+    mingw-no-asm-explicit:
+      runs-on: windows-2022
+      defaults:
+        run:
+          shell: bash
+      steps:
+        - uses: actions/checkout@v3
+        - name: Setup ccache
+          uses: hendrikmuhs/ccache-action@v1.2
+          with:
+            key: mingw-ccache
+        - uses: actions/setup-python@v4
+          with:
+            python-version: '3.8'
+        - uses: lukka/get-cmake@latest
+        - name: GCC Version
+          run: gcc --version # If this fails MINGW is not setup correctly
+        - name: Configure
           run: cmake -S. -B build -D UPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Release -D ENABLE_WERROR=ON -D USE_MASM=OFF
           env:
             LDFLAGS: -fuse-ld=lld # MINGW linking is very slow. Use llvm linker instead.

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -134,13 +134,42 @@ if(WIN32)
     if (USE_MASM)
         enable_language(ASM_MASM)
     endif()
+    # Test if the detected compiler actually works.
+    # Unfortunately, CMake's detection of ASM_MASM is not reliable, so we need to do this ourselves.
+    if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/masm_check.asm [=[
+.model flat
+.code
+extrn _start:near
+    xor eax, eax
+    ret
+end
+]=])
+    else()
+        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/masm_check.asm [=[
+.code
+extrn start:near
+    xor rax, rax
+    ret
+end
+]=])
+    endif ()
+    if(MINGW)
+        set(CMAKE_ASM_MASM_FLAGS ${CMAKE_ASM_MASM_FLAGS} ${JWASM_FLAGS})
+    elseif(NOT CMAKE_CL_64 AND NOT JWASM_FOUND)
+        set(CMAKE_ASM_MASM_FLAGS ${CMAKE_ASM_MASM_FLAGS} /safeseh)
+    endif()
+    # try_compile does not work here due to the same reasons as static above.
+    execute_process(COMMAND ${CMAKE_ASM_MASM_COMPILER} ${CMAKE_ASM_MASM_FLAGS} -c -Fo ${CMAKE_CURRENT_BINARY_DIR}/masm_check.obj ${CMAKE_CURRENT_BINARY_DIR}/masm_check.asm
+        RESULT_VARIABLE CMAKE_ASM_MASM_COMPILER_WORKS
+        OUTPUT_QUIET ERROR_QUIET)
+    # Convert the return code to a boolean
+    if(CMAKE_ASM_MASM_COMPILER_WORKS EQUAL 0)
+        set(CMAKE_ASM_MASM_COMPILER_WORKS true)
+    else()
+        set(CMAKE_ASM_MASM_COMPILER_WORKS false)
+    endif()
     if(CMAKE_ASM_MASM_COMPILER_WORKS)
-        if(MINGW)
-            set(CMAKE_ASM_MASM_FLAGS ${CMAKE_ASM_MASM_FLAGS} ${JWASM_FLAGS})
-        elseif(NOT CMAKE_CL_64 AND NOT JWASM_FOUND)
-            set(CMAKE_ASM_MASM_FLAGS ${CMAKE_ASM_MASM_FLAGS} /safeseh)
-        endif()
-
         add_executable(asm_offset asm_offset.c)
         target_link_libraries(asm_offset PRIVATE loader_specific_options)
         # If am emulator is provided (Like Wine), or running on native, run asm_offset to generate gen_defines.asm


### PR DESCRIPTION
CMake's detection of MASM is very broken, especially if not using MSVC. This adds a check to see if MASM is working, and if not, disables it, going back to the fallback path, as intended.

@sfan5 can you check if this branch causes issues for you? I have tried with having uasm installed and not installed


Related to https://github.com/KhronosGroup/Vulkan-Loader/pull/1306