### PR TITLE
gn: asm_offset.c shouldn't be compiled

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -106,7 +106,6 @@ if (!is_android) {
       "loader/adapters.h",
       "loader/allocation.c",
       "loader/allocation.h",
-      "loader/asm_offset.c",
       "loader/cJSON.c",
       "loader/cJSON.h",
       "loader/debug_utils.c",


### PR DESCRIPTION
asm_offset.c only makes sense for an executable