### PR TITLE
Fix Debug callbacks in layers in vkCreateInstance

### DIFF
--- a/loader/debug_utils.c
+++ b/loader/debug_utils.c
@@ -124,7 +124,6 @@ void util_DestroyDebugUtilsMessenger(struct loader_instance *inst, VkDebugUtilsM
             pPrev->pNext = pTrav->pNext;
             if (inst->current_dbg_function_head == pTrav) inst->current_dbg_function_head = pTrav->pNext;
             if (inst->instance_only_dbg_function_head == pTrav) inst->instance_only_dbg_function_head = pTrav->pNext;
-            if (inst->standard_dbg_function_head == pTrav) inst->standard_dbg_function_head = pTrav->pNext;
             loader_free_with_instance_fallback(pAllocator, inst, pTrav);
             break;
         }
@@ -220,9 +219,8 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDebugUtilsMessengerEXT(VkInstanc
     new_dbg_func_node->messenger.messageSeverity = pCreateInfo->messageSeverity;
     new_dbg_func_node->messenger.messageType = pCreateInfo->messageType;
     new_dbg_func_node->pUserData = pCreateInfo->pUserData;
-    new_dbg_func_node->pNext = inst->standard_dbg_function_head;
-    inst->standard_dbg_function_head = new_dbg_func_node;
-    inst->current_dbg_function_head = inst->standard_dbg_function_head;
+    new_dbg_func_node->pNext = inst->current_dbg_function_head;
+    inst->current_dbg_function_head = new_dbg_func_node;
 
     *(VkDebugUtilsMessengerEXT **)pMessenger = icd_info;
     new_dbg_func_node->messenger.messenger = *pMessenger;
@@ -380,7 +378,7 @@ void util_DestroyDebugReportCallback(struct loader_instance *inst, VkDebugReport
             pPrev->pNext = pTrav->pNext;
             if (inst->current_dbg_function_head == pTrav) inst->current_dbg_function_head = pTrav->pNext;
             if (inst->instance_only_dbg_function_head == pTrav) inst->instance_only_dbg_function_head = pTrav->pNext;
-            if (inst->standard_dbg_function_head == pTrav) inst->standard_dbg_function_head = pTrav->pNext;
+            if (inst->current_dbg_function_head == pTrav) inst->current_dbg_function_head = pTrav->pNext;
             loader_free_with_instance_fallback(pAllocator, inst, pTrav);
             break;
         }
@@ -478,7 +476,6 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDebugReportCallbackEXT(VkInstanc
     new_dbg_func_node->pUserData = pCreateInfo->pUserData;
     new_dbg_func_node->pNext = inst->current_dbg_function_head;
     inst->current_dbg_function_head = new_dbg_func_node;
-    inst->standard_dbg_function_head = inst->current_dbg_function_head;
 
     *(VkDebugReportCallbackEXT **)pCallback = icd_info;
     new_dbg_func_node->report.msgCallback = *pCallback;

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2078,10 +2078,8 @@ bool verify_meta_layer_component_layers(const struct loader_instance *inst, stru
                prop->component_layer_names.count);
 
     // If layer logging is on, list the internals included in the meta-layer
-    if ((loader_get_global_debug_level() & VULKAN_LOADER_LAYER_BIT) != 0) {
-        for (uint32_t comp_layer = 0; comp_layer < prop->component_layer_names.count; comp_layer++) {
-            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "  [%d] %s", comp_layer, prop->component_layer_names.list[comp_layer]);
-        }
+    for (uint32_t comp_layer = 0; comp_layer < prop->component_layer_names.count; comp_layer++) {
+        loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "  [%d] %s", comp_layer, prop->component_layer_names.list[comp_layer]);
     }
     return true;
 }
@@ -4656,27 +4654,25 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
 
         // If layer debugging is enabled, let's print out the full callstack with layers in their
         // defined order.
-        if ((loader_get_global_debug_level() & VULKAN_LOADER_LAYER_BIT) != 0) {
-            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "vkCreateInstance layer callstack setup to:");
-            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   <Application>");
-            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "     ||");
-            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   <Loader>");
-            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "     ||");
-            for (uint32_t cur_layer = 0; cur_layer < num_activated_layers; ++cur_layer) {
-                uint32_t index = num_activated_layers - cur_layer - 1;
-                loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   %s", activated_layers[index].name);
-                loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Type: %s",
-                           activated_layers[index].is_implicit ? "Implicit" : "Explicit");
-                if (activated_layers[index].is_implicit) {
-                    loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "               Disable Env Var:  %s",
-                               activated_layers[index].disable_env);
-                }
-                loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Manifest: %s", activated_layers[index].manifest);
-                loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Library:  %s", activated_layers[index].library);
-                loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "     ||");
+        loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "vkCreateInstance layer callstack setup to:");
+        loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   <Application>");
+        loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "     ||");
+        loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   <Loader>");
+        loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "     ||");
+        for (uint32_t cur_layer = 0; cur_layer < num_activated_layers; ++cur_layer) {
+            uint32_t index = num_activated_layers - cur_layer - 1;
+            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   %s", activated_layers[index].name);
+            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Type: %s",
+                       activated_layers[index].is_implicit ? "Implicit" : "Explicit");
+            if (activated_layers[index].is_implicit) {
+                loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "               Disable Env Var:  %s",
+                           activated_layers[index].disable_env);
             }
-            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   <Drivers>");
+            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Manifest: %s", activated_layers[index].manifest);
+            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Library:  %s", activated_layers[index].library);
+            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "     ||");
         }
+        loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   <Drivers>");
 
         res = fpCreateInstance(&loader_create_info, pAllocator, created_instance);
     } else {
@@ -4921,29 +4917,25 @@ VkResult loader_create_device_chain(const VkPhysicalDevice pd, const VkDeviceCre
         // If layer debugging is enabled, let's print out the full callstack with layers in their
         // defined order.
         uint32_t layer_driver_bits = VULKAN_LOADER_LAYER_BIT | VULKAN_LOADER_DRIVER_BIT;
-        if ((loader_get_global_debug_level() & layer_driver_bits) != 0) {
-            loader_log(inst, layer_driver_bits, 0, "vkCreateDevice layer callstack setup to:");
-            loader_log(inst, layer_driver_bits, 0, "   <Application>");
-            loader_log(inst, layer_driver_bits, 0, "     ||");
-            loader_log(inst, layer_driver_bits, 0, "   <Loader>");
-            loader_log(inst, layer_driver_bits, 0, "     ||");
-            if ((loader_get_global_debug_level() & VULKAN_LOADER_LAYER_BIT) != 0) {
-                for (uint32_t cur_layer = 0; cur_layer < num_activated_layers; ++cur_layer) {
-                    uint32_t index = num_activated_layers - cur_layer - 1;
-                    loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   %s", activated_layers[index].name);
-                    loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Type: %s",
-                               activated_layers[index].is_implicit ? "Implicit" : "Explicit");
-                    if (activated_layers[index].is_implicit) {
-                        loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "               Disable Env Var:  %s",
-                                   activated_layers[index].disable_env);
-                    }
-                    loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Manifest: %s", activated_layers[index].manifest);
-                    loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Library:  %s", activated_layers[index].library);
-                    loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "     ||");
-                }
+        loader_log(inst, layer_driver_bits, 0, "vkCreateDevice layer callstack setup to:");
+        loader_log(inst, layer_driver_bits, 0, "   <Application>");
+        loader_log(inst, layer_driver_bits, 0, "     ||");
+        loader_log(inst, layer_driver_bits, 0, "   <Loader>");
+        loader_log(inst, layer_driver_bits, 0, "     ||");
+        for (uint32_t cur_layer = 0; cur_layer < num_activated_layers; ++cur_layer) {
+            uint32_t index = num_activated_layers - cur_layer - 1;
+            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "   %s", activated_layers[index].name);
+            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Type: %s",
+                       activated_layers[index].is_implicit ? "Implicit" : "Explicit");
+            if (activated_layers[index].is_implicit) {
+                loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "               Disable Env Var:  %s",
+                           activated_layers[index].disable_env);
             }
-            loader_log(inst, layer_driver_bits, 0, "   <Device>");
+            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Manifest: %s", activated_layers[index].manifest);
+            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Library:  %s", activated_layers[index].library);
+            loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "     ||");
         }
+        loader_log(inst, layer_driver_bits, 0, "   <Device>");
         create_info_disp.pNext = loader_create_info.pNext;
         loader_create_info.pNext = &create_info_disp;
         res = fpCreateDevice(pd, &loader_create_info, pAllocator, &created_device);

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -310,7 +310,6 @@ struct loader_instance {
     // Stores debug callbacks - used in the log.
     VkLayerDbgFunctionNode *current_dbg_function_head;        // Current head
     VkLayerDbgFunctionNode *instance_only_dbg_function_head;  // Only used for instance create/destroy
-    VkLayerDbgFunctionNode *standard_dbg_function_head;       // Always used until destroyed
 
     VkAllocationCallbacks alloc_callbacks;
 

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -307,13 +307,10 @@ struct loader_instance {
     struct loader_extension_list ext_list;  // icds and loaders extensions
     struct loader_instance_extension_enables enabled_known_extensions;
 
-    // Stores debug callbacks - used in the log
-    VkLayerDbgFunctionNode *DbgFunctionHead;
-
-    // Stores the debug callbacks set during instance creation
-    // These are kept separate because they aren't to be used outside of instance creation and destruction
-    // So they are swapped out at the end of instance creation and swapped in at instance destruction
-    VkLayerDbgFunctionNode *InstanceCreationDeletionDebugFunctionHead;
+    // Stores debug callbacks - used in the log.
+    VkLayerDbgFunctionNode *current_dbg_function_head;        // Current head
+    VkLayerDbgFunctionNode *instance_only_dbg_function_head;  // Only used for instance create/destroy
+    VkLayerDbgFunctionNode *standard_dbg_function_head;       // Always used until destroyed
 
     VkAllocationCallbacks alloc_callbacks;
 

--- a/loader/loader_linux.c
+++ b/loader/loader_linux.c
@@ -437,16 +437,14 @@ VkResult linux_sort_physical_device_groups(struct loader_instance *inst, uint32_
     // Sort device groups by PCI info
     qsort(sorted_group_term, group_count, sizeof(struct loader_physical_device_group_term), compare_device_groups);
 
-    if (loader_get_global_debug_level() & (VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT)) {
-        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "linux_sort_physical_device_groups:  Sorted order:");
-        for (uint32_t group = 0; group < group_count; ++group) {
-            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "           Group %u", group);
-            for (uint32_t gpu = 0; gpu < sorted_group_term[group].group_props.physicalDeviceCount; ++gpu) {
-                loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "               [%u] %s %p %s", gpu,
-                           sorted_group_term[group].internal_device_info[gpu].device_name,
-                           sorted_group_term[group].internal_device_info[gpu].physical_device,
-                           (sorted_group_term[group].internal_device_info[gpu].default_device ? "[default]" : ""));
-            }
+    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "linux_sort_physical_device_groups:  Sorted order:");
+    for (uint32_t group = 0; group < group_count; ++group) {
+        loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "           Group %u", group);
+        for (uint32_t gpu = 0; gpu < sorted_group_term[group].group_props.physicalDeviceCount; ++gpu) {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0, "               [%u] %s %p %s", gpu,
+                       sorted_group_term[group].internal_device_info[gpu].device_name,
+                       sorted_group_term[group].internal_device_info[gpu].physical_device,
+                       (sorted_group_term[group].internal_device_info[gpu].default_device ? "[default]" : ""));
         }
     }
 

--- a/loader/log.c
+++ b/loader/log.c
@@ -88,8 +88,6 @@ void loader_init_global_debug_level(void) {
 
 void loader_set_global_debug_level(uint32_t new_loader_debug) { g_loader_debug = new_loader_debug; }
 
-uint32_t loader_get_global_debug_level(void) { return g_loader_debug; }
-
 void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t msg_code, const char *format, ...) {
     (void)msg_code;
     char msg[512] = {0};

--- a/loader/log.h
+++ b/loader/log.h
@@ -54,9 +54,6 @@ void loader_init_global_debug_level(void);
 // Sets the global debug level - used by global settings files
 void loader_set_global_debug_level(uint32_t new_loader_debug);
 
-// Returns a bitmask that indicates the current flags that should be output
-uint32_t loader_get_global_debug_level(void);
-
 // The asm declaration prevents name mangling which is necessary for macOS
 #if defined(MODIFY_UNKNOWN_FUNCTION_DECLS)
 #define ASM_NAME(name) __asm(name)

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -486,7 +486,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
 
 // Add the "instance-only" debug functions to the list of active debug functions
 // at the very end.  This way it doesn't get replaced by any new messengers
-static void AddInstanceOnlyDebugFunctions(struct loader_instance *ptr_instance) {
+void loader_add_instance_only_debug_funcs(struct loader_instance *ptr_instance) {
     VkLayerDbgFunctionNode *cur_node = ptr_instance->current_dbg_function_head;
     if (cur_node == NULL) {
         ptr_instance->current_dbg_function_head = ptr_instance->instance_only_dbg_function_head;
@@ -507,7 +507,7 @@ static void AddInstanceOnlyDebugFunctions(struct loader_instance *ptr_instance) 
 
 // Remove the "instance-only" debug functions from the list of active debug functions.
 // It should be added after the last actual debug utils/debug report function.
-static void RemoveInstanceOnlyDebugFunctions(struct loader_instance *ptr_instance) {
+void loader_remove_instance_only_debug_funcs(struct loader_instance *ptr_instance) {
     VkLayerDbgFunctionNode *cur_node = ptr_instance->current_dbg_function_head;
 
     // Only thing in list is the instance only head
@@ -788,7 +788,7 @@ out:
             loader_instance_heap_free(ptr_instance, ptr_instance);
         } else {
             // success path, swap out created debug callbacks out so they aren't used until instance destruction
-            RemoveInstanceOnlyDebugFunctions(ptr_instance);
+            loader_remove_instance_only_debug_funcs(ptr_instance);
         }
         // Only unlock when ptr_instance isn't NULL, as if it is, the above code didn't make it to when loader_lock was locked.
         loader_platform_thread_unlock_mutex(&loader_lock);
@@ -822,7 +822,7 @@ LOADER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyInstance(VkInstance instance, 
     destroy_debug_callbacks_chain(ptr_instance, pAllocator);
 
     // Swap in the debug callbacks created during instance creation
-    AddInstanceOnlyDebugFunctions(ptr_instance);
+    loader_add_instance_only_debug_funcs(ptr_instance);
 
     disp = loader_get_instance_layer_dispatch(instance);
     disp->DestroyInstance(ptr_instance->instance, pAllocator);


### PR DESCRIPTION
After a layer calls down to vkCreateInstance, it may need to create a DebugUtils Messenger (or Report object) for capturing debug information. With the old design, it would get handled as a "during vkCreateInstance" debug utils messenger object because the loader trampoline was still in the middle of "vkCreateInstance".  However, treat it separately if it was created with a call to vkCreateDebugUtilsMessenger and that allows it to capture info all the way until the instance is destroyed.