### PR TITLE
Fixed Compiler Frontend Detection for Clang with GNU frontend on Win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(loader_common_options INTERFACE -Wno-missing-field-initializers)
 
     # need to prepend /clang: to compiler arguments when using clang-cl
-    if (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_CXX_SIMULATE_ID}" MATCHES "MSVC")
+    if (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_C_COMPILER_FRONTEND_VARIANT}" MATCHES "MSVC")
         target_compile_options(loader_common_options INTERFACE /clang:-fno-strict-aliasing)
     else()
         target_compile_options(loader_common_options INTERFACE -fno-strict-aliasing)


### PR DESCRIPTION
The frontend detection code incorrectly used `CMAKE_CXX_SIMULATE_ID` which is `MSVC` when using Clang with a GNU frontend on Windows. The correct variable is `CMAKE_CXX_COMPILER_FRONTEND_VARIANT`.
There was a previous attempt to fix this here: https://github.com/KhronosGroup/Vulkan-Loader/pull/1403. But I suppose they missed this.
