### PR TITLE
Add unknown functions assembly code for linux-armhf 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ VKConfig.h
 *.files
 *.includes
 .vscode/
+.cache
 .DS_Store
 _out64
 out32/*

--- a/BUILD.md
+++ b/BUILD.md
@@ -16,6 +16,7 @@ Instructions for building this repository on Linux, Windows, and MacOS.
     - [Repository Dependencies](#repository-dependencies)
       - [Vulkan-Headers](#vulkan-headers)
       - [Test Dependencies](#test-dependencies)
+    - [Warnings as errors off by default!](#warnings-as-errors-off-by-default)
     - [Build and Install Directory Locations](#build-and-install-directory-locations)
     - [Building Dependent Repositories with Known-Good Revisions](#building-dependent-repositories-with-known-good-revisions)
       - [Automatically](#automatically)
@@ -54,7 +55,6 @@ Instructions for building this repository on Linux, Windows, and MacOS.
   - [Cross Compilation](#cross-compilation)
     - [Unknown function handling which requires explicit assembly implementations](#unknown-function-handling-which-requires-explicit-assembly-implementations)
       - [Platforms which fully support unknown function handling](#platforms-which-fully-support-unknown-function-handling)
-    - [Link Time Optimization](#link-time-optimization)
   - [Tests](#tests)
 
 
@@ -633,6 +633,8 @@ can be manually disabled by setting `USE_GAS` or `USE_MASM` to `OFF`.
 * 64 bit Linux (x64)
 * 32 bit Linux (x86)
 * 64 bit Arm (aarch64)
+* 32 bit Arm (aarch32)
+
 
 Platforms not listed will use a fallback C Code path that relies on tail-call optimization to work.
 No guarantees are made about the use of the fallback code paths.

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -229,12 +229,17 @@ elseif(UNIX OR MINGW OR (WIN32 AND USE_GAS)) # i.e.: Linux & Apple & MinGW & Win
             endif()
 
             if(ASSEMBLER_WORKS)
-                set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas_aarch64.S)
+                set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas_aarch.S)
             endif()
         elseif (${SYSTEM_PROCESSOR} MATCHES "aarch64|arm64")
             try_compile(ASSEMBLER_WORKS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/asm_test_aarch64.S OUTPUT_VARIABLE TRY_COMPILE_OUTPUT)
             if(ASSEMBLER_WORKS)
-                set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas_aarch64.S)
+                set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas_aarch.S)
+            endif()
+        elseif (${SYSTEM_PROCESSOR} MATCHES "aarch32|armhf")
+            try_compile(ASSEMBLER_WORKS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/asm_test_aarch32.S OUTPUT_VARIABLE TRY_COMPILE_OUTPUT)
+            if(ASSEMBLER_WORKS)
+                set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas_aarch.S)
             endif()
         # Covers x86_64, amd64, x86, i386, i686, I386, I686
         elseif(${SYSTEM_PROCESSOR} MATCHES "amd64|86")
@@ -251,13 +256,16 @@ elseif(UNIX OR MINGW OR (WIN32 AND USE_GAS)) # i.e.: Linux & Apple & MinGW & Win
     endif()
 
     # When compiling for x86 on x64, we can't use CMAKE_SYSTEM_PROCESSOR to determine which architecture to use,
-    # Instead, check the size of void* and if its 4, set ASM_OFFSET_SYSTEM_PROCESSOR to x86
-    # Note - there is no 32 bit arm assembly code, so this only applies to x86 currently.
+    # Instead, check the size of void* and if its 4, set ASM_OFFSET_SYSTEM_PROCESSOR to x86 if we aren't on arm
     if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
         set(ASM_OFFSET_SYSTEM_PROCESSOR ${SYSTEM_PROCESSOR}) # x86_64 or aarch64/arm64
         string(REPLACE amd64 x86_64 ASM_OFFSET_SYSTEM_PROCESSOR "${ASM_OFFSET_SYSTEM_PROCESSOR}")
     else()
-        set(ASM_OFFSET_SYSTEM_PROCESSOR "x86")
+        if(${SYSTEM_PROCESSOR} MATCHES "86")
+            set(ASM_OFFSET_SYSTEM_PROCESSOR "x86")
+        else()
+            set(ASM_OFFSET_SYSTEM_PROCESSOR ${SYSTEM_PROCESSOR})
+        endif()
     endif()
 
     if(ASSEMBLER_WORKS)
@@ -289,6 +297,7 @@ elseif(UNIX OR MINGW OR (WIN32 AND USE_GAS)) # i.e.: Linux & Apple & MinGW & Win
             else()
                 message(FATAL_ERROR "C_COMPILER_ID not supported!")
             endif()
+            message(STATUS "CMAKE_CROSSCOMPILING FALSE")
 
             find_package(Python3 REQUIRED QUIET)
             # Run parse_asm_values.py on asm_offset's assembly file to generate the gen_defines.asm, which the asm code depends on

--- a/loader/asm_offset.c
+++ b/loader/asm_offset.c
@@ -132,9 +132,13 @@ int main(int argc, char **argv) {
 #if defined(__x86_64__)
         fprintf(file, ".set X86_64, 1\n");
 #endif  // defined(__x86_64__)
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(__arm__)
         const char *comment_delimiter = "//";
+#if defined(__aarch64__)
         fprintf(file, ".set AARCH_64, 1\n");
+#else
+        fprintf(file, ".set AARCH_64, 0\n");
+#endif
 #else
         // Default comment delimiter
         const char *comment_delimiter = "#";

--- a/loader/asm_test_aarch32.S
+++ b/loader/asm_test_aarch32.S
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2024 Valve Corporation
+// Copyright (c) 2024 LunarG, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+.text
+.global sample
+.set PHYS_DEV_OFFSET_INST_DISPATCH, 10
+.set PTR_SIZE, 4
+sample:
+  mov r1, #(PHYS_DEV_OFFSET_INST_DISPATCH + (PTR_SIZE * 4))
+  ldr r0, [r0, r1]

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5323,7 +5323,8 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateInstance(const VkInstanceCreateI
                    "#LLP_LAYER_21)");
     } else if (LOADER_MAGIC_NUMBER != ptr_instance->magic) {
         loader_log(ptr_instance, VULKAN_LOADER_WARN_BIT, 0,
-                   "terminator_CreateInstance: Instance pointer (%p) has invalid MAGIC value 0x%08lx. Instance value possibly "
+                   "terminator_CreateInstance: Instance pointer (%p) has invalid MAGIC value 0x%08" PRIx64
+                   ". Instance value possibly "
                    "corrupted by active layer (Policy #LLP_LAYER_21).  ",
                    ptr_instance, ptr_instance->magic);
     }
@@ -5719,7 +5720,8 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
                    "#LLP_LAYER_22)");
     } else if (DEVICE_DISP_TABLE_MAGIC_NUMBER != dev->loader_dispatch.core_dispatch.magic) {
         loader_log(icd_term->this_instance, VULKAN_LOADER_WARN_BIT, 0,
-                   "terminator_CreateDevice: Device pointer (%p) has invalid MAGIC value 0x%08lx. The expected value is "
+                   "terminator_CreateDevice: Device pointer (%p) has invalid MAGIC value 0x%08" PRIx64
+                   ". The expected value is "
                    "0x10ADED040410ADED. Device value possibly "
                    "corrupted by active layer (Policy #LLP_LAYER_22).  ",
                    dev, dev->loader_dispatch.core_dispatch.magic);

--- a/loader/unknown_ext_chain_gas_aarch.S
+++ b/loader/unknown_ext_chain_gas_aarch.S
@@ -1,5 +1,7 @@
 //
 // Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2024 Valve Corporation
+// Copyright (c) 2024 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +16,7 @@
 // limitations under the License.
 //
 // Author: Eric Sullivan <esullivan@nvidia.com>
+// Author: Charles Giessen <charles@lunarg.com>
 //
 
 // This code is used to pass on device (including physical device) extensions through the call chain. It must do this without
@@ -76,6 +79,67 @@ vkdev_ext\num:
     mov     x10, (EXT_OFFSET_DEVICE_DISPATCH + (PTR_SIZE * \num)) // Offset of the desired function in the dispatch table
     ldr     x11, [x9, x10]                                        // Load the function address
     br      x11
+.endm
+
+.else // AARCH_32
+
+.macro PhysDevExtTramp num
+.global vkPhysDevExtTramp\num
+#if defined(__ELF__)
+ .hidden vkPhysDevExtTramp\num
+#endif
+.balign 4
+
+vkPhysDevExtTrampDispatchEntry\num: .word PHYS_DEV_OFFSET_INST_DISPATCH + (PTR_SIZE * \num)
+vkPhysDevExtTramp\num:
+    ldr     r4, [r0]                                                 // Load the loader_instance_dispatch_table* into r4
+    ldr     r0, [r0, #PHYS_DEV_OFFSET_PHYS_DEV_TRAMP]                 // Load the unwrapped VkPhysicalDevice into r0
+    ldr     r5, vkPhysDevExtTrampDispatchEntry\num // Put the offset of the entry in the dispatch table for the function
+    ldr     r6, [r4, r5]                                           // Load the address to branch to out of the dispatch table
+    bx      r6                                                      // Branch to the next member of the dispatch chain
+
+.endm
+
+.macro PhysDevExtTermin num
+.global vkPhysDevExtTermin\num
+#if defined(__ELF__)
+ .hidden vkPhysDevExtTermin\num
+#endif
+.balign 4
+vkPhysDevExtTerminDispatchEntry\num: .word DISPATCH_OFFSET_ICD_TERM + (PTR_SIZE * \num)
+vkPhysDevExtTerminFunctionNameEntry\num: .word FUNCTION_OFFSET_INSTANCE + (CHAR_PTR_SIZE * \num)
+vkPhysDevExtTermin\num:
+    ldr     r4, [r0, #ICD_TERM_OFFSET_PHYS_DEV_TERM] // Load the loader_icd_term* in r4
+    ldr     r6, vkPhysDevExtTerminDispatchEntry\num // Put the offset into the dispatch table in r6
+    ldr     r5, [r4, r6]                           // Load the address of the next function in the dispatch chain
+    cmp     r5, #0
+    beq     terminError\num                          // Go to the error section if the next function in the chain is NULL
+    ldr     r0, [r0, #PHYS_DEV_OFFSET_PHYS_DEV_TERM] // Unwrap the VkPhysicalDevice in r0
+    bx      r5                                      // Jump to the next function in the chain
+terminError\num:
+    ldr     r5, vkPhysDevExtTerminFunctionNameEntry\num // Offset of the function name string in the instance
+    ldr     r6, [r4, #INSTANCE_OFFSET_ICD_TERM]         // Load the instance pointer
+    mov     r0, r6                                      // Vulkan instance pointer (first arg)
+    mov     r1, #VULKAN_LOADER_ERROR_BIT                 // The error logging bit (second arg)
+    mov     r2, #0                                       // Zero (third arg)
+    ldr     r3, [r6, r5]                               // The function name (fourth arg)
+    bl      loader_log_asm_function_not_supported        // Log the error message before we crash
+    mov     r0, #0
+    bx      r0                                           // Crash intentionally by jumping to address zero
+.endm
+
+.macro DevExtTramp num
+.global vkdev_ext\num
+#if defined(__ELF__)
+ .hidden vkdev_ext\num
+#endif
+.balign 4
+vkdev_ext_dispatch_entry\num: .word EXT_OFFSET_DEVICE_DISPATCH + (PTR_SIZE * \num)
+vkdev_ext\num:
+    ldr     r4, [r0]                          // Load the loader_instance_dispatch_table* into r4
+    ldr     r5, vkdev_ext_dispatch_entry\num // Offset of the desired function in the dispatch table
+    ldr     r6, [r4, r5]                    // Load the function address
+    bx      r6
 .endm
 
 .endif

--- a/scripts/parse_asm_values.py
+++ b/scripts/parse_asm_values.py
@@ -35,7 +35,7 @@ source_asm_file = sys.argv[2]
 assembler_type = sys.argv[3]
 # Whether we are using gcc, clang, or msvc
 compiler = sys.argv[4]
-# taken from CMAKE_SYSTEM_PROCESSOR - x86_64, aarch64, or x86
+# taken from CMAKE_SYSTEM_PROCESSOR - x86_64, aarch64|arm64, x86, aarch32|armhf
 # Only used with GAS - MASM doesn't need this, as it has its own way to determine x86 vs x64
 arch = sys.argv[5]
 
@@ -74,6 +74,8 @@ with open(destination_file, "w", encoding="utf-8") as dest:
             dest.write(".set X86_64, 1\n")
         elif arch == "aarch64" or arch == "arm64":
             dest.write(".set AARCH_64, 1\n")
+        elif arch == "aarch32" or arch == "armhf":
+            dest.write(".set AARCH_64, 0\n")
         # Nothing to write in the x86 case
 
     for d in defines:


### PR DESCRIPTION
This allows linux loaders built for armhf architectures to support unknown
physical device and device functions. The previous fallback path could have
worked for armhf (using the appropriate compiler flags) so as to not disrupt
users, the aarch64 assembly code for unknown functions was ported to armhf.

Since CI support is limited, this was manually built & tested using on a
raspberry pi 4B.