### PR TITLE
Support Clang with GNU interface on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ option(ENABLE_WERROR "Enable warnings as errors" ON)
 # Set warnings as errors and the main diagnostic flags
 # Must be set first so the warning silencing later on works properly
 # Note that clang-cl.exe should use MSVC flavor flags, not GNU
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC"))
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))
     if (ENABLE_WERROR)
         target_compile_options(loader_common_options INTERFACE /WX)
     endif()
@@ -182,7 +182,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang
     target_compile_options(loader_common_options INTERFACE -Wpointer-arith)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC"))
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))
     # /sdl: Enable additional security checks
     # /GR-: Disable RTTI
     # /guard:cf: Enable control flow guard

--- a/tests/framework/shim/windows_shim.cpp
+++ b/tests/framework/shim/windows_shim.cpp
@@ -370,7 +370,12 @@ LONG WINAPI ShimGetPackagesByPackageFamily(_In_ PCWSTR packageFamilyName, _Inout
         *bufferLength = ARRAYSIZE(package_full_name);
         if (too_small) return ERROR_INSUFFICIENT_BUFFER;
 
-        wcscpy(buffer, package_full_name);
+        for (size_t i = 0; i < sizeof(package_full_name) / sizeof(wchar_t); i++) {
+            if (i >= *bufferLength) {
+                break;
+            }
+            buffer[i] = package_full_name[i];
+        }
         *packageFullNames = buffer;
         return 0;
     }
@@ -391,7 +396,12 @@ LONG WINAPI ShimGetPackagePathByFullName(_In_ PCWSTR packageFullName, _Inout_ UI
         *pathLength = static_cast<UINT32>(platform_shim.app_package_path.size() + 1);
         return ERROR_INSUFFICIENT_BUFFER;
     }
-    wcscpy(path, platform_shim.app_package_path.c_str());
+    for (size_t i = 0; i < platform_shim.app_package_path.length(); i++) {
+        if (i >= *pathLength) {
+            break;
+        }
+        path[i] = platform_shim.app_package_path.c_str()[i];
+    }
     return 0;
 }
 


### PR DESCRIPTION
By using CMAKE_CXX_COMPILER_FRONTEND_VARIANT, CMake will now distinguish clang from clang-cl, allowing the correct command line argument formats to be used.

Making tests work required fixing up windows_shim.cpp's usage of wcscpy since that was triggering deprecation warnings. A simple for loop was used instead.

Fixes #1402 