### PR TITLE
Fix GN build by removing unnecessary files

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -109,7 +109,8 @@ if (!is_android) {
       "loader/cJSON.h",
       "loader/debug_utils.c",
       "loader/debug_utils.h",
-      "loader/dev_ext_trampoline.c",
+      # Should only be linked when assembler is used
+      # "loader/dev_ext_trampoline.c",
       "loader/extension_manual.c",
       "loader/extension_manual.h",
       "loader/generated/vk_layer_dispatch_table.h",
@@ -124,7 +125,8 @@ if (!is_android) {
       "loader/loader.h",
       "loader/log.c",
       "loader/log.h",
-      "loader/phys_dev_ext.c",
+      # Should only be linked when assembler is used
+      # "loader/phys_dev_ext.c",
       "loader/settings.c",
       "loader/settings.h",
       "loader/stack_allocation.h",


### PR DESCRIPTION
The phys_dev_ext.c and dev_ext_trampoline.c are only needed when compiling assembly support for unknown functions in, which is not the case for the GN builds. Doing that causes linker failues which are resolved with this fix.