### PR TITLE
Fix settings file crash found through fuzzers

### DIFF
--- a/tests/framework/data/fuzzer_output.json
+++ b/tests/framework/data/fuzzer_output.json
@@ -1,0 +1,125 @@
+{
+    "file_format_version": "1.2.0",
+    "settings_array": [
+        {
+            "device_e": [
+                "/out/settings_fuzzer",
+                "/work/settings_fuzzer"
+            ],
+            "stderr_log": [
+                "all",
+                "info",
+                "warn",
+                "perf",
+                "error",
+                "debug",
+                "layer",
+                "driver",
+                "validation"
+            ],
+            "log_locations": [
+                {
+                    "destinations": [
+                        "/tmp"
+                    ],
+                    "filters": [
+                        "all"
+                    ]
+                }
+            ],
+            "layers": [
+                {
+                    "control": "auto",
+                    "name": "test_auto",
+                    "path": "test",
+                    "treat_as_implicit_manifest": true
+                },
+                {
+                    "control": "on",
+                    "tame": "test_on",
+                    "path": "test",
+                    "treat_as_implicit_manifeÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿst": true
+                },
+                {
+                    "control": "off",
+                    "name": "test_off",
+                    "path": "test",
+                    "treat_as_implicit_manifest": true
+                }
+            ]
+        },
+        {
+            "app_keys": [
+                "val1",
+                "val0",
+                "val3",
+                "val4"
+            ]
+        }
+    ],
+    "layers": [
+        {
+            "name": "VK_LAYER_test_layer_1",
+            "type": "INSTANCE",
+            "api_version": "1.3.231",
+            "implementation_version": "1",
+            "description": "Test layer 1",
+            "library_path": "libVkLayer_khronos_validation.so",
+            "component_layers": [
+                "VK_LAYER_test_layer_1",
+                "VK_LAYER_test_layer_2"
+            ],
+            "disable_environment": {
+                "test_key": "test_value"
+            },
+            "enbale_environment": {
+                "test_key": "test_value"
+            },
+            "app_keys": [
+                "/out/settings_fuzzer"
+            ]
+        },
+        {
+            "name": "VK_LAYER_test_layer_2",
+            "type": "GLOBAL",
+            "api_version": "1.3.231",
+            "implementation_version": "1",
+            "description": "Test layer 2",
+            "library_path": "libVkLayer_khronos_validation.so",
+            "component_*layers": [
+                "VK_LAYER_test_layer_1",
+                "VK_LAYER_test_layer_2"
+            ],
+            "disable_environment": {
+                "test_key": "test_value"
+            },
+            "enable_environment": {
+                "test_key": "test_value"
+            },
+            "app_keys": [
+                "/out/settings_fuzzer"
+            ]
+        },
+        {
+            "name": "VK_LAYER_KHRONOS_validation",
+            "type": "GLOBAL",
+            "api_version": "0.3.231",
+            "implementation_version": "1",
+            "description": "Khronos validation",
+            "library_path": "libVkLayer_khronos_validation.so",
+            "disable_environment": {
+                "test_key": "test_value"
+            },
+            "enable_environment": {
+                "test_key": "test_value"
+            },
+            "app_keys": [
+                "/out/settings_fuzzer"
+            ]
+        }
+    ],
+    "ICD": {
+        "library_path": "scuvrl//kan-loader/tests/framework/data/binaries/libdummy with error 386.so",
+        "api_version": "1.3.231"
+    }
+}

--- a/tests/framework/framework_config.h.in
+++ b/tests/framework/framework_config.h.in
@@ -69,6 +69,7 @@
 #define TEST_LAYER_WRAP_OBJECTS_3 "$<TARGET_FILE:test_layer_wrap_objects_3>"
 
 #define COMPLEX_JSON_FILE "${CMAKE_CURRENT_SOURCE_DIR}/data/VkLayer_complex_file.json"
+#define FUZZER_OUTPUT_JSON_FILE "${CMAKE_CURRENT_SOURCE_DIR}/data/fuzzer_output.json"
 
 // Dummy Binaries
 #if _WIN32 || _WIN64

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -507,6 +507,16 @@ TEST(SettingsFile, InvalidSettingsFile) {
         ASSERT_TRUE(string_eq(layers.at(1).layerName, explicit_layer_name));
     };
 
+    {
+        std::fstream fuzzer_output_json_file{FUZZER_OUTPUT_JSON_FILE, std::ios_base::in};
+        ASSERT_TRUE(fuzzer_output_json_file.is_open());
+        std::stringstream fuzzer_output_json;
+        fuzzer_output_json << fuzzer_output_json_file.rdbuf();
+        env.write_settings_file(fuzzer_output_json.str());
+
+        check_integrity();
+    }
+
     // No actual settings
     {
         JsonWriter writer{};


### PR DESCRIPTION
A few error conditions weren't properly handled whenever the settings file is invalid. Added the exact json file which caused the errors, then fixed issues with releasing memory properly.