### PR TITLE
Only require C compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,9 @@
 # ~~~
 cmake_minimum_required(VERSION 3.17.2)
 
-project(VULKAN_LOADER VERSION 1.3.274)
+project(VULKAN_LOADER VERSION 1.3.274 LANGUAGES C)
 
 add_subdirectory(scripts)
-
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
 
 # By default, loader & tests are built without sanitizers
 # Use these options to force a specific sanitizer on the loader and test executables
@@ -74,11 +71,6 @@ if(UNIX)
     set(SYSCONFDIR "" CACHE STRING
             "System-wide search directory. If not set or empty, CMAKE_INSTALL_FULL_SYSCONFDIR and /etc are used.")
 endif()
-
-# For MSVC/Windows, replace /GR with an empty string, this prevents warnings of /GR being overriden by /GR-
-# Newer CMake versions (3.20) have better solutions for this through policy - using the old
-# way while waiting for when updating can occur
-string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 if(WIN32)
     option(ENABLE_WIN10_ONECORE "Link the loader with OneCore umbrella libraries" OFF)
@@ -138,11 +130,7 @@ target_link_libraries(loader_common_options INTERFACE platform_wsi)
 target_compile_definitions(loader_common_options INTERFACE VK_ENABLE_BETA_EXTENSIONS)
 
 target_compile_features(loader_common_options INTERFACE c_std_99)
-target_compile_features(loader_common_options INTERFACE cxx_std_17)
 set(LOADER_STANDARD_C_PROPERTIES C_STANDARD 99 C_STANDARD_REQUIRED YES C_EXTENSIONS OFF)
-set(LOADER_STANDARD_CXX_PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS OFF)
-
-set(TESTS_STANDARD_CXX_PROPERTIES ${LOADER_STANDARD_CXX_PROPERTIES} MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
 # Force the use of the multithreaded, static version of the C runtime.
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
@@ -152,12 +140,12 @@ option(ENABLE_WERROR "Enable warnings as errors" ON)
 # Set warnings as errors and the main diagnostic flags
 # Must be set first so the warning silencing later on works properly
 # Note that clang-cl.exe should use MSVC flavor flags, not GNU
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))
+if (CMAKE_C_COMPILER_ID STREQUAL "MSVC" OR (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))
     if (ENABLE_WERROR)
         target_compile_options(loader_common_options INTERFACE /WX)
     endif()
     target_compile_options(loader_common_options INTERFACE /W4)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+elseif(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     # using GCC or Clang with the regular front end
     if (ENABLE_WERROR)
         target_compile_options(loader_common_options INTERFACE -Werror)
@@ -165,12 +153,12 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "C
     target_compile_options(loader_common_options INTERFACE -Wall -Wextra)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(loader_common_options INTERFACE -Wno-missing-field-initializers)
 
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
         target_compile_options(loader_common_options INTERFACE -Wno-stringop-truncation -Wno-stringop-overflow)
-        if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.1)
+        if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 7.1)
             target_compile_options(loader_common_options INTERFACE -Wshadow=local) #only added in GCC 7
         endif()
     endif()
@@ -182,7 +170,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang
     target_compile_options(loader_common_options INTERFACE -Wpointer-arith)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))
+if(CMAKE_C_COMPILER_ID MATCHES "MSVC" OR (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))
     # /sdl: Enable additional security checks
     # /GR-: Disable RTTI
     # /guard:cf: Enable control flow guard
@@ -248,108 +236,7 @@ endif()
 add_subdirectory(loader)
 
 option(BUILD_TESTS "Build Tests")
-if(BUILD_TESTS)
-    # Set gtest build configuration
-    # Attempt to enable if it is available.
-    if(TARGET gtest)
-        # Already enabled as a target (perhaps by a project enclosing this one)
-        message(STATUS "Vulkan-Loader/external: " "googletest already configured - using it")
-    elseif(IS_DIRECTORY "${GOOGLETEST_INSTALL_DIR}/googletest")
-        set(BUILD_GTEST ON CACHE BOOL "Builds the googletest subproject")
-        set(BUILD_GMOCK OFF CACHE BOOL "Builds the googlemock subproject")
-        set(gtest_force_shared_crt ON CACHE BOOL "Link gtest runtimes dynamically" FORCE)
-        set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
-        set(INSTALL_GTEST OFF CACHE BOOL "Don't install gtest")
-        # The googletest directory exists, so enable it as a target.
-        message(STATUS "Vulkan-Loader/external: " "googletest found - configuring it for tests")
-        add_subdirectory("${GOOGLETEST_INSTALL_DIR}")
-    else()
-        message(SEND_ERROR "Could not find googletest directory. Be sure to run update_deps.py with the --tests option to download the appropriate version of googletest")
-        set(BUILD_TESTS OFF)
-    endif()
-
-    # make sure gtest uses the dynamic runtime instead
-    set_target_properties(gtest PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
-    set_target_properties(gtest_main PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
-
-    if (WIN32)
-        if(TARGET detours)
-            # Already enabled as a target (perhaps by a project enclosing this one)
-            message(STATUS "Vulkan-Loader/external: " "detours already configured - using it")
-        else()
-            if(IS_DIRECTORY ${DETOURS_INSTALL_DIR})
-                # The detours directory exists, so enable it as a target.
-                message(STATUS "Vulkan-Loader/external: " "detours found - configuring it for tests")
-            else()
-                message(SEND_ERROR "Could not find detours directory. Be sure to run update_deps.py with the --tests option to download the appropriate version of detours")
-                set(BUILD_TESTS OFF)
-            endif()
-            add_library(detours STATIC
-                ${DETOURS_INSTALL_DIR}/src/creatwth.cpp
-                ${DETOURS_INSTALL_DIR}/src/detours.cpp
-                ${DETOURS_INSTALL_DIR}/src/detours.h
-                ${DETOURS_INSTALL_DIR}/src/detver.h
-                ${DETOURS_INSTALL_DIR}/src/disasm.cpp
-                ${DETOURS_INSTALL_DIR}/src/disolarm.cpp
-                ${DETOURS_INSTALL_DIR}/src/disolarm64.cpp
-                ${DETOURS_INSTALL_DIR}/src/disolia64.cpp
-                ${DETOURS_INSTALL_DIR}/src/disolx64.cpp
-                ${DETOURS_INSTALL_DIR}/src/disolx86.cpp
-                ${DETOURS_INSTALL_DIR}/src/image.cpp
-                ${DETOURS_INSTALL_DIR}/src/modules.cpp
-                )
-            target_include_directories(detours PUBLIC ${DETOURS_INSTALL_DIR}/src)
-
-            macro(GET_WIN32_WINNT version)
-                if(WIN32 AND CMAKE_SYSTEM_VERSION)
-            		set(ver ${CMAKE_SYSTEM_VERSION})
-            		string(REGEX MATCH "^([0-9]+).([0-9])" ver ${ver})
-            		string(REGEX MATCH "^([0-9]+)" verMajor ${ver})
-            		# Check for Windows 10, b/c we'll need to convert to hex 'A'.
-            		if("${verMajor}" MATCHES "10")
-            			set(verMajor "A")
-            			string(REGEX REPLACE "^([0-9]+)" ${verMajor} ver ${ver})
-            		endif("${verMajor}" MATCHES "10")
-            		# Remove all remaining '.' characters.
-            		string(REPLACE "." "" ver ${ver})
-            		# Prepend each digit with a zero.
-            		string(REGEX REPLACE "([0-9A-Z])" "0\\1" ver ${ver})
-            		set(${version} "0x${ver}")
-                endif()
-            endmacro()
-
-            set(DETOURS_MAJOR_VERSION "4")
-            set(DETOURS_MINOR_VERSION "0")
-            set(DETOURS_PATCH_VERSION "1")
-            set(DETOURS_VERSION "${DETOURS_MAJOR_VERSION}.${DETOURS_MINOR_VERSION}.${DETOURS_PATCH_VERSION}")
-
-            target_include_directories(detours PUBLIC ${DETOURS_INSTALL_DIR}/src)
-
-            if(MSVC_VERSION GREATER_EQUAL 1700)
-                target_compile_definitions(detours PUBLIC DETOURS_CL_17_OR_NEWER)
-            endif(MSVC_VERSION GREATER_EQUAL 1700)
-            GET_WIN32_WINNT(ver)
-            if(ver EQUAL 0x0700)
-                target_compile_definitions(detours PUBLIC _USING_V110_SDK71_ DETOURS_WIN_7)
-            endif(ver EQUAL 0x0700)
-            target_compile_definitions(detours PUBLIC "_WIN32_WINNT=${ver}")
-
-            target_compile_definitions(detours PUBLIC  "DETOURS_VERSION=0x4c0c1" WIN32_LEAN_AND_MEAN)
-
-            if(MSVC)
-                target_compile_definitions(detours PUBLIC  "_CRT_SECURE_NO_WARNINGS=1")
-                set_target_properties(detours PROPERTIES COMPILE_FLAGS /EHsc ${TESTS_STANDARD_CXX_PROPERTIES})
-            endif()
-
-            # Silence errors found in clang-cl
-            if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC")
-                target_compile_options(detours PRIVATE -Wno-sizeof-pointer-memaccess -Wno-microsoft-goto -Wno-microsoft-cast)
-            endif()
-        endif()
-    endif()
-
-    if (BUILD_TESTS)
-        enable_testing()
-        add_subdirectory(tests)
-    endif()
+if (BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
 endif()

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -27,8 +27,7 @@ if(WIN32)
     if(ENABLE_WIN10_ONECORE)
         # Note: When linking your app or driver to OneCore.lib, be sure to remove any links to non-umbrella libs (such as
         # kernel32.lib).
-        set(CMAKE_CXX_STANDARD_LIBRARIES " ") # space is intentional
-        set(CMAKE_C_STANDARD_LIBRARIES ${CMAKE_CXX_STANDARD_LIBRARIES})
+        set(CMAKE_C_STANDARD_LIBRARIES " ") # space is intentional
     endif()
 
     # ~~~
@@ -197,7 +196,7 @@ end
             # Run parse_asm_values.py on asm_offset's assembly file to generate the gen_defines.asm, which the asm code depends on
             add_custom_command(TARGET asm_offset POST_BUILD
                 COMMAND Python3::Interpreter ${PROJECT_SOURCE_DIR}/scripts/parse_asm_values.py "${CMAKE_CURRENT_BINARY_DIR}/gen_defines.asm"
-                    "$<TARGET_FILE_DIR:asm_offset>/asm_offset.asm" "MASM" "${CMAKE_CXX_COMPILER_ID}" "${CMAKE_SYSTEM_PROCESSOR}"
+                    "$<TARGET_FILE_DIR:asm_offset>/asm_offset.asm" "MASM" "${CMAKE_C_COMPILER_ID}" "${CMAKE_SYSTEM_PROCESSOR}"
                 BYPRODUCTS gen_defines.asm
             )
         endif()
@@ -262,25 +261,25 @@ elseif(UNIX) # i.e.: Linux & Apple
         else()
             # Forces compiler to write the intermediate asm file, needed so that we can get sizeof/offset of info out of it.
             target_compile_options(asm_offset PRIVATE -save-temps=obj)
-            if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
                 set(ASM_OFFSET_EXECUTABLE_LOCATION "$<TARGET_FILE_DIR:asm_offset>/gen_defines.asm")
                 set(ASM_OFFSET_INTERMEDIATE_LOCATION "$<TARGET_FILE_DIR:asm_offset>/CMakeFiles/asm_offset.dir/asm_offset.c.s")
-            elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+            elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang")
                 set(ASM_OFFSET_EXECUTABLE_LOCATION "$<TARGET_FILE_DIR:asm_offset>/gen_defines.asm")
                 set(ASM_OFFSET_INTERMEDIATE_LOCATION "$<TARGET_FILE_DIR:asm_offset>/CMakeFiles/asm_offset.dir/asm_offset.s")
-            elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+            elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
             # Need to use the current binary dir since the asm_offset.s file is in that folder rather than the bundle
                 set(ASM_OFFSET_EXECUTABLE_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/gen_defines.asm")
                 set(ASM_OFFSET_INTERMEDIATE_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/asm_offset.dir/asm_offset.s")
             else()
-                message(FATAL_ERROR "CXX_COMPILER_ID not supported!")
+                message(FATAL_ERROR "C_COMPILER_ID not supported!")
             endif()
 
             find_package(Python3 REQUIRED QUIET)
             # Run parse_asm_values.py on asm_offset's assembly file to generate the gen_defines.asm, which the asm code depends on
             add_custom_command(TARGET asm_offset POST_BUILD
                 COMMAND Python3::Interpreter ${PROJECT_SOURCE_DIR}/scripts/parse_asm_values.py "${ASM_OFFSET_EXECUTABLE_LOCATION}"
-                    "${ASM_OFFSET_INTERMEDIATE_LOCATION}" "GAS" "${CMAKE_CXX_COMPILER_ID}" "${ASM_OFFSET_SYSTEM_PROCESSOR}"
+                    "${ASM_OFFSET_INTERMEDIATE_LOCATION}" "GAS" "${CMAKE_C_COMPILER_ID}" "${ASM_OFFSET_SYSTEM_PROCESSOR}"
                 BYPRODUCTS gen_defines.asm
             )
         endif()
@@ -380,6 +379,9 @@ else()
         SOVERSION "1"
         VERSION "${VULKAN_LOADER_VERSION}"
     )
+
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
 
     target_link_libraries(vulkan PRIVATE ${CMAKE_DL_LIBS} m Threads::Threads)
 

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -105,13 +105,13 @@ def main(argv):
                 print('update', repo_filename)
                 shutil.copyfile(temp_filename, repo_filename)
 
-    # write out the header version used to generate the code to a checked in CMake FIle
+    # write out the header version used to generate the code to a checked in CMake file
     if args.generated_version:
         # Update the CMake project version
         with open(common_codegen.repo_relative('CMakeLists.txt'), "r+") as f:
             data = f.read()
             f.seek(0)
-            f.write(re.sub("project.*VERSION.*", f"project(VULKAN_LOADER VERSION {args.generated_version})", data))
+            f.write(re.sub("project.*VERSION.*", f"project(VULKAN_LOADER VERSION {args.generated_version} LANGUAGES C)", data))
             f.truncate()
 
         with open(common_codegen.repo_relative('loader/loader.rc.in'), "r") as rc_file:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2014-2022 Valve Corporation
-# Copyright (c) 2014-2022 LunarG, Inc.
+# Copyright (c) 2014-2023 Valve Corporation
+# Copyright (c) 2014-2023 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,63 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ~~~
+enable_language(CXX) # Tests use C++
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Make sure tests uses the dynamic runtime instead
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+
+# For MSVC/Windows, replace /GR with an empty string, this prevents warnings of /GR being overriden by /GR-
+# Newer CMake versions (3.20) have better solutions for this through policy - using the old
+# way while waiting for when updating can occur
+string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+if (IS_DIRECTORY "${GOOGLETEST_INSTALL_DIR}/googletest")
+    set(BUILD_GTEST ON)
+    set(BUILD_GMOCK OFF)
+    set(gtest_force_shared_crt ON)
+    set(BUILD_SHARED_LIBS ON)
+    set(INSTALL_GTEST OFF)
+    add_subdirectory("${GOOGLETEST_INSTALL_DIR}" ${CMAKE_CURRENT_BINARY_DIR}/gtest)
+else()
+    message(FATAL_ERROR "Could not find googletest directory. See BUILD.md")
+endif()
+
+if (WIN32)
+    if(NOT IS_DIRECTORY ${DETOURS_INSTALL_DIR})
+        message(FATAL_ERROR "Could not find detours! See BUILD.md")
+    endif()
+    add_library(detours STATIC
+        ${DETOURS_INSTALL_DIR}/src/creatwth.cpp
+        ${DETOURS_INSTALL_DIR}/src/detours.cpp
+        ${DETOURS_INSTALL_DIR}/src/detours.h
+        ${DETOURS_INSTALL_DIR}/src/detver.h
+        ${DETOURS_INSTALL_DIR}/src/disasm.cpp
+        ${DETOURS_INSTALL_DIR}/src/disolarm.cpp
+        ${DETOURS_INSTALL_DIR}/src/disolarm64.cpp
+        ${DETOURS_INSTALL_DIR}/src/disolia64.cpp
+        ${DETOURS_INSTALL_DIR}/src/disolx64.cpp
+        ${DETOURS_INSTALL_DIR}/src/disolx86.cpp
+        ${DETOURS_INSTALL_DIR}/src/image.cpp
+        ${DETOURS_INSTALL_DIR}/src/modules.cpp
+    )
+    target_include_directories(detours PUBLIC ${DETOURS_INSTALL_DIR}/src)
+
+    target_compile_definitions(detours PUBLIC WIN32_LEAN_AND_MEAN)
+
+    if(MSVC)
+        target_compile_definitions(detours PUBLIC  "_CRT_SECURE_NO_WARNINGS=1")
+        set_target_properties(detours PROPERTIES COMPILE_FLAGS /EHsc)
+    endif()
+
+    # Silence errors found in clang-cl
+    if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_C_SIMULATE_ID}" MATCHES "MSVC")
+        target_compile_options(detours PRIVATE -Wno-sizeof-pointer-memaccess -Wno-microsoft-goto -Wno-microsoft-cast)
+    endif()
+endif()
 
 option(ENABLE_LIVE_VERIFICATION_TESTS "Enable tests which expect to run on live drivers. Meant for manual verification only" OFF)
 
@@ -36,7 +93,6 @@ add_executable(
         loader_unknown_ext_tests.cpp
         loader_wsi_tests.cpp)
 target_link_libraries(test_regression PUBLIC testing_dependencies)
-set_target_properties(test_regression PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 target_compile_definitions(test_regression PUBLIC VK_NO_PROTOTYPES)
 
 # Threading tests live in separate executabe just for threading tests as it'll need support
@@ -46,7 +102,6 @@ add_executable(
         loader_testing_main.cpp
         loader_threading_tests.cpp)
 target_link_libraries(test_threading PUBLIC testing_dependencies)
-set_target_properties(test_threading PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 target_compile_definitions(test_threading PUBLIC VK_NO_PROTOTYPES)
 
 # executables that are meant for testing against real drivers rather than the mocks

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -17,7 +17,6 @@
 
 add_library(testing_framework_util STATIC test_util.cpp)
 target_link_libraries(testing_framework_util PUBLIC loader_common_options Vulkan::Headers)
-set_target_properties(testing_framework_util PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 
 if(UNIX OR APPLE)
     target_link_libraries(testing_framework_util PUBLIC ${CMAKE_DL_LIBS})
@@ -60,7 +59,6 @@ function(AddSharedLibrary LIBRARY_NAME)
     add_library(${LIBRARY_NAME} SHARED ${PARSED_ARGS_SOURCES})
     target_link_libraries(${LIBRARY_NAME} PUBLIC testing_framework_util)
     target_compile_definitions(${LIBRARY_NAME} PRIVATE ${PARSED_ARGS_DEFINITIONS} VK_NO_PROTOTYPES)
-    set_target_properties(${LIBRARY_NAME} PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
     # Windows requires export definitions for these libraries
     if(WIN32)
         target_sources(${LIBRARY_NAME} PRIVATE export_definitions/${PARSED_ARGS_DEF_FILE}.def)
@@ -97,7 +95,6 @@ target_link_libraries(testing_dependencies
     PUBLIC gtest Vulkan::Headers testing_framework_util shim-library)
 target_include_directories(testing_dependencies PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_compile_definitions(testing_dependencies PUBLIC "GTEST_LINKED_AS_SHARED_LIBRARY=1")
-set_target_properties(testing_dependencies PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 if (APPLE_STATIC_LOADER)
     target_compile_definitions(testing_dependencies PUBLIC "APPLE_STATIC_LOADER=1")
     target_link_libraries(testing_dependencies PUBLIC vulkan)

--- a/tests/framework/shim/CMakeLists.txt
+++ b/tests/framework/shim/CMakeLists.txt
@@ -18,7 +18,6 @@
 add_library(shim-common STATIC shim_common.cpp)
 target_link_libraries(shim-common PUBLIC testing_framework_util)
 target_include_directories(shim-common PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-set_target_properties(shim-common PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 
 if (WIN32)
     # need adapters.h which is in the loader folder
@@ -27,17 +26,14 @@ if (WIN32)
 
     add_library(shim-library SHARED windows_shim.cpp)
     target_link_libraries(shim-library PRIVATE detours cfgmgr32)
-    set_target_properties(shim-library PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 
 elseif(UNIX)
     if(APPLE)
         add_library(shim-library SHARED unix_shim.cpp)
         target_link_libraries(shim-library PRIVATE "-framework CoreFoundation")
-        set_target_properties(shim-library PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
     else()
         add_library(shim-library STATIC unix_shim.cpp)
     endif()
 endif()
 #common attributes
 target_link_libraries(shim-library PUBLIC shim-common)
-set_target_properties(shim-library PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})

--- a/tests/live_verification/CMakeLists.txt
+++ b/tests/live_verification/CMakeLists.txt
@@ -17,14 +17,12 @@
 
 add_executable(dynamic_rendering_get_proc_addr dynamic_rendering_get_proc_addr.cpp)
 target_link_libraries(dynamic_rendering_get_proc_addr testing_dependencies)
-set_target_properties(dynamic_rendering_get_proc_addr PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 
 add_subdirectory(dynamic_loader_behavior)
 
 if(APPLE_STATIC_LOADER)
     add_executable(macos_static_loader_build macos_static_loader_build.cpp)
     target_link_libraries(macos_static_loader_build loader_common_options vulkan Vulkan::Headers)
-    set_target_properties(macos_static_loader_build PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
     if (TEST_USE_THREAD_SANITIZER)
         target_compile_options(macos_static_loader_build PUBLIC -fsanitize=thread)
         target_link_options(macos_static_loader_build PUBLIC -fsanitize=thread)

--- a/tests/live_verification/dynamic_loader_behavior/CMakeLists.txt
+++ b/tests/live_verification/dynamic_loader_behavior/CMakeLists.txt
@@ -21,17 +21,14 @@ else()
 add_library(dynamic_library_a dynamic_library.cpp)
 target_link_libraries(dynamic_library_a PUBLIC testing_framework_util)
 target_compile_definitions(dynamic_library_a PRIVATE PRINT_OUTPUT_A)
-set_target_properties(dynamic_library_a PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 
 add_library(dynamic_library_b dynamic_library.cpp)
 target_link_libraries(dynamic_library_b PUBLIC testing_framework_util)
 target_compile_definitions(dynamic_library_b PRIVATE PRINT_OUTPUT_B)
-set_target_properties(dynamic_library_b PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 
 add_library(dynamic_library_c dynamic_library.cpp)
 target_link_libraries(dynamic_library_c PUBLIC testing_framework_util)
 target_compile_definitions(dynamic_library_c PRIVATE PRINT_OUTPUT_C)
-set_target_properties(dynamic_library_c PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 
 add_executable(test_dynamic_linking_a_first test_dynamic_linking.cpp)
 add_executable(test_dynamic_linking_b_first test_dynamic_linking.cpp)
@@ -39,19 +36,14 @@ add_executable(test_dynamic_linking_c_then_load test_dynamic_linking.cpp)
 target_link_libraries(test_dynamic_linking_a_first PUBLIC dynamic_library_a dynamic_library_b)
 target_link_libraries(test_dynamic_linking_b_first PUBLIC dynamic_library_b dynamic_library_a)
 target_link_libraries(test_dynamic_linking_c_then_load PUBLIC dynamic_library_c)
-set_target_properties(test_dynamic_linking_a_first PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
-set_target_properties(test_dynamic_linking_b_first PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
-set_target_properties(test_dynamic_linking_c_then_load PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 target_compile_definitions(test_dynamic_linking_c_then_load PRIVATE PRINT_OUTPUT_C)
 
 
 add_executable(test_dynamic_loading test_dynamic_loading.cpp)
 target_link_libraries(test_dynamic_loading PUBLIC testing_framework_util)
-set_target_properties(test_dynamic_loading PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 
 add_executable(test_dynamic_loading_and_linking test_dynamic_loading_and_linking.cpp)
 target_link_libraries(test_dynamic_loading_and_linking PUBLIC testing_framework_util)
 target_link_libraries(test_dynamic_loading_and_linking PUBLIC dynamic_library_a)
-set_target_properties(test_dynamic_loading_and_linking PROPERTIES ${TESTS_STANDARD_CXX_PROPERTIES})
 
 endif()


### PR DESCRIPTION
By default the loader only requires the C compiler.

But by default the C and CXX compilers are enabled.

Only enable the C compiler. Move corresponding C++ code into tests directory.