### PR TITLE
Define _FILE_OFFSET_BITS=64 for 32 bit linux builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,11 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     endif()
 
     target_compile_options(loader_common_options INTERFACE -Wpointer-arith)
+
+    # Force GLIBC to use the 64 bit interface for file operations instead of 32 bit - More info in issue #1551
+    if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4")
+        target_compile_definitions(loader_common_options INTERFACE _FILE_OFFSET_BITS=64)
+    endif()
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "MSVC" OR (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))

--- a/loader/dirent_on_windows.c
+++ b/loader/dirent_on_windows.c
@@ -92,6 +92,10 @@ struct dirent *readdir(DIR *dir) {
             result = &dir->result;
             result->d_name = dir->info.name;
         }
+        // _findnext sets errno to ENOENT when no more matching files could be found, does not indicate an error
+        if (errno == ENOENT) {
+            errno = 0;
+        }
     } else {
         errno = EBADF;
     }

--- a/tests/framework/icd/CMakeLists.txt
+++ b/tests/framework/icd/CMakeLists.txt
@@ -46,7 +46,7 @@ AddSharedLibrary(test_icd_version_7_without_exports DEF_FILE test_icd_7_without_
     SOURCES test_icd.cpp
     DEFINITIONS TEST_ICD_EXPORT_VERSION_7=0 TEST_ICD_EXPORT_ICD_GPDPA=1
         TEST_ICD_EXPORT_ICD_ENUMERATE_ADAPTER_PHYSICAL_DEVICES=1 ${TEST_ICD_VERSION_2_DEFINES})
-AddSharedLibrary(test_unicode DEF_FILE test_icd_2
+AddSharedLibrary(test_unicode DEF_FILE 🌋
     SOURCES test_icd.cpp
     DEFINITIONS ${TEST_ICD_VERSION_2_DEFINES})
 set_target_properties(test_unicode PROPERTIES OUTPUT_NAME "🌋") # Test unicode library

--- a/tests/framework/icd/export_definitions/🌋.def
+++ b/tests/framework/icd/export_definitions/🌋.def
@@ -1,0 +1,4 @@
+LIBRARY 🌋
+EXPORTS
+    vk_icdGetInstanceProcAddr
+    vk_icdNegotiateLoaderICDInterfaceVersion


### PR DESCRIPTION
Certain file systems (such as bcachefs) use 64 bit inodes, which glibc truncates to 32 bits by default. This causes EOVERFLOW to be returned from readdir, causing not all files to be read from a directory.

The fix is to use the 64 bit versions of file system access functions, by defining _FILE_OFFSET_BITS=64 in 32 bit builds.

Because this issue does not affect 64 bit builds, it is only applied to 32 bit builds.