### PR TITLE
Fix version installation of vulkan-loader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,6 +338,7 @@ jobs:
             - name: Generate build files
               run: cmake -S. -B build -D CMAKE_BUILD_TYPE=${{matrix.config}} -D ${{matrix.static_build}} -D BUILD_TESTS=ON -D UPDATE_DEPS=ON -D ENABLE_WERROR=ON -D LOADER_ENABLE_ADDRESS_SANITIZER=ON -G "Ninja"
               env:
+                # Prevents regression of KhronosGroup/Vulkan-Loader/issues/1332
                 LDFLAGS: -Wl,-fatal_warnings
 
             - run: cmake --build build

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -378,7 +378,7 @@ else()
 
     set_target_properties(vulkan PROPERTIES
         SOVERSION "1"
-        VERSION ${VULKAN_LOADER_VERSION}
+        VERSION "${VULKAN_LOADER_VERSION}"
     )
 
     target_link_libraries(vulkan PRIVATE ${CMAKE_DL_LIBS} m Threads::Threads)
@@ -420,13 +420,6 @@ else()
             target_compile_definitions(vulkan-framework PRIVATE MODIFY_UNKNOWN_FUNCTION_DECLS)
         endif()
 
-        # Workaround linker warning: https://github.com/KhronosGroup/Vulkan-Loader/issues/1332
-        set(APPLE_VULKAN_LOADER_VERSION "${VULKAN_LOADER_VERSION_MAJOR}.${VULKAN_LOADER_VERSION_MINOR}.0")
-
-        message(STATUS "APPLE_VULKAN_LOADER_VERSION = ${APPLE_VULKAN_LOADER_VERSION}")
-
-        set_target_properties(vulkan PROPERTIES VERSION ${APPLE_VULKAN_LOADER_VERSION})
-
         # The FRAMEWORK_VERSION needs to be "A" here so that Xcode code-signing works when a user adds their framework to an Xcode
         # project and does "Sign on Copy". It would have been nicer to use "1" to denote Vulkan 1. Although Apple docs say that a
         # framework version does not have to be "A", this part of the Apple toolchain expects it.
@@ -436,11 +429,20 @@ else()
             OUTPUT_NAME vulkan
             FRAMEWORK TRUE
             FRAMEWORK_VERSION A
-            VERSION "${APPLE_VULKAN_LOADER_VERSION}"
+            VERSION "${VULKAN_LOADER_VERSION}"
             SOVERSION "1.0.0"
             MACOSX_FRAMEWORK_IDENTIFIER com.lunarg.vulkanFramework
             PUBLIC_HEADER "${FRAMEWORK_HEADERS}"
         )
+
+        # Workaround linker warning: https://github.com/KhronosGroup/Vulkan-Loader/issues/1332
+        #
+        # MACHO_CURRENT_VERSION specifically applies to the -current_version linker option which is the
+        # linker warning we are trying to address.
+        set(APPLE_VULKAN_LOADER_VERSION "${VULKAN_LOADER_VERSION_MAJOR}.${VULKAN_LOADER_VERSION_MINOR}.0")
+        set_target_properties(vulkan PROPERTIES MACHO_CURRENT_VERSION "${APPLE_VULKAN_LOADER_VERSION}")
+        set_target_properties(vulkan-framework PROPERTIES MACHO_CURRENT_VERSION "${APPLE_VULKAN_LOADER_VERSION}")
+
         install(TARGETS vulkan-framework
             PUBLIC_HEADER DESTINATION vulkan
             FRAMEWORK DESTINATION loader


### PR DESCRIPTION
Currently libvulkan.1.3.0.dylib gets installed instead of libvulkan.1.3.273.dylib

This fixes that while keeping the fix for the linker warning.