### PR TITLE
Emulate VK_EXT_surface_maintenance1 if not supported by a driver

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5459,14 +5459,18 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateInstance(const VkInstanceCreateI
 #endif  // LOADER_ENABLE_LINUX_SORT
 
         // Determine if vkGetPhysicalDeviceProperties2 is available to this Instance
+        // Also determine if VK_EXT_surface_maintenance1 is available on the ICD
         if (icd_term->scanned_icd->api_version >= VK_API_VERSION_1_1) {
             icd_term->supports_get_dev_prop_2 = true;
-        } else {
-            for (uint32_t j = 0; j < icd_create_info.enabledExtensionCount; j++) {
-                if (!strcmp(filtered_extension_names[j], VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
-                    icd_term->supports_get_dev_prop_2 = true;
-                    break;
-                }
+        }
+        for (uint32_t j = 0; j < icd_create_info.enabledExtensionCount; j++) {
+            if (!strcmp(filtered_extension_names[j], VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
+                icd_term->supports_get_dev_prop_2 = true;
+                continue;
+            }
+            if (!strcmp(filtered_extension_names[j], VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME)) {
+                icd_term->supports_ext_surface_maintenance_1 = true;
+                continue;
             }
         }
 

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -266,6 +266,7 @@ struct loader_icd_term {
 
     PFN_PhysDevExt phys_dev_ext[MAX_NUM_UNKNOWN_EXTS];
     bool supports_get_dev_prop_2;
+    bool supports_ext_surface_maintenance_1;
 
     uint32_t physical_device_count;
 

--- a/tests/framework/icd/physical_device.h
+++ b/tests/framework/icd/physical_device.h
@@ -55,6 +55,10 @@ struct PhysicalDevice {
     BUILDER_VALUE(PhysicalDevice, VkSurfaceCapabilitiesKHR, surface_capabilities, {})
     BUILDER_VECTOR(PhysicalDevice, VkSurfaceFormatKHR, surface_formats, surface_format)
     BUILDER_VECTOR(PhysicalDevice, VkPresentModeKHR, surface_present_modes, surface_present_mode)
+    BUILDER_VALUE(PhysicalDevice, VkSurfacePresentScalingCapabilitiesEXT, surface_present_scaling_capabilities, {})
+    // No good way to make this a builder value. Each std::vector<VkPresentModeKHR> corresponds to each surface_present_modes
+    // element
+    std::vector<std::vector<VkPresentModeKHR>> surface_present_mode_compatibility{};
 
     BUILDER_VECTOR(PhysicalDevice, VkDisplayPropertiesKHR, display_properties, display_properties)
     BUILDER_VECTOR(PhysicalDevice, VkDisplayPlanePropertiesKHR, display_plane_properties, display_plane_properties)

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -799,6 +799,15 @@ inline bool operator==(const VkSurfaceCapabilitiesKHR& props1, const VkSurfaceCa
            props1.currentTransform == props2.currentTransform && props1.supportedCompositeAlpha == props2.supportedCompositeAlpha &&
            props1.supportedUsageFlags == props2.supportedUsageFlags;
 }
+inline bool operator==(const VkSurfacePresentScalingCapabilitiesEXT& caps1, const VkSurfacePresentScalingCapabilitiesEXT& caps2) {
+    return caps1.supportedPresentScaling == caps2.supportedPresentScaling &&
+           caps1.supportedPresentGravityX == caps2.supportedPresentGravityX &&
+           caps1.supportedPresentGravityY == caps2.supportedPresentGravityY &&
+           caps1.minScaledImageExtent.width == caps2.minScaledImageExtent.width &&
+           caps1.minScaledImageExtent.height == caps2.minScaledImageExtent.height &&
+           caps1.maxScaledImageExtent.width == caps2.maxScaledImageExtent.width &&
+           caps1.maxScaledImageExtent.height == caps2.maxScaledImageExtent.height;
+}
 inline bool operator==(const VkSurfaceFormatKHR& format1, const VkSurfaceFormatKHR& format2) {
     return format1.format == format2.format && format1.colorSpace == format2.colorSpace;
 }
@@ -845,6 +854,9 @@ inline bool operator==(const VkDisplayPlanePropertiesKHR& props1, const VkDispla
 }
 inline bool operator==(const VkDisplayPlanePropertiesKHR& props1, const VkDisplayPlaneProperties2KHR& props2) {
     return props1 == props2.displayPlaneProperties;
+}
+inline bool operator==(const VkExtent2D& ext1, const VkExtent2D& ext2) {
+    return ext1.height == ext2.height && ext1.width == ext2.width;
 }
 // Allow comparison of vectors of different types as long as their elements are comparable (just has to make sure to only apply when
 // T != U)

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -850,3 +850,127 @@ TEST(WsiTests, SwapchainFunctional) {
     }
     env.vulkan_functions.vkDestroySurfaceKHR(inst.inst, surface, nullptr);
 }
+
+TEST(WsiTests, EXTSurfaceMaintenance1) {
+    FrameworkEnvironment env{};
+
+    std::vector<VkPresentModeKHR> present_modes{VK_PRESENT_MODE_FIFO_KHR, VK_PRESENT_MODE_IMMEDIATE_KHR,
+                                                VK_PRESENT_MODE_MAILBOX_KHR, VK_PRESENT_MODE_FIFO_RELAXED_KHR};
+    VkSurfaceCapabilitiesKHR surface_caps{};
+    surface_caps.maxImageExtent = VkExtent2D{300, 300};
+    surface_caps.minImageExtent = VkExtent2D{100, 100};
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+        .setup_WSI()
+        .add_instance_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME)
+        .add_physical_device(PhysicalDevice{}
+                                 .add_extension("VK_KHR_swapchain")
+                                 .set_deviceName("no")
+                                 .set_surface_capabilities(surface_caps)
+                                 .add_surface_present_modes(present_modes)
+                                 .finish());
+    VkSurfacePresentScalingCapabilitiesEXT scaling_capabilities{};
+    scaling_capabilities.supportedPresentScaling = VK_PRESENT_SCALING_ONE_TO_ONE_BIT_EXT;
+    scaling_capabilities.supportedPresentGravityX = VK_PRESENT_SCALING_ASPECT_RATIO_STRETCH_BIT_EXT;
+    scaling_capabilities.supportedPresentGravityY = VK_PRESENT_SCALING_STRETCH_BIT_EXT;
+    scaling_capabilities.minScaledImageExtent = {60, 60};
+    scaling_capabilities.maxScaledImageExtent = {1000, 1000};
+    auto& icd2 = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+                     .setup_WSI()
+                     .add_instance_extension(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME)
+                     .add_instance_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME)
+                     .add_physical_device(PhysicalDevice{}
+                                              .add_extension("VK_KHR_swapchain")
+                                              .set_deviceName("yes")
+                                              .set_surface_capabilities(surface_caps)
+                                              .add_surface_present_modes(present_modes)
+                                              .set_surface_present_scaling_capabilities(scaling_capabilities)
+                                              .finish());
+    std::vector<std::vector<VkPresentModeKHR>> compatible_present_modes{
+        {VK_PRESENT_MODE_FIFO_KHR, VK_PRESENT_MODE_FIFO_RELAXED_KHR},
+        {VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_MAILBOX_KHR},
+        {VK_PRESENT_MODE_MAILBOX_KHR, VK_PRESENT_MODE_IMMEDIATE_KHR},
+        {VK_PRESENT_MODE_FIFO_RELAXED_KHR, VK_PRESENT_MODE_FIFO_KHR},
+    };
+    icd2.physical_devices[0].surface_present_mode_compatibility = compatible_present_modes;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+        .setup_WSI()
+        .add_physical_device(PhysicalDevice{}
+                                 .add_extension("VK_KHR_swapchain")
+                                 .set_deviceName("no")
+                                 .set_surface_capabilities(surface_caps)
+                                 .add_surface_present_modes(present_modes)
+                                 .finish());
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.setup_WSI();
+    inst.create_info.add_extension(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME);
+    inst.create_info.add_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
+    inst.CheckCreate();
+
+    VkSurfaceKHR surface{};
+    ASSERT_EQ(VK_SUCCESS, create_surface(inst, surface));
+    WrappedHandle<VkSurfaceKHR, VkInstance, PFN_vkDestroySurfaceKHR> wrapped_surface{surface, inst.inst,
+                                                                                     env.vulkan_functions.vkDestroySurfaceKHR};
+    auto physical_devices = inst.GetPhysDevs(3);
+
+    for (auto physical_device : physical_devices) {
+        VkPhysicalDeviceProperties phys_dev_props{};
+        inst->vkGetPhysicalDeviceProperties(physical_device, &phys_dev_props);
+        bool driver_support_surface_maintenance1 = string_eq(phys_dev_props.deviceName, "yes");
+
+        uint32_t present_mode_count = 4;
+        std::vector<VkPresentModeKHR> queried_present_modes{present_mode_count};
+        inst->vkGetPhysicalDeviceSurfacePresentModesKHR(physical_device, surface, &present_mode_count,
+                                                        queried_present_modes.data());
+
+        for (uint32_t i = 0; i < present_mode_count; i++) {
+            VkSurfacePresentModeEXT present_mode{};
+            present_mode.sType = VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_EXT;
+            present_mode.presentMode = queried_present_modes[i];
+
+            VkPhysicalDeviceSurfaceInfo2KHR surface_info{};
+            surface_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
+            surface_info.surface = surface;
+            surface_info.pNext = &present_mode;
+
+            VkSurfacePresentModeCompatibilityEXT SurfacePresentModeCompatibilityEXT{};
+            SurfacePresentModeCompatibilityEXT.sType = VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_COMPATIBILITY_EXT;
+
+            VkSurfacePresentScalingCapabilitiesEXT SurfacePresentScalingCapabilitiesEXT{};
+            SurfacePresentScalingCapabilitiesEXT.sType = VK_STRUCTURE_TYPE_SURFACE_PRESENT_SCALING_CAPABILITIES_EXT;
+            SurfacePresentScalingCapabilitiesEXT.pNext = &SurfacePresentModeCompatibilityEXT;
+
+            VkSurfaceCapabilities2KHR surface_caps2{};
+            surface_caps2.sType = VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR;
+            surface_caps2.pNext = &SurfacePresentScalingCapabilitiesEXT;
+
+            ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkGetPhysicalDeviceSurfaceCapabilities2KHR(physical_device, &surface_info,
+                                                                                                  &surface_caps2));
+            if (driver_support_surface_maintenance1) {
+                ASSERT_EQ(SurfacePresentModeCompatibilityEXT.presentModeCount, 2U);
+            } else {
+                ASSERT_EQ(SurfacePresentModeCompatibilityEXT.presentModeCount, 1U);
+            }
+            std::vector<VkPresentModeKHR> queried_compatible_present_modes{SurfacePresentModeCompatibilityEXT.presentModeCount};
+            SurfacePresentModeCompatibilityEXT.pPresentModes = queried_compatible_present_modes.data();
+
+            ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkGetPhysicalDeviceSurfaceCapabilities2KHR(physical_device, &surface_info,
+                                                                                                  &surface_caps2));
+
+            if (driver_support_surface_maintenance1) {
+                ASSERT_EQ(compatible_present_modes[i], queried_compatible_present_modes);
+                ASSERT_EQ(scaling_capabilities, SurfacePresentScalingCapabilitiesEXT);
+            } else {
+                // Make sure the emulation returned the values we expect - 1 compatible present mode which is the mode we are
+                // querying, Scaling capabilities is 0 (aka none) and the extent is just the surface caps extent
+                ASSERT_EQ(SurfacePresentModeCompatibilityEXT.presentModeCount, 1U);
+                ASSERT_EQ(SurfacePresentModeCompatibilityEXT.pPresentModes[0], queried_present_modes[i]);
+                ASSERT_EQ(SurfacePresentScalingCapabilitiesEXT.supportedPresentScaling, 0U);
+                ASSERT_EQ(SurfacePresentScalingCapabilitiesEXT.supportedPresentGravityX, 0u);
+                ASSERT_EQ(SurfacePresentScalingCapabilitiesEXT.supportedPresentGravityY, 0U);
+                ASSERT_EQ(SurfacePresentScalingCapabilitiesEXT.minScaledImageExtent, surface_caps.minImageExtent);
+                ASSERT_EQ(SurfacePresentScalingCapabilitiesEXT.maxScaledImageExtent, surface_caps.maxImageExtent);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The VK_EXT_surface_maintance1 extension is an instance level extension, which means the loader will advertise support for it when at least one driver supports it. However, there is presently no way for an application to know which VkPhysicalDevice's will fill out the structs the extension defines and which VkPhysicalDevice's will ignore the structs.

Add support for testing the surface_maintenance1 implementation - making sure that a driver which supports the extension isn't affected and correctly filling out the structs for drivers which do and do not support vkGetPhysicalDeviceSurfaceCapabilities2KHR as well.