### PR TITLE
Fix preloaded icd's being freed with custom allocators

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -6529,7 +6529,7 @@ void unload_drivers_without_physical_devices(struct loader_instance *inst) {
                     for (uint32_t i = 0; i < preloaded_icds.count; i++) {
                         if (NULL != preloaded_icds.scanned_list[i].lib_name && NULL != scanned_icd_to_remove->lib_name &&
                             strcmp(preloaded_icds.scanned_list[i].lib_name, scanned_icd_to_remove->lib_name) == 0) {
-                            loader_unload_scanned_icd(inst, &preloaded_icds.scanned_list[i]);
+                            loader_unload_scanned_icd(NULL, &preloaded_icds.scanned_list[i]);
                             // condense the list so that it doesn't contain empty elements.
                             if (i < preloaded_icds.count - 1) {
                                 memcpy((void *)&preloaded_icds.scanned_list[i],


### PR DESCRIPTION
During unloading of unused drivers, the loader checks for the driver in its list of preloaded ICD's, and removes it if it is in it. If the user provided a custom callback during instance creation, this was being used during this unloading, which is wrong because preloaded icd's weren't allocated with the custom allocator in the first place.

