### PR TITLE
Distinguish OOM from json parsing errors

### DIFF
--- a/tests/loader_alloc_callback_tests.cpp
+++ b/tests/loader_alloc_callback_tests.cpp
@@ -416,6 +416,51 @@ TEST(Allocation, CreateInstanceIntentionalAllocFail) {
     }
 }
 
+// Test failure during vkCreateInstance to make sure we don't leak memory if
+// one of the out-of-memory conditions trigger and there are invalid jsons in the same folder
+TEST(Allocation, CreateInstanceIntentionalAllocFailInvalidManifests) {
+    FrameworkEnvironment env{FrameworkSettings{}.set_log_filter("error,warn")};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
+
+    std::vector<std::string> invalid_jsons;
+    invalid_jsons.push_back(",");
+    invalid_jsons.push_back("{},[]");
+    invalid_jsons.push_back("{ \"foo\":\"bar\", }");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": [], },");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": [{},] },");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": {\"fee\"} },");
+    invalid_jsons.push_back("{\"\":\"bar\", \"baz\": {}");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": {\"fee\":1234, true, \"ab\":\"bc\"} },");
+
+    for (size_t i = 0; i < invalid_jsons.size(); i++) {
+        auto file_name = std::string("invalid_implicit_layer_") + std::to_string(i) + ".json";
+        fs::path new_path = env.get_folder(ManifestLocation::implicit_layer).write_manifest(file_name, invalid_jsons[i]);
+        env.platform_shim->add_manifest(ManifestCategory::implicit_layer, new_path);
+    }
+
+    const char* layer_name = "VkLayerImplicit0";
+    env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
+                                                         .set_name(layer_name)
+                                                         .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                                         .set_disable_environment("DISABLE_ENV")),
+                           "test_layer.json");
+
+    size_t fail_index = 0;
+    VkResult result = VK_ERROR_OUT_OF_HOST_MEMORY;
+    while (result == VK_ERROR_OUT_OF_HOST_MEMORY && fail_index <= 10000) {
+        MemoryTracker tracker({false, 0, true, fail_index});
+
+        VkInstance instance;
+        InstanceCreateInfo inst_create_info{};
+        result = env.vulkan_functions.vkCreateInstance(inst_create_info.get(), tracker.get(), &instance);
+        if (result == VK_SUCCESS) {
+            env.vulkan_functions.vkDestroyInstance(instance, tracker.get());
+        }
+        ASSERT_TRUE(tracker.empty());
+        fail_index++;
+    }
+}
+
 // Test failure during vkCreateInstance & surface creation to make sure we don't leak memory if
 // one of the out-of-memory conditions trigger.
 TEST(Allocation, CreateSurfaceIntentionalAllocFail) {

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -4147,3 +4147,51 @@ TEST(Layer, LLP_LAYER_22) {
             R"(possibly corrupted by active layer \(Policy #LLP_LAYER_22\))"));
 #endif
 }
+
+TEST(InvalidManifest, ICD) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device({});
+
+    std::vector<std::string> invalid_jsons;
+    invalid_jsons.push_back(",");
+    invalid_jsons.push_back("{},[]");
+    invalid_jsons.push_back("{ \"foo\":\"bar\", }");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": [], },");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": [{},] },");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": {\"fee\"} },");
+    invalid_jsons.push_back("{\"\":\"bar\", \"baz\": {}");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": {\"fee\":1234, true, \"ab\":\"bc\"} },");
+
+    for (size_t i = 0; i < invalid_jsons.size(); i++) {
+        auto file_name = std::string("invalid_driver_") + std::to_string(i) + ".json";
+        fs::path new_path = env.get_folder(ManifestLocation::driver).write_manifest(file_name, invalid_jsons[i]);
+        env.platform_shim->add_manifest(ManifestCategory::icd, new_path);
+    }
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.CheckCreate();
+}
+
+TEST(InvalidManifest, Layer) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device({});
+
+    std::vector<std::string> invalid_jsons;
+    invalid_jsons.push_back(",");
+    invalid_jsons.push_back("{},[]");
+    invalid_jsons.push_back("{ \"foo\":\"bar\", }");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": [], },");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": [{},] },");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": {\"fee\"} },");
+    invalid_jsons.push_back("{\"\":\"bar\", \"baz\": {}");
+    invalid_jsons.push_back("{\"foo\":\"bar\", \"baz\": {\"fee\":1234, true, \"ab\":\"bc\"} },");
+
+    for (size_t i = 0; i < invalid_jsons.size(); i++) {
+        auto file_name = std::string("invalid_implicit_layer_") + std::to_string(i) + ".json";
+        fs::path new_path = env.get_folder(ManifestLocation::implicit_layer).write_manifest(file_name, invalid_jsons[i]);
+        env.platform_shim->add_manifest(ManifestCategory::implicit_layer, new_path);
+    }
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.CheckCreate();
+}


### PR DESCRIPTION
Whenever an invalid JSON file was encoutered, the loader would return VK_ERROR_OUT_OF_HOST_MEMORY because it couldn't distinguish an invalid JSON file from the inability to allocate memory while parsing JSON. This commit adds the necessary logic to be able to tell the two conditions apart as well as adding rudimentary testing of it.

Fixes #1324