### PR TITLE
Fix lack of pthread linking in ubuntu 20.04

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -72,6 +72,9 @@ else()
     if(HAVE_ALLOCA_H)
         target_compile_definitions(loader_specific_options INTERFACE HAVE_ALLOCA_H)
     endif()
+
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
 endif()
 
 set(NORMAL_LOADER_SRCS
@@ -380,9 +383,6 @@ else()
         SOVERSION "1"
         VERSION "${VULKAN_LOADER_VERSION}"
     )
-
-    set(THREADS_PREFER_PTHREAD_FLAG ON)
-    find_package(Threads REQUIRED)
 
     target_link_libraries(vulkan PRIVATE ${CMAKE_DL_LIBS} m Threads::Threads)
 


### PR DESCRIPTION
Ubuntu 20.04 saw a regression that caused the pthread library to no longer be a part of libvulkan.so's linked libraries. This didn't cause the loader to fail to load, rather any library that used pthread functions without linking to pthreads themselves would fail to run, for example the Vulkan-ValidationLayers (VVL). While it is currently unclear why VVL were trying to link to these symbols, this would make loading validation layers impossible.

The issue turns out to be this line of CMake
`set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)`. Specifically, that line of code appearing *before* `find_package(Threads REQUIRED)` causes CMake to 'find' CMAKE_HAVE_LIBC_PTHREAD successfully, whereas previously it would fail. Since this variable indicates that linking to libc is enough to get threading capabilities, CMake no longer links to pthread.

This commit is an effort to prevent breaking ABI due to changing the link library list in Ubuntu 20.04. It should be noted that in Ubuntu 23.10, the location of `find_package(Threads)` has no bearing on the value of CMAKE_HAVE_LIBC_PTHREAD.