### PR TITLE
Gracefully handle error results from vkEnumeratePhysicalDevices

### DIFF
--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -802,14 +802,12 @@ VkResult enumerate_adapter_physical_devices(struct loader_instance *inst, struct
     VkResult res = icd_term->scanned_icd->EnumerateAdapterPhysicalDevices(icd_term->instance, luid, &count, NULL);
     if (res == VK_ERROR_OUT_OF_HOST_MEMORY) {
         return res;
-    } else if (res == VK_ERROR_INCOMPATIBLE_DRIVER) {
+    } else if (res == VK_ERROR_INCOMPATIBLE_DRIVER || res == VK_ERROR_INITIALIZATION_FAILED || 0 == count) {
         return VK_SUCCESS;  // This driver doesn't support the adapter
     } else if (res != VK_SUCCESS) {
         loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
-                   "Failed to convert DXGI adapter into Vulkan physical device with unexpected error code");
-        return res;
-    } else if (0 == count) {
-        return VK_SUCCESS;  // This driver doesn't support the adapter
+                   "Failed to convert DXGI adapter into Vulkan physical device with unexpected error code: %d", res);
+        return VK_SUCCESS;
     }
 
     // Take a pointer to the last element of icd_phys_devs_array to simplify usage

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -214,6 +214,9 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroyInstance([[maybe_unused]] VkInstance in
 // VK_SUCCESS,VK_INCOMPLETE
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDevices([[maybe_unused]] VkInstance instance, uint32_t* pPhysicalDeviceCount,
                                                                VkPhysicalDevice* pPhysicalDevices) {
+    if (icd.enum_physical_devices_return_code != VK_SUCCESS) {
+        return icd.enum_physical_devices_return_code;
+    }
     if (pPhysicalDevices == nullptr) {
         *pPhysicalDeviceCount = static_cast<uint32_t>(icd.physical_devices.size());
     } else {
@@ -1104,6 +1107,9 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetCalibratedTimestampsEXT(VkDevice, uint3
 VKAPI_ATTR VkResult VKAPI_CALL test_vk_icdEnumerateAdapterPhysicalDevices(VkInstance instance, LUID adapterLUID,
                                                                           uint32_t* pPhysicalDeviceCount,
                                                                           VkPhysicalDevice* pPhysicalDevices) {
+    if (icd.enum_adapter_physical_devices_return_code != VK_SUCCESS) {
+        return icd.enum_adapter_physical_devices_return_code;
+    }
     if (adapterLUID.LowPart != icd.adapterLUID.LowPart || adapterLUID.HighPart != icd.adapterLUID.HighPart) {
         *pPhysicalDeviceCount = 0;
         return VK_ERROR_INCOMPATIBLE_DRIVER;

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -139,6 +139,9 @@ struct TestICD {
 
     VkInstanceCreateFlags passed_in_instance_create_flags{};
 
+    BUILDER_VALUE(TestICD, VkResult, enum_physical_devices_return_code, VK_SUCCESS);
+    BUILDER_VALUE(TestICD, VkResult, enum_adapter_physical_devices_return_code, VK_SUCCESS);
+
     PhysicalDevice& GetPhysDevice(VkPhysicalDevice physicalDevice) {
         for (auto& phys_dev : physical_devices) {
             if (phys_dev.vk_physical_device.handle == physicalDevice) return phys_dev;


### PR DESCRIPTION
If any driver returned non-VK_SUCCESS values (except for OOHM) when the loader calls vkEnumeratePhysicalDevices, it would give up and return immediately. This could result in perfectly functional drivers being ignored.

The solution is to just skip over drivers that return non-VK_SUCCESS.