### PR TITLE
Revert "ci: Disable GHA windows build until image is fixed"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,8 +173,6 @@ jobs:
               working-directory: build/
 
     windows_vs:
-        # https://github.com/actions/runner-images/issues/10004
-        if: false
         runs-on: windows-latest
         strategy:
             matrix:
@@ -194,8 +192,6 @@ jobs:
             - run: ctest --output-on-failure -C ${{matrix.config}} --test-dir build/
 
     windows_vs-no-asm:
-        # https://github.com/actions/runner-images/issues/10004
-        if: false
         runs-on: windows-latest
         strategy:
             matrix:
@@ -215,8 +211,6 @@ jobs:
 
     # Test both clang and clang-cl (Chromium project uses clang-cl)
     windows_clang:
-      # https://github.com/actions/runner-images/issues/10001
-      if: false
       runs-on: windows-2022
       strategy:
         matrix:


### PR DESCRIPTION
This reverts commit 1bae807cd919890f7174fa14228b6e672e8d296e.

Images appear to be fixed upstream