### PR TITLE
BUILD_WERROR OFF by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
                 -D BUILD_TESTS=ON \
                 -D UPDATE_DEPS=ON \
                 -D LOADER_ENABLE_ADDRESS_SANITIZER=ON \
-                -D ENABLE_WERROR=ON \
+                -D BUILD_WERROR=ON \
                 -D CMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} \
                 -D CMAKE_C_COMPILER=${{ matrix.compiler.cc }}
             - run: cmake --build build
@@ -89,7 +89,7 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release \
                 -D BUILD_TESTS=ON \
                 -D UPDATE_DEPS=ON \
-                -D ENABLE_WERROR=ON \
+                -D BUILD_WERROR=ON \
                 -D USE_GAS=OFF \
                 -D CMAKE_C_COMPILER=clang \
                 -D CMAKE_CXX_COMPILER=clang++
@@ -122,7 +122,7 @@ jobs:
                 -D CMAKE_BUILD_TYPE=${{matrix.config}} \
                 -D BUILD_TESTS=ON \
                 -D UPDATE_DEPS=ON \
-                -D ENABLE_WERROR=ON \
+                -D BUILD_WERROR=ON \
                 -D SYSCONFDIR=/etc/not_vulkan \
                 -G Ninja
               env:
@@ -157,7 +157,7 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release \
                 -D BUILD_TESTS=ON \
                 -D UPDATE_DEPS=ON \
-                -D ENABLE_WERROR=ON \
+                -D BUILD_WERROR=ON \
                 -D USE_GAS=OFF \
                 -G Ninja
               env:
@@ -183,7 +183,7 @@ jobs:
                 -D UPDATE_DEPS=ON `
                 -D CMAKE_BUILD_TYPE=${{matrix.config}} `
                 -A ${{ matrix.arch }} `
-                -D ENABLE_WERROR=ON
+                -D BUILD_WERROR=ON
             - run: cmake --build build/ --config ${{matrix.config}}
             - run: cmake --install build --prefix build/install --config ${{matrix.config}}
             - run: ctest --output-on-failure -C ${{matrix.config}} --test-dir build/
@@ -202,7 +202,7 @@ jobs:
                 -D USE_MASM=OFF `
                 -D CMAKE_BUILD_TYPE=Release `
                 -A ${{ matrix.arch }} `
-                -D ENABLE_WERROR=ON
+                -D BUILD_WERROR=ON
             - run: cmake --build build/ --config Release
             - run: ctest --output-on-failure -C Release -E UnknownFunction --test-dir build/
 
@@ -222,7 +222,7 @@ jobs:
               -D CMAKE_CXX_COMPILER=${{matrix.compiler}} `
               -D UPDATE_DEPS=ON `
               -D CMAKE_BUILD_TYPE=${{matrix.config}} `
-              -D ENABLE_WERROR=ON `
+              -D BUILD_WERROR=ON `
               -D BUILD_TESTS=ON `
               -G Ninja
           - run: cmake --build build/
@@ -247,7 +247,7 @@ jobs:
                 -D ${{matrix.static_build}} \
                 -D BUILD_TESTS=ON \
                 -D UPDATE_DEPS=ON \
-                -D ENABLE_WERROR=ON \
+                -D BUILD_WERROR=ON \
                 -D LOADER_ENABLE_ADDRESS_SANITIZER=ON \
                 -G Ninja
               env:
@@ -275,7 +275,7 @@ jobs:
               "-D CMAKE_OSX_ARCHITECTURES=arm64;x86_64" \
               -D CMAKE_BUILD_TYPE=Debug \
               -D UPDATE_DEPS=ON \
-              -D ENABLE_WERROR=ON \
+              -D BUILD_WERROR=ON \
               -G Ninja
             env:
               LDFLAGS: -Wl,-fatal_warnings
@@ -308,7 +308,7 @@ jobs:
                 "-D CMAKE_OSX_ARCHITECTURES=arm64;x86_64" \
                 -D BUILD_TESTS=ON \
                 -D UPDATE_DEPS=ON \
-                -D ENABLE_WERROR=ON \
+                -D BUILD_WERROR=ON \
                 -G ${{ matrix.generator }}
               env:
                 LDFLAGS: -Wl,-fatal_warnings
@@ -348,6 +348,7 @@ jobs:
             cmake -S. -B build \
             -D UPDATE_DEPS=ON \
             -D CMAKE_BUILD_TYPE=Release \
+            -D BUILD_WERROR=ON \
             -G Ninja
         - run: cmake --build build
         - run: cmake --install build --prefix /tmp
@@ -368,6 +369,7 @@ jobs:
             cmake -S. -B build \
             -D UPDATE_DEPS=ON \
             -D CMAKE_BUILD_TYPE=Release \
+            -D BUILD_WERROR=ON \
             -G Ninja
         - run: cmake --build build
         - run: cmake --install build --prefix /tmp
@@ -384,7 +386,7 @@ jobs:
             cmake -S. -B build \
             -D UPDATE_DEPS=ON \
             -D CMAKE_BUILD_TYPE=Release \
-            -D ENABLE_WERROR=ON \
+            -D BUILD_WERROR=ON \
             -D USE_MASM=OFF \
             -G Ninja
         - run: cmake --build build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Generate build files
       if: matrix.language == 'cpp'
-      run: cmake -S. -B build -D CMAKE_BUILD_TYPE=Release -D UPDATE_DEPS=ON -D LOADER_ENABLE_ADDRESS_SANITIZER=ON -D ENABLE_WERROR=ON
+      run: cmake -S. -B build -D CMAKE_BUILD_TYPE=Release -D UPDATE_DEPS=ON
       env:
         CC: gcc
         CXX: g++

--- a/BUILD.md
+++ b/BUILD.md
@@ -127,6 +127,16 @@ cmake ... -D UPDATE_DEPS=ON -D BUILD_TESTS=ON ...
 ```
 This will ensure googletest and detours is downloaded and the appropriate version is used.
 
+### Warnings as errors off by default!
+
+By default `BUILD_WERROR` is `OFF`. The idiom for open source projects is to NOT enable warnings as errors.
+
+System/language package managers have to build on multiple different platforms and compilers.
+
+By defaulting to `ON` we cause issues for package managers since there is no standard way to disable warnings.
+
+Add `-D BUILD_WERROR=ON` to your workflow
+
 ### Build and Install Directory Locations
 
 A common convention is to place the `build` directory in the top directory of

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,19 +135,19 @@ set(LOADER_STANDARD_C_PROPERTIES C_STANDARD 99 C_STANDARD_REQUIRED YES C_EXTENSI
 # Force the use of the multithreaded, static version of the C runtime.
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-option(ENABLE_WERROR "Enable warnings as errors" ON)
+option(BUILD_WERROR "Enable warnings as errors")
 
 # Set warnings as errors and the main diagnostic flags
 # Must be set first so the warning silencing later on works properly
 # Note that clang-cl.exe should use MSVC flavor flags, not GNU
 if (CMAKE_C_COMPILER_ID STREQUAL "MSVC" OR (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))
-    if (ENABLE_WERROR)
+    if (BUILD_WERROR)
         target_compile_options(loader_common_options INTERFACE /WX)
     endif()
     target_compile_options(loader_common_options INTERFACE /W4)
 elseif(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     # using GCC or Clang with the regular front end
-    if (ENABLE_WERROR)
+    if (BUILD_WERROR)
         target_compile_options(loader_common_options INTERFACE -Werror)
     endif()
     target_compile_options(loader_common_options INTERFACE -Wall -Wextra)


### PR DESCRIPTION
Consistent naming with other repos we maintain.

OFF by default to avoid issues with newer compilers, specific generators (Xcode), etc.