### PR TITLE
Remove SetDllDirectory as it caused crashes

### DIFF
--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -77,11 +77,9 @@ void windows_initialization(void) {
         loader_log(NULL, VULKAN_LOADER_INFO_BIT, 0, "Using Vulkan Loader %s", dll_location);
     }
 
-    SetDllDirectory("");  // Remove current directory from default DLL search order
     // This is needed to ensure that newer APIs are available right away
     // and not after the first call that has been statically linked
     LoadLibrary("gdi32.dll");
-    SetDllDirectory(NULL);  // Restores the default search order
 
     wchar_t systemPath[MAX_PATH] = L"";
     GetSystemDirectoryW(systemPath, MAX_PATH);


### PR DESCRIPTION
The removal of the current directory from windows Dll searching then using the default search paths caused a crash in a shipping application. This requires removal of the offending calls while a better solution for making LoadLibrary not use the current directory is developed.