### PR TITLE
Cleanup loader_icd_init_entries

### DIFF
--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -54,8 +54,7 @@ extern const VkLayerInstanceDispatchTable instance_disp;
 // Array of extension strings for instance extensions we support.
 extern const char *const LOADER_INSTANCE_EXTENSIONS[];
 
-VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_icd_term *icd_term, VkInstance inst,
-                                                   const PFN_vkGetInstanceProcAddr fp_gipa);
+VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_instance* inst, struct loader_icd_term *icd_term);
 
 // Init Device function pointer dispatch table with core commands
 VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_dispatch_table *dev_table, PFN_vkGetDeviceProcAddr gpa,

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5413,8 +5413,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateInstance(const VkInstanceCreateI
             continue;
         }
 
-        if (!loader_icd_init_entries(icd_term, icd_term->instance,
-                                     ptr_instance->icd_tramp_list.scanned_list[i].GetInstanceProcAddr)) {
+        if (!loader_icd_init_entries(ptr_instance, icd_term)) {
             loader_log(ptr_instance, VULKAN_LOADER_WARN_BIT, 0,
                        "terminator_CreateInstance: Failed to CreateInstance and find entrypoints with ICD.  Skipping ICD.");
             ptr_instance->icd_terms = icd_term->next;

--- a/loader/log.c
+++ b/loader/log.c
@@ -102,9 +102,9 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
 
     if (inst) {
         VkDebugUtilsMessageSeverityFlagBitsEXT severity = 0;
-        VkDebugUtilsMessageTypeFlagsEXT type;
-        VkDebugUtilsMessengerCallbackDataEXT callback_data;
-        VkDebugUtilsObjectNameInfoEXT object_name;
+        VkDebugUtilsMessageTypeFlagsEXT type = 0;
+        VkDebugUtilsMessengerCallbackDataEXT callback_data = {0};
+        VkDebugUtilsObjectNameInfoEXT object_name = {0};
 
         if ((msg_type & VULKAN_LOADER_INFO_BIT) != 0) {
             severity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
@@ -130,22 +130,13 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
         }
 
         callback_data.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT;
-        callback_data.pNext = NULL;
-        callback_data.flags = 0;
         callback_data.pMessageIdName = "Loader Message";
-        callback_data.messageIdNumber = 0;
         callback_data.pMessage = msg;
-        callback_data.queueLabelCount = 0;
-        callback_data.pQueueLabels = NULL;
-        callback_data.cmdBufLabelCount = 0;
-        callback_data.pCmdBufLabels = NULL;
         callback_data.objectCount = 1;
         callback_data.pObjects = &object_name;
         object_name.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
-        object_name.pNext = NULL;
         object_name.objectType = VK_OBJECT_TYPE_INSTANCE;
         object_name.objectHandle = (uint64_t)(uintptr_t)inst;
-        object_name.pObjectName = NULL;
 
         util_SubmitDebugUtilsMessageEXT(inst, severity, type, &callback_data);
     }

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -1333,14 +1333,19 @@ PFN_vkVoidFunction get_physical_device_func([[maybe_unused]] VkInstance instance
         return to_vkVoidFunction(test_vkGetPhysicalDeviceQueueFamilyProperties);
     if (string_eq(pName, "vkCreateDevice")) return to_vkVoidFunction(test_vkCreateDevice);
 
-    if (string_eq(pName, "vkGetPhysicalDeviceFeatures")) return to_vkVoidFunction(test_vkGetPhysicalDeviceFeatures);
-    if (string_eq(pName, "vkGetPhysicalDeviceProperties")) return to_vkVoidFunction(test_vkGetPhysicalDeviceProperties);
-    if (string_eq(pName, "vkGetPhysicalDeviceMemoryProperties")) return to_vkVoidFunction(test_vkGetPhysicalDeviceMemoryProperties);
+    if (string_eq(pName, "vkGetPhysicalDeviceFeatures"))
+        return icd.can_query_GetPhysicalDeviceFuncs ? to_vkVoidFunction(test_vkGetPhysicalDeviceFeatures) : nullptr;
+    if (string_eq(pName, "vkGetPhysicalDeviceProperties"))
+        return icd.can_query_GetPhysicalDeviceFuncs ? to_vkVoidFunction(test_vkGetPhysicalDeviceProperties) : nullptr;
+    if (string_eq(pName, "vkGetPhysicalDeviceMemoryProperties"))
+        return icd.can_query_GetPhysicalDeviceFuncs ? to_vkVoidFunction(test_vkGetPhysicalDeviceMemoryProperties) : nullptr;
     if (string_eq(pName, "vkGetPhysicalDeviceSparseImageFormatProperties"))
-        return to_vkVoidFunction(test_vkGetPhysicalDeviceSparseImageFormatProperties);
-    if (string_eq(pName, "vkGetPhysicalDeviceFormatProperties")) return to_vkVoidFunction(test_vkGetPhysicalDeviceFormatProperties);
+        return icd.can_query_GetPhysicalDeviceFuncs ? to_vkVoidFunction(test_vkGetPhysicalDeviceSparseImageFormatProperties)
+                                                    : nullptr;
+    if (string_eq(pName, "vkGetPhysicalDeviceFormatProperties"))
+        return icd.can_query_GetPhysicalDeviceFuncs ? to_vkVoidFunction(test_vkGetPhysicalDeviceFormatProperties) : nullptr;
     if (string_eq(pName, "vkGetPhysicalDeviceImageFormatProperties"))
-        return to_vkVoidFunction(test_vkGetPhysicalDeviceImageFormatProperties);
+        return icd.can_query_GetPhysicalDeviceFuncs ? to_vkVoidFunction(test_vkGetPhysicalDeviceImageFormatProperties) : nullptr;
 
     if (IsInstanceExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
         if (string_eq(pName, "vkGetPhysicalDeviceFeatures2KHR")) return to_vkVoidFunction(test_vkGetPhysicalDeviceFeatures2);

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -121,6 +121,7 @@ struct TestICD {
     std::vector<uint64_t> swapchain_handles;
 
     BUILDER_VALUE(TestICD, bool, can_query_vkEnumerateInstanceVersion, true);
+    BUILDER_VALUE(TestICD, bool, can_query_GetPhysicalDeviceFuncs, true);
 
     // Unknown instance functions Add a `VulkanFunction` to this list which will be searched in
     // vkGetInstanceProcAddr for custom_instance_functions and vk_icdGetPhysicalDeviceProcAddr for

--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -178,6 +178,25 @@ TEST(GetProcAddr, GlobalFunctions) {
     }
 }
 
+TEST(GetProcAddr, Verify10FunctionsFailToLoadWithSingleDriver) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device({}).set_can_query_GetPhysicalDeviceFuncs(false);
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.CheckCreate(VK_ERROR_INCOMPATIBLE_DRIVER);
+}
+
+TEST(GetProcAddr, Verify10FunctionsLoadWithMultipleDrivers) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device({});
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device({}).set_can_query_GetPhysicalDeviceFuncs(false);
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.CheckCreate();
+
+    inst.GetPhysDevs(1);
+}
+
 // Swapchain functions which require a terminator in all cases have situations where the driver may have a
 // NULL function pointer but the loader shouldn't abort() if that is the case. Rather, it should log a message
 // and return VK_SUCCESS to maintain previous behavior.


### PR DESCRIPTION
The logic of the function indicates that at a previous time, the functions being loaded used dlsym/GetProcAddress to query functions. Whenever that was changed to vkGetInstanceProcAddr, the error logging wasn't updated to remove loader_platform_get_proc_address_error. Trying to call dlerror() when no error has occured will return NULL, which was dutifully passed onto loader_log, causing crashes.

The cleanup removes usage of that, as well as making the loading logic uses 2 macros, one for required & one for non-required function pointers.