### PR TITLE
Fix RegCloseKey exeption when double-closing hKeys

### DIFF
--- a/tests/framework/shim/windows_shim.cpp
+++ b/tests/framework/shim/windows_shim.cpp
@@ -346,7 +346,8 @@ LSTATUS __stdcall ShimRegCloseKey(HKEY hKey) {
             return ERROR_SUCCESS;
         }
     }
-    return ERROR_SUCCESS;
+    // means that RegCloseKey was called with an invalid key value (one that doesn't exist or has already been closed)
+    exit(-1);
 }
 
 // Windows app package shims


### PR DESCRIPTION
While the application still can run, RegCloseKey will throw an error when key is double-closed. This was caused by the test framework not catching when the double-close occurs.