### PR TITLE
Check for nullptr in vkCreateInstance trampoline

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -489,7 +489,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
     struct loader_instance *ptr_instance = NULL;
     VkInstance created_instance = VK_NULL_HANDLE;
     VkResult res = VK_ERROR_INITIALIZATION_FAILED;
-    VkInstanceCreateInfo ici = *pCreateInfo;
+    VkInstanceCreateInfo ici = {0};
     struct loader_envvar_all_filters layer_filters = {0};
 
     LOADER_PLATFORM_THREAD_ONCE(&once_init, loader_initialize);
@@ -499,6 +499,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
                    "vkCreateInstance: \'pCreateInfo\' is NULL (VUID-vkCreateInstance-pCreateInfo-parameter)");
         goto out;
     }
+    ici = *pCreateInfo;
+
     if (pInstance == NULL) {
         loader_log(NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,
                    "vkCreateInstance \'pInstance\' not valid (VUID-vkCreateInstance-pInstance-parameter)");


### PR DESCRIPTION
pCreateInfo must not be NULL, but the loader was dereferencing the pointer before checking if it is NULL. Moving the dereference below the check for NULL ensures no nullptr dereferencing occurs.