### PR TITLE
Revert "ci: Prevent duplicate CI runs when pushing to repo"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,6 @@ concurrency:
 
 on:
   push:
-    branches:
-    - main
   pull_request:
     branches:
     - main


### PR DESCRIPTION
Causes pushes to branches on forks to no longer trigger Github Actions.