### PR TITLE
Allow layers to call global functions in vkCreateInstance

### DIFF
--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -131,6 +131,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(
     const VkAllocationCallbacks*                pAllocator,
     VkDevice*                                   pDevice);
 VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateInstanceExtensionProperties(
+    const char*                                 pLayerName,
+    uint32_t*                                   pPropertyCount,
+    VkExtensionProperties*                      pProperties);
+VKAPI_ATTR VkResult VKAPI_CALL terminator_pre_instance_EnumerateInstanceExtensionProperties(
     const VkEnumerateInstanceExtensionPropertiesChain* chain,
     const char*                                 pLayerName,
     uint32_t*                                   pPropertyCount,
@@ -141,6 +145,9 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateDeviceExtensionProperties(
     uint32_t*                                   pPropertyCount,
     VkExtensionProperties*                      pProperties);
 VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateInstanceLayerProperties(
+    uint32_t*                                   pPropertyCount,
+    VkLayerProperties*                          pProperties);
+VKAPI_ATTR VkResult VKAPI_CALL terminator_pre_instance_EnumerateInstanceLayerProperties(
     const VkEnumerateInstanceLayerPropertiesChain* chain,
     uint32_t*                                   pPropertyCount,
     VkLayerProperties*                          pProperties);
@@ -158,6 +165,8 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceSparseImageFormatProperti
     uint32_t*                                   pPropertyCount,
     VkSparseImageFormatProperties*              pProperties);
 VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateInstanceVersion(
+    uint32_t*                                   pApiVersion);
+VKAPI_ATTR VkResult VKAPI_CALL terminator_pre_instance_EnumerateInstanceVersion(
     const VkEnumerateInstanceVersionChain* chain,
     uint32_t*                                   pApiVersion);
 VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumeratePhysicalDeviceGroups(

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -177,7 +177,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
                 .version = VK_CURRENT_CHAIN_VERSION,
                 .size = sizeof(chain_tail),
             },
-        .pfnNextLayer = &terminator_EnumerateInstanceExtensionProperties,
+        .pfnNextLayer = &terminator_pre_instance_EnumerateInstanceExtensionProperties,
         .pNextLink = NULL,
     };
     VkEnumerateInstanceExtensionPropertiesChain *chain_head = &chain_tail;
@@ -283,7 +283,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
                 .version = VK_CURRENT_CHAIN_VERSION,
                 .size = sizeof(chain_tail),
             },
-        .pfnNextLayer = &terminator_EnumerateInstanceLayerProperties,
+        .pfnNextLayer = &terminator_pre_instance_EnumerateInstanceLayerProperties,
         .pNextLink = NULL,
     };
     VkEnumerateInstanceLayerPropertiesChain *chain_head = &chain_tail;
@@ -396,7 +396,7 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
                 .version = VK_CURRENT_CHAIN_VERSION,
                 .size = sizeof(chain_tail),
             },
-        .pfnNextLayer = &terminator_EnumerateInstanceVersion,
+        .pfnNextLayer = &terminator_pre_instance_EnumerateInstanceVersion,
         .pNextLink = NULL,
     };
     VkEnumerateInstanceVersionChain *chain_head = &chain_tail;

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -799,15 +799,21 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 mod_string = new_terminator.replace("VKAPI_CALL vk", "VKAPI_CALL terminator_")
 
                 if cur_cmd.name in PRE_INSTANCE_FUNCTIONS:
+                    pre_instance_basic_version = mod_string
+                    mod_string = mod_string.replace("terminator_", "terminator_pre_instance_")
                     mod_string = mod_string.replace(cur_cmd.name[2:] + '(\n', cur_cmd.name[2:] + '(\n    const Vk' + cur_cmd.name[2:] + 'Chain* chain,\n')
 
-                if (cur_cmd.protect is not None):
+                if cur_cmd.protect is not None:
                     terminators += '#if defined(%s)\n' % cur_cmd.protect
+
+                if cur_cmd.name in PRE_INSTANCE_FUNCTIONS:
+                    terminators += pre_instance_basic_version
+                    terminators += '\n'
 
                 terminators += mod_string
                 terminators += '\n'
 
-                if (cur_cmd.protect is not None):
+                if cur_cmd.protect is not None:
                     terminators += '#endif // %s\n' % cur_cmd.protect
 
         terminators += '\n'

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -195,6 +195,10 @@ struct TestLayer {
     // Clober the data pointed to by pDevice to overwrite the magic value
     BUILDER_VALUE(TestLayer, bool, clobber_pDevice, false)
 
+    BUILDER_VALUE(TestLayer, bool, query_vkEnumerateInstanceLayerProperties, false)
+    BUILDER_VALUE(TestLayer, bool, query_vkEnumerateInstanceExtensionProperties, false)
+    BUILDER_VALUE(TestLayer, bool, query_vkEnumerateInstanceVersion, false)
+
     PFN_vkGetInstanceProcAddr next_vkGetInstanceProcAddr = VK_NULL_HANDLE;
     PFN_GetPhysicalDeviceProcAddr next_GetPhysicalDeviceProcAddr = VK_NULL_HANDLE;
     PFN_vkGetDeviceProcAddr next_vkGetDeviceProcAddr = VK_NULL_HANDLE;


### PR DESCRIPTION
Layers that want to call other global functions during vkCreateInstance couldn't due to loader_gpa_instance_terminator missing the necessary logic. Because those global functions have a different signature, it was decided to update the terminator_<function> signatures to match the Vulkan API, and make dedicated pre-instance intercetpion functions with the appropriate Chain object as the first parameter.

Now during the call down to vkCreateInstance a layer can query for pre-instance functions with vkGetInstanceProcAddr and is able to call them using the Vulkan API function signature.