### PR TITLE
Dont assert in vkAllocateCommandBuffers

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -1933,7 +1933,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAllocateCommandBuffers(VkDevice d
     if (res == VK_SUCCESS) {
         for (uint32_t i = 0; i < pAllocateInfo->commandBufferCount; i++) {
             if (pCommandBuffers[i]) {
-                loader_init_dispatch(pCommandBuffers[i], disp);
+                loader_set_dispatch(pCommandBuffers[i], disp);
             }
         }
     }


### PR DESCRIPTION
The loader_init_dispatch first checks if the dispatchable handle has the ICD_MAGIC_VALUE before setting the handle to the correct dispatch pointer. This is useful to check that driver's are correctly creating the handle using VK_LOADER_DATA.

Because layers are capable of wrapping handles, the loader_init_dispatch function should only be called in terminators which run before any layers have a chance to modify the ICD_MAGIC_VALUE. Otherwise the assert fails.

vkGetDeviceQueue & vkGetDeviceQueue2 uses loader_set_dispatch, which does the same code as loader_init_dispatch but without the assert.

This commit changes vkAllocateCommandBuffers to use loader_set_dispatch.