### PR TITLE
Unload drivers which report 0 physical devices

### DIFF
--- a/loader/cJSON.c
+++ b/loader/cJSON.c
@@ -442,7 +442,7 @@ static char *print_string_ptr(const VkAllocationCallbacks *pAllocator, const cha
 /* Invoke print_string_ptr (which is useful) on an item. */
 static char *print_string(cJSON *item, printbuffer *p) { return print_string_ptr(item->pAllocator, item->valuestring, p); }
 
-/* Predeclare these prototypes. */
+/* Declare these prototypes. */
 static const char *parse_value(cJSON *item, const char *value, bool *out_of_memory);
 static char *print_value(cJSON *item, int depth, int fmt, printbuffer *p);
 static const char *parse_array(cJSON *item, const char *value, bool *out_of_memory);
@@ -1014,7 +1014,7 @@ VkResult loader_get_json(const struct loader_instance *inst, const char *filenam
     bool out_of_memory = false;
     *json = cJSON_Parse(inst ? &inst->alloc_callbacks : NULL, json_buf, &out_of_memory);
     if (out_of_memory) {
-        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "loader_get_json: Out of Memory error occured while parsing JSON file %s.",
+        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "loader_get_json: Out of Memory error occurred while parsing JSON file %s.",
                    filename);
         res = VK_ERROR_OUT_OF_HOST_MEMORY;
         goto out;

--- a/loader/cJSON.h
+++ b/loader/cJSON.h
@@ -105,7 +105,7 @@ VkResult loader_parse_json_string_to_existing_str(const struct loader_instance *
 // It is the callers responsibility to free out_string.
 VkResult loader_parse_json_string(cJSON *object, const char *key, char **out_string);
 
-// Given a cJSON object, find the array of strings assocated with they key and writes the count into out_count and data into
+// Given a cJSON object, find the array of strings associated with they key and writes the count into out_count and data into
 // out_array_of_strings. It is the callers responsibility to free out_array_of_strings.
 VkResult loader_parse_json_array_of_strings(const struct loader_instance *inst, cJSON *object, const char *key,
                                             struct loader_string_list *string_list);

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1725,13 +1725,13 @@ VkResult loader_scanned_icd_add(const struct loader_instance *inst, struct loade
         fp_create_inst = loader_platform_get_proc_address(handle, "vkCreateInstance");
         if (NULL == fp_create_inst) {
             loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                       "loader_scanned_icd_add:  Failed querying \'vkCreateInstance\' via dlsym/loadlibrary for ICD %s", filename);
+                       "loader_scanned_icd_add:  Failed querying \'vkCreateInstance\' via dlsym/LoadLibrary for ICD %s", filename);
             goto out;
         }
         fp_get_inst_ext_props = loader_platform_get_proc_address(handle, "vkEnumerateInstanceExtensionProperties");
         if (NULL == fp_get_inst_ext_props) {
             loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                       "loader_scanned_icd_add: Could not get \'vkEnumerateInstanceExtensionProperties\' via dlsym/loadlibrary "
+                       "loader_scanned_icd_add: Could not get \'vkEnumerateInstanceExtensionProperties\' via dlsym/LoadLibrary "
                        "for ICD %s",
                        filename);
             goto out;
@@ -1929,7 +1929,7 @@ char *loader_get_next_path(char *path) {
 }
 
 /* Processes a json manifest's library_path and the location of the json manifest to create the path of the library
- * The output is stored in out_fullpath by allocating a string - so its the caller's repsonsibility to free it
+ * The output is stored in out_fullpath by allocating a string - so its the caller's responsibility to free it
  * The output is the combination of the base path of manifest_file_path concatenated with library path
  * If library_path is an absolute path, we do not prepend the base path of manifest_file_path
  *
@@ -1967,14 +1967,14 @@ VkResult combine_manifest_directory_and_library_path(const struct loader_instanc
         goto out;
     }
     size_t cur_loc_in_out_fullpath = 0;
-    // look for the last occurance of DIRECTORY_SYMBOL in manifest_file_path
+    // look for the last occurrence of DIRECTORY_SYMBOL in manifest_file_path
     size_t last_directory_symbol = 0;
     bool found_directory_symbol = false;
     for (size_t i = 0; i < manifest_file_path_str_len; i++) {
         if (manifest_file_path[i] == DIRECTORY_SYMBOL) {
             last_directory_symbol = i + 1;  // we want to include the symbol
             found_directory_symbol = true;
-            // dont break because we want to find the last occurance
+            // dont break because we want to find the last occurrence
         }
     }
     // Add manifest_file_path up to the last directory symbol
@@ -2131,7 +2131,7 @@ bool update_meta_layer_extensions_from_component_layers(const struct loader_inst
     return res;
 }
 
-// Verify that all meta-layers in a layer verify_meta_layer_component_layerslist are valid.
+// Verify that all meta-layers in a layer list are valid.
 VkResult verify_all_meta_layers(struct loader_instance *inst, const struct loader_envvar_all_filters *filters,
                                 struct loader_layer_list *instance_layers, bool *override_layer_present) {
     VkResult res = VK_SUCCESS;
@@ -2606,7 +2606,7 @@ VkResult loader_read_layer_json(const struct loader_instance *inst, struct loade
     if (loader_cJSON_GetObjectItem(layer_node, "app_keys")) {
         if (!props.is_override) {
             loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0,
-                       "Layer %s contains app_keys, but any app_keys can only be provided by the override metalayer. "
+                       "Layer %s contains app_keys, but any app_keys can only be provided by the override meta layer. "
                        "These will be ignored.",
                        props.info.layerName);
         }
@@ -3774,7 +3774,7 @@ VkResult loader_scan_for_layers(struct loader_instance *inst, struct loader_laye
         goto out;
     }
 
-    // If we should not look for layers using other mechanisms, assing settings_layers to instance_layers and jump to the
+    // If we should not look for layers using other mechanisms, assign settings_layers to instance_layers and jump to the
     // output
     if (!should_search_for_other_layers) {
         *instance_layers = settings_layers;
@@ -3855,7 +3855,7 @@ VkResult loader_scan_for_implicit_layers(struct loader_instance *inst, struct lo
         goto out;
     }
 
-    // If we should not look for layers using other mechanisms, assing settings_layers to instance_layers and jump to the
+    // If we should not look for layers using other mechanisms, assign settings_layers to instance_layers and jump to the
     // output
     if (!should_search_for_other_layers) {
         *instance_layers = settings_layers;
@@ -3972,11 +3972,11 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL loader_gpa_instance_terminator(VkInstan
         return (PFN_vkVoidFunction)terminator_CreateInstance;
     }
 
-    // While the spec is very clear that quering vkCreateDevice requires a valid VkInstance, because the loader allowed querying
+    // While the spec is very clear that querying vkCreateDevice requires a valid VkInstance, because the loader allowed querying
     // with a NULL VkInstance handle for a long enough time, it is impractical to fix this bug in the loader
 
     // As such, this is a bug to maintain compatibility for the RTSS layer (Riva Tuner Statistics Server) but may
-    // be dependend upon by other layers out in the wild.
+    // be depended upon by other layers out in the wild.
     if (!strcmp(pName, "vkCreateDevice")) {
         return (PFN_vkVoidFunction)terminator_CreateDevice;
     }
@@ -5051,7 +5051,7 @@ VkResult loader_validate_instance_extensions(struct loader_instance *inst, const
             goto out;
         }
     } else {
-        // Build the lists of active layers (including metalayers) and expanded layers (with metalayers resolved to their
+        // Build the lists of active layers (including meta layers) and expanded layers (with meta layers resolved to their
         // components)
         res = loader_add_implicit_layers(inst, layer_filters, &active_layers, &expanded_layers, instance_layers);
         if (res != VK_SUCCESS) {
@@ -6353,7 +6353,7 @@ out:
 }
 /**
  * Iterates through all drivers and unloads any which do not contain physical devices.
- * This saves address space, which for 32 bit applications is scarse.
+ * This saves address space, which for 32 bit applications is scarce.
  * This must only be called after a call to vkEnumeratePhysicalDevices that isn't just querying the count
  */
 void unload_drivers_without_physical_devices(struct loader_instance *inst) {

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -94,7 +94,7 @@ loader_platform_thread_mutex loader_global_instance_list_lock;
 // functionality, but the fact that the libraries already been loaded causes any call that needs to load ICD libraries to speed up
 // significantly. This can have a huge impact when making repeated calls to vkEnumerateInstanceExtensionProperties and
 // vkCreateInstance.
-struct loader_icd_tramp_list scanned_icds;
+struct loader_icd_tramp_list preloaded_icds;
 
 // controls whether loader_platform_close_library() closes the libraries or not - controlled by an environment
 // variables - this is just the definition of the variable, usage is in vk_loader_platform.h
@@ -1342,6 +1342,24 @@ struct loader_icd_term *loader_icd_add(struct loader_instance *ptr_inst, const s
 
     return icd_term;
 }
+// Closes the library handle in the scanned ICD, free the lib_name string, and zeros out all data
+void loader_unload_scanned_icd(struct loader_instance *inst, struct loader_scanned_icd *scanned_icd) {
+    if (NULL == scanned_icd) {
+        return;
+    }
+    if (scanned_icd->handle) {
+        loader_platform_close_library(scanned_icd->handle);
+        scanned_icd->handle = NULL;
+    }
+    loader_instance_heap_free(inst, scanned_icd->lib_name);
+    scanned_icd->lib_name = NULL;
+    scanned_icd->CreateInstance = NULL;
+    scanned_icd->EnumerateInstanceExtensionProperties = NULL;
+    scanned_icd->GetInstanceProcAddr = NULL;
+    scanned_icd->GetPhysicalDeviceProcAddr = NULL;
+    scanned_icd->api_version = 0;
+    scanned_icd->interface_version = 0;
+}
 
 // Determine the ICD interface version to use.
 //     @param icd
@@ -1377,7 +1395,7 @@ bool loader_get_icd_interface_version(PFN_vkNegotiateLoaderICDInterfaceVersion f
     return true;
 }
 
-void loader_scanned_icd_clear(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list) {
+void loader_clear_scanned_icd_list(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list) {
     if (0 != icd_tramp_list->capacity && icd_tramp_list->scanned_list) {
         for (uint32_t i = 0; i < icd_tramp_list->count; i++) {
             if (icd_tramp_list->scanned_list[i].handle) {
@@ -1393,14 +1411,14 @@ void loader_scanned_icd_clear(const struct loader_instance *inst, struct loader_
     icd_tramp_list->scanned_list = NULL;
 }
 
-VkResult loader_scanned_icd_init(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list) {
+VkResult loader_init_scanned_icd_list(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list) {
     VkResult res = VK_SUCCESS;
-    loader_scanned_icd_clear(inst, icd_tramp_list);
+    loader_clear_scanned_icd_list(inst, icd_tramp_list);
     icd_tramp_list->capacity = 8 * sizeof(struct loader_scanned_icd);
     icd_tramp_list->scanned_list = loader_instance_heap_alloc(inst, icd_tramp_list->capacity, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
     if (NULL == icd_tramp_list->scanned_list) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "loader_scanned_icd_init: Realloc failed for layer list when attempting to add new layer");
+                   "loader_init_scanned_icd_list: Realloc failed for layer list when attempting to add new layer");
         res = VK_ERROR_OUT_OF_HOST_MEMORY;
     }
     return res;
@@ -1876,14 +1894,14 @@ void loader_preload_icds(void) {
     loader_platform_thread_lock_mutex(&loader_preload_icd_lock);
 
     // Already preloaded, skip loading again.
-    if (scanned_icds.scanned_list != NULL) {
+    if (preloaded_icds.scanned_list != NULL) {
         loader_platform_thread_unlock_mutex(&loader_preload_icd_lock);
         return;
     }
 
-    VkResult result = loader_icd_scan(NULL, &scanned_icds, NULL, NULL);
+    VkResult result = loader_icd_scan(NULL, &preloaded_icds, NULL, NULL);
     if (result != VK_SUCCESS) {
-        loader_scanned_icd_clear(NULL, &scanned_icds);
+        loader_clear_scanned_icd_list(NULL, &preloaded_icds);
     }
     loader_platform_thread_unlock_mutex(&loader_preload_icd_lock);
 }
@@ -1891,7 +1909,7 @@ void loader_preload_icds(void) {
 // Release the ICD libraries that were preloaded
 void loader_unload_preloaded_icds(void) {
     loader_platform_thread_lock_mutex(&loader_preload_icd_lock);
-    loader_scanned_icd_clear(NULL, &scanned_icds);
+    loader_clear_scanned_icd_list(NULL, &preloaded_icds);
     loader_platform_thread_unlock_mutex(&loader_preload_icd_lock);
 }
 
@@ -3560,7 +3578,7 @@ VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_t
     struct ICDManifestInfo *icd_details = NULL;
 
     // Set up the ICD Trampoline list so elements can be written into it.
-    res = loader_scanned_icd_init(inst, icd_tramp_list);
+    res = loader_init_scanned_icd_list(inst, icd_tramp_list);
     if (res == VK_ERROR_OUT_OF_HOST_MEMORY) {
         return res;
     }
@@ -5517,8 +5535,6 @@ VKAPI_ATTR void VKAPI_CALL terminator_DestroyInstance(VkInstance instance, const
     if (NULL == ptr_instance) {
         return;
     }
-    struct loader_icd_term *icd_terms = ptr_instance->icd_terms;
-    struct loader_icd_term *next_icd_term;
 
     // Remove this instance from the list of instances:
     struct loader_instance *prev = NULL;
@@ -5538,18 +5554,19 @@ VKAPI_ATTR void VKAPI_CALL terminator_DestroyInstance(VkInstance instance, const
     }
     loader_platform_thread_unlock_mutex(&loader_global_instance_list_lock);
 
+    struct loader_icd_term *icd_terms = ptr_instance->icd_terms;
     while (NULL != icd_terms) {
         if (icd_terms->instance) {
             icd_terms->dispatch.DestroyInstance(icd_terms->instance, pAllocator);
         }
-        next_icd_term = icd_terms->next;
+        struct loader_icd_term *next_icd_term = icd_terms->next;
         icd_terms->instance = VK_NULL_HANDLE;
         loader_icd_destroy(ptr_instance, icd_terms, pAllocator);
 
         icd_terms = next_icd_term;
     }
 
-    loader_scanned_icd_clear(ptr_instance, &ptr_instance->icd_tramp_list);
+    loader_clear_scanned_icd_list(ptr_instance, &ptr_instance->icd_tramp_list);
     loader_destroy_generic_list(ptr_instance, (struct loader_generic_list *)&ptr_instance->ext_list);
     if (NULL != ptr_instance->phys_devs_term) {
         for (uint32_t i = 0; i < ptr_instance->phys_dev_count_term; i++) {
@@ -6183,6 +6200,7 @@ VkResult setup_loader_term_phys_devs(struct loader_instance *inst) {
         }
         icd_phys_dev_array[icd_idx].icd_term = icd_term;
         icd_phys_dev_array[icd_idx].icd_index = icd_idx;
+        icd_term->physical_device_count = icd_phys_dev_array[icd_idx].device_count;
         icd_term = icd_term->next;
         ++icd_idx;
     }
@@ -6346,6 +6364,63 @@ out:
     }
 
     return res;
+}
+/**
+ * Iterates through all drivers and unloads any which do not contain physical devices.
+ * This saves address space, which for 32 bit applications is scarse.
+ * This must only be called after a call to vkEnumeratePhysicalDevices that isn't just querying the count
+ */
+void unload_drivers_without_physical_devices(struct loader_instance *inst) {
+    struct loader_icd_term *cur_icd_term = inst->icd_terms;
+    struct loader_icd_term *prev_icd_term = NULL;
+
+    while (NULL != cur_icd_term) {
+        struct loader_icd_term *next_icd_term = cur_icd_term->next;
+        if (cur_icd_term->physical_device_count == 0) {
+            uint32_t cur_scanned_icd_index = UINT32_MAX;
+            if (inst->icd_tramp_list.scanned_list) {
+                for (uint32_t i = 0; i < inst->icd_tramp_list.count; i++) {
+                    if (&(inst->icd_tramp_list.scanned_list[i]) == cur_icd_term->scanned_icd) {
+                        cur_scanned_icd_index = i;
+                        break;
+                    }
+                }
+            }
+            if (cur_scanned_icd_index != UINT32_MAX) {
+                loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+                           "Removing driver %s due to not having any physical devices", cur_icd_term->scanned_icd->lib_name);
+                if (cur_icd_term->instance) {
+                    cur_icd_term->dispatch.DestroyInstance(cur_icd_term->instance, &(inst->alloc_callbacks));
+                }
+                cur_icd_term->instance = VK_NULL_HANDLE;
+                loader_icd_destroy(inst, cur_icd_term, &(inst->alloc_callbacks));
+                cur_icd_term = NULL;
+                struct loader_scanned_icd *scanned_icd_to_remove = &inst->icd_tramp_list.scanned_list[cur_scanned_icd_index];
+                // Iterate through preloaded ICDs and remove the corresponding driver from that list
+                loader_platform_thread_lock_mutex(&loader_preload_icd_lock);
+                if (NULL != preloaded_icds.scanned_list) {
+                    for (uint32_t i = 0; i < preloaded_icds.count; i++) {
+                        if (strcmp(preloaded_icds.scanned_list[i].lib_name, scanned_icd_to_remove->lib_name) == 0) {
+                            loader_unload_scanned_icd(inst, &preloaded_icds.scanned_list[i]);
+                            break;
+                        }
+                    }
+                }
+                loader_platform_thread_unlock_mutex(&loader_preload_icd_lock);
+
+                loader_unload_scanned_icd(inst, scanned_icd_to_remove);
+            }
+
+            if (NULL == prev_icd_term) {
+                inst->icd_terms = next_icd_term;
+            } else {
+                prev_icd_term->next = next_icd_term;
+            }
+        } else {
+            prev_icd_term = cur_icd_term;
+        }
+        cur_icd_term = next_icd_term;
+    }
 }
 
 VkResult setup_loader_tramp_phys_dev_groups(struct loader_instance *inst, uint32_t group_count,
@@ -6662,7 +6737,7 @@ terminator_EnumerateInstanceExtensionProperties(const VkEnumerateInstanceExtensi
         }
     } else {
         // Preload ICD libraries so subsequent calls to EnumerateInstanceExtensionProperties don't have to load them
-        loader_preload_icds();
+        // loader_preload_icds();
 
         // Scan/discover all ICD libraries
         res = loader_icd_scan(NULL, &icd_tramp_list, NULL, NULL);
@@ -6675,7 +6750,7 @@ terminator_EnumerateInstanceExtensionProperties(const VkEnumerateInstanceExtensi
         if (VK_SUCCESS != res) {
             goto out;
         }
-        loader_scanned_icd_clear(NULL, &icd_tramp_list);
+        loader_clear_scanned_icd_list(NULL, &icd_tramp_list);
 
         // Append enabled implicit layers.
         res = loader_scan_for_implicit_layers(NULL, &instance_layers, &layer_filters);

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -325,10 +325,8 @@ void free_string_list(const struct loader_instance *inst, struct loader_string_l
             string_list->list[i] = NULL;
         }
         loader_instance_heap_free(inst, string_list->list);
-        string_list->list = NULL;
     }
-    string_list->count = 0;
-    string_list->allocated_count = 0;
+    memset(string_list, 0, sizeof(struct loader_string_list));
 }
 
 // Given string of three part form "maj.min.pat" convert to a vulkan version number.
@@ -503,6 +501,7 @@ void loader_delete_layer_list_and_properties(const struct loader_instance *inst,
         layer_list->capacity = 0;
         loader_instance_heap_free(inst, layer_list->list);
     }
+    memset(layer_list, 0, sizeof(struct loader_layer_list));
 }
 
 void loader_remove_layer_in_list(const struct loader_instance *inst, struct loader_layer_list *layer_list,
@@ -715,9 +714,7 @@ VkResult loader_init_generic_list(const struct loader_instance *inst, struct loa
 
 void loader_destroy_generic_list(const struct loader_instance *inst, struct loader_generic_list *list) {
     loader_instance_heap_free(inst, list->list);
-    list->count = 0;
-    list->capacity = 0;
-    list->list = NULL;
+    memset(list, 0, sizeof(struct loader_generic_list));
 }
 
 // Append non-duplicate extension properties defined in props to the given ext_list.
@@ -837,9 +834,7 @@ bool loader_names_array_has_layer_property(const VkLayerProperties *vk_layer_pro
 
 void loader_destroy_pointer_layer_list(const struct loader_instance *inst, struct loader_pointer_layer_list *layer_list) {
     loader_instance_heap_free(inst, layer_list->list);
-    layer_list->count = 0;
-    layer_list->capacity = 0;
-    layer_list->list = NULL;
+    memset(layer_list, 0, sizeof(struct loader_pointer_layer_list));
 }
 
 // Append layer properties defined in prop_list to the given layer_info list
@@ -1349,16 +1344,9 @@ void loader_unload_scanned_icd(struct loader_instance *inst, struct loader_scann
     }
     if (scanned_icd->handle) {
         loader_platform_close_library(scanned_icd->handle);
-        scanned_icd->handle = NULL;
     }
     loader_instance_heap_free(inst, scanned_icd->lib_name);
-    scanned_icd->lib_name = NULL;
-    scanned_icd->CreateInstance = NULL;
-    scanned_icd->EnumerateInstanceExtensionProperties = NULL;
-    scanned_icd->GetInstanceProcAddr = NULL;
-    scanned_icd->GetPhysicalDeviceProcAddr = NULL;
-    scanned_icd->api_version = 0;
-    scanned_icd->interface_version = 0;
+    memset(scanned_icd, 0, sizeof(struct loader_scanned_icd));
 }
 
 // Determine the ICD interface version to use.
@@ -1406,9 +1394,7 @@ void loader_clear_scanned_icd_list(const struct loader_instance *inst, struct lo
         }
         loader_instance_heap_free(inst, icd_tramp_list->scanned_list);
     }
-    icd_tramp_list->capacity = 0;
-    icd_tramp_list->count = 0;
-    icd_tramp_list->scanned_list = NULL;
+    memset(icd_tramp_list, 0, sizeof(struct loader_icd_tramp_list));
 }
 
 VkResult loader_init_scanned_icd_list(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list) {

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -149,8 +149,8 @@ void loader_destroy_pointer_layer_list(const struct loader_instance *inst, struc
 void loader_delete_layer_list_and_properties(const struct loader_instance *inst, struct loader_layer_list *layer_list);
 void loader_remove_layer_in_list(const struct loader_instance *inst, struct loader_layer_list *layer_list,
                                  uint32_t layer_to_remove);
-VkResult loader_scanned_icd_init(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
-void loader_scanned_icd_clear(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
+VkResult loader_init_scanned_icd_list(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
+void loader_clear_scanned_icd_list(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list);
 VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_tramp_list *icd_tramp_list,
                          const VkInstanceCreateInfo *pCreateInfo, bool *skipped_portability_drivers);
 void loader_icd_destroy(struct loader_instance *ptr_inst, struct loader_icd_term *icd_term,
@@ -199,6 +199,7 @@ VkResult loader_validate_device_extensions(struct loader_instance *this_instance
 VkResult setup_loader_tramp_phys_devs(struct loader_instance *inst, uint32_t phys_dev_count, VkPhysicalDevice *phys_devs);
 VkResult setup_loader_tramp_phys_dev_groups(struct loader_instance *inst, uint32_t group_count,
                                             VkPhysicalDeviceGroupProperties *groups);
+void unload_drivers_without_physical_devices(struct loader_instance *inst);
 
 VkStringErrorFlags vk_string_validate(const int max_length, const char *char_array);
 char *loader_get_next_path(char *path);

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -404,8 +404,8 @@ struct loader_physical_device_term {
 };
 
 #if defined(LOADER_ENABLE_LINUX_SORT)
-// Structure for storing the relevent device information for selecting a device.
-// NOTE: Needs to be defined here so we can store this content in the term structrue
+// Structure for storing the relevant device information for selecting a device.
+// NOTE: Needs to be defined here so we can store this content in the term structure
 //       for quicker sorting.
 struct LinuxSortedDeviceInfo {
     // Associated Vulkan Physical Device

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -229,6 +229,8 @@ struct loader_icd_term {
 
     PFN_PhysDevExt phys_dev_ext[MAX_NUM_UNKNOWN_EXTS];
     bool supports_get_dev_prop_2;
+
+    uint32_t physical_device_count;
 };
 
 // Per ICD library structure

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -46,7 +46,7 @@
 #include <winternl.h>
 #include <strsafe.h>
 #if defined(__MINGW32__)
-#undef strcpy  // fix error with redfined strcpy when building with MinGW-w64
+#undef strcpy  // fix error with redefined strcpy when building with MinGW-w64
 #endif
 #include <dxgi1_6.h>
 #include "adapters.h"
@@ -688,7 +688,7 @@ VkResult windows_read_manifest_from_d3d_adapters(const struct loader_instance *i
                 goto out;
             }
 
-            // If this is a string and not a multi-string, we don't want to go throught the loop more than once
+            // If this is a string and not a multi-string, we don't want to go through the loop more than once
             if (full_info->value_type == REG_SZ) {
                 break;
             }
@@ -865,7 +865,7 @@ VkResult enumerate_adapter_physical_devices(struct loader_instance *inst, struct
     return VK_SUCCESS;
 }
 
-// Whenever there are multiple drivers for the same hardware and one of the drivers is an implementation layered ontop of another
+// Whenever there are multiple drivers for the same hardware and one of the drivers is an implementation layered on top of another
 // API (such as the Dozen driver which converts vulkan to Dx12), we want to make sure the layered driver appears after the 'native'
 // driver. This function iterates over all physical devices and make sure any with matching LUID's are sorted such that drivers with
 // a underlyingAPI of VK_LAYERED_DRIVER_UNDERLYING_API_D3D12_MSFT are ordered after drivers without it.

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -37,9 +37,8 @@ loader_settings global_loader_settings;
 
 void free_layer_configuration(const struct loader_instance* inst, loader_settings_layer_configuration* layer_configuration) {
     loader_instance_heap_free(inst, layer_configuration->name);
-    layer_configuration->name = NULL;
     loader_instance_heap_free(inst, layer_configuration->path);
-    layer_configuration->path = NULL;
+    memset(layer_configuration, 0, sizeof(loader_settings_layer_configuration));
 }
 
 void free_loader_settings(const struct loader_instance* inst, loader_settings* settings) {
@@ -50,7 +49,6 @@ void free_loader_settings(const struct loader_instance* inst, loader_settings* s
     }
     loader_instance_heap_free(inst, settings->layer_configurations);
     loader_instance_heap_free(inst, settings->settings_file_path);
-    settings->layer_configurations = NULL;
     memset(settings, 0, sizeof(loader_settings));
 }
 

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -333,7 +333,7 @@ VkResult get_loader_settings(const struct loader_instance* inst, loader_settings
 
     // Corresponds to the settings object that has no app keys
     int global_settings_index = -1;
-    // Corresponds to the settings object which has a matchign app key
+    // Corresponds to the settings object which has a matching app key
     int index_to_use = -1;
 
     char current_process_path[1024];
@@ -547,7 +547,7 @@ VkResult get_settings_layers(const struct loader_instance* inst, struct loader_l
         }
 
         // The special layer location that indicates where unordered layers should go only should have the
-        // settings_control_value set - everythign else should be NULL
+        // settings_control_value set - everything else should be NULL
         if (layer_config->control == LOADER_SETTINGS_LAYER_UNORDERED_LAYER_LOCATION) {
             struct loader_layer_properties props = {0};
             props.settings_control_value = LOADER_SETTINGS_LAYER_UNORDERED_LAYER_LOCATION;

--- a/loader/settings.h
+++ b/loader/settings.h
@@ -48,7 +48,7 @@ typedef enum loader_settings_layer_control {
 } loader_settings_layer_control;
 
 // If a loader_settings_layer_configuration has a name of loader_settings_unknown_layers_location, then it specifies that the
-// layer configuation it was found in shall be the location all layers not listed in the settings file that are enabled.
+// layer configuration it was found in shall be the location all layers not listed in the settings file that are enabled.
 #define LOADER_SETTINGS_UNKNOWN_LAYERS_LOCATION "loader_settings_unknown_layers_location"
 
 #define LOADER_SETTINGS_MAX_NAME_SIZE 256U;
@@ -73,7 +73,7 @@ typedef struct loader_settings {
 } loader_settings;
 
 // Call this function to get the current settings that the loader should use.
-// It will open up the current loader settings file and return a loader_settigns in out_loader_settings if it.
+// It will open up the current loader settings file and return a loader_settings in out_loader_settings if it.
 // It should be called on every call to the global functions excluding vkGetInstanceProcAddr
 // Caller is responsible for cleaning up by calling free_loader_settings()
 VkResult get_loader_settings(const struct loader_instance* inst, loader_settings* out_loader_settings);

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -764,7 +764,7 @@ out:
             loader_destroy_pointer_layer_list(ptr_instance, &ptr_instance->app_activated_layer_list);
 
             loader_delete_layer_list_and_properties(ptr_instance, &ptr_instance->instance_layer_list);
-            loader_scanned_icd_clear(ptr_instance, &ptr_instance->icd_tramp_list);
+            loader_clear_scanned_icd_list(ptr_instance, &ptr_instance->icd_tramp_list);
             loader_destroy_generic_list(ptr_instance, (struct loader_generic_list *)&ptr_instance->ext_list);
 
             // Free any icd_terms that were created.
@@ -886,11 +886,15 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumeratePhysicalDevices(VkInstan
         if (VK_SUCCESS != update_res) {
             res = update_res;
         }
+
+        // Unloads any drivers that do not expose any physical devices - should save some address space
+        unload_drivers_without_physical_devices(inst);
     }
 
 out:
 
     loader_platform_thread_unlock_mutex(&loader_lock);
+
     return res;
 }
 

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -343,7 +343,7 @@ static inline char *loader_platform_executable_path(char *buffer, size_t size) {
 }
 #endif  // defined (__QNX__)
 
-// Compatability with compilers that don't support __has_feature
+// Compatibility with compilers that don't support __has_feature
 #if !defined(__has_feature)
 #define __has_feature(x) 0
 #endif

--- a/tests/live_verification/CMakeLists.txt
+++ b/tests/live_verification/CMakeLists.txt
@@ -30,3 +30,6 @@ if(APPLE AND BUILD_STATIC_LOADER)
         target_link_options(macos_static_loader_build PUBLIC -fsanitize=thread)
     endif()
 endif()
+
+add_executable(time_dynamic_loading time_dynamic_loading.cpp)
+target_link_libraries(time_dynamic_loading Vulkan::Headers vulkan)

--- a/tests/live_verification/time_dynamic_loading.cpp
+++ b/tests/live_verification/time_dynamic_loading.cpp
@@ -30,26 +30,45 @@
 #include <chrono>
 #include <iostream>
 #include <vector>
+#include <string>
+#include <iomanip>
+#include <thread>
 
 int main() {
-    uint32_t iterations = 20;
-    std::vector<std::chrono::milliseconds> samples;
-    samples.resize(iterations);
-    for (uint32_t i = 0; i < iterations; i++) {
-        auto t1 = std::chrono::system_clock::now();
-        uint32_t count = 0;
-        vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr);
-        // vkEnumerateInstanceLayerProperties(&count, nullptr);
-        // vkEnumerateInstanceVersion(&count);
-        auto t2 = std::chrono::system_clock::now();
-        samples[i] = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
-    }
-    std::chrono::milliseconds total_time{};
-    for (uint32_t i = 0; i < iterations; i++) {
-        total_time += samples[i];
-    }
-    std::cout << "average time " << total_time.count() / iterations << "ms\n";
-    std::cout << "first call time " << samples[0].count() << "ms\n";
-    std::cout << "second call time " << samples[1].count() << "ms\n";
-    std::cout << "last call time " << samples[iterations - 1].count() << "ms\n";
+    // uint32_t iterations = 20;
+    // std::vector<std::chrono::microseconds> samples;
+    // samples.resize(iterations);
+    // for (uint32_t i = 0; i < iterations; i++) {
+    //     auto t1 = std::chrono::system_clock::now();
+    //     uint32_t count = 0;
+    //     vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr);
+    //     // vkEnumerateInstanceLayerProperties(&count, nullptr);
+    //     // vkEnumerateInstanceVersion(&count);
+    //     auto t2 = std::chrono::system_clock::now();
+    //     samples[i] = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1);
+    // }
+    // std::chrono::microseconds total_time{};
+    // for (uint32_t i = 0; i < iterations; i++) {
+    //     total_time += samples[i];
+    // }
+    // std::cout << "average time " << total_time.count() / iterations << " (μs)\n";
+    // std::cout << std::setw(10) << "Iteration" << std::setw(12) << " Time (μs)\n";
+    // for (uint32_t i = 0; i < iterations; i++) {
+    //     std::cout << std::setw(10) << std::to_string(i) << std::setw(12) << samples[i].count() << "\n";
+    // }
+
+    uint32_t count = 0;
+    VkInstanceCreateInfo ci{};
+    VkInstance i{};
+    auto res = vkCreateInstance(&ci, nullptr, &i);
+    if (res != VK_SUCCESS) return -1;
+    std::cout << "After called vkCreateInstance\n";
+    do {
+        std::cout << '\n' << "Press a key to continue...";
+    } while (std::cin.get() != '\n');
+    vkDestroyInstance(i, nullptr);
+    std::cout << "After called vkDestroyInstance\n";
+    do {
+        std::cout << '\n' << "Press a key to continue...";
+    } while (std::cin.get() != '\n');
 }

--- a/tests/live_verification/time_dynamic_loading.cpp
+++ b/tests/live_verification/time_dynamic_loading.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and/or associated documentation files (the "Materials"), to
+ * deal in the Materials without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Materials, and to permit persons to whom the Materials are
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice(s) and this permission notice shall be included in
+ * all copies or substantial portions of the Materials.
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE
+ * USE OR OTHER DEALINGS IN THE MATERIALS.
+ *
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+#include <vulkan/vulkan.h>
+
+#include <chrono>
+#include <iostream>
+#include <vector>
+
+int main() {
+    uint32_t iterations = 20;
+    std::vector<std::chrono::milliseconds> samples;
+    samples.resize(iterations);
+    for (uint32_t i = 0; i < iterations; i++) {
+        auto t1 = std::chrono::system_clock::now();
+        uint32_t count = 0;
+        vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr);
+        // vkEnumerateInstanceLayerProperties(&count, nullptr);
+        // vkEnumerateInstanceVersion(&count);
+        auto t2 = std::chrono::system_clock::now();
+        samples[i] = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
+    }
+    std::chrono::milliseconds total_time{};
+    for (uint32_t i = 0; i < iterations; i++) {
+        total_time += samples[i];
+    }
+    std::cout << "average time " << total_time.count() / iterations << "ms\n";
+    std::cout << "first call time " << samples[0].count() << "ms\n";
+    std::cout << "second call time " << samples[1].count() << "ms\n";
+    std::cout << "last call time " << samples[iterations - 1].count() << "ms\n";
+}

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -4369,3 +4369,130 @@ TEST(EnumerateAdapterPhysicalDevices, SameAdapterLUID_same_order) {
     EXPECT_EQ(layered_driver_properties_msft.underlyingAPI, VK_LAYERED_DRIVER_UNDERLYING_API_NONE_MSFT);
 }
 #endif  // defined(WIN32)
+
+void try_create_swapchain(DeviceWrapper& dev, VkSurfaceKHR& surface) {
+    PFN_vkCreateSwapchainKHR CreateSwapchainKHR = dev.load("vkCreateSwapchainKHR");
+    PFN_vkGetSwapchainImagesKHR GetSwapchainImagesKHR = dev.load("vkGetSwapchainImagesKHR");
+    PFN_vkDestroySwapchainKHR DestroySwapchainKHR = dev.load("vkDestroySwapchainKHR");
+    ASSERT_TRUE(nullptr != CreateSwapchainKHR);
+    ASSERT_TRUE(nullptr != GetSwapchainImagesKHR);
+    ASSERT_TRUE(nullptr != DestroySwapchainKHR);
+
+    VkSwapchainKHR swapchain{};
+    VkSwapchainCreateInfoKHR swap_create_info{};
+    swap_create_info.surface = surface;
+
+    ASSERT_EQ(VK_SUCCESS, CreateSwapchainKHR(dev, &swap_create_info, nullptr, &swapchain));
+    uint32_t count = 0;
+    ASSERT_EQ(VK_SUCCESS, GetSwapchainImagesKHR(dev, swapchain, &count, nullptr));
+    ASSERT_GT(count, 0U);
+    std::array<VkImage, 16> images;
+    ASSERT_EQ(VK_SUCCESS, GetSwapchainImagesKHR(dev, swapchain, &count, images.data()));
+    DestroySwapchainKHR(dev, swapchain, nullptr);
+}
+
+TEST(DriverUnloadingFromZeroPhysDevs, InterspersedThroughout) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+        .setup_WSI()
+        .add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain").finish());
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+        .setup_WSI()
+        .add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain").finish());
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.setup_WSI();
+    inst.CheckCreate();
+
+    auto phys_devs = inst.GetPhysDevs();
+    VkSurfaceKHR surface{};
+    create_surface(inst, surface);
+    for (const auto& phys_dev : phys_devs) {
+        DeviceWrapper dev{inst};
+        dev.create_info.add_extension("VK_KHR_swapchain");
+        dev.CheckCreate(phys_dev);
+
+        try_create_swapchain(dev, surface);
+    }
+    env.vulkan_functions.vkDestroySurfaceKHR(inst.inst, surface, nullptr);
+}
+
+TEST(DriverUnloadingFromZeroPhysDevs, InMiddleOfList) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+        .setup_WSI()
+        .add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain").finish());
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+        .setup_WSI()
+        .add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain").finish());
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.setup_WSI();
+    inst.CheckCreate();
+
+    auto phys_devs = inst.GetPhysDevs();
+    VkSurfaceKHR surface{};
+    create_surface(inst, surface);
+    for (const auto& phys_dev : phys_devs) {
+        DeviceWrapper dev{inst};
+        dev.create_info.add_extension("VK_KHR_swapchain");
+        dev.CheckCreate(phys_dev);
+
+        try_create_swapchain(dev, surface);
+    }
+    env.vulkan_functions.vkDestroySurfaceKHR(inst.inst, surface, nullptr);
+}
+
+TEST(DriverUnloadingFromZeroPhysDevs, AtFrontAndBack) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+        .setup_WSI()
+        .add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain").finish());
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+        .setup_WSI()
+        .add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain").finish());
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.setup_WSI();
+    inst.CheckCreate();
+
+    auto phys_devs = inst.GetPhysDevs();
+    VkSurfaceKHR surface{};
+    create_surface(inst, surface);
+    for (const auto& phys_dev : phys_devs) {
+        DeviceWrapper dev{inst};
+        dev.create_info.add_extension("VK_KHR_swapchain");
+        dev.CheckCreate(phys_dev);
+
+        try_create_swapchain(dev, surface);
+    }
+    env.vulkan_functions.vkDestroySurfaceKHR(inst.inst, surface, nullptr);
+}
+
+TEST(DriverUnloadingFromZeroPhysDevs, NoPhysicaldevices) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).setup_WSI();
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.setup_WSI();
+    inst.CheckCreate();
+    // No physical devices == VK_ERROR_INITIALIZATION_FAILED
+    inst.GetPhysDevs(VK_ERROR_INITIALIZATION_FAILED);
+
+    VkSurfaceKHR surface{};
+    create_surface(inst, surface);
+
+    env.vulkan_functions.vkDestroySurfaceKHR(inst.inst, surface, nullptr);
+}


### PR DESCRIPTION
The loader did not unload any ICD's which contained zero physical devices, which
could cause premature exhaustion of memory in some circumstances, like 32 bit
applications. While the policy of the loader has been to keep things open for
the duration of the instance, these ICD's don't meaningfully participate in
anything due to the lack of VkPhysicalDevices.

This change adds a check after vkEnumeratePhysicalDevices where pPhysicalDevices
is not NULL such that all loader_icd_terms which reported zero physical devices
have its vkDestroyInstance called, and removed from the loader_instance's
icd_term linked list.

Fixes #1338 