### PR TITLE
fix dEQP-VK.api.object_management.multithreaded_per_thread_resources.…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,13 @@ endif()
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(loader_common_options INTERFACE -Wno-missing-field-initializers)
 
+    # need to prepend /clang: to compiler arguments when using clang-cl
+    if (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC")
+        target_compile_options(loader_common_options INTERFACE /clang:-fno-strict-aliasing)
+    else()
+        target_compile_options(loader_common_options INTERFACE -fno-strict-aliasing)
+    endif()
+
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
         target_compile_options(loader_common_options INTERFACE -Wno-stringop-truncation -Wno-stringop-overflow)
         if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 7.1)

--- a/scripts/qnx/common.mk
+++ b/scripts/qnx/common.mk
@@ -32,7 +32,7 @@ include $(MKFILES_ROOT)/qtargets.mk
 
 CCFLAGS += -DVK_USE_PLATFORM_SCREEN_QNX=1 -DVK_ENABLE_BETA_EXTENSIONS
 CCFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers
-CCFLAGS += -Wno-stringop-truncation
+CCFLAGS += -fno-strict-aliasing -Wno-stringop-truncation
 CCFLAGS += -Wno-stringop-overflow -fvisibility=hidden
 CCFLAGS += -Wpointer-arith -fPIC
 


### PR DESCRIPTION
…device_group crash

This commit reverts the a4ff6a54e4f06638fa8fb367913818bf9d189bdb, which will cause this CTS case crash when build the loader with release type.