### PR TITLE
Fix vkCreateSharedSwapchainsKHR not unwrapping handles correctly

### DIFF
--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -936,10 +936,15 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhys
 }
 // VK_KHR_display_swapchain
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSharedSwapchainsKHR([[maybe_unused]] VkDevice device, uint32_t swapchainCount,
-                                                                [[maybe_unused]] const VkSwapchainCreateInfoKHR* pCreateInfos,
+                                                                const VkSwapchainCreateInfoKHR* pCreateInfos,
                                                                 [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
                                                                 VkSwapchainKHR* pSwapchains) {
     for (uint32_t i = 0; i < swapchainCount; i++) {
+        uint64_t surface_integer_value = from_nondispatch_handle(pCreateInfos[i].surface);
+        auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), surface_integer_value);
+        if (found_iter == icd.surface_handles.end()) {
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
         common_nondispatch_handle_creation(icd.swapchain_handles, &pSwapchains[i]);
     }
     return VK_SUCCESS;

--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -213,6 +213,9 @@ TEST(GetDeviceProcAddr, SwapchainFuncsWithTerminator) {
     VkSurfaceKHR surface{};
     ASSERT_EQ(VK_SUCCESS, create_surface(inst, surface));
 
+    VkSurfaceKHR surface2{};
+    ASSERT_EQ(VK_SUCCESS, create_surface(inst, surface2));
+
     DebugUtilsWrapper log{inst};
     ASSERT_EQ(VK_SUCCESS, CreateDebugUtilsMessenger(log));
     auto phys_dev = inst.GetPhysDev();
@@ -286,9 +289,15 @@ TEST(GetDeviceProcAddr, SwapchainFuncsWithTerminator) {
         VkDeviceGroupPresentModeFlagsKHR modes{};
         GetDeviceGroupSurfacePresentModesKHR(dev.dev, surface, &modes);
 
-        CreateSharedSwapchainsKHR(dev.dev, 1, &info, nullptr, &swapchain);
+        std::array<VkSwapchainCreateInfoKHR, 2> infos{};
+        infos[0] = info;
+        infos[1].sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+        infos[1].surface = surface2;
+
+        ASSERT_EQ(VK_SUCCESS, CreateSharedSwapchainsKHR(dev.dev, 2, infos.data(), nullptr, &swapchain));
     }
     env.vulkan_functions.vkDestroySurfaceKHR(inst.inst, surface, nullptr);
+    env.vulkan_functions.vkDestroySurfaceKHR(inst.inst, surface2, nullptr);
 }
 
 // Verify that the various ways to get vkGetDeviceProcAddr return the same value


### PR DESCRIPTION
The loader would unwrap the first surface and use that for all created swapchains rather than unwrap each surface handle individually for each VkSwapchainCreateInfoKHR struct.