### PR TITLE
Only initialize mutexes during DllMain

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1932,12 +1932,18 @@ out:
     return res;
 }
 
+#if defined(_WIN32)
+BOOL __stdcall loader_initialize(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *Context) {
+    (void)InitOnce;
+    (void)Parameter;
+    (void)Context;
+#else
 void loader_initialize(void) {
-    // initialize mutexes
     loader_platform_thread_create_mutex(&loader_lock);
     loader_platform_thread_create_mutex(&loader_preload_icd_lock);
     loader_platform_thread_create_mutex(&loader_global_instance_list_lock);
     init_global_loader_settings();
+#endif
 
     // initialize logging
     loader_init_global_debug_level();
@@ -1963,6 +1969,9 @@ void loader_initialize(void) {
     loader_free_getenv(loader_disable_dynamic_library_unloading_env_var, NULL);
 #if defined(LOADER_USE_UNSAFE_FILE_SEARCH)
     loader_log(NULL, VULKAN_LOADER_WARN_BIT, 0, "Vulkan Loader: unsafe searching is enabled");
+#endif
+#if defined(_WIN32)
+    return TRUE;
 #endif
 }
 

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -94,7 +94,11 @@ VkResult loader_validate_instance_extensions(struct loader_instance *inst, const
                                              const struct loader_envvar_all_filters *layer_filters,
                                              const VkInstanceCreateInfo *pCreateInfo);
 
+#if defined(_WIN32)
+BOOL __stdcall loader_initialize(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *Context);
+#else
 void loader_initialize(void);
+#endif
 void loader_release(void);
 void loader_preload_icds(void);
 void loader_unload_preloaded_icds(void);

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -99,7 +99,11 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved) {
     (void)hinst;
     switch (reason) {
         case DLL_PROCESS_ATTACH:
-            loader_initialize();
+            // Only initialize necessary sync primitives
+            loader_platform_thread_create_mutex(&loader_lock);
+            loader_platform_thread_create_mutex(&loader_preload_icd_lock);
+            loader_platform_thread_create_mutex(&loader_global_instance_list_lock);
+            init_global_loader_settings();
             break;
         case DLL_PROCESS_DETACH:
             if (NULL == reserved) {


### PR DESCRIPTION
Defer all other initialization of the loader internals to after the call to DllMain by using InitOnceExecuteOnce, mirroring the initialization needed for statically linked MacOS.

This required splitting up the mutex creation and other initialization into its own function, and having DllMain call that function, while on linux loader_initialize will call that function first thing.

This commit makes the loader follow Dynamic-Link Library Best Practices as defined by Microsoft from the following article:

https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-best-practices