### PR TITLE
Warn if apiVersion is below VK_API_VERSION_1_0 and above 0

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -595,6 +595,15 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         log_settings(ptr_instance, &ptr_instance->settings);
     }
 
+    // Providing an apiVersion less than VK_API_VERSION_1_0 but greater than zero prevents the validation layers from starting
+    if (pCreateInfo->pApplicationInfo && pCreateInfo->pApplicationInfo->apiVersion < VK_API_VERSION_1_0) {
+        loader_log(ptr_instance, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT, 0,
+                   "VkInstanceCreateInfo::pApplicationInfo::apiVersion has value of %u which is not permitted. If apiVersion is "
+                   "not 0, then it must be "
+                   "greater than or equal to the value of VK_API_VERSION_1_0 [VUID-VkApplicationInfo-apiVersion]",
+                   pCreateInfo->pApplicationInfo->apiVersion);
+    }
+
     // Check the VkInstanceCreateInfoFlags wether to allow the portability enumeration flag
     if ((pCreateInfo->flags & VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR) == 1) {
         ptr_instance->portability_enumeration_flag_bit_set = true;

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -125,6 +125,21 @@ TEST(CreateInstance, RelativePaths) {
     ASSERT_TRUE(string_eq(layers.at(0).layerName, layer_name));
 }
 
+TEST(CreateInstance, ApiVersionBelow1_0) {
+    FrameworkEnvironment env{};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_min_icd_interface_version(5);
+
+    DebugUtilsLogger debug_log{VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT};
+    InstWrapper inst{env.vulkan_functions};
+    FillDebugUtilsCreateDetails(inst.create_info, debug_log);
+    inst.create_info.api_version = 1;
+    inst.CheckCreate();
+    ASSERT_TRUE(
+        debug_log.find("VkInstanceCreateInfo::pApplicationInfo::apiVersion has value of 1 which is not permitted. If apiVersion is "
+                       "not 0, then it must be "
+                       "greater than or equal to the value of VK_API_VERSION_1_0 [VUID-VkApplicationInfo-apiVersion]"));
+}
+
 TEST(CreateInstance, ConsecutiveCreate) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));


### PR DESCRIPTION
Setting the apiVersion to an invalid value is an easy mistake to make. But because it causes drivers to fail, the validation layers can not catch it in time.

This commit makes it a 'fatal error' which forces log_message to write out the message, regardless of whether or not VK_LOADER_DEBUG is set or if the application has setup a debug callback in the pNext chain.