### PR TITLE
Cleanup tests

### DIFF
--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -738,6 +738,9 @@ inline bool operator==(const VkQueueFamilyProperties& a, const VkQueueFamilyProp
 }
 inline bool operator!=(const VkQueueFamilyProperties& a, const VkQueueFamilyProperties& b) { return !(a == b); }
 
+inline bool operator==(const VkQueueFamilyProperties& a, const VkQueueFamilyProperties2& b) { return a == b.queueFamilyProperties; }
+inline bool operator!=(const VkQueueFamilyProperties& a, const VkQueueFamilyProperties2& b) { return a != b.queueFamilyProperties; }
+
 inline bool operator==(const VkLayerProperties& a, const VkLayerProperties& b) {
     return string_eq(a.layerName, b.layerName, 256) && string_eq(a.description, b.description, 256) &&
            a.implementationVersion == b.implementationVersion && a.specVersion == b.specVersion;
@@ -748,6 +751,158 @@ inline bool operator==(const VkExtensionProperties& a, const VkExtensionProperti
     return string_eq(a.extensionName, b.extensionName, 256) && a.specVersion == b.specVersion;
 }
 inline bool operator!=(const VkExtensionProperties& a, const VkExtensionProperties& b) { return !(a == b); }
+
+inline bool operator==(const VkPhysicalDeviceFeatures& feats1, const VkPhysicalDeviceFeatures2& feats2) {
+    return feats1.robustBufferAccess == feats2.features.robustBufferAccess &&
+           feats1.fullDrawIndexUint32 == feats2.features.fullDrawIndexUint32 &&
+           feats1.imageCubeArray == feats2.features.imageCubeArray && feats1.independentBlend == feats2.features.independentBlend &&
+           feats1.geometryShader == feats2.features.geometryShader &&
+           feats1.tessellationShader == feats2.features.tessellationShader &&
+           feats1.sampleRateShading == feats2.features.sampleRateShading && feats1.dualSrcBlend == feats2.features.dualSrcBlend &&
+           feats1.logicOp == feats2.features.logicOp && feats1.multiDrawIndirect == feats2.features.multiDrawIndirect &&
+           feats1.drawIndirectFirstInstance == feats2.features.drawIndirectFirstInstance &&
+           feats1.depthClamp == feats2.features.depthClamp && feats1.depthBiasClamp == feats2.features.depthBiasClamp &&
+           feats1.fillModeNonSolid == feats2.features.fillModeNonSolid && feats1.depthBounds == feats2.features.depthBounds &&
+           feats1.wideLines == feats2.features.wideLines && feats1.largePoints == feats2.features.largePoints &&
+           feats1.alphaToOne == feats2.features.alphaToOne && feats1.multiViewport == feats2.features.multiViewport &&
+           feats1.samplerAnisotropy == feats2.features.samplerAnisotropy &&
+           feats1.textureCompressionETC2 == feats2.features.textureCompressionETC2 &&
+           feats1.textureCompressionASTC_LDR == feats2.features.textureCompressionASTC_LDR &&
+           feats1.textureCompressionBC == feats2.features.textureCompressionBC &&
+           feats1.occlusionQueryPrecise == feats2.features.occlusionQueryPrecise &&
+           feats1.pipelineStatisticsQuery == feats2.features.pipelineStatisticsQuery &&
+           feats1.vertexPipelineStoresAndAtomics == feats2.features.vertexPipelineStoresAndAtomics &&
+           feats1.fragmentStoresAndAtomics == feats2.features.fragmentStoresAndAtomics &&
+           feats1.shaderTessellationAndGeometryPointSize == feats2.features.shaderTessellationAndGeometryPointSize &&
+           feats1.shaderImageGatherExtended == feats2.features.shaderImageGatherExtended &&
+           feats1.shaderStorageImageExtendedFormats == feats2.features.shaderStorageImageExtendedFormats &&
+           feats1.shaderStorageImageMultisample == feats2.features.shaderStorageImageMultisample &&
+           feats1.shaderStorageImageReadWithoutFormat == feats2.features.shaderStorageImageReadWithoutFormat &&
+           feats1.shaderStorageImageWriteWithoutFormat == feats2.features.shaderStorageImageWriteWithoutFormat &&
+           feats1.shaderUniformBufferArrayDynamicIndexing == feats2.features.shaderUniformBufferArrayDynamicIndexing &&
+           feats1.shaderSampledImageArrayDynamicIndexing == feats2.features.shaderSampledImageArrayDynamicIndexing &&
+           feats1.shaderStorageBufferArrayDynamicIndexing == feats2.features.shaderStorageBufferArrayDynamicIndexing &&
+           feats1.shaderStorageImageArrayDynamicIndexing == feats2.features.shaderStorageImageArrayDynamicIndexing &&
+           feats1.shaderClipDistance == feats2.features.shaderClipDistance &&
+           feats1.shaderCullDistance == feats2.features.shaderCullDistance &&
+           feats1.shaderFloat64 == feats2.features.shaderFloat64 && feats1.shaderInt64 == feats2.features.shaderInt64 &&
+           feats1.shaderInt16 == feats2.features.shaderInt16 &&
+           feats1.shaderResourceResidency == feats2.features.shaderResourceResidency &&
+           feats1.shaderResourceMinLod == feats2.features.shaderResourceMinLod &&
+           feats1.sparseBinding == feats2.features.sparseBinding &&
+           feats1.sparseResidencyBuffer == feats2.features.sparseResidencyBuffer &&
+           feats1.sparseResidencyImage2D == feats2.features.sparseResidencyImage2D &&
+           feats1.sparseResidencyImage3D == feats2.features.sparseResidencyImage3D &&
+           feats1.sparseResidency2Samples == feats2.features.sparseResidency2Samples &&
+           feats1.sparseResidency4Samples == feats2.features.sparseResidency4Samples &&
+           feats1.sparseResidency8Samples == feats2.features.sparseResidency8Samples &&
+           feats1.sparseResidency16Samples == feats2.features.sparseResidency16Samples &&
+           feats1.sparseResidencyAliased == feats2.features.sparseResidencyAliased &&
+           feats1.variableMultisampleRate == feats2.features.variableMultisampleRate &&
+           feats1.inheritedQueries == feats2.features.inheritedQueries;
+}
+
+inline bool operator==(const VkPhysicalDeviceMemoryProperties& props1, const VkPhysicalDeviceMemoryProperties2& props2) {
+    bool equal = true;
+    equal = equal && props1.memoryTypeCount == props2.memoryProperties.memoryTypeCount;
+    equal = equal && props1.memoryHeapCount == props2.memoryProperties.memoryHeapCount;
+    for (uint32_t i = 0; i < props1.memoryHeapCount; ++i) {
+        equal = equal && props1.memoryHeaps[i].size == props2.memoryProperties.memoryHeaps[i].size;
+        equal = equal && props1.memoryHeaps[i].flags == props2.memoryProperties.memoryHeaps[i].flags;
+    }
+    for (uint32_t i = 0; i < props1.memoryTypeCount; ++i) {
+        equal = equal && props1.memoryTypes[i].propertyFlags == props2.memoryProperties.memoryTypes[i].propertyFlags;
+        equal = equal && props1.memoryTypes[i].heapIndex == props2.memoryProperties.memoryTypes[i].heapIndex;
+    }
+    return equal;
+}
+inline bool operator==(const VkSparseImageFormatProperties& props1, const VkSparseImageFormatProperties& props2) {
+    return props1.aspectMask == props2.aspectMask && props1.imageGranularity.width == props2.imageGranularity.width &&
+           props1.imageGranularity.height == props2.imageGranularity.height &&
+           props1.imageGranularity.depth == props2.imageGranularity.depth && props1.flags == props2.flags;
+}
+inline bool operator==(const VkSparseImageFormatProperties& props1, const VkSparseImageFormatProperties2& props2) {
+    return props1 == props2.properties;
+}
+inline bool operator==(const VkExternalMemoryProperties& props1, const VkExternalMemoryProperties& props2) {
+    return props1.externalMemoryFeatures == props2.externalMemoryFeatures &&
+           props1.exportFromImportedHandleTypes == props2.exportFromImportedHandleTypes &&
+           props1.compatibleHandleTypes == props2.compatibleHandleTypes;
+}
+inline bool operator==(const VkExternalSemaphoreProperties& props1, const VkExternalSemaphoreProperties& props2) {
+    return props1.externalSemaphoreFeatures == props2.externalSemaphoreFeatures &&
+           props1.exportFromImportedHandleTypes == props2.exportFromImportedHandleTypes &&
+           props1.compatibleHandleTypes == props2.compatibleHandleTypes;
+}
+inline bool operator==(const VkExternalFenceProperties& props1, const VkExternalFenceProperties& props2) {
+    return props1.externalFenceFeatures == props2.externalFenceFeatures &&
+           props1.exportFromImportedHandleTypes == props2.exportFromImportedHandleTypes &&
+           props1.compatibleHandleTypes == props2.compatibleHandleTypes;
+}
+inline bool operator==(const VkSurfaceCapabilitiesKHR& props1, const VkSurfaceCapabilitiesKHR& props2) {
+    return props1.minImageCount == props2.minImageCount && props1.maxImageCount == props2.maxImageCount &&
+           props1.currentExtent.width == props2.currentExtent.width && props1.currentExtent.height == props2.currentExtent.height &&
+           props1.minImageExtent.width == props2.minImageExtent.width &&
+           props1.minImageExtent.height == props2.minImageExtent.height &&
+           props1.maxImageExtent.width == props2.maxImageExtent.width &&
+           props1.maxImageExtent.height == props2.maxImageExtent.height &&
+           props1.maxImageArrayLayers == props2.maxImageArrayLayers && props1.supportedTransforms == props2.supportedTransforms &&
+           props1.currentTransform == props2.currentTransform && props1.supportedCompositeAlpha == props2.supportedCompositeAlpha &&
+           props1.supportedUsageFlags == props2.supportedUsageFlags;
+}
+inline bool operator==(const VkSurfaceFormatKHR& format1, const VkSurfaceFormatKHR& format2) {
+    return format1.format == format2.format && format1.colorSpace == format2.colorSpace;
+}
+inline bool operator==(const VkSurfaceFormatKHR& format1, const VkSurfaceFormat2KHR& format2) {
+    return format1 == format2.surfaceFormat;
+}
+inline bool operator==(const VkDisplayPropertiesKHR& props1, const VkDisplayPropertiesKHR& props2) {
+    return props1.display == props2.display && props1.physicalDimensions.width == props2.physicalDimensions.width &&
+           props1.physicalDimensions.height == props2.physicalDimensions.height &&
+           props1.physicalResolution.width == props2.physicalResolution.width &&
+           props1.physicalResolution.height == props2.physicalResolution.height &&
+           props1.supportedTransforms == props2.supportedTransforms && props1.planeReorderPossible == props2.planeReorderPossible &&
+           props1.persistentContent == props2.persistentContent;
+}
+inline bool operator==(const VkDisplayPropertiesKHR& props1, const VkDisplayProperties2KHR& props2) {
+    return props1 == props2.displayProperties;
+}
+inline bool operator==(const VkDisplayModePropertiesKHR& disp1, const VkDisplayModePropertiesKHR& disp2) {
+    return disp1.displayMode == disp2.displayMode && disp1.parameters.visibleRegion.width == disp2.parameters.visibleRegion.width &&
+           disp1.parameters.visibleRegion.height == disp2.parameters.visibleRegion.height &&
+           disp1.parameters.refreshRate == disp2.parameters.refreshRate;
+}
+
+inline bool operator==(const VkDisplayModePropertiesKHR& disp1, const VkDisplayModeProperties2KHR& disp2) {
+    return disp1 == disp2.displayModeProperties;
+}
+inline bool operator==(const VkDisplayPlaneCapabilitiesKHR& caps1, const VkDisplayPlaneCapabilitiesKHR& caps2) {
+    return caps1.supportedAlpha == caps2.supportedAlpha && caps1.minSrcPosition.x == caps2.minSrcPosition.x &&
+           caps1.minSrcPosition.y == caps2.minSrcPosition.y && caps1.maxSrcPosition.x == caps2.maxSrcPosition.x &&
+           caps1.maxSrcPosition.y == caps2.maxSrcPosition.y && caps1.minSrcExtent.width == caps2.minSrcExtent.width &&
+           caps1.minSrcExtent.height == caps2.minSrcExtent.height && caps1.maxSrcExtent.width == caps2.maxSrcExtent.width &&
+           caps1.maxSrcExtent.height == caps2.maxSrcExtent.height && caps1.minDstPosition.x == caps2.minDstPosition.x &&
+           caps1.minDstPosition.y == caps2.minDstPosition.y && caps1.maxDstPosition.x == caps2.maxDstPosition.x &&
+           caps1.maxDstPosition.y == caps2.maxDstPosition.y && caps1.minDstExtent.width == caps2.minDstExtent.width &&
+           caps1.minDstExtent.height == caps2.minDstExtent.height && caps1.maxDstExtent.width == caps2.maxDstExtent.width &&
+           caps1.maxDstExtent.height == caps2.maxDstExtent.height;
+}
+
+inline bool operator==(const VkDisplayPlaneCapabilitiesKHR& caps1, const VkDisplayPlaneCapabilities2KHR& caps2) {
+    return caps1 == caps2.capabilities;
+}
+inline bool operator==(const VkDisplayPlanePropertiesKHR& props1, const VkDisplayPlanePropertiesKHR& props2) {
+    return props1.currentDisplay == props2.currentDisplay && props1.currentStackIndex == props2.currentStackIndex;
+}
+inline bool operator==(const VkDisplayPlanePropertiesKHR& props1, const VkDisplayPlaneProperties2KHR& props2) {
+    return props1 == props2.displayPlaneProperties;
+}
+// Allow comparison of vectors of different types as long as their elements are comparable (just has to make sure to only apply when
+// T != U)
+template <typename T, typename U, typename = std::enable_if_t<!std::is_same_v<T, U>>>
+bool operator==(const std::vector<T>& a, const std::vector<U>& b) {
+    return std::equal(a.begin(), a.end(), b.begin(), b.end(), [](const auto& left, const auto& right) { return left == right; });
+}
 
 struct VulkanFunction {
     std::string name;

--- a/tests/loader_alloc_callback_tests.cpp
+++ b/tests/loader_alloc_callback_tests.cpp
@@ -870,7 +870,7 @@ TEST(Allocation, EnumeratePhysicalDevicesIntentionalAllocFail) {
     size_t fail_index = 0;
     bool reached_the_end = false;
     uint32_t starting_physical_dev_count = 3;
-    while (!reached_the_end && fail_index <= 100) {
+    while (!reached_the_end && fail_index <= 10000) {
         fail_index++;  // applies to the next loop
         uint32_t physical_dev_count = starting_physical_dev_count;
         VkResult result = VK_ERROR_OUT_OF_HOST_MEMORY;

--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -236,25 +236,16 @@ TEST(GetDeviceProcAddr, SwapchainFuncsWithTerminator) {
         info.surface = surface;
 
         VkSwapchainKHR swapchain{};
-        if (CreateSwapchainKHR) CreateSwapchainKHR(dev.dev, &info, nullptr, &swapchain);
-        ASSERT_FALSE(
-            log.find("vkCreateSwapchainKHR: Driver's function pointer was NULL, returning VK_SUCCESS. Was the VK_KHR_swapchain "
-                     "extension enabled?"));
         log.logger.clear();
-        if (dev_funcs.vkDestroySwapchainKHR) dev_funcs.vkDestroySwapchainKHR(dev.dev, swapchain, nullptr);
+        ASSERT_FALSE(dev_funcs.vkDestroySwapchainKHR);
+
         // try to call the vkCreateSwapchainKHR acquired from the instance - this *should* abort due to not enabling the extension
-        if (inst_CreateSwapchainKHR) {
-            ASSERT_DEATH(inst_CreateSwapchainKHR(dev.dev, &info, nullptr, &swapchain),
-                         "vkCreateSwapchainKHR: Driver's function pointer was NULL, returning VK_SUCCESS. Was the VK_KHR_swapchain "
-                         "extension enabled?");
-        }
+        ASSERT_DEATH(inst_CreateSwapchainKHR(dev.dev, &info, nullptr, &swapchain),
+                     "vkCreateSwapchainKHR: Driver's function pointer was NULL, returning VK_SUCCESS. Was the VK_KHR_swapchain "
+                     "extension enabled?");
+
         log.logger.clear();
-        if (dev_funcs.vkDestroySwapchainKHR) dev_funcs.vkDestroySwapchainKHR(dev.dev, swapchain, nullptr);
-
-        VkDeviceGroupPresentModeFlagsKHR modes{};
-        if (GetDeviceGroupSurfacePresentModesKHR) GetDeviceGroupSurfacePresentModesKHR(dev.dev, surface, &modes);
-
-        if (CreateSharedSwapchainsKHR) CreateSharedSwapchainsKHR(dev.dev, 1, &info, nullptr, &swapchain);
+        ASSERT_FALSE(dev_funcs.vkDestroySwapchainKHR);
     }
     driver.physical_devices.at(0).add_extensions({"VK_KHR_swapchain", "VK_KHR_display_swapchain", "VK_EXT_debug_marker"});
     {
@@ -272,29 +263,30 @@ TEST(GetDeviceProcAddr, SwapchainFuncsWithTerminator) {
         ASSERT_TRUE(inst_CreateSwapchainKHR);
         ASSERT_TRUE(GetDeviceGroupSurfacePresentModesKHR);
         ASSERT_TRUE(CreateSharedSwapchainsKHR);
+        ASSERT_TRUE(dev_funcs.vkDestroySwapchainKHR);
 
         VkSwapchainCreateInfoKHR info{};
         info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
         info.surface = surface;
 
         VkSwapchainKHR swapchain{};
-        if (CreateSwapchainKHR) CreateSwapchainKHR(dev.dev, &info, nullptr, &swapchain);
+        CreateSwapchainKHR(dev.dev, &info, nullptr, &swapchain);
         ASSERT_FALSE(
             log.find("vkCreateSwapchainKHR: Driver's function pointer was NULL, returning VK_SUCCESS. Was the VK_KHR_swapchain "
                      "extension enabled?"));
         log.logger.clear();
-        if (dev_funcs.vkDestroySwapchainKHR) dev_funcs.vkDestroySwapchainKHR(dev.dev, swapchain, nullptr);
-        if (inst_CreateSwapchainKHR) inst_CreateSwapchainKHR(dev.dev, &info, nullptr, &swapchain);
+        dev_funcs.vkDestroySwapchainKHR(dev.dev, swapchain, nullptr);
+        inst_CreateSwapchainKHR(dev.dev, &info, nullptr, &swapchain);
         ASSERT_FALSE(
             log.find("vkCreateSwapchainKHR: Driver's function pointer was NULL, returning VK_SUCCESS. Was the VK_KHR_swapchain "
                      "extension enabled?"));
         log.logger.clear();
-        if (dev_funcs.vkDestroySwapchainKHR) dev_funcs.vkDestroySwapchainKHR(dev.dev, swapchain, nullptr);
+        dev_funcs.vkDestroySwapchainKHR(dev.dev, swapchain, nullptr);
 
         VkDeviceGroupPresentModeFlagsKHR modes{};
-        if (GetDeviceGroupSurfacePresentModesKHR) GetDeviceGroupSurfacePresentModesKHR(dev.dev, surface, &modes);
+        GetDeviceGroupSurfacePresentModesKHR(dev.dev, surface, &modes);
 
-        if (CreateSharedSwapchainsKHR) CreateSharedSwapchainsKHR(dev.dev, 1, &info, nullptr, &swapchain);
+        CreateSharedSwapchainsKHR(dev.dev, 1, &info, nullptr, &swapchain);
     }
     env.vulkan_functions.vkDestroySurfaceKHR(inst.inst, surface, nullptr);
 }

--- a/tests/loader_phys_dev_inst_ext_tests.cpp
+++ b/tests/loader_phys_dev_inst_ext_tests.cpp
@@ -28,6 +28,8 @@
 
 #include "test_environment.h"
 
+#include <algorithm>
+
 // These tests are all instance extension tests that touch physical devices.  This was
 // before the idea that physical device extensions were more appropriately found in the
 // list of device extensions.  Because of that, all these tests need to support devices
@@ -411,57 +413,6 @@ void FillInRandomFeatures(VkPhysicalDeviceFeatures& feats) {
     feats.inheritedQueries = (rand() % 2) == 0 ? VK_FALSE : VK_TRUE;
 }
 
-// Compare the contents of the feature structs
-bool CompareFeatures(const VkPhysicalDeviceFeatures& feats1, const VkPhysicalDeviceFeatures2& feats2) {
-    return feats1.robustBufferAccess == feats2.features.robustBufferAccess &&
-           feats1.fullDrawIndexUint32 == feats2.features.fullDrawIndexUint32 &&
-           feats1.imageCubeArray == feats2.features.imageCubeArray && feats1.independentBlend == feats2.features.independentBlend &&
-           feats1.geometryShader == feats2.features.geometryShader &&
-           feats1.tessellationShader == feats2.features.tessellationShader &&
-           feats1.sampleRateShading == feats2.features.sampleRateShading && feats1.dualSrcBlend == feats2.features.dualSrcBlend &&
-           feats1.logicOp == feats2.features.logicOp && feats1.multiDrawIndirect == feats2.features.multiDrawIndirect &&
-           feats1.drawIndirectFirstInstance == feats2.features.drawIndirectFirstInstance &&
-           feats1.depthClamp == feats2.features.depthClamp && feats1.depthBiasClamp == feats2.features.depthBiasClamp &&
-           feats1.fillModeNonSolid == feats2.features.fillModeNonSolid && feats1.depthBounds == feats2.features.depthBounds &&
-           feats1.wideLines == feats2.features.wideLines && feats1.largePoints == feats2.features.largePoints &&
-           feats1.alphaToOne == feats2.features.alphaToOne && feats1.multiViewport == feats2.features.multiViewport &&
-           feats1.samplerAnisotropy == feats2.features.samplerAnisotropy &&
-           feats1.textureCompressionETC2 == feats2.features.textureCompressionETC2 &&
-           feats1.textureCompressionASTC_LDR == feats2.features.textureCompressionASTC_LDR &&
-           feats1.textureCompressionBC == feats2.features.textureCompressionBC &&
-           feats1.occlusionQueryPrecise == feats2.features.occlusionQueryPrecise &&
-           feats1.pipelineStatisticsQuery == feats2.features.pipelineStatisticsQuery &&
-           feats1.vertexPipelineStoresAndAtomics == feats2.features.vertexPipelineStoresAndAtomics &&
-           feats1.fragmentStoresAndAtomics == feats2.features.fragmentStoresAndAtomics &&
-           feats1.shaderTessellationAndGeometryPointSize == feats2.features.shaderTessellationAndGeometryPointSize &&
-           feats1.shaderImageGatherExtended == feats2.features.shaderImageGatherExtended &&
-           feats1.shaderStorageImageExtendedFormats == feats2.features.shaderStorageImageExtendedFormats &&
-           feats1.shaderStorageImageMultisample == feats2.features.shaderStorageImageMultisample &&
-           feats1.shaderStorageImageReadWithoutFormat == feats2.features.shaderStorageImageReadWithoutFormat &&
-           feats1.shaderStorageImageWriteWithoutFormat == feats2.features.shaderStorageImageWriteWithoutFormat &&
-           feats1.shaderUniformBufferArrayDynamicIndexing == feats2.features.shaderUniformBufferArrayDynamicIndexing &&
-           feats1.shaderSampledImageArrayDynamicIndexing == feats2.features.shaderSampledImageArrayDynamicIndexing &&
-           feats1.shaderStorageBufferArrayDynamicIndexing == feats2.features.shaderStorageBufferArrayDynamicIndexing &&
-           feats1.shaderStorageImageArrayDynamicIndexing == feats2.features.shaderStorageImageArrayDynamicIndexing &&
-           feats1.shaderClipDistance == feats2.features.shaderClipDistance &&
-           feats1.shaderCullDistance == feats2.features.shaderCullDistance &&
-           feats1.shaderFloat64 == feats2.features.shaderFloat64 && feats1.shaderInt64 == feats2.features.shaderInt64 &&
-           feats1.shaderInt16 == feats2.features.shaderInt16 &&
-           feats1.shaderResourceResidency == feats2.features.shaderResourceResidency &&
-           feats1.shaderResourceMinLod == feats2.features.shaderResourceMinLod &&
-           feats1.sparseBinding == feats2.features.sparseBinding &&
-           feats1.sparseResidencyBuffer == feats2.features.sparseResidencyBuffer &&
-           feats1.sparseResidencyImage2D == feats2.features.sparseResidencyImage2D &&
-           feats1.sparseResidencyImage3D == feats2.features.sparseResidencyImage3D &&
-           feats1.sparseResidency2Samples == feats2.features.sparseResidency2Samples &&
-           feats1.sparseResidency4Samples == feats2.features.sparseResidency4Samples &&
-           feats1.sparseResidency8Samples == feats2.features.sparseResidency8Samples &&
-           feats1.sparseResidency16Samples == feats2.features.sparseResidency16Samples &&
-           feats1.sparseResidencyAliased == feats2.features.sparseResidencyAliased &&
-           feats1.variableMultisampleRate == feats2.features.variableMultisampleRate &&
-           feats1.inheritedQueries == feats2.features.inheritedQueries;
-}
-
 // Test vkGetPhysicalDeviceFeatures2KHR where nothing supports it.
 TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRNoSupport) {
     FrameworkEnvironment env{};
@@ -513,7 +464,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRInstanceAndICDSupport) {
     instance->vkGetPhysicalDeviceFeatures(physical_device, &feats);
     VkPhysicalDeviceFeatures2 feats2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR};
     GetPhysDevFeats2KHR(physical_device, &feats2);
-    ASSERT_TRUE(CompareFeatures(feats, feats2));
+    ASSERT_EQ(feats, feats2);
 }
 
 // Test vkGetPhysicalDeviceFeatures2 where instance supports, an ICD, and a device under that ICD
@@ -545,7 +496,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2Simple) {
         instance->vkGetPhysicalDeviceFeatures(physical_device, &feats);
         VkPhysicalDeviceFeatures2 feats2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
         GetPhysDevFeats2(physical_device, &feats2);
-        ASSERT_TRUE(CompareFeatures(feats, feats2));
+        ASSERT_EQ(feats, feats2);
     }
     {  // Now do the same logic but the application didn't enable 1.0 or the extension so they get the emulated call
         InstWrapper instance(env.vulkan_functions);
@@ -566,7 +517,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2Simple) {
         instance->vkGetPhysicalDeviceFeatures(physical_device, &feats);
         VkPhysicalDeviceFeatures2 feats2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
         GetPhysDevFeats2(physical_device, &feats2);
-        ASSERT_TRUE(CompareFeatures(feats, feats2));
+        ASSERT_EQ(feats, feats2);
 
         ASSERT_TRUE(log.find("Emulating call in ICD"));
     }
@@ -595,7 +546,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2Simple) {
         instance->vkGetPhysicalDeviceFeatures(physical_device, &feats);
         VkPhysicalDeviceFeatures2 feats2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
         GetPhysDevFeats2(physical_device, &feats2);
-        ASSERT_TRUE(CompareFeatures(feats, feats2));
+        ASSERT_EQ(feats, feats2);
 
         ASSERT_FALSE(log.find("Emulating call in ICD"));
     }
@@ -635,11 +586,11 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRInstanceSupports11) {
 
     VkPhysicalDeviceFeatures2KHR feats2KHR{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR};
     GetPhysDevFeats2KHR(physical_device, &feats2KHR);
-    ASSERT_TRUE(CompareFeatures(feats, feats2KHR));
+    ASSERT_EQ(feats, feats2KHR);
 
     VkPhysicalDeviceFeatures2 feats2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
     GetPhysDevFeats2(physical_device, &feats2);
-    ASSERT_TRUE(CompareFeatures(feats, feats2));
+    ASSERT_EQ(feats, feats2);
 
     ASSERT_FALSE(log.find("Emulating call in ICD"));
 }
@@ -711,7 +662,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeatsMixed) {
         instance->vkGetPhysicalDeviceFeatures(physical_devices[dev], &feats);
         VkPhysicalDeviceFeatures2 feats2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
         GetPhysDevFeats2(physical_devices[dev], &feats2);
-        ASSERT_TRUE(CompareFeatures(feats, feats2));
+        ASSERT_EQ(feats, feats2);
     }
 }
 
@@ -1439,22 +1390,6 @@ void FillInRandomMemoryData(VkPhysicalDeviceMemoryProperties& props) {
     }
 }
 
-// Compare the memory structs
-bool CompareMemoryData(const VkPhysicalDeviceMemoryProperties& props1, const VkPhysicalDeviceMemoryProperties2& props2) {
-    bool equal = true;
-    equal = equal && props1.memoryTypeCount == props2.memoryProperties.memoryTypeCount;
-    equal = equal && props1.memoryHeapCount == props2.memoryProperties.memoryHeapCount;
-    for (uint32_t i = 0; i < props1.memoryHeapCount; ++i) {
-        equal = equal && props1.memoryHeaps[i].size == props2.memoryProperties.memoryHeaps[i].size;
-        equal = equal && props1.memoryHeaps[i].flags == props2.memoryProperties.memoryHeaps[i].flags;
-    }
-    for (uint32_t i = 0; i < props1.memoryTypeCount; ++i) {
-        equal = equal && props1.memoryTypes[i].propertyFlags == props2.memoryProperties.memoryTypes[i].propertyFlags;
-        equal = equal && props1.memoryTypes[i].heapIndex == props2.memoryProperties.memoryTypes[i].heapIndex;
-    }
-    return equal;
-}
-
 // Test vkGetPhysicalDeviceMemoryProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -1481,7 +1416,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRInstanceAndICDSupport) {
 
     VkPhysicalDeviceMemoryProperties2 props2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2};
     GetPhysDevMemoryProps2KHR(physical_device, &props2);
-    ASSERT_TRUE(CompareMemoryData(props, props2));
+    ASSERT_EQ(props, props2);
 }
 
 // Test vkGetPhysicalDeviceMemoryProperties2 where instance supports, an ICD, and a device under that ICD
@@ -1513,7 +1448,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2Simple) {
 
         VkPhysicalDeviceMemoryProperties2 props2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2};
         GetPhysDevMemoryProps2(physical_device, &props2);
-        ASSERT_TRUE(CompareMemoryData(props, props2));
+        ASSERT_EQ(props, props2);
     }
     {  // Now do the same logic but the application didn't enable 1.0 or the extension so they get the emulated call
         InstWrapper instance(env.vulkan_functions);
@@ -1535,7 +1470,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2Simple) {
 
         VkPhysicalDeviceMemoryProperties2 props2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2};
         GetPhysDevMemoryProps2(physical_device, &props2);
-        ASSERT_TRUE(CompareMemoryData(props, props2));
+        ASSERT_EQ(props, props2);
         ASSERT_TRUE(log.find("Emulating call in ICD"));
     }
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -1564,7 +1499,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2Simple) {
 
         VkPhysicalDeviceMemoryProperties2 props2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2};
         GetPhysDevMemoryProps2(physical_device, &props2);
-        ASSERT_TRUE(CompareMemoryData(props, props2));
+        ASSERT_EQ(props, props2);
         ASSERT_FALSE(log.find("Emulating call in ICD"));
     }
 }
@@ -1604,11 +1539,11 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRInstanceSupports11) {
 
     VkPhysicalDeviceMemoryProperties2 props2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2};
     GetPhysDevMemoryProps2(physical_device, &props2);
-    ASSERT_TRUE(CompareMemoryData(props, props2));
+    ASSERT_EQ(props, props2);
 
     VkPhysicalDeviceMemoryProperties2KHR props2KHR{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2_KHR};
     GetPhysDevMemoryProps2KHR(physical_device, &props2KHR);
-    ASSERT_TRUE(CompareMemoryData(props, props2KHR));
+    ASSERT_EQ(props, props2KHR);
 
     ASSERT_FALSE(log.find("Emulating call in ICD"));
 }
@@ -1680,7 +1615,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryPropsMixed) {
 
         VkPhysicalDeviceMemoryProperties2 props2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2};
         GetPhysDevMemoryProps2(physical_devices[dev], &props2);
-        ASSERT_TRUE(CompareMemoryData(props, props2));
+        ASSERT_EQ(props, props2);
     }
 }
 
@@ -1728,25 +1663,6 @@ uint32_t FillInRandomQueueFamilyData(std::vector<MockQueueFamilyProperties>& pro
     return static_cast<uint32_t>(props.size());
 }
 
-// Compare the queue family structs
-bool CompareQueueFamilyData(const std::vector<VkQueueFamilyProperties>& props1,
-                            const std::vector<VkQueueFamilyProperties2>& props2) {
-    if (props1.size() != props2.size()) return false;
-    bool equal = true;
-    for (uint32_t i = 0; i < props1.size(); ++i) {
-        equal = equal && props1[i].queueFlags == props2[i].queueFamilyProperties.queueFlags;
-        equal = equal && props1[i].queueCount == props2[i].queueFamilyProperties.queueCount;
-        equal = equal && props1[i].timestampValidBits == props2[i].queueFamilyProperties.timestampValidBits;
-        equal = equal &&
-                props1[i].minImageTransferGranularity.width == props2[i].queueFamilyProperties.minImageTransferGranularity.width;
-        equal = equal &&
-                props1[i].minImageTransferGranularity.height == props2[i].queueFamilyProperties.minImageTransferGranularity.height;
-        equal = equal &&
-                props1[i].minImageTransferGranularity.depth == props2[i].queueFamilyProperties.minImageTransferGranularity.depth;
-    }
-    return equal;
-}
-
 // Test vkGetPhysicalDeviceQueueFamilyProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -1782,7 +1698,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRInstanceAndICDSupport) {
     ASSERT_EQ(ret_fam_1, ret_fam_2);
     props2.resize(ret_fam_2, VkQueueFamilyProperties2{VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2});
     GetPhysDevQueueFamilyProps2KHR(physical_device, &ret_fam_2, props2.data());
-    ASSERT_TRUE(CompareQueueFamilyData(props, props2));
+    ASSERT_EQ(props, props2);
 }
 
 // Test vkGetPhysicalDeviceQueueFamilyProperties2 where instance supports, an ICD, and a device under that ICD
@@ -1824,7 +1740,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2Simple) {
         ASSERT_EQ(ret_fam_1, ret_fam_2);
         props2.resize(ret_fam_2, VkQueueFamilyProperties2{VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2});
         GetPhysDevQueueFamilyProps2(physical_device, &ret_fam_2, props2.data());
-        ASSERT_TRUE(CompareQueueFamilyData(props, props2));
+        ASSERT_EQ(props, props2);
     }
     {  // Now do the same logic but the application didn't enable 1.0 or the extension so they get the emulated call
         InstWrapper instance(env.vulkan_functions);
@@ -1856,7 +1772,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2Simple) {
         ASSERT_EQ(ret_fam_1, ret_fam_2);
         props2.resize(ret_fam_2, VkQueueFamilyProperties2{VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2});
         GetPhysDevQueueFamilyProps2(physical_device, &ret_fam_2, props2.data());
-        ASSERT_TRUE(CompareQueueFamilyData(props, props2));
+        ASSERT_EQ(props, props2);
         ASSERT_TRUE(log.find("Emulating call in ICD"));
     }
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -1895,7 +1811,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2Simple) {
         ASSERT_EQ(ret_fam_1, ret_fam_2);
         props2.resize(ret_fam_2, VkQueueFamilyProperties2{VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2});
         GetPhysDevQueueFamilyProps2(physical_device, &ret_fam_2, props2.data());
-        ASSERT_TRUE(CompareQueueFamilyData(props, props2));
+        ASSERT_EQ(props, props2);
         ASSERT_FALSE(log.find("Emulating call in ICD"));
     }
 }
@@ -1945,7 +1861,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRInstanceSupports11) {
     ASSERT_EQ(ret_fam_1, ret_fam_2);
     props2.resize(ret_fam_2, VkQueueFamilyProperties2{VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2});
     GetPhysDevQueueFamilyProps2(physical_device, &ret_fam_2, props2.data());
-    ASSERT_TRUE(CompareQueueFamilyData(props, props2));
+    ASSERT_EQ(props, props2);
 
     std::vector<VkQueueFamilyProperties2KHR> props2KHR{};
     uint32_t ret_fam_2_khr = 0;
@@ -1953,7 +1869,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRInstanceSupports11) {
     ASSERT_EQ(ret_fam_1, ret_fam_2_khr);
     props2KHR.resize(ret_fam_2_khr, VkQueueFamilyProperties2KHR{VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2_KHR});
     GetPhysDevQueueFamilyProps2KHR(physical_device, &ret_fam_2_khr, props2KHR.data());
-    ASSERT_TRUE(CompareQueueFamilyData(props, props2KHR));
+    ASSERT_EQ(props, props2KHR);
 
     ASSERT_FALSE(log.find("Emulating call in ICD"));
 }
@@ -2034,7 +1950,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyPropsMixed) {
         ASSERT_EQ(ret_fam_1, ret_fam_2);
         props2.resize(ret_fam_2, VkQueueFamilyProperties2{VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2});
         GetPhysDevQueueFamilyProps2(physical_devices[dev], &ret_fam_2, props2.data());
-        ASSERT_TRUE(CompareQueueFamilyData(props, props2));
+        ASSERT_EQ(props, props2);
     }
 }
 
@@ -2076,21 +1992,6 @@ void FillInRandomSparseImageFormatData(std::vector<VkSparseImageFormatProperties
                                      static_cast<uint32_t>(rand() % 512)};
         props[i].flags = static_cast<VkSparseImageFormatFlags>((rand() % 6) + 1);
     }
-}
-
-// Compare the sparse image format structs
-bool CompareSparseImageFormatData(const std::vector<VkSparseImageFormatProperties>& props1,
-                                  const std::vector<VkSparseImageFormatProperties2>& props2) {
-    if (props1.size() != props2.size()) return false;
-    bool equal = true;
-    for (uint32_t i = 0; i < props1.size(); ++i) {
-        equal = equal && props1[i].aspectMask == props2[i].properties.aspectMask;
-        equal = equal && props1[i].imageGranularity.width == props2[i].properties.imageGranularity.width;
-        equal = equal && props1[i].imageGranularity.height == props2[i].properties.imageGranularity.height;
-        equal = equal && props1[i].imageGranularity.depth == props2[i].properties.imageGranularity.depth;
-        equal = equal && props1[i].flags == props2[i].properties.flags;
-    }
-    return equal;
 }
 
 // Test vkGetPhysicalDeviceSparseImageFormatProperties2KHR where instance and ICD supports it, but device does not support it.
@@ -2142,7 +2043,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRInstanceAndICDSuppo
     props2.resize(sparse_count_2, VkSparseImageFormatProperties2{VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2});
     GetPhysDevSparseImageFormatProps2KHR(physical_device, &info2, &sparse_count_2, props2.data());
     ASSERT_EQ(sparse_count_1, sparse_count_2);
-    ASSERT_TRUE(CompareSparseImageFormatData(props, props2));
+    ASSERT_EQ(props, props2);
 }
 
 // Test vkGetPhysicalDeviceSparseImageFormatProperties2 where instance supports, an ICD, and a device under that ICD
@@ -2198,7 +2099,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2Simple) {
         props2.resize(sparse_count_2, VkSparseImageFormatProperties2{VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2});
         GetPhysDevSparseImageFormatProps2(physical_device, &info2, &sparse_count_2, props2.data());
         ASSERT_EQ(sparse_count_1, sparse_count_2);
-        ASSERT_TRUE(CompareSparseImageFormatData(props, props2));
+        ASSERT_EQ(props, props2);
     }
     {  // Now do the same logic but the application didn't enable 1.0 or the extension so they get the emulated call
         InstWrapper instance(env.vulkan_functions);
@@ -2244,7 +2145,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2Simple) {
         props2.resize(sparse_count_2, VkSparseImageFormatProperties2{VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2});
         GetPhysDevSparseImageFormatProps2(physical_device, &info2, &sparse_count_2, props2.data());
         ASSERT_EQ(sparse_count_1, sparse_count_2);
-        ASSERT_TRUE(CompareSparseImageFormatData(props, props2));
+        ASSERT_EQ(props, props2);
         ASSERT_TRUE(log.find("Emulating call in ICD"));
     }
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -2297,7 +2198,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2Simple) {
         props2.resize(sparse_count_2, VkSparseImageFormatProperties2{VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2});
         GetPhysDevSparseImageFormatProps2(physical_device, &info2, &sparse_count_2, props2.data());
         ASSERT_EQ(sparse_count_1, sparse_count_2);
-        ASSERT_TRUE(CompareSparseImageFormatData(props, props2));
+        ASSERT_EQ(props, props2);
         ASSERT_FALSE(log.find("Emulating call in ICD"));
     }
 }
@@ -2361,7 +2262,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRInstanceSupports11)
     props2.resize(sparse_count_2, VkSparseImageFormatProperties2{VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2});
     GetPhysDevSparseImageFormatProps2(physical_device, &info2, &sparse_count_2, props2.data());
     ASSERT_EQ(sparse_count_1, sparse_count_2);
-    ASSERT_TRUE(CompareSparseImageFormatData(props, props2));
+    ASSERT_EQ(props, props2);
 
     std::vector<VkSparseImageFormatProperties2KHR> props2KHR{};
     uint32_t sparse_count_2_khr = 0;
@@ -2370,7 +2271,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRInstanceSupports11)
     props2KHR.resize(sparse_count_2, VkSparseImageFormatProperties2KHR{VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2_KHR});
     GetPhysDevSparseImageFormatProps2KHR(physical_device, &info2, &sparse_count_2_khr, props2KHR.data());
     ASSERT_EQ(sparse_count_1, sparse_count_2_khr);
-    ASSERT_TRUE(CompareSparseImageFormatData(props, props2KHR));
+    ASSERT_EQ(props, props2KHR);
 
     ASSERT_FALSE(log.find("Emulating call in ICD"));
 }
@@ -2467,7 +2368,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatPropsMixed) {
         props2.resize(sparse_count_2, VkSparseImageFormatProperties2{VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2});
         GetPhysDevSparseImageFormatProps2(physical_devices[dev], &info2, &sparse_count_2, props2.data());
         ASSERT_EQ(sparse_count_1, sparse_count_2);
-        ASSERT_TRUE(CompareSparseImageFormatData(props, props2));
+        ASSERT_EQ(props, props2);
     }
 }
 
@@ -2511,22 +2412,6 @@ void FillInRandomExtMemoryData(VkExternalMemoryProperties& props) {
     props.compatibleHandleTypes = static_cast<VkExternalMemoryHandleTypeFlags>((rand() % 0x1FFE) + 1);
 }
 
-// Compare the external memory data structs
-bool CompareExtMemoryData(const VkExternalMemoryProperties& props1, const VkExternalMemoryProperties& props2,
-                          bool supported = true) {
-    bool equal = true;
-    if (supported) {
-        equal = equal && props1.externalMemoryFeatures == props2.externalMemoryFeatures;
-        equal = equal && props1.exportFromImportedHandleTypes == props2.exportFromImportedHandleTypes;
-        equal = equal && props1.compatibleHandleTypes == props2.compatibleHandleTypes;
-    } else {
-        equal = equal && 0 == props2.externalMemoryFeatures;
-        equal = equal && 0 == props2.exportFromImportedHandleTypes;
-        equal = equal && 0 == props2.compatibleHandleTypes;
-    }
-    return equal;
-}
-
 // Test vkGetPhysicalDeviceExternalBufferPropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -2551,8 +2436,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2KHRInstanceAndICDSupport) {
     VkPhysicalDeviceExternalBufferInfoKHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO_KHR};
     VkExternalBufferPropertiesKHR props{VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR};
     GetPhysicalDeviceExternalBufferPropertiesKHR(physical_device, &info, &props);
-    ASSERT_TRUE(CompareExtMemoryData(env.get_test_icd(0).physical_devices.back().external_memory_properties,
-                                     props.externalMemoryProperties));
+    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_memory_properties, props.externalMemoryProperties);
 }
 
 // Test vkGetPhysicalDeviceExternalBufferProperties where instance supports, an ICD, and a device under that ICD
@@ -2583,8 +2467,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2Simple) {
         VkPhysicalDeviceExternalBufferInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO};
         VkExternalBufferProperties props{VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES};
         GetPhysicalDeviceExternalBufferProperties(physical_device, &info, &props);
-        ASSERT_TRUE(CompareExtMemoryData(env.get_test_icd(0).physical_devices.back().external_memory_properties,
-                                         props.externalMemoryProperties));
+        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_memory_properties, props.externalMemoryProperties);
     }
     {  // Now do the same logic but the application didn't enable 1.0 or the extension so they get the emulated call
         InstWrapper instance(env.vulkan_functions);
@@ -2606,7 +2489,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2Simple) {
         VkExternalBufferProperties props{VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES};
         GetPhysicalDeviceExternalBufferProperties(physical_device, &info, &props);
         // Compare against 'zeroed' out VkExternalMemoryProperties
-        ASSERT_TRUE(CompareExtMemoryData(VkExternalMemoryProperties{}, props.externalMemoryProperties));
+        ASSERT_EQ(VkExternalMemoryProperties{}, props.externalMemoryProperties);
         ASSERT_TRUE(log.find("Emulating call in ICD"));
     }
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -2634,8 +2517,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2Simple) {
         VkPhysicalDeviceExternalBufferInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO};
         VkExternalBufferProperties props{VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES};
         GetPhysicalDeviceExternalBufferProperties(physical_device, &info, &props);
-        ASSERT_TRUE(CompareExtMemoryData(env.get_test_icd(0).physical_devices.back().external_memory_properties,
-                                         props.externalMemoryProperties));
+        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_memory_properties, props.externalMemoryProperties);
         ASSERT_FALSE(log.find("Emulating call in ICD"));
     }
 }
@@ -2722,7 +2604,12 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsMixed) {
                     VkExternalBufferProperties props{VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES};
                     GetPhysicalDeviceExternalBufferProperties(physical_devices[dev], &info, &props);
                     // No driver support for extension or 1.1 for ICD 1, all others support
-                    ASSERT_TRUE(CompareExtMemoryData(cur_dev.external_memory_properties, props.externalMemoryProperties, icd != 1));
+                    if (icd != 1) {
+                        ASSERT_EQ(cur_dev.external_memory_properties, props.externalMemoryProperties);
+                    } else {
+                        ASSERT_EQ(props.externalMemoryProperties, VkExternalMemoryProperties{});
+                    }
+
                     found = true;
                     break;
                 }
@@ -2776,22 +2663,6 @@ void FillInRandomExtSemData(VkExternalSemaphoreProperties& props) {
     props.externalSemaphoreFeatures = static_cast<VkExternalSemaphoreFeatureFlags>((rand() % 0xFFF) + 1);
 }
 
-// Compare the external semaphore data structs
-bool CompareExtSemaphoreData(const VkExternalSemaphoreProperties& props1, const VkExternalSemaphoreProperties& props2,
-                             bool supported = true) {
-    bool equal = true;
-    if (supported) {
-        equal = equal && props1.externalSemaphoreFeatures == props2.externalSemaphoreFeatures;
-        equal = equal && props1.exportFromImportedHandleTypes == props2.exportFromImportedHandleTypes;
-        equal = equal && props1.compatibleHandleTypes == props2.compatibleHandleTypes;
-    } else {
-        equal = equal && 0 == props2.externalSemaphoreFeatures;
-        equal = equal && 0 == props2.exportFromImportedHandleTypes;
-        equal = equal && 0 == props2.compatibleHandleTypes;
-    }
-    return equal;
-}
-
 // Test vkGetPhysicalDeviceExternalSemaphorePropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -2816,7 +2687,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2KHRInstanceAndICDSupport) {
     VkPhysicalDeviceExternalSemaphoreInfoKHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO_KHR};
     VkExternalSemaphorePropertiesKHR props{VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES_KHR};
     GetPhysicalDeviceExternalSemaphorePropertiesKHR(physical_device, &info, &props);
-    ASSERT_TRUE(CompareExtSemaphoreData(env.get_test_icd(0).physical_devices.back().external_semaphore_properties, props));
+    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_semaphore_properties, props);
 }
 
 // Test vkGetPhysicalDeviceExternalSemaphoreProperties where instance supports, an ICD, and a device under that ICD
@@ -2847,7 +2718,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2Simple) {
         VkPhysicalDeviceExternalSemaphoreInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO};
         VkExternalSemaphoreProperties props{VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES};
         GetPhysicalDeviceExternalSemaphoreProperties(physical_device, &info, &props);
-        ASSERT_TRUE(CompareExtSemaphoreData(env.get_test_icd(0).physical_devices.back().external_semaphore_properties, props));
+        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_semaphore_properties, props);
     }
     {  // Now do the same logic but the application didn't enable 1.0 or the extension so they get the emulated call
         InstWrapper instance(env.vulkan_functions);
@@ -2868,7 +2739,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2Simple) {
         VkExternalSemaphoreProperties props{VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES};
         GetPhysicalDeviceExternalSemaphoreProperties(physical_device, &info, &props);
         // Compare against 'zeroed' out VkExternalSemaphoreProperties
-        ASSERT_TRUE(CompareExtSemaphoreData(VkExternalSemaphoreProperties{}, props));
+        ASSERT_EQ(VkExternalSemaphoreProperties{}, props);
         ASSERT_TRUE(log.find("Emulating call in ICD"));
     }
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -2895,7 +2766,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2Simple) {
         VkPhysicalDeviceExternalSemaphoreInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO};
         VkExternalSemaphoreProperties props{VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES};
         GetPhysicalDeviceExternalSemaphoreProperties(physical_device, &info, &props);
-        ASSERT_TRUE(CompareExtSemaphoreData(env.get_test_icd(0).physical_devices.back().external_semaphore_properties, props));
+        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_semaphore_properties, props);
         ASSERT_FALSE(log.find("Emulating call in ICD"));
     }
 }
@@ -2982,7 +2853,11 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsMixed) {
                     VkExternalSemaphoreProperties props{VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES};
                     GetPhysicalDeviceExternalSemaphoreProperties(physical_devices[dev], &info, &props);
                     // No driver support for extension or 1.1 for ICD 1, all others support
-                    ASSERT_TRUE(CompareExtSemaphoreData(cur_dev.external_semaphore_properties, props, icd != 1));
+                    if (icd != 1) {
+                        ASSERT_EQ(cur_dev.external_semaphore_properties, props);
+                    } else {
+                        ASSERT_EQ(props, VkExternalSemaphoreProperties{});
+                    }
                     found = true;
                     break;
                 }
@@ -3036,21 +2911,6 @@ void FillInRandomExtFenceData(VkExternalFenceProperties& props) {
     props.externalFenceFeatures = static_cast<VkExternalFenceFeatureFlags>((rand() % 0xFFF) + 1);
 }
 
-// Compare the external fence data structs
-bool CompareExtFenceData(const VkExternalFenceProperties& props1, const VkExternalFenceProperties& props2, bool supported = true) {
-    bool equal = true;
-    if (supported) {
-        equal = equal && props1.externalFenceFeatures == props2.externalFenceFeatures;
-        equal = equal && props1.exportFromImportedHandleTypes == props2.exportFromImportedHandleTypes;
-        equal = equal && props1.compatibleHandleTypes == props2.compatibleHandleTypes;
-    } else {
-        equal = equal && 0 == props2.externalFenceFeatures;
-        equal = equal && 0 == props2.exportFromImportedHandleTypes;
-        equal = equal && 0 == props2.compatibleHandleTypes;
-    }
-    return equal;
-}
-
 // Test vkGetPhysicalDeviceExternalFencePropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -3075,7 +2935,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2KHRInstanceAndICDSupport) {
     VkPhysicalDeviceExternalFenceInfoKHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO_KHR};
     VkExternalFencePropertiesKHR props{VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES_KHR};
     GetPhysicalDeviceExternalFencePropertiesKHR(physical_device, &info, &props);
-    ASSERT_TRUE(CompareExtFenceData(env.get_test_icd(0).physical_devices.back().external_fence_properties, props));
+    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_fence_properties, props);
 }
 
 // Test vkGetPhysicalDeviceExternalFenceProperties where instance supports, an ICD, and a device under that ICD
@@ -3106,7 +2966,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2Simple) {
         VkPhysicalDeviceExternalFenceInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO};
         VkExternalFenceProperties props{VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES};
         GetPhysicalDeviceExternalFenceProperties(physical_device, &info, &props);
-        ASSERT_TRUE(CompareExtFenceData(env.get_test_icd(0).physical_devices.back().external_fence_properties, props));
+        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_fence_properties, props);
     }
     {  // Now do the same logic but the application didn't enable 1.0 or the extension so they get the emulated call
         InstWrapper instance(env.vulkan_functions);
@@ -3128,7 +2988,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2Simple) {
         VkExternalFenceProperties props{VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES};
         GetPhysicalDeviceExternalFenceProperties(physical_device, &info, &props);
         // Compare against 'zeroed' out VkExternalFenceProperties
-        ASSERT_TRUE(CompareExtFenceData(VkExternalFenceProperties{}, props));
+        ASSERT_EQ(VkExternalFenceProperties{}, props);
         ASSERT_TRUE(log.find("Emulating call in ICD"));
     }
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -3155,7 +3015,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2Simple) {
         VkPhysicalDeviceExternalFenceInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO};
         VkExternalFenceProperties props{VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES};
         GetPhysicalDeviceExternalFenceProperties(physical_device, &info, &props);
-        ASSERT_TRUE(CompareExtFenceData(env.get_test_icd(0).physical_devices.back().external_fence_properties, props));
+        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_fence_properties, props);
         ASSERT_FALSE(log.find("Emulating call in ICD"));
     }
 }
@@ -3241,7 +3101,11 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsMixed) {
                     VkExternalFenceProperties props{VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES};
                     GetPhysicalDeviceExternalFenceProperties(physical_devices[dev], &info, &props);
                     // No driver support for extension or 1.1 for ICD 1, all others support
-                    ASSERT_TRUE(CompareExtFenceData(cur_dev.external_fence_properties, props, icd != 1));
+                    if (icd != 1) {
+                        ASSERT_EQ(cur_dev.external_fence_properties, props);
+                    } else {
+                        ASSERT_EQ(props, VkExternalFenceProperties{});
+                    }
                     found = true;
                     break;
                 }
@@ -3303,41 +3167,6 @@ void FillInRandomSurfaceCapsData(VkSurfaceCapabilitiesKHR& props) {
     props.supportedUsageFlags = static_cast<VkImageUsageFlags>((rand() % 0xFFF) + 1);
 }
 
-// Compare the surface capability data structs
-bool CompareSurfaceCapsData(const VkSurfaceCapabilitiesKHR& props1, const VkSurfaceCapabilitiesKHR& props2, bool supported = true) {
-    bool equal = true;
-    if (supported) {
-        equal = equal && props1.minImageCount == props2.minImageCount;
-        equal = equal && props1.maxImageCount == props2.maxImageCount;
-        equal = equal && props1.currentExtent.width == props2.currentExtent.width;
-        equal = equal && props1.currentExtent.height == props2.currentExtent.height;
-        equal = equal && props1.minImageExtent.width == props2.minImageExtent.width;
-        equal = equal && props1.minImageExtent.height == props2.minImageExtent.height;
-        equal = equal && props1.maxImageExtent.width == props2.maxImageExtent.width;
-        equal = equal && props1.maxImageExtent.height == props2.maxImageExtent.height;
-        equal = equal && props1.maxImageArrayLayers == props2.maxImageArrayLayers;
-        equal = equal && props1.supportedTransforms == props2.supportedTransforms;
-        equal = equal && props1.currentTransform == props2.currentTransform;
-        equal = equal && props1.supportedCompositeAlpha == props2.supportedCompositeAlpha;
-        equal = equal && props1.supportedUsageFlags == props2.supportedUsageFlags;
-    } else {
-        equal = equal && 0 == props2.minImageCount;
-        equal = equal && 0 == props2.maxImageCount;
-        equal = equal && 0 == props2.currentExtent.width;
-        equal = equal && 0 == props2.currentExtent.height;
-        equal = equal && 0 == props2.minImageExtent.width;
-        equal = equal && 0 == props2.minImageExtent.height;
-        equal = equal && 0 == props2.maxImageExtent.width;
-        equal = equal && 0 == props2.maxImageExtent.height;
-        equal = equal && 0 == props2.maxImageArrayLayers;
-        equal = equal && 0 == props2.supportedTransforms;
-        equal = equal && 0 == props2.currentTransform;
-        equal = equal && 0 == props2.supportedCompositeAlpha;
-        equal = equal && 0 == props2.supportedUsageFlags;
-    }
-    return equal;
-}
-
 // Test vkGetPhysicalDeviceSurfaceCapabilities2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -3383,7 +3212,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRInstanceAndICDSupport) {
     VkPhysicalDeviceSurfaceInfo2KHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, nullptr, surface};
     VkSurfaceCapabilities2KHR props2{VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR};
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceCapabilities2KHR(physical_device, &info, &props2));
-    ASSERT_TRUE(CompareSurfaceCapsData(props, props2.surfaceCapabilities));
+    ASSERT_EQ(props, props2.surfaceCapabilities);
 
     DestroySurfaceKHR(instance.inst, surface, nullptr);
 }
@@ -3479,7 +3308,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRMixed) {
         VkPhysicalDeviceSurfaceInfo2KHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, nullptr, surface};
         VkSurfaceCapabilities2KHR props2{VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR};
         ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceCapabilities2KHR(physical_devices[dev], &info, &props2));
-        ASSERT_TRUE(CompareSurfaceCapsData(props, props2.surfaceCapabilities));
+        ASSERT_EQ(props, props2.surfaceCapabilities);
     }
 
     DestroySurfaceKHR(instance.inst, surface, nullptr);
@@ -3523,23 +3352,6 @@ void FillInRandomSurfaceFormatsData(std::vector<VkSurfaceFormatKHR>& props) {
     }
 }
 
-// Compare the surface formats data structs
-bool CompareSurfaceFormatsData(const std::vector<VkSurfaceFormatKHR>& props1, const std::vector<VkSurfaceFormat2KHR>& props2,
-                               bool supported = true) {
-    if (props1.size() != props2.size()) return false;
-    bool equal = true;
-    for (uint32_t i = 0; i < props1.size(); ++i) {
-        if (supported) {
-            equal = equal && props1[i].format == props2[i].surfaceFormat.format;
-            equal = equal && props1[i].colorSpace == props2[i].surfaceFormat.colorSpace;
-        } else {
-            equal = equal && 0 == props2[i].surfaceFormat.format;
-            equal = equal && 0 == props2[i].surfaceFormat.colorSpace;
-        }
-    }
-    return equal;
-}
-
 // Test vkGetPhysicalDeviceSurfaceFormats2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -3579,23 +3391,22 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRInstanceAndICDSupport) {
     VkHeadlessSurfaceCreateInfoEXT create_info{VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT};
     ASSERT_EQ(VK_SUCCESS, CreateHeadlessSurfaceEXT(instance.inst, &create_info, nullptr, &surface));
 
-    std::vector<VkSurfaceFormatKHR> props{};
+    std::vector<VkSurfaceFormatKHR> formats{};
     uint32_t count_1 = 0;
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface, &count_1, nullptr));
     ASSERT_EQ(env.get_test_icd(0).physical_devices.back().surface_formats.size(), count_1);
-    props.resize(count_1);
-    ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface, &count_1, props.data()));
+    formats.resize(count_1);
+    ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface, &count_1, formats.data()));
     ASSERT_EQ(env.get_test_icd(0).physical_devices.back().surface_formats.size(), count_1);
 
     VkPhysicalDeviceSurfaceInfo2KHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, nullptr, surface};
-    std::vector<VkSurfaceFormat2KHR> props2{};
+    std::vector<VkSurfaceFormat2KHR> formats2{};
     uint32_t count_2 = 0;
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormats2KHR(physical_device, &info, &count_2, nullptr));
     ASSERT_EQ(count_1, count_2);
-    props2.resize(count_2, VkSurfaceFormat2KHR{VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR});
-    ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormats2KHR(physical_device, &info, &count_2, props2.data()));
-    ASSERT_TRUE(CompareSurfaceFormatsData(props, props2));
-
+    formats2.resize(count_2, VkSurfaceFormat2KHR{VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR});
+    ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormats2KHR(physical_device, &info, &count_2, formats2.data()));
+    ASSERT_EQ(formats, formats2);
     DestroySurfaceKHR(instance.inst, surface, nullptr);
 }
 
@@ -3684,23 +3495,23 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRMixed) {
     ASSERT_EQ(VK_SUCCESS, CreateHeadlessSurfaceEXT(instance.inst, &create_info, nullptr, &surface));
 
     for (uint32_t dev = 0; dev < device_count; ++dev) {
-        std::vector<VkSurfaceFormatKHR> props{};
+        std::vector<VkSurfaceFormatKHR> formats{};
         uint32_t count_1 = 0;
         ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormatsKHR(physical_devices[dev], surface, &count_1, nullptr));
         ASSERT_NE(0U, count_1);
-        props.resize(count_1);
-        ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormatsKHR(physical_devices[dev], surface, &count_1, props.data()));
+        formats.resize(count_1);
+        ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormatsKHR(physical_devices[dev], surface, &count_1, formats.data()));
         ASSERT_NE(0U, count_1);
 
         VkPhysicalDeviceSurfaceInfo2KHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, nullptr, surface};
-        std::vector<VkSurfaceFormat2KHR> props2{};
+        std::vector<VkSurfaceFormat2KHR> formats2{};
         uint32_t count_2 = 0;
         ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormats2KHR(physical_devices[dev], &info, &count_2, nullptr));
         ASSERT_EQ(count_1, count_2);
-        props2.resize(count_2, VkSurfaceFormat2KHR{VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR});
-        ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormats2KHR(physical_devices[dev], &info, &count_2, props2.data()));
+        formats2.resize(count_2, VkSurfaceFormat2KHR{VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR});
+        ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormats2KHR(physical_devices[dev], &info, &count_2, formats2.data()));
         ASSERT_EQ(count_1, count_2);
-        ASSERT_TRUE(CompareSurfaceFormatsData(props, props2));
+        ASSERT_EQ(formats, formats2);
     }
 
     DestroySurfaceKHR(instance.inst, surface, nullptr);
@@ -3760,23 +3571,6 @@ void FillInRandomDisplayPropData(std::vector<VkDisplayPropertiesKHR>& props) {
     }
 }
 
-// Compare the display property data structs
-bool CompareDisplayPropData(const std::vector<VkDisplayPropertiesKHR>& props1, const std::vector<VkDisplayPropertiesKHR>& props2) {
-    if (props1.size() != props2.size()) return false;
-    bool equal = true;
-    for (uint32_t i = 0; i < props1.size(); ++i) {
-        equal = equal && props1[i].display == props2[i].display;
-        equal = equal && props1[i].physicalDimensions.width == props2[i].physicalDimensions.width;
-        equal = equal && props1[i].physicalDimensions.height == props2[i].physicalDimensions.height;
-        equal = equal && props1[i].physicalResolution.width == props2[i].physicalResolution.width;
-        equal = equal && props1[i].physicalResolution.height == props2[i].physicalResolution.height;
-        equal = equal && props1[i].supportedTransforms == props2[i].supportedTransforms;
-        equal = equal && props1[i].planeReorderPossible == props2[i].planeReorderPossible;
-        equal = equal && props1[i].persistentContent == props2[i].persistentContent;
-    }
-    return equal;
-}
-
 // Test vGetPhysicalDeviceDisplayPropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -3806,7 +3600,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRInstanceAndICDSupport) {
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPropertiesKHR(physical_device, &prop_count, props.data()));
     ASSERT_EQ(env.get_test_icd(0).physical_devices.back().display_properties.size(), prop_count);
 
-    ASSERT_TRUE(CompareDisplayPropData(props, env.get_test_icd(0).physical_devices.back().display_properties));
+    ASSERT_EQ(props, env.get_test_icd(0).physical_devices.back().display_properties);
 }
 
 // Test vkGetPhysicalDeviceDisplayPropertiesKHR where instance supports it with some ICDs that both support
@@ -3902,7 +3696,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRMixed) {
                                   GetPhysicalDeviceDisplayPropertiesKHR(physical_devices[dev], &prop_count, props.data()));
                         ASSERT_EQ(cur_dev.display_properties.size(), prop_count);
 
-                        ASSERT_TRUE(CompareDisplayPropData(props, cur_dev.display_properties));
+                        ASSERT_EQ(props, cur_dev.display_properties);
                     }
                     found = true;
                     break;
@@ -3953,18 +3747,6 @@ void FillInRandomDisplayPlanePropData(std::vector<VkDisplayPlanePropertiesKHR>& 
     }
 }
 
-// Compare the display plane property data structs
-bool CompareDisplayPlanePropData(const std::vector<VkDisplayPlanePropertiesKHR>& props1,
-                                 const std::vector<VkDisplayPlanePropertiesKHR>& props2) {
-    if (props1.size() != props2.size()) return false;
-    bool equal = true;
-    for (uint32_t i = 0; i < props1.size(); ++i) {
-        equal = equal && props1[i].currentDisplay == props2[i].currentDisplay;
-        equal = equal && props1[i].currentStackIndex == props2[i].currentStackIndex;
-    }
-    return equal;
-}
-
 // Test vGetPhysicalDeviceDisplayPlanePropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -3994,7 +3776,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRInstanceAndICDSupport) {
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPlanePropertiesKHR(physical_device, &prop_count, props.data()));
     ASSERT_EQ(env.get_test_icd(0).physical_devices.back().display_plane_properties.size(), prop_count);
 
-    ASSERT_TRUE(CompareDisplayPlanePropData(props, env.get_test_icd(0).physical_devices.back().display_plane_properties));
+    ASSERT_EQ(props, env.get_test_icd(0).physical_devices.back().display_plane_properties);
 }
 
 // Test vkGetPhysicalDeviceDisplayPlanePropertiesKHR where instance supports it with some ICDs that both support
@@ -4090,7 +3872,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRMixed) {
                                   GetPhysicalDeviceDisplayPlanePropertiesKHR(physical_devices[dev], &prop_count, props.data()));
                         ASSERT_EQ(cur_dev.display_plane_properties.size(), prop_count);
 
-                        ASSERT_TRUE(CompareDisplayPlanePropData(props, cur_dev.display_plane_properties));
+                        ASSERT_EQ(props, cur_dev.display_plane_properties);
                     }
                     found = true;
                     break;
@@ -4140,16 +3922,6 @@ void GenerateRandomDisplays(std::vector<VkDisplayKHR>& disps) {
     }
 }
 
-// Compare the display plane property data structs
-bool CompareDisplays(const std::vector<VkDisplayKHR>& disps1, const std::vector<VkDisplayKHR>& disps2) {
-    if (disps1.size() != disps2.size()) return false;
-    bool equal = true;
-    for (uint32_t i = 0; i < disps1.size(); ++i) {
-        equal = equal && disps1[i] == disps2[i];
-    }
-    return equal;
-}
-
 // Test vGetDisplayPlaneSupportedDisplaysKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -4179,7 +3951,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRInstanceAndICDSupport) {
     ASSERT_EQ(VK_SUCCESS, GetDisplayPlaneSupportedDisplaysKHR(physical_device, 0, &disp_count, disps.data()));
     ASSERT_EQ(env.get_test_icd(0).physical_devices.back().displays.size(), disp_count);
 
-    ASSERT_TRUE(CompareDisplays(disps, env.get_test_icd(0).physical_devices.back().displays));
+    ASSERT_EQ(disps, env.get_test_icd(0).physical_devices.back().displays);
 }
 
 // Test vkGetDisplayPlaneSupportedDisplaysKHR where instance supports it with some ICDs that both support
@@ -4275,7 +4047,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRMixed) {
                                   GetDisplayPlaneSupportedDisplaysKHR(physical_devices[dev], 0, &disp_count, disps.data()));
                         ASSERT_EQ(cur_dev.displays.size(), disp_count);
 
-                        ASSERT_TRUE(CompareDisplays(disps, cur_dev.displays));
+                        ASSERT_EQ(disps, cur_dev.displays);
                     }
                     found = true;
                     break;
@@ -4326,20 +4098,6 @@ void GenerateRandomDisplayModeProps(std::vector<VkDisplayModePropertiesKHR>& dis
     }
 }
 
-// Compare the display mode properties data structs
-bool CompareDisplayModeProps(const std::vector<VkDisplayModePropertiesKHR>& disps1,
-                             const std::vector<VkDisplayModePropertiesKHR>& disps2) {
-    if (disps1.size() != disps2.size()) return false;
-    bool equal = true;
-    for (uint32_t i = 0; i < disps1.size(); ++i) {
-        equal = equal && disps1[i].displayMode == disps2[i].displayMode;
-        equal = equal && disps1[i].parameters.visibleRegion.width == disps2[i].parameters.visibleRegion.width;
-        equal = equal && disps1[i].parameters.visibleRegion.height == disps2[i].parameters.visibleRegion.height;
-        equal = equal && disps1[i].parameters.refreshRate == disps2[i].parameters.refreshRate;
-    }
-    return equal;
-}
-
 // Test vGetDisplayModePropertiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDispModePropsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -4368,7 +4126,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRInstanceAndICDSupport) {
     ASSERT_EQ(VK_SUCCESS, GetDisplayModePropertiesKHR(physical_device, VK_NULL_HANDLE, &props_count, props.data()));
     ASSERT_EQ(env.get_test_icd(0).physical_devices.back().display_mode_properties.size(), props_count);
 
-    ASSERT_TRUE(CompareDisplayModeProps(props, env.get_test_icd(0).physical_devices.back().display_mode_properties));
+    ASSERT_EQ(props, env.get_test_icd(0).physical_devices.back().display_mode_properties);
 }
 
 // Test vkGetDisplayModePropertiesKHR where instance supports it with some ICDs that both support
@@ -4464,7 +4222,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRMixed) {
                                   GetDisplayModePropertiesKHR(physical_devices[dev], VK_NULL_HANDLE, &props_count, props.data()));
                         ASSERT_EQ(cur_dev.display_mode_properties.size(), props_count);
 
-                        ASSERT_TRUE(CompareDisplayModeProps(props, cur_dev.display_mode_properties));
+                        ASSERT_EQ(props, cur_dev.display_mode_properties);
                     }
                     found = true;
                     break;
@@ -4504,9 +4262,6 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRNoICDSupport) {
     ASSERT_EQ(CreateDisplayModeKHR, nullptr);
 }
 
-// Compare the display modes
-bool CompareDisplayModes(const VkDisplayModeKHR& disps1, VkDisplayModeKHR& disps2) { return disps1 == disps2; }
-
 // Test vkCreateDisplayModeKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDispModesKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -4530,7 +4285,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRInstanceAndICDSupport) {
     VkDisplayModeKHR mode{};
     VkDisplayModeCreateInfoKHR create_info{VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR};
     ASSERT_EQ(VK_SUCCESS, CreateDisplayModeKHR(physical_device, VK_NULL_HANDLE, &create_info, nullptr, &mode));
-    ASSERT_TRUE(CompareDisplayModes(mode, env.get_test_icd(0).physical_devices.back().display_mode));
+    ASSERT_EQ(mode, env.get_test_icd(0).physical_devices.back().display_mode);
 }
 
 // Test vkCreateDisplayModeKHR where instance supports it with some ICDs that both support
@@ -4620,7 +4375,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRMixed) {
                     } else {
                         ASSERT_EQ(VK_SUCCESS,
                                   CreateDisplayModeKHR(physical_devices[dev], VK_NULL_HANDLE, &create_info, nullptr, &mode));
-                        ASSERT_TRUE(CompareDisplayModes(mode, cur_dev.display_mode));
+                        ASSERT_EQ(mode, cur_dev.display_mode);
                     }
                     found = true;
                     break;
@@ -4681,50 +4436,6 @@ void GenerateRandomDisplayPlaneCaps(VkDisplayPlaneCapabilitiesKHR& caps) {
     caps.maxDstExtent.height = static_cast<uint32_t>((rand() % 0xFFFFFFF) + 1);
 }
 
-// Compare the display plane caps
-bool CompareDisplayPlaneCaps(const VkDisplayPlaneCapabilitiesKHR& caps1, VkDisplayPlaneCapabilitiesKHR& caps2,
-                             bool supported = true) {
-    bool equal = true;
-    if (supported) {
-        equal = equal && caps1.supportedAlpha == caps2.supportedAlpha;
-        equal = equal && caps1.minSrcPosition.x == caps2.minSrcPosition.x;
-        equal = equal && caps1.minSrcPosition.y == caps2.minSrcPosition.y;
-        equal = equal && caps1.maxSrcPosition.x == caps2.maxSrcPosition.x;
-        equal = equal && caps1.maxSrcPosition.y == caps2.maxSrcPosition.y;
-        equal = equal && caps1.minSrcExtent.width == caps2.minSrcExtent.width;
-        equal = equal && caps1.minSrcExtent.height == caps2.minSrcExtent.height;
-        equal = equal && caps1.maxSrcExtent.width == caps2.maxSrcExtent.width;
-        equal = equal && caps1.maxSrcExtent.height == caps2.maxSrcExtent.height;
-        equal = equal && caps1.minDstPosition.x == caps2.minDstPosition.x;
-        equal = equal && caps1.minDstPosition.y == caps2.minDstPosition.y;
-        equal = equal && caps1.maxDstPosition.x == caps2.maxDstPosition.x;
-        equal = equal && caps1.maxDstPosition.y == caps2.maxDstPosition.y;
-        equal = equal && caps1.minDstExtent.width == caps2.minDstExtent.width;
-        equal = equal && caps1.minDstExtent.height == caps2.minDstExtent.height;
-        equal = equal && caps1.maxDstExtent.width == caps2.maxDstExtent.width;
-        equal = equal && caps1.maxDstExtent.height == caps2.maxDstExtent.height;
-    } else {
-        equal = equal && caps1.supportedAlpha == 0;
-        equal = equal && caps1.minSrcPosition.x == 0;
-        equal = equal && caps1.minSrcPosition.y == 0;
-        equal = equal && caps1.maxSrcPosition.x == 0;
-        equal = equal && caps1.maxSrcPosition.y == 0;
-        equal = equal && caps1.minSrcExtent.width == 0;
-        equal = equal && caps1.minSrcExtent.height == 0;
-        equal = equal && caps1.maxSrcExtent.width == 0;
-        equal = equal && caps1.maxSrcExtent.height == 0;
-        equal = equal && caps1.minDstPosition.x == 0;
-        equal = equal && caps1.minDstPosition.y == 0;
-        equal = equal && caps1.maxDstPosition.x == 0;
-        equal = equal && caps1.maxDstPosition.y == 0;
-        equal = equal && caps1.minDstExtent.width == 0;
-        equal = equal && caps1.minDstExtent.height == 0;
-        equal = equal && caps1.maxDstExtent.width == 0;
-        equal = equal && caps1.maxDstExtent.height == 0;
-    }
-    return equal;
-}
-
 // Test vkGetDisplayPlaneCapabilitiesKHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -4747,7 +4458,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRInstanceAndICDSupport) {
 
     VkDisplayPlaneCapabilitiesKHR caps{};
     ASSERT_EQ(VK_SUCCESS, GetDisplayPlaneCapabilitiesKHR(physical_device, 0, 0, &caps));
-    ASSERT_TRUE(CompareDisplayPlaneCaps(caps, env.get_test_icd(0).physical_devices.back().display_plane_capabilities));
+    ASSERT_EQ(caps, env.get_test_icd(0).physical_devices.back().display_plane_capabilities);
 }
 
 // Test vkGetDisplayPlaneCapabilitiesKHR where instance supports it with some ICDs that both support
@@ -4830,7 +4541,11 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRMixed) {
                     cur_dev.properties.vendorID == pd_props.vendorID) {
                     VkDisplayPlaneCapabilitiesKHR caps{};
                     ASSERT_EQ(VK_SUCCESS, GetDisplayPlaneCapabilitiesKHR(physical_devices[dev], 0, 0, &caps));
-                    ASSERT_TRUE(CompareDisplayPlaneCaps(caps, cur_dev.display_plane_capabilities, icd != 1));
+                    if (icd != 1) {
+                        ASSERT_EQ(caps, cur_dev.display_plane_capabilities);
+                    } else {
+                        ASSERT_EQ(caps, VkDisplayPlaneCapabilitiesKHR{});
+                    }
                     found = true;
                     break;
                 }
@@ -4875,23 +4590,6 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRNoICDSupport) {
     ASSERT_EQ(GetPhysicalDeviceDisplayProperties2KHR, nullptr);
 }
 
-// Compare the display property data structs
-bool CompareDisplayPropData(const std::vector<VkDisplayPropertiesKHR>& props1, const std::vector<VkDisplayProperties2KHR>& props2) {
-    if (props1.size() != props2.size()) return false;
-    bool equal = true;
-    for (uint32_t i = 0; i < props1.size(); ++i) {
-        equal = equal && props1[i].display == props2[i].displayProperties.display;
-        equal = equal && props1[i].physicalDimensions.width == props2[i].displayProperties.physicalDimensions.width;
-        equal = equal && props1[i].physicalDimensions.height == props2[i].displayProperties.physicalDimensions.height;
-        equal = equal && props1[i].physicalResolution.width == props2[i].displayProperties.physicalResolution.width;
-        equal = equal && props1[i].physicalResolution.height == props2[i].displayProperties.physicalResolution.height;
-        equal = equal && props1[i].supportedTransforms == props2[i].displayProperties.supportedTransforms;
-        equal = equal && props1[i].planeReorderPossible == props2[i].displayProperties.planeReorderPossible;
-        equal = equal && props1[i].persistentContent == props2[i].displayProperties.persistentContent;
-    }
-    return equal;
-}
-
 // Test vGetPhysicalDeviceDisplayProperties2KHR where instance and ICD supports it, but device does not support it.
 TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
@@ -4932,8 +4630,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRInstanceAndICDSupport) {
     props2.resize(prop_count_2, {VK_STRUCTURE_TYPE_DISPLAY_PROPERTIES_2_KHR});
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayProperties2KHR(physical_device, &prop_count_2, props2.data()));
     ASSERT_EQ(prop_count, prop_count_2);
-
-    ASSERT_TRUE(CompareDisplayPropData(props, props2));
+    ASSERT_EQ(props, props2);
 }
 
 // Test vkGetPhysicalDeviceDisplayProperties2KHR where instance supports it with some ICDs that both support
@@ -5020,8 +4717,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRMixed) {
         props2.resize(prop_count_2, {VK_STRUCTURE_TYPE_DISPLAY_PROPERTIES_2_KHR});
         ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayProperties2KHR(physical_devices[dev], &prop_count_2, props2.data()));
         ASSERT_EQ(prop_count, prop_count_2);
-
-        ASSERT_TRUE(CompareDisplayPropData(props, props2));
+        ASSERT_EQ(props, props2);
     }
 }
 
@@ -5052,18 +4748,6 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRNoICDSupport) {
     PFN_vkGetPhysicalDeviceDisplayPlaneProperties2KHR GetPhysicalDeviceDisplayPlaneProperties2KHR =
         instance.load("vkGetPhysicalDeviceDisplayPlaneProperties2KHR");
     ASSERT_EQ(GetPhysicalDeviceDisplayPlaneProperties2KHR, nullptr);
-}
-
-// Compare the display plane property data structs
-bool CompareDisplayPlanePropData(const std::vector<VkDisplayPlanePropertiesKHR>& props1,
-                                 const std::vector<VkDisplayPlaneProperties2KHR>& props2) {
-    if (props1.size() != props2.size()) return false;
-    bool equal = true;
-    for (uint32_t i = 0; i < props1.size(); ++i) {
-        equal = equal && props1[i].currentDisplay == props2[i].displayPlaneProperties.currentDisplay;
-        equal = equal && props1[i].currentStackIndex == props2[i].displayPlaneProperties.currentStackIndex;
-    }
-    return equal;
 }
 
 // Test vGetPhysicalDeviceDisplayPlaneProperties2KHR where instance and ICD supports it, but device does not support it.
@@ -5105,8 +4789,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRInstanceAndICDSupport) {
     ASSERT_EQ(prop_count, prop_count2);
     props2.resize(prop_count2, {VK_STRUCTURE_TYPE_DISPLAY_PLANE_PROPERTIES_2_KHR});
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPlaneProperties2KHR(physical_device, &prop_count2, props2.data()));
-
-    ASSERT_TRUE(CompareDisplayPlanePropData(props, props2));
+    ASSERT_EQ(props, props2);
 }
 
 // Test vkGetPhysicalDeviceDisplayPlaneProperties2KHR where instance supports it with some ICDs that both support
@@ -5192,8 +4875,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRMixed) {
         ASSERT_EQ(prop_count, prop_count2);
         props2.resize(prop_count2, {VK_STRUCTURE_TYPE_DISPLAY_PLANE_PROPERTIES_2_KHR});
         ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPlaneProperties2KHR(physical_devices[dev], &prop_count2, props2.data()));
-
-        ASSERT_TRUE(CompareDisplayPlanePropData(props, props2));
+        ASSERT_EQ(props, props2);
     }
 }
 
@@ -5222,22 +4904,6 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRNoICDSupport) {
 
     PFN_vkGetDisplayModeProperties2KHR GetDisplayModeProperties2KHR = instance.load("vkGetDisplayModeProperties2KHR");
     ASSERT_EQ(GetDisplayModeProperties2KHR, nullptr);
-}
-
-// Compare the display mode properties data structs
-bool CompareDisplayModeProps(const std::vector<VkDisplayModePropertiesKHR>& disps1,
-                             const std::vector<VkDisplayModeProperties2KHR>& disps2) {
-    if (disps1.size() != disps2.size()) return false;
-
-    bool equal = true;
-    for (uint32_t i = 0; i < disps1.size(); ++i) {
-        equal = equal && disps1[i].displayMode == disps2[i].displayModeProperties.displayMode;
-        equal = equal && disps1[i].parameters.visibleRegion.width == disps2[i].displayModeProperties.parameters.visibleRegion.width;
-        equal =
-            equal && disps1[i].parameters.visibleRegion.height == disps2[i].displayModeProperties.parameters.visibleRegion.height;
-        equal = equal && disps1[i].parameters.refreshRate == disps2[i].displayModeProperties.parameters.refreshRate;
-    }
-    return equal;
 }
 
 // Test vGetDisplayModeProperties2KHR where instance and ICD supports it, but device does not support it.
@@ -5277,8 +4943,7 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRInstanceAndICDSupport) {
     ASSERT_EQ(props_count1, props_count2);
     props2.resize(props_count2, {VK_STRUCTURE_TYPE_DISPLAY_MODE_PROPERTIES_2_KHR});
     ASSERT_EQ(VK_SUCCESS, GetDisplayModeProperties2KHR(physical_device, VK_NULL_HANDLE, &props_count2, props2.data()));
-
-    ASSERT_TRUE(CompareDisplayModeProps(props, props2));
+    ASSERT_EQ(props, props2);
 }
 
 // Test vkGetDisplayModeProperties2KHR where instance supports it with some ICDs that both support
@@ -5362,8 +5027,7 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRMixed) {
         ASSERT_EQ(props_count1, props_count2);
         props2.resize(props_count2, {VK_STRUCTURE_TYPE_DISPLAY_MODE_PROPERTIES_2_KHR});
         ASSERT_EQ(VK_SUCCESS, GetDisplayModeProperties2KHR(physical_devices[dev], VK_NULL_HANDLE, &props_count2, props2.data()));
-
-        ASSERT_TRUE(CompareDisplayModeProps(props, props2));
+        ASSERT_EQ(props, props2);
     }
 }
 
@@ -5392,29 +5056,6 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRNoICDSupport) {
 
     PFN_vkGetDisplayPlaneCapabilitiesKHR GetDisplayPlaneCapabilitiesKHR = instance.load("vkGetDisplayPlaneCapabilitiesKHR");
     ASSERT_EQ(GetDisplayPlaneCapabilitiesKHR, nullptr);
-}
-
-// Compare the display plane caps
-bool CompareDisplayPlaneCaps(const VkDisplayPlaneCapabilitiesKHR& caps1, VkDisplayPlaneCapabilities2KHR& caps2) {
-    bool equal = true;
-    equal = equal && caps1.supportedAlpha == caps2.capabilities.supportedAlpha;
-    equal = equal && caps1.minSrcPosition.x == caps2.capabilities.minSrcPosition.x;
-    equal = equal && caps1.minSrcPosition.y == caps2.capabilities.minSrcPosition.y;
-    equal = equal && caps1.maxSrcPosition.x == caps2.capabilities.maxSrcPosition.x;
-    equal = equal && caps1.maxSrcPosition.y == caps2.capabilities.maxSrcPosition.y;
-    equal = equal && caps1.minSrcExtent.width == caps2.capabilities.minSrcExtent.width;
-    equal = equal && caps1.minSrcExtent.height == caps2.capabilities.minSrcExtent.height;
-    equal = equal && caps1.maxSrcExtent.width == caps2.capabilities.maxSrcExtent.width;
-    equal = equal && caps1.maxSrcExtent.height == caps2.capabilities.maxSrcExtent.height;
-    equal = equal && caps1.minDstPosition.x == caps2.capabilities.minDstPosition.x;
-    equal = equal && caps1.minDstPosition.y == caps2.capabilities.minDstPosition.y;
-    equal = equal && caps1.maxDstPosition.x == caps2.capabilities.maxDstPosition.x;
-    equal = equal && caps1.maxDstPosition.y == caps2.capabilities.maxDstPosition.y;
-    equal = equal && caps1.minDstExtent.width == caps2.capabilities.minDstExtent.width;
-    equal = equal && caps1.minDstExtent.height == caps2.capabilities.minDstExtent.height;
-    equal = equal && caps1.maxDstExtent.width == caps2.capabilities.maxDstExtent.width;
-    equal = equal && caps1.maxDstExtent.height == caps2.capabilities.maxDstExtent.height;
-    return equal;
 }
 
 // Test vkGetDisplayPlaneCapabilities2KHR where instance and ICD supports it, but device does not support it.
@@ -5446,7 +5087,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRInstanceAndICDSupport) {
     VkDisplayPlaneCapabilities2KHR caps2{};
     VkDisplayPlaneInfo2KHR info{VK_STRUCTURE_TYPE_DISPLAY_PLANE_INFO_2_KHR};
     ASSERT_EQ(VK_SUCCESS, GetDisplayPlaneCapabilities2KHR(physical_device, &info, &caps2));
-    ASSERT_TRUE(CompareDisplayPlaneCaps(caps, caps2));
+    ASSERT_EQ(caps, caps2);
 }
 
 // Test vkGetDisplayPlaneCapabilities2KHR where instance supports it with some ICDs that both support
@@ -5522,7 +5163,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRMixed) {
         VkDisplayPlaneCapabilities2KHR caps2{};
         VkDisplayPlaneInfo2KHR info{VK_STRUCTURE_TYPE_DISPLAY_PLANE_INFO_2_KHR};
         ASSERT_EQ(VK_SUCCESS, GetDisplayPlaneCapabilities2KHR(physical_devices[dev], &info, &caps2));
-        CompareDisplayPlaneCaps(caps, caps2);
+        ASSERT_EQ(caps, caps2);
     }
 }
 

--- a/tests/loader_unknown_ext_tests.cpp
+++ b/tests/loader_unknown_ext_tests.cpp
@@ -710,7 +710,7 @@ TEST(UnknownFunction, DeviceFromGIPAWithLayerImplementation) {
 }
 
 TEST(UnknownFunction, DeviceFromGIPAWithLayerInterception) {
-    unknown_function_test_impl<VkInstance, VkDevice>({TestConfig::add_layer_implementation});
+    unknown_function_test_impl<VkInstance, VkDevice>({TestConfig::add_layer_interception});
 }
 
 TEST(UnknownFunction, DeviceFromGIPAWithLayerInterceptionAndLayerImplementation) {
@@ -741,7 +741,7 @@ TEST(UnknownFunction, CommandBufferFromGIPAWithLayerImplementation) {
 }
 
 TEST(UnknownFunction, CommandBufferFromGIPAWithLayerInterception) {
-    unknown_function_test_impl<VkInstance, VkCommandBuffer>({TestConfig::add_layer_implementation});
+    unknown_function_test_impl<VkInstance, VkCommandBuffer>({TestConfig::add_layer_interception});
 }
 
 TEST(UnknownFunction, CommandBufferFromGIPAWithLayerInterceptionAndLayerImplementation) {
@@ -772,7 +772,7 @@ TEST(UnknownFunction, QueueFromGIPAWithLayer) {
 }
 
 TEST(UnknownFunction, QueueFromGIPAWithLayerInterception) {
-    unknown_function_test_impl<VkInstance, VkQueue>({TestConfig::add_layer_implementation});
+    unknown_function_test_impl<VkInstance, VkQueue>({TestConfig::add_layer_interception});
 }
 
 TEST(UnknownFunction, QueueFromGIPAWithLayerInterceptionAndLayerImplementation) {


### PR DESCRIPTION
Fixed a few bugs resulting in some tests not running everything they were intended to, remove dead code, simplify codepaths, etc.

This was done using code coverage to find test code which wasn't being executed.