### PR TITLE
Use ASM unknown function trampolines on GN

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -36,9 +36,7 @@ if (is_win) {
 }
 
 config("vulkan_internal_config") {
-  defines = [
-    "VK_ENABLE_BETA_EXTENSIONS",
-  ]
+  defines = [ "VK_ENABLE_BETA_EXTENSIONS" ]
   if (is_clang || !is_win) {
     cflags = [
       "-Wno-conversion",
@@ -99,6 +97,52 @@ if (!is_android) {
   } else {
     library_type = "static_library"
   }
+  support_unknown_function_handling = false
+  if (ar_path != "" && !is_win && (current_cpu == "arm64" || current_cpu == "x86_64")) {
+    support_unknown_function_handling = true
+    static_library("asm_offset") {
+      sources = [ "loader/asm_offset.c" ]
+      deps = [
+        "$vulkan_headers_dir:vulkan_headers",
+      ]
+
+      if (is_fuchsia) {
+        deps += [
+          ":dlopen_fuchsia",
+        ]
+      }
+
+      # Output raw assembly instead of compiled object file. The assembly will be included as a member of the output ar file.
+      cflags = [ "-S" ]
+      configs += [ ":vulkan_internal_config" ]
+      configs += [ ":vulkan_loader_config" ]
+    }
+
+    action("gen_defines") {
+      script = "scripts/parse_asm_values.py"
+      deps = [ ":asm_offset" ]
+
+      inputs = [
+        "$target_out_dir/libasm_offset.a",
+        ar_path,
+      ]
+      if (current_cpu == "arm64") {
+        cpu = "aarch64"
+      } else {
+        cpu = "x86_64"
+      }
+      args = [
+        rebase_path("$target_gen_dir/gen_defines.asm", root_build_dir),
+        rebase_path("$target_out_dir/libasm_offset.a", root_build_dir),
+        "GAS",
+        "Clang",
+        cpu,
+        rebase_path(ar_path, root_build_dir),
+        "libasm_offset.asm_offset.c.o",
+      ]
+      outputs = [ "$target_gen_dir/gen_defines.asm" ]
+    }
+  }
 
   target(library_type, "libvulkan") {
     sources = [
@@ -135,8 +179,6 @@ if (!is_android) {
       "loader/unknown_function_handling.h",
       "loader/unknown_function_handling.c",
       "loader/vk_loader_layer.h",
-
-      # TODO(jmadill): Use assembler where available.
       "loader/vk_loader_platform.h",
       "loader/wsi.c",
       "loader/wsi.h",
@@ -216,6 +258,19 @@ if (!is_android) {
       ]
 
       runtime_deps = [ "//sdk/lib/fdio:fdio_sdk" ]
+    }
+    if (support_unknown_function_handling) {
+      if (current_cpu == "arm64") {
+        sources += [ "loader/unknown_ext_chain_gas_aarch.S" ]
+      } else if (current_cpu == "x86_64") {
+        sources += [ "loader/unknown_ext_chain_gas_x86.S" ]
+      } else {
+        assert(false, "Unexpected CPU $current_cpu")
+      }
+
+      defines += ["UNKNOWN_FUNCTIONS_SUPPORTED=1"]
+      deps += [ ":gen_defines" ]
+      include_dirs = [ "$target_gen_dir" ]
     }
   }
 }

--- a/loader/unknown_ext_chain_gas_aarch.S
+++ b/loader/unknown_ext_chain_gas_aarch.S
@@ -24,7 +24,7 @@
 // VkPhysicalDevice or a dispatchable object it can unwrap the object, possibly overwriting the wrapped physical device, and then
 // jump to the next function in the call chain
 
-.include "gen_defines.asm"
+#include "gen_defines.asm"
 
 /*
  * References:
@@ -56,6 +56,7 @@
 .macro PhysDevExtTramp num
 .global vkPhysDevExtTramp\num
 #if defined(__ELF__)
+ .type vkPhysDevExtTramp\num, @function
  .hidden vkPhysDevExtTramp\num
 #endif
 .balign 4
@@ -77,6 +78,7 @@ vkPhysDevExtTramp\num:
 .macro PhysDevExtTermin num
 .global vkPhysDevExtTermin\num
 #if defined(__ELF__)
+ .type vkPhysDevExtTermin\num, @function
  .hidden vkPhysDevExtTermin\num
 #endif
 .balign 4

--- a/loader/unknown_ext_chain_gas_x86.S
+++ b/loader/unknown_ext_chain_gas_x86.S
@@ -33,7 +33,7 @@
 #endif
 
 .intel_syntax noprefix
-.include "gen_defines.asm"
+#include "gen_defines.asm"
 
 .ifdef X86_64
 

--- a/scripts/gn/secondary/build_overrides/vulkan_loader.gni
+++ b/scripts/gn/secondary/build_overrides/vulkan_loader.gni
@@ -21,3 +21,5 @@ vulkan_gen_subdir = ""
 # Vulkan loader build options
 vulkan_loader_shared = true
 
+# Path to ar or llvm-ar
+ar_path = ""


### PR DESCRIPTION
The GN build doesn't currently support unknown function trampolines. To fix that, we can use the assembly trampolines. To generate the asm_offset assembly file, we can build it in a static library and pass -S to it; that causes the assembly file to be copied into the .a file. The python script can then extract it. This requires access to the "ar" executable, so this mechanism is only used if a path to ar is specified in //build_overrides/vulkan_loader.gni.

To fix incremental builds, "gen_defines.asm" must be included using "#include", not ".include", since .include isn't a preprocessor directive and isn't picked up by clang's depfile creation.