### PR TITLE
Use std::filesystem instead of custom fs::path

### DIFF
--- a/tests/framework/README.md
+++ b/tests/framework/README.md
@@ -136,7 +136,6 @@ There are many utilities that the test framework and tests have access to. These
 * Environment Variable Wrapper: `EnvVarWrapper` for creating, setting, getting, and removing environment variables in a RAII manner
 * Windows API error handling helpers
 * filesystem abstractions:
-  * `fs::path` - wrapper around std::string that has a similar API to C++17's `filesystem::path` library
   * `create_folder`/`delete_folder`
   * `FolderManager`
     * Creates a new folder with the given name at construction time.

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -75,7 +75,7 @@ inline std::ostream& operator<<(std::ostream& os, const InterfaceVersionCheck& r
 // clang-format on
 
 struct TestICD {
-    fs::path manifest_file_path;
+    std::filesystem::path manifest_file_path;
 
     BUILDER_VALUE(TestICD, bool, exposes_vk_icdNegotiateLoaderICDInterfaceVersion, true)
     BUILDER_VALUE(TestICD, bool, exposes_vkEnumerateInstanceExtensionProperties, true)

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -89,7 +89,7 @@ struct TestLayer;
 using FP_layer_callback = VkResult (*)(TestLayer& layer, void* data);
 
 struct TestLayer {
-    fs::path manifest_file_path;
+    std::filesystem::path manifest_file_path;
     uint32_t manifest_version = VK_MAKE_API_VERSION(0, 1, 1, 2);
 
     BUILDER_VALUE(TestLayer, bool, is_meta_layer, false)

--- a/tests/framework/shim/shim.h
+++ b/tests/framework/shim/shim.h
@@ -59,9 +59,9 @@ enum class GpuType { unspecified, integrated, discrete, external };
 
 struct RegistryEntry {
     RegistryEntry() = default;
-    RegistryEntry(std::string const& name) noexcept : name(name) {}
-    RegistryEntry(std::string const& name, DWORD value) noexcept : name(name), value(value) {}
-    std::string name;
+    RegistryEntry(std::filesystem::path const& name) noexcept : name(name) {}
+    RegistryEntry(std::filesystem::path const& name, DWORD value) noexcept : name(name), value(value) {}
+    std::filesystem::path name;
     DWORD value{};
 };
 
@@ -102,9 +102,9 @@ struct DXGIAdapter {
 };
 
 struct D3DKMT_Adapter {
-    D3DKMT_Adapter& add_driver_manifest_path(fs::path const& src);
-    D3DKMT_Adapter& add_implicit_layer_manifest_path(fs::path const& src);
-    D3DKMT_Adapter& add_explicit_layer_manifest_path(fs::path const& src);
+    D3DKMT_Adapter& add_driver_manifest_path(std::filesystem::path const& src);
+    D3DKMT_Adapter& add_implicit_layer_manifest_path(std::filesystem::path const& src);
+    D3DKMT_Adapter& add_explicit_layer_manifest_path(std::filesystem::path const& src);
 
     UINT hAdapter;
     LUID adapter_luid;
@@ -113,7 +113,7 @@ struct D3DKMT_Adapter {
     std::vector<std::wstring> explicit_layer_paths;
 
    private:
-    D3DKMT_Adapter& add_path(fs::path src, std::vector<std::wstring>& dest);
+    D3DKMT_Adapter& add_path(std::filesystem::path src, std::vector<std::wstring>& dest);
 };
 
 #elif COMMON_UNIX_PLATFORMS
@@ -143,18 +143,18 @@ struct PlatformShim {
     // Test Framework interface
     void reset();
 
-    void redirect_all_paths(fs::path const& path);
-    void redirect_category(fs::path const& new_path, ManifestCategory category);
+    void redirect_all_paths(std::filesystem::path const& path);
+    void redirect_category(std::filesystem::path const& new_path, ManifestCategory category);
 
     // fake paths are paths that the loader normally looks in but actually point to locations inside the test framework
-    void set_fake_path(ManifestCategory category, fs::path const& path);
+    void set_fake_path(ManifestCategory category, std::filesystem::path const& path);
 
     // known paths are real paths but since the test framework guarantee's the order files are found in, files in these paths
     // need to be ordered correctly
-    void add_known_path(fs::path const& path);
+    void add_known_path(std::filesystem::path const& path);
 
-    void add_manifest(ManifestCategory category, fs::path const& path);
-    void add_unsecured_manifest(ManifestCategory category, fs::path const& path);
+    void add_manifest(ManifestCategory category, std::filesystem::path const& path);
+    void add_unsecured_manifest(ManifestCategory category, std::filesystem::path const& path);
 
 // platform specific shim interface
 #if defined(WIN32)
@@ -164,20 +164,20 @@ struct PlatformShim {
 
     void add_dxgi_adapter(GpuType gpu_preference, DXGI_ADAPTER_DESC1 desc1);
     void add_d3dkmt_adapter(D3DKMT_Adapter const& adapter);
-    void set_app_package_path(fs::path const& path);
+    void set_app_package_path(std::filesystem::path const& path);
 
     std::unordered_map<uint32_t, DXGIAdapter> dxgi_adapters;
 
     std::vector<D3DKMT_Adapter> d3dkmt_adapters;
 
     // TODO:
-    void add_CM_Device_ID(std::wstring const& id, fs::path const& icd_path, fs::path const& layer_path);
+    void add_CM_Device_ID(std::wstring const& id, std::filesystem::path const& icd_path, std::filesystem::path const& layer_path);
     std::wstring CM_device_ID_list = {L'\0'};
     std::vector<RegistryEntry> CM_device_ID_registry_keys;
 
     uint32_t random_base_path = 0;
 
-    std::vector<fs::path> icd_paths;
+    std::vector<std::filesystem::path> icd_paths;
 
     std::vector<RegistryEntry> hkey_current_user_explicit_layers;
     std::vector<RegistryEntry> hkey_current_user_implicit_layers;
@@ -194,22 +194,22 @@ struct PlatformShim {
     std::vector<HKeyHandle> created_keys;
 
 #elif COMMON_UNIX_PLATFORMS
-    bool is_fake_path(fs::path const& path);
-    fs::path const& get_real_path_from_fake_path(fs::path const& path);
+    bool is_fake_path(std::filesystem::path const& path);
+    std::filesystem::path const& get_real_path_from_fake_path(std::filesystem::path const& path);
 
-    void redirect_path(fs::path const& path, fs::path const& new_path);
-    void remove_redirect(fs::path const& path);
+    void redirect_path(std::filesystem::path const& path, std::filesystem::path const& new_path);
+    void remove_redirect(std::filesystem::path const& path);
 
-    bool is_known_path(fs::path const& path);
-    void remove_known_path(fs::path const& path);
+    bool is_known_path(std::filesystem::path const& path);
+    void remove_known_path(std::filesystem::path const& path);
 
-    void redirect_dlopen_name(fs::path const& filename, fs::path const& actual_path);
-    bool is_dlopen_redirect_name(fs::path const& filename);
+    void redirect_dlopen_name(std::filesystem::path const& filename, std::filesystem::path const& actual_path);
+    bool is_dlopen_redirect_name(std::filesystem::path const& filename);
 
-    fs::path query_default_redirect_path(ManifestCategory category);
+    std::filesystem::path query_default_redirect_path(ManifestCategory category);
 
-    std::unordered_map<std::string, fs::path> redirection_map;
-    std::unordered_map<std::string, fs::path> dlopen_redirection_map;
+    std::unordered_map<std::string, std::filesystem::path> redirection_map;
+    std::unordered_map<std::string, std::filesystem::path> dlopen_redirection_map;
     std::unordered_set<std::string> known_path_set;
 
     void set_elevated_privilege(bool elev) { use_fake_elevation = elev; }
@@ -227,7 +227,8 @@ struct PlatformShim {
 std::vector<std::string> parse_env_var_list(std::string const& var);
 std::string category_path_name(ManifestCategory category);
 
-std::vector<std::string> get_folder_contents(std::vector<fs::FolderManager>* folders, std::string folder_name) noexcept;
+std::vector<std::filesystem::path> get_folder_contents(std::vector<fs::FolderManager>* folders,
+                                                       std::filesystem::path folder_name) noexcept;
 
 extern "C" {
 // dynamically link on windows and macos

--- a/tests/framework/shim/unix_shim.cpp
+++ b/tests/framework/shim/unix_shim.cpp
@@ -135,7 +135,7 @@ FRAMEWORK_EXPORT DIR* OPENDIR_FUNC_NAME(const char* path_name) {
     }
     DIR* dir;
     if (platform_shim.is_fake_path(path_name)) {
-        auto real_path_name = platform_shim.get_real_path_from_fake_path(fs::path(path_name));
+        auto real_path_name = platform_shim.get_real_path_from_fake_path(std::filesystem::path(path_name));
         dir = real_opendir(real_path_name.c_str());
         platform_shim.dir_entries.push_back(DirEntry{dir, std::string(path_name), {}, 0, true});
     } else if (platform_shim.is_known_path(path_name)) {
@@ -175,7 +175,7 @@ FRAMEWORK_EXPORT struct dirent* READDIR_FUNC_NAME(DIR* dir_stream) {
         }
         auto real_path = it->folder_path;
         if (it->is_fake_path) {
-            real_path = platform_shim.redirection_map.at(it->folder_path).str();
+            real_path = platform_shim.redirection_map.at(it->folder_path);
         }
         auto filenames = get_folder_contents(platform_shim.folders, real_path);
 
@@ -215,13 +215,13 @@ FRAMEWORK_EXPORT int ACCESS_FUNC_NAME(const char* in_pathname, int mode) {
 #if !defined(__APPLE__)
     if (!real_access) real_access = (PFN_ACCESS)dlsym(RTLD_NEXT, "access");
 #endif
-    fs::path path{in_pathname};
+    std::filesystem::path path{in_pathname};
     if (!path.has_parent_path()) {
         return real_access(in_pathname, mode);
     }
 
     if (platform_shim.is_fake_path(path.parent_path())) {
-        fs::path real_path = platform_shim.get_real_path_from_fake_path(path.parent_path());
+        std::filesystem::path real_path = platform_shim.get_real_path_from_fake_path(path.parent_path());
         real_path /= path.filename();
         return real_access(real_path.c_str(), mode);
     }
@@ -232,7 +232,7 @@ FRAMEWORK_EXPORT FILE* FOPEN_FUNC_NAME(const char* in_filename, const char* mode
 #if !defined(__APPLE__)
     if (!real_fopen) real_fopen = (PFN_FOPEN)dlsym(RTLD_NEXT, "fopen");
 #endif
-    fs::path path{in_filename};
+    std::filesystem::path path{in_filename};
     if (!path.has_parent_path()) {
         return real_fopen(in_filename, mode);
     }

--- a/tests/framework/shim/windows_shim.cpp
+++ b/tests/framework/shim/windows_shim.cpp
@@ -326,12 +326,13 @@ LSTATUS __stdcall ShimRegEnumValueA(HKEY hKey, DWORD dwIndex, LPSTR lpValueName,
     const auto &location = *location_ptr;
     if (dwIndex >= location.size()) return ERROR_NO_MORE_ITEMS;
 
-    if (*lpcchValueName < location[dwIndex].name.size()) return ERROR_NO_MORE_ITEMS;
-    for (size_t i = 0; i < location[dwIndex].name.size(); i++) {
-        lpValueName[i] = location[dwIndex].name[i];
+    std::string name = narrow(location[dwIndex].name);
+    if (*lpcchValueName < name.size()) return ERROR_NO_MORE_ITEMS;
+    for (size_t i = 0; i < name.size(); i++) {
+        lpValueName[i] = name[i];
     }
-    lpValueName[location[dwIndex].name.size()] = '\0';
-    *lpcchValueName = static_cast<DWORD>(location[dwIndex].name.size() + 1);
+    lpValueName[name.size()] = '\0';
+    *lpcchValueName = static_cast<DWORD>(name.size() + 1);
     if (*lpcbData < sizeof(DWORD)) return ERROR_NO_MORE_ITEMS;
     DWORD *lpcbData_dword = reinterpret_cast<DWORD *>(lpData);
     *lpcbData_dword = location[dwIndex].value;

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -478,7 +478,7 @@ void FillDebugUtilsCreateDetails(InstanceCreateInfo& create_info, DebugUtilsWrap
 
 struct LoaderSettingsLayerConfiguration {
     BUILDER_VALUE(LoaderSettingsLayerConfiguration, std::string, name, {})
-    BUILDER_VALUE(LoaderSettingsLayerConfiguration, std::string, path, {})
+    BUILDER_VALUE(LoaderSettingsLayerConfiguration, std::filesystem::path, path, {})
     BUILDER_VALUE(LoaderSettingsLayerConfiguration, std::string, control, {})
     BUILDER_VALUE(LoaderSettingsLayerConfiguration, bool, treat_as_implicit_manifest, false)
 };
@@ -529,35 +529,39 @@ struct PlatformShimWrapper {
 
 struct TestICDHandle {
     TestICDHandle() noexcept;
-    TestICDHandle(fs::path const& icd_path) noexcept;
+    TestICDHandle(std::filesystem::path const& icd_path) noexcept;
     TestICD& reset_icd() noexcept;
     TestICD& get_test_icd() noexcept;
-    fs::path get_icd_full_path() noexcept;
-    fs::path get_icd_manifest_path() noexcept;
-    fs::path get_shimmed_manifest_path() noexcept;
+    std::filesystem::path get_icd_full_path() noexcept;
+    std::filesystem::path get_icd_manifest_path() noexcept;
+    std::filesystem::path get_shimmed_manifest_path() noexcept;
 
     // Must use statically
     LibraryWrapper icd_library;
     GetTestICDFunc proc_addr_get_test_icd = nullptr;
     GetNewTestICDFunc proc_addr_reset_icd = nullptr;
-    fs::path manifest_path;  // path to the manifest file is on the actual filesystem (aka <build_folder>/tests/framework/<...>)
-    fs::path shimmed_manifest_path;  // path to where the loader will find the manifest file (eg /usr/local/share/vulkan/<...>)
+    std::filesystem::path
+        manifest_path;  // path to the manifest file is on the actual filesystem (aka <build_folder>/tests/framework/<...>)
+    std::filesystem::path
+        shimmed_manifest_path;  // path to where the loader will find the manifest file (eg /usr/local/share/vulkan/<...>)
 };
 struct TestLayerHandle {
     TestLayerHandle() noexcept;
-    TestLayerHandle(fs::path const& layer_path) noexcept;
+    TestLayerHandle(std::filesystem::path const& layer_path) noexcept;
     TestLayer& reset_layer() noexcept;
     TestLayer& get_test_layer() noexcept;
-    fs::path get_layer_full_path() noexcept;
-    fs::path get_layer_manifest_path() noexcept;
-    fs::path get_shimmed_manifest_path() noexcept;
+    std::filesystem::path get_layer_full_path() noexcept;
+    std::filesystem::path get_layer_manifest_path() noexcept;
+    std::filesystem::path get_shimmed_manifest_path() noexcept;
 
     // Must use statically
     LibraryWrapper layer_library;
     GetTestLayerFunc proc_addr_get_test_layer = nullptr;
     GetNewTestLayerFunc proc_addr_reset_layer = nullptr;
-    fs::path manifest_path;  // path to the manifest file is on the actual filesystem (aka <build_folder>/tests/framework/<...>)
-    fs::path shimmed_manifest_path;  // path to where the loader will find the manifest file (eg /usr/local/share/vulkan/<...>)
+    std::filesystem::path
+        manifest_path;  // path to the manifest file is on the actual filesystem (aka <build_folder>/tests/framework/<...>)
+    std::filesystem::path
+        shimmed_manifest_path;  // path to where the loader will find the manifest file (eg /usr/local/share/vulkan/<...>)
 };
 
 // Controls whether to create a manifest and where to put it
@@ -581,11 +585,11 @@ enum class LibraryPathType {
 
 struct TestICDDetails {
     TestICDDetails(ManifestICD icd_manifest) noexcept : icd_manifest(icd_manifest) {}
-    TestICDDetails(fs::path icd_binary_path, uint32_t api_version = VK_API_VERSION_1_0) noexcept {
-        icd_manifest.set_lib_path(icd_binary_path.str()).set_api_version(api_version);
+    TestICDDetails(std::filesystem::path icd_binary_path, uint32_t api_version = VK_API_VERSION_1_0) noexcept {
+        icd_manifest.set_lib_path(icd_binary_path).set_api_version(api_version);
     }
     BUILDER_VALUE(TestICDDetails, ManifestICD, icd_manifest, {});
-    BUILDER_VALUE(TestICDDetails, std::string, json_name, "test_icd");
+    BUILDER_VALUE(TestICDDetails, std::filesystem::path, json_name, "test_icd");
     // Uses the json_name without modification - default is to append _1 in the json file to distinguish drivers
     BUILDER_VALUE(TestICDDetails, bool, disable_icd_inc, false);
     BUILDER_VALUE(TestICDDetails, ManifestDiscoveryType, discovery_type, ManifestDiscoveryType::generic);
@@ -655,15 +659,15 @@ struct FrameworkEnvironment {
 
     TestICD& get_test_icd(size_t index = 0) noexcept;
     TestICD& reset_icd(size_t index = 0) noexcept;
-    fs::path get_test_icd_path(size_t index = 0) noexcept;
-    fs::path get_icd_manifest_path(size_t index = 0) noexcept;
-    fs::path get_shimmed_icd_manifest_path(size_t index = 0) noexcept;
+    std::filesystem::path get_test_icd_path(size_t index = 0) noexcept;
+    std::filesystem::path get_icd_manifest_path(size_t index = 0) noexcept;
+    std::filesystem::path get_shimmed_icd_manifest_path(size_t index = 0) noexcept;
 
     TestLayer& get_test_layer(size_t index = 0) noexcept;
     TestLayer& reset_layer(size_t index = 0) noexcept;
-    fs::path get_test_layer_path(size_t index = 0) noexcept;
-    fs::path get_layer_manifest_path(size_t index = 0) noexcept;
-    fs::path get_shimmed_layer_manifest_path(size_t index = 0) noexcept;
+    std::filesystem::path get_test_layer_path(size_t index = 0) noexcept;
+    std::filesystem::path get_layer_manifest_path(size_t index = 0) noexcept;
+    std::filesystem::path get_shimmed_layer_manifest_path(size_t index = 0) noexcept;
 
     fs::FolderManager& get_folder(ManifestLocation location) noexcept;
     fs::FolderManager const& get_folder(ManifestLocation location) const noexcept;

--- a/tests/loader_alloc_callback_tests.cpp
+++ b/tests/loader_alloc_callback_tests.cpp
@@ -434,7 +434,8 @@ TEST(Allocation, CreateInstanceIntentionalAllocFailInvalidManifests) {
 
     for (size_t i = 0; i < invalid_jsons.size(); i++) {
         auto file_name = std::string("invalid_implicit_layer_") + std::to_string(i) + ".json";
-        fs::path new_path = env.get_folder(ManifestLocation::implicit_layer).write_manifest(file_name, invalid_jsons[i]);
+        std::filesystem::path new_path =
+            env.get_folder(ManifestLocation::implicit_layer).write_manifest(file_name, invalid_jsons[i]);
         env.platform_shim->add_manifest(ManifestCategory::implicit_layer, new_path);
     }
 
@@ -525,7 +526,7 @@ TEST(Allocation, CreateInstanceIntentionalAllocFailWithSettingsFilePresent) {
             LoaderSettingsLayerConfiguration{}
                 .set_name(layer_name)
                 .set_control("auto")
-                .set_path(env.get_shimmed_layer_manifest_path(0).str()))));
+                .set_path(env.get_shimmed_layer_manifest_path(0)))));
 
     size_t fail_index = 0;
     VkResult result = VK_ERROR_OUT_OF_HOST_MEMORY;
@@ -561,7 +562,7 @@ TEST(Allocation, CreateSurfaceIntentionalAllocFailWithSettingsFilePresent) {
             LoaderSettingsLayerConfiguration{}
                 .set_name(layer_name)
                 .set_control("auto")
-                .set_path(env.get_shimmed_layer_manifest_path(0).str()))));
+                .set_path(env.get_shimmed_layer_manifest_path(0)))));
 
     size_t fail_index = 0;
     VkResult result = VK_ERROR_OUT_OF_HOST_MEMORY;
@@ -608,7 +609,8 @@ TEST(Allocation, DriverEnvVarIntentionalAllocFail) {
                            "test_layer.json");
     env.get_test_layer().set_do_spurious_allocations_in_create_instance(true).set_do_spurious_allocations_in_create_device(true);
 
-    env.env_var_vk_icd_filenames.add_to_list((fs::path("totally_made_up") / "path_to_fake" / "jason_file.json").str());
+    env.env_var_vk_icd_filenames.add_to_list("totally_made_up/path_to_fake/jason_file.json");
+    env.env_var_vk_icd_filenames.add_to_list("another\\bonkers\\file_path.json");
     size_t fail_index = 0;
     VkResult result = VK_ERROR_OUT_OF_HOST_MEMORY;
     while (result == VK_ERROR_OUT_OF_HOST_MEMORY && fail_index <= 10000) {
@@ -745,8 +747,8 @@ TEST(Allocation, CreateInstanceDeviceIntentionalAllocFail) {
     std::stringstream custom_json_file_contents;
     custom_json_file_contents << custom_json_file.rdbuf();
 
-    fs::path new_path = env.get_folder(ManifestLocation::explicit_layer)
-                            .write_manifest("VK_LAYER_complex_file.json", custom_json_file_contents.str());
+    std::filesystem::path new_path = env.get_folder(ManifestLocation::explicit_layer)
+                                         .write_manifest("VK_LAYER_complex_file.json", custom_json_file_contents.str());
     env.platform_shim->add_manifest(ManifestCategory::explicit_layer, new_path);
 
     size_t fail_index = 0;

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -78,9 +78,9 @@ TEST(EnvVarICDOverrideSetup, version_2_negotiate_interface_version_and_icd_gipa)
 // export vk_icdNegotiateLoaderICDInterfaceVersion and vk_icdGetInstanceProcAddr
 TEST(EnvVarICDOverrideSetup, version_2_negotiate_interface_version_and_icd_gipa_unicode) {
     FrameworkEnvironment env{};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_UNICODE)
+    env.add_icd(TestICDDetails(widen(TEST_ICD_PATH_VERSION_2_UNICODE))
                     .set_discovery_type(ManifestDiscoveryType::env_var)
-                    .set_json_name(TEST_JSON_NAME_VERSION_2_UNICODE));
+                    .set_json_name(widen(TEST_JSON_NAME_VERSION_2_UNICODE)));
 
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
@@ -203,8 +203,8 @@ TEST(EnvVarICDOverrideSetup, XDG) {
     // Set up a layer path that includes default and user-specified locations,
     // so that the test app can find them.  Include some badly specified elements as well.
     // Need to redirect the 'home' directory
-    fs::path HOME = "/home/fake_home";
-    EnvVarWrapper home_env_var{"HOME", HOME.str()};
+    std::filesystem::path HOME = "/home/fake_home";
+    EnvVarWrapper home_env_var{"HOME", HOME};
     EnvVarWrapper xdg_config_dirs_env_var{"XDG_CONFIG_DIRS", ":/tmp/goober:::::/tmp/goober/::::"};
     EnvVarWrapper xdg_config_home_env_var{"XDG_CONFIG_HOME", ":/tmp/goober:::::/tmp/goober2/::::"};
     EnvVarWrapper xdg_data_dirs_env_var{"XDG_DATA_DIRS", "::::/tmp/goober3:/tmp/goober4/with spaces:::"};
@@ -218,10 +218,10 @@ TEST(EnvVarICDOverrideSetup, XDG) {
     inst.CheckCreate();
 
     auto check_paths = [](DebugUtilsLogger const& debug_log, ManifestCategory category) {
-        EXPECT_TRUE(debug_log.find((fs::path("/tmp/goober/vulkan") / category_path_name(category)).str()));
-        EXPECT_TRUE(debug_log.find((fs::path("/tmp/goober2/vulkan") / category_path_name(category)).str()));
-        EXPECT_TRUE(debug_log.find((fs::path("/tmp/goober3/vulkan") / category_path_name(category)).str()));
-        EXPECT_TRUE(debug_log.find((fs::path("/tmp/goober4/with spaces/vulkan") / category_path_name(category)).str()));
+        EXPECT_TRUE(debug_log.find((std::filesystem::path("/tmp/goober/vulkan") / category_path_name(category))));
+        EXPECT_TRUE(debug_log.find((std::filesystem::path("/tmp/goober2/vulkan") / category_path_name(category))));
+        EXPECT_TRUE(debug_log.find((std::filesystem::path("/tmp/goober3/vulkan") / category_path_name(category))));
+        EXPECT_TRUE(debug_log.find((std::filesystem::path("/tmp/goober4/with spaces/vulkan") / category_path_name(category))));
     };
     check_paths(env.debug_log, ManifestCategory::icd);
     check_paths(env.debug_log, ManifestCategory::implicit_layer);
@@ -307,10 +307,10 @@ TEST(EnvVarICDOverrideSetup, TestOnlyLayerEnvVar) {
     // Now set up a layer path that includes default and user-specified locations,
     // so that the test app can find them.  Include some badly specified elements as well.
     // Need to redirect the 'home' directory
-    fs::path HOME = "/home/fake_home";
-    EnvVarWrapper home_env_var{"HOME", HOME.str()};
+    std::filesystem::path HOME = "/home/fake_home";
+    EnvVarWrapper home_env_var{"HOME", HOME};
     std::string vk_layer_path = ":/tmp/carol::::/:";
-    vk_layer_path += (HOME / "/ with spaces/:::::/tandy:").str();
+    vk_layer_path += (HOME / "/ with spaces/:::::/tandy:");
     EnvVarWrapper layer_path_env_var{"VK_LAYER_PATH", vk_layer_path};
     InstWrapper inst1{env.vulkan_functions};
     inst1.create_info.add_layer(layer_name);
@@ -320,7 +320,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyLayerEnvVar) {
     // look for VK_LAYER_PATHS
     EXPECT_TRUE(env.debug_log.find("/tmp/carol"));
     EXPECT_TRUE(env.debug_log.find("/tandy"));
-    EXPECT_TRUE(env.debug_log.find((HOME / "/ with spaces/").str()));
+    EXPECT_TRUE(env.debug_log.find((HOME / "/ with spaces/")));
 
     env.debug_log.clear();
 
@@ -352,10 +352,10 @@ TEST(EnvVarICDOverrideSetup, TestOnlyAddLayerEnvVar) {
     // Set up a layer path that includes default and user-specified locations,
     // so that the test app can find them.  Include some badly specified elements as well.
     // Need to redirect the 'home' directory
-    fs::path HOME = "/home/fake_home";
-    EnvVarWrapper home_env_var{"HOME", HOME.str()};
+    std::filesystem::path HOME = "/home/fake_home";
+    EnvVarWrapper home_env_var{"HOME", HOME};
     std::string vk_layer_path = ":/tmp/carol::::/:";
-    vk_layer_path += (HOME / "/ with spaces/:::::/tandy:").str();
+    vk_layer_path += (HOME / "/ with spaces/:::::/tandy:");
     EnvVarWrapper add_layer_path_env_var{"VK_ADD_LAYER_PATH", vk_layer_path};
 
     InstWrapper inst1{env.vulkan_functions};
@@ -366,7 +366,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyAddLayerEnvVar) {
     // look for VK_ADD_LAYER_PATHS
     EXPECT_TRUE(env.debug_log.find("/tmp/carol"));
     EXPECT_TRUE(env.debug_log.find("/tandy"));
-    EXPECT_TRUE(env.debug_log.find((HOME / "/ with spaces/").str()));
+    EXPECT_TRUE(env.debug_log.find((HOME / "/ with spaces/")));
 
     env.debug_log.clear();
 

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -988,7 +988,7 @@ TEST(ImplicitLayers, DuplicateLayers) {
 #if defined(WIN32)
     env.platform_shim->add_manifest(ManifestCategory::implicit_layer, env.get_folder(ManifestLocation::override_layer).location());
 #elif COMMON_UNIX_PLATFORMS
-    env.platform_shim->redirect_path(fs::path(USER_LOCAL_SHARE_DIR "/vulkan/implicit_layer.d"),
+    env.platform_shim->redirect_path(std::filesystem::path(USER_LOCAL_SHARE_DIR "/vulkan/implicit_layer.d"),
                                      env.get_folder(ManifestLocation::override_layer).location());
 #endif
 
@@ -1512,14 +1512,14 @@ TEST(OverrideMetaLayer, BasicOverridePaths) {
                                                             .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                             .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0)))
                                              .get_manifest_str());
-    env.add_implicit_layer(ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(
-                               ManifestLayer::LayerDescription{}
-                                   .set_name(lunarg_meta_layer_name)
-                                   .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                   .add_component_layer(regular_layer_name)
-                                   .set_disable_environment("DisableMeIfYouCan")
-                                   .add_override_path(fs::make_native(override_layer_folder.location().str()))),
-                           "meta_test_layer.json");
+    env.add_implicit_layer(
+        ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(ManifestLayer::LayerDescription{}
+                                                                         .set_name(lunarg_meta_layer_name)
+                                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                                                         .add_component_layer(regular_layer_name)
+                                                                         .set_disable_environment("DisableMeIfYouCan")
+                                                                         .add_override_path(override_layer_folder.location())),
+        "meta_test_layer.json");
 
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.set_api_version(1, 1, 0);
@@ -1551,14 +1551,14 @@ TEST(OverrideMetaLayer, BasicOverridePathsIgnoreOtherLayers) {
                                                             .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                             .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0)))
                                              .get_manifest_str());
-    env.add_implicit_layer(ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(
-                               ManifestLayer::LayerDescription{}
-                                   .set_name(lunarg_meta_layer_name)
-                                   .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                   .add_component_layer(special_layer_name)
-                                   .set_disable_environment("DisableMeIfYouCan")
-                                   .add_override_path(fs::make_native(override_layer_folder.location().str()))),
-                           "meta_test_layer.json");
+    env.add_implicit_layer(
+        ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(ManifestLayer::LayerDescription{}
+                                                                         .set_name(lunarg_meta_layer_name)
+                                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                                                         .add_component_layer(special_layer_name)
+                                                                         .set_disable_environment("DisableMeIfYouCan")
+                                                                         .add_override_path(override_layer_folder.location())),
+        "meta_test_layer.json");
 
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.set_api_version(1, 1, 0);
@@ -1598,7 +1598,7 @@ TEST(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
                                    .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
                                    .add_component_layer(regular_layer_name)
                                    .set_disable_environment("DisableMeIfYouCan")
-                                   .add_override_path(env.get_folder(ManifestLocation::override_layer).location().str())),
+                                   .add_override_path(env.get_folder(ManifestLocation::override_layer).location())),
                            "meta_test_layer.json");
 
     auto meta_layer_path = env.get_folder(ManifestLocation::override_layer).location();
@@ -1613,7 +1613,7 @@ TEST(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
         std::string("Ignoring VK_LAYER_PATH. The Override layer is active and has override paths set, which takes priority. "
                     "VK_LAYER_PATH is set to ") +
         env.env_var_vk_layer_paths.value()));
-    ASSERT_TRUE(env.debug_log.find("Override layer has override paths set to " + meta_layer_path.str()));
+    ASSERT_TRUE(env.debug_log.find("Override layer has override paths set to " + meta_layer_path.string()));
 
     env.layers.clear();
 }
@@ -1646,7 +1646,7 @@ TEST(OverrideMetaLayer, OverridePathsEnableImplicitLayerInDefaultPaths) {
                                    .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
                                    .add_component_layers({regular_layer_name, implicit_layer_name})
                                    .set_disable_environment("DisableMeIfYouCan")
-                                   .add_override_path(fs::make_native(override_layer_folder.location().str()))),
+                                   .add_override_path(override_layer_folder.location())),
                            "meta_test_layer.json");
 
     InstWrapper inst{env.vulkan_functions};
@@ -1672,14 +1672,14 @@ TEST(OverrideMetaLayer, ManifestFileFormatVersionTooOld) {
                                                             .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                             .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0)))
                                              .get_manifest_str());
-    env.add_implicit_layer(ManifestLayer{}.set_file_format_version({1, 0, 0}).add_layer(
-                               ManifestLayer::LayerDescription{}
-                                   .set_name(lunarg_meta_layer_name)
-                                   .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                   .add_component_layer(regular_layer_name)
-                                   .set_disable_environment("DisableMeIfYouCan")
-                                   .add_override_path(fs::make_native(override_layer_folder.location().str()))),
-                           "meta_test_layer.json");
+    env.add_implicit_layer(
+        ManifestLayer{}.set_file_format_version({1, 0, 0}).add_layer(ManifestLayer::LayerDescription{}
+                                                                         .set_name(lunarg_meta_layer_name)
+                                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                                                         .add_component_layer(regular_layer_name)
+                                                                         .set_disable_environment("DisableMeIfYouCan")
+                                                                         .add_override_path(override_layer_folder.location())),
+        "meta_test_layer.json");
 
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.set_api_version(1, 1, 0);
@@ -1767,15 +1767,15 @@ TEST(OverrideMetaLayer, RunningWithElevatedPrivilegesFromSecureLocation) {
                                                             .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                             .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0)))
                                              .get_manifest_str());
-    auto override_folder_location = fs::make_native(override_layer_folder.location().str());
-    env.add_implicit_layer(TestLayerDetails{ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(
-                                                ManifestLayer::LayerDescription{}
-                                                    .set_name(lunarg_meta_layer_name)
-                                                    .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                                    .add_component_layer(regular_layer_name)
-                                                    .set_disable_environment("DisableMeIfYouCan")
-                                                    .add_override_path(fs::make_native(override_layer_folder.location().str()))),
-                                            "meta_test_layer.json"});
+    auto override_folder_location = override_layer_folder.location().string();
+    env.add_implicit_layer(TestLayerDetails{
+        ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(ManifestLayer::LayerDescription{}
+                                                                         .set_name(lunarg_meta_layer_name)
+                                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                                                         .add_component_layer(regular_layer_name)
+                                                                         .set_disable_environment("DisableMeIfYouCan")
+                                                                         .add_override_path(override_layer_folder.location())),
+        "meta_test_layer.json"});
 
     {  // try with no elevated privileges
         auto layer_props = env.GetLayerProperties(2);
@@ -1822,14 +1822,14 @@ TEST(OverrideMetaLayer, RunningWithElevatedPrivilegesFromUnsecureLocation) {
                                                             .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
                                                             .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0)))
                                              .get_manifest_str());
-    env.add_implicit_layer(TestLayerDetails{ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(
-                                                ManifestLayer::LayerDescription{}
-                                                    .set_name(lunarg_meta_layer_name)
-                                                    .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                                                    .add_component_layer(regular_layer_name)
-                                                    .set_disable_environment("DisableMeIfYouCan")
-                                                    .add_override_path(fs::make_native(override_layer_folder.location().str()))),
-                                            "meta_test_layer.json"}
+    env.add_implicit_layer(TestLayerDetails{
+        ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(ManifestLayer::LayerDescription{}
+                                                                         .set_name(lunarg_meta_layer_name)
+                                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                                                         .add_component_layer(regular_layer_name)
+                                                                         .set_disable_environment("DisableMeIfYouCan")
+                                                                         .add_override_path(override_layer_folder.location())),
+        "meta_test_layer.json"}
                                .set_discovery_type(ManifestDiscoveryType::unsecured_generic));
 
     {  // try with no elevated privileges
@@ -1939,7 +1939,7 @@ TEST(ExplicitLayers, LayerSettingsPreInstanceFunctions) {
         LoaderSettingsLayerConfiguration{}
             .set_name(explicit_layer_name)
             .set_control("on")
-            .set_path(env.get_shimmed_layer_manifest_path(0).str())
+            .set_path(env.get_shimmed_layer_manifest_path(0))
             .set_treat_as_implicit_manifest(false)));
     env.update_loader_settings(env.loader_settings);
 
@@ -2279,7 +2279,7 @@ TEST(ExplicitLayers, DuplicateLayersInVK_LAYER_PATH) {
     auto& layer1 = env.get_test_layer(0);
     layer1.set_description("actually_layer_1");
     layer1.set_make_spurious_log_in_create_instance("actually_layer_1");
-    env.env_var_vk_layer_paths.add_to_list(env.get_folder(ManifestLocation::override_layer).location().str());
+    env.env_var_vk_layer_paths.add_to_list(narrow(env.get_folder(ManifestLocation::override_layer).location()));
 
     env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                                           .set_name(same_layer_name_1)
@@ -2354,7 +2354,7 @@ TEST(ExplicitLayers, DuplicateLayersInVK_ADD_LAYER_PATH) {
     auto& layer1 = env.get_test_layer(0);
     layer1.set_description("actually_layer_1");
     layer1.set_make_spurious_log_in_create_instance("actually_layer_1");
-    env.add_env_var_vk_layer_paths.add_to_list(env.get_folder(ManifestLocation::override_layer).location().str());
+    env.add_env_var_vk_layer_paths.add_to_list(narrow(env.get_folder(ManifestLocation::override_layer).location()));
 
     env.add_explicit_layer(TestLayerDetails(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                                           .set_name(same_layer_name_1)
@@ -2503,7 +2503,7 @@ TEST(ExplicitLayers, DuplicateLayersInVkLayerPath) {
                                .set_is_dir(true));
     auto& layer2 = env.get_test_layer(1);
     layer2.set_description("actually_layer_2");
-    env.env_var_vk_layer_paths.add_to_list(env.get_folder(ManifestLocation::override_layer).location().str());
+    env.env_var_vk_layer_paths.add_to_list(env.get_folder(ManifestLocation::override_layer).location().string());
 
     auto layer_props = env.GetLayerProperties(2);
     ASSERT_TRUE(string_eq(layer_name, layer_props[0].layerName));
@@ -5124,7 +5124,7 @@ TEST(TestLayers, AllowFilterWithExplicitLayer) {
             LoaderSettingsLayerConfiguration{}
                 .set_name(layer_name)
                 .set_control("on")
-                .set_path(env.get_shimmed_layer_manifest_path(0).str())
+                .set_path(env.get_shimmed_layer_manifest_path(0))
                 .set_treat_as_implicit_manifest(false)));
         env.update_loader_settings(env.loader_settings);
 
@@ -5206,7 +5206,7 @@ TEST(TestLayers, AllowFilterWithImplicitLayer) {
             LoaderSettingsLayerConfiguration{}
                 .set_name(layer_name)
                 .set_control("on")
-                .set_path(env.get_shimmed_layer_manifest_path(0).str())
+                .set_path(env.get_shimmed_layer_manifest_path(0))
                 .set_treat_as_implicit_manifest(true)));
         env.update_loader_settings(env.loader_settings);
 
@@ -5278,7 +5278,7 @@ TEST(TestLayers, AllowFilterWithImplicitLayer) {
             LoaderSettingsLayerConfiguration{}
                 .set_name(layer_name)
                 .set_control("on")
-                .set_path(env.get_shimmed_layer_manifest_path(0).str())
+                .set_path(env.get_shimmed_layer_manifest_path(0))
                 .set_treat_as_implicit_manifest(true)));
         env.update_loader_settings(env.loader_settings);
 
@@ -5358,7 +5358,7 @@ TEST(TestLayers, AllowFilterWithConditionallyImlicitLayer) {
             LoaderSettingsLayerConfiguration{}
                 .set_name(layer_name)
                 .set_control("on")
-                .set_path(env.get_shimmed_layer_manifest_path(0).str())
+                .set_path(env.get_shimmed_layer_manifest_path(0))
                 .set_treat_as_implicit_manifest(true)));
         env.update_loader_settings(env.loader_settings);
 
@@ -5431,7 +5431,7 @@ TEST(TestLayers, AllowFilterWithConditionallyImlicitLayer) {
             LoaderSettingsLayerConfiguration{}
                 .set_name(layer_name)
                 .set_control("on")
-                .set_path(env.get_shimmed_layer_manifest_path(0).str())
+                .set_path(env.get_shimmed_layer_manifest_path(0))
                 .set_treat_as_implicit_manifest(true)));
         env.update_loader_settings(env.loader_settings);
 
@@ -5476,15 +5476,14 @@ TEST(TestLayers, AllowFilterWithConditionallyImlicitLayerWithOverrideLayer) {
                                             "test_layer_all.json"}
                                .set_discovery_type(ManifestDiscoveryType::override_folder));
 
-    env.add_implicit_layer(
-        ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(
-            ManifestLayer::LayerDescription{}
-                .set_name(lunarg_meta_layer_name)
-                .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
-                .add_component_layer(layer_name)
-                .set_disable_environment("DisableMeIfYouCan")
-                .add_override_path(fs::make_native(env.get_folder(ManifestLocation::override_layer).location().str()))),
-        "meta_test_layer.json");
+    env.add_implicit_layer(ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(
+                               ManifestLayer::LayerDescription{}
+                                   .set_name(lunarg_meta_layer_name)
+                                   .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                   .add_component_layer(layer_name)
+                                   .set_disable_environment("DisableMeIfYouCan")
+                                   .add_override_path(env.get_folder(ManifestLocation::override_layer).location().string())),
+                           "meta_test_layer.json");
 
     EnvVarWrapper allow{"VK_LOADER_LAYERS_ALLOW", layer_name};
 
@@ -5531,7 +5530,7 @@ TEST(TestLayers, AllowFilterWithConditionallyImlicitLayerWithOverrideLayer) {
             LoaderSettingsLayerConfiguration{}
                 .set_name(layer_name)
                 .set_control("on")
-                .set_path(env.get_shimmed_layer_manifest_path(0).str())
+                .set_path(env.get_shimmed_layer_manifest_path(0))
                 .set_treat_as_implicit_manifest(true)));
         env.update_loader_settings(env.loader_settings);
 

--- a/tests/loader_testing_main.cpp
+++ b/tests/loader_testing_main.cpp
@@ -56,16 +56,16 @@ int main(int argc, char** argv) {
 #endif
 
     // clean up folders from old test
-    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "null_dir");
-    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "icd_manifests");
-    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "icd_env_vars_manifests");
-    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "explicit_layer_manifests");
-    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "explicit_env_var_layer_folder");
-    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "explicit_add_env_var_layer_folder");
-    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "implicit_layer_manifests");
-    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "override_layer_manifests");
-    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "app_package_manifests");
-    fs::delete_folder(fs::path(FRAMEWORK_BUILD_DIRECTORY) / "macos_bundle");
+    fs::delete_folder(std::filesystem::path(FRAMEWORK_BUILD_DIRECTORY) / "null_dir");
+    fs::delete_folder(std::filesystem::path(FRAMEWORK_BUILD_DIRECTORY) / "icd_manifests");
+    fs::delete_folder(std::filesystem::path(FRAMEWORK_BUILD_DIRECTORY) / "icd_env_vars_manifests");
+    fs::delete_folder(std::filesystem::path(FRAMEWORK_BUILD_DIRECTORY) / "explicit_layer_manifests");
+    fs::delete_folder(std::filesystem::path(FRAMEWORK_BUILD_DIRECTORY) / "explicit_env_var_layer_folder");
+    fs::delete_folder(std::filesystem::path(FRAMEWORK_BUILD_DIRECTORY) / "explicit_add_env_var_layer_folder");
+    fs::delete_folder(std::filesystem::path(FRAMEWORK_BUILD_DIRECTORY) / "implicit_layer_manifests");
+    fs::delete_folder(std::filesystem::path(FRAMEWORK_BUILD_DIRECTORY) / "override_layer_manifests");
+    fs::delete_folder(std::filesystem::path(FRAMEWORK_BUILD_DIRECTORY) / "app_package_manifests");
+    fs::delete_folder(std::filesystem::path(FRAMEWORK_BUILD_DIRECTORY) / "macos_bundle");
 
     // make sure the tests don't find these env-vars if they were set on the system
     EnvVarWrapper vk_icd_filenames_env_var{"VK_ICD_FILENAMES"};

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -1380,7 +1380,8 @@ TEST(DriverManifest, VersionMismatchWithEnumerateInstanceVersion) {
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate();
 
-    ASSERT_TRUE(env.debug_log.find(std::string("terminator_CreateInstance: Manifest ICD for \"") + env.get_test_icd_path().str() +
+    ASSERT_TRUE(env.debug_log.find(std::string("terminator_CreateInstance: Manifest ICD for \"") +
+                                   env.get_test_icd_path().string() +
                                    "\" contained a 1.1 or greater API version, but "
                                    "vkEnumerateInstanceVersion returned 1.0, treating as a 1.0 ICD"));
 }
@@ -1397,7 +1398,8 @@ TEST(DriverManifest, EnumerateInstanceVersionNotSupported) {
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate();
 
-    ASSERT_TRUE(env.debug_log.find(std::string("terminator_CreateInstance: Manifest ICD for \"") + env.get_test_icd_path().str() +
+    ASSERT_TRUE(env.debug_log.find(std::string("terminator_CreateInstance: Manifest ICD for \"") +
+                                   env.get_test_icd_path().string() +
                                    "\" contained a 1.1 or greater API version, but does "
                                    "not support vkEnumerateInstanceVersion, treating as a 1.0 ICD"));
 }


### PR DESCRIPTION
Removes code and makes the codebase more understandable (by not introducing weird behavior unique to fs::path).

Replaces a lot of the bespoke logic to handle string<->wstring due to using std::filesystem::path.