### PR TITLE
Only search system32 for gdi32.dll

### DIFF
--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -79,7 +79,7 @@ void windows_initialization(void) {
 
     // This is needed to ensure that newer APIs are available right away
     // and not after the first call that has been statically linked
-    LoadLibrary("gdi32.dll");
+    LoadLibraryEx("gdi32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
 
     wchar_t systemPath[MAX_PATH] = L"";
     GetSystemDirectoryW(systemPath, MAX_PATH);


### PR DESCRIPTION
LoadLibraryEx allows specifying where to search for dll's, including system only paths which is useful for guaranteeing the authenticity of a loaded dll, which is gdi32.dll in our case.