### PR TITLE
Instance extensions unsupported by physical devices now return ERROR_EXTENSION_NOT_PRESENT

### DIFF
--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -7200,7 +7200,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_AcquireDrmDisplayEXT(
     if (NULL == icd_term->dispatch.AcquireDrmDisplayEXT) {
         loader_log(icd_term->this_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD associated with VkPhysicalDevice does not support AcquireDrmDisplayEXT");
-        return VK_ERROR_INITIALIZATION_FAILED;
+        return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
     return icd_term->dispatch.AcquireDrmDisplayEXT(phys_dev_term->phys_dev, drmFd, display);
 }
@@ -7232,7 +7232,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDrmDisplayEXT(
     if (NULL == icd_term->dispatch.GetDrmDisplayEXT) {
         loader_log(icd_term->this_instance, VULKAN_LOADER_ERROR_BIT, 0,
                    "ICD associated with VkPhysicalDevice does not support GetDrmDisplayEXT");
-        return VK_ERROR_INITIALIZATION_FAILED;
+        return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
     return icd_term->dispatch.GetDrmDisplayEXT(phys_dev_term->phys_dev, drmFd, connectorId, display);
 }

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -1199,7 +1199,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     # If this is an instance function taking a physical device (i.e. pre Vulkan 1.1), we need to behave and not crash so return an
                     # error here.
                     if ext_cmd.ext_type =='instance' and has_return_type:
-                        funcs += '        return VK_ERROR_INITIALIZATION_FAILED;\n'
+                        funcs += '        return VK_ERROR_EXTENSION_NOT_PRESENT;\n'
                     else:
                         funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
                     funcs += '    }\n'

--- a/tests/loader_phys_dev_inst_ext_tests.cpp
+++ b/tests/loader_phys_dev_inst_ext_tests.cpp
@@ -5667,7 +5667,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTMixed) {
                     if (icd == 1) {
                         // For this extension, if no support exists (like for ICD 1), the value of 0 should be returned by the
                         // loader.
-                        ASSERT_EQ(VK_ERROR_INITIALIZATION_FAILED, AcquireDrmDisplayEXT(physical_devices[dev], 0, display));
+                        ASSERT_EQ(VK_ERROR_EXTENSION_NOT_PRESENT, AcquireDrmDisplayEXT(physical_devices[dev], 0, display));
                     } else {
                         ASSERT_EQ(VK_SUCCESS, AcquireDrmDisplayEXT(physical_devices[dev], 0, display));
                     }
@@ -5820,7 +5820,7 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTMixed) {
                     if (icd == 1) {
                         // For this extension, if no support exists (like for ICD 1), the value of 0 should be returned by the
                         // loader.
-                        ASSERT_EQ(VK_ERROR_INITIALIZATION_FAILED, GetDrmDisplayEXT(physical_devices[dev], 0, 0, &display));
+                        ASSERT_EQ(VK_ERROR_EXTENSION_NOT_PRESENT, GetDrmDisplayEXT(physical_devices[dev], 0, 0, &display));
                     } else {
                         ASSERT_EQ(VK_SUCCESS, GetDrmDisplayEXT(physical_devices[dev], 0, 0, &display));
                         ASSERT_EQ(display, cur_dev.displays[0]);


### PR DESCRIPTION
This is makes the code gen for VK_EXT_acquire_drm_display be in line with the wsi code whenever calls to drivers are made which do not support the given extension.