### PR TITLE
Use memcpy to access sType in pNext chains

### DIFF
--- a/loader/debug_utils.c
+++ b/loader/debug_utils.c
@@ -134,7 +134,9 @@ VkResult util_CreateDebugUtilsMessengers(struct loader_instance *inst, const voi
                                          const VkAllocationCallbacks *pAllocator) {
     const void *pNext = pChain;
     while (pNext) {
-        if (((const VkBaseInStructure *)pNext)->sType == VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT) {
+        VkBaseInStructure in_structure = {0};
+        memcpy(&in_structure, pNext, sizeof(VkBaseInStructure));
+        if (in_structure.sType == VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT) {
             // Assign a unique handle to each messenger (just use the address of the VkDebugUtilsMessengerCreateInfoEXT)
             // This is only being used this way due to it being for an 'anonymous' callback during instance creation
             VkDebugUtilsMessengerEXT messenger_handle = (VkDebugUtilsMessengerEXT)(uintptr_t)pNext;
@@ -144,7 +146,7 @@ VkResult util_CreateDebugUtilsMessengers(struct loader_instance *inst, const voi
                 return ret;
             }
         }
-        pNext = (void *)((VkBaseInStructure *)pNext)->pNext;
+        pNext = in_structure.pNext;
     }
     return VK_SUCCESS;
 }
@@ -409,7 +411,9 @@ VkResult util_CreateDebugReportCallbacks(struct loader_instance *inst, const voi
                                          const VkAllocationCallbacks *pAllocator) {
     const void *pNext = pChain;
     while (pNext) {
-        if (((VkBaseInStructure *)pNext)->sType == VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT) {
+        VkBaseInStructure in_structure = {0};
+        memcpy(&in_structure, pNext, sizeof(VkBaseInStructure));
+        if (in_structure.sType == VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT) {
             // Assign a unique handle to each callback (just use the address of the VkDebugReportCallbackCreateInfoEXT):
             // This is only being used this way due to it being for an 'anonymous' callback during instance creation
             VkDebugReportCallbackEXT report_handle = (VkDebugReportCallbackEXT)(uintptr_t)pNext;
@@ -419,7 +423,7 @@ VkResult util_CreateDebugReportCallbacks(struct loader_instance *inst, const voi
                 return ret;
             }
         }
-        pNext = (void *)((VkBaseInStructure *)pNext)->pNext;
+        pNext = in_structure.pNext;
     }
     return VK_SUCCESS;
 }

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1667,13 +1667,15 @@ VkResult loader_scan_for_direct_drivers(const struct loader_instance *inst, cons
     }
     const VkDirectDriverLoadingListLUNARG *ddl_list = NULL;
     // Find the VkDirectDriverLoadingListLUNARG struct in the pNext chain of vkInstanceCreateInfo
-    const VkBaseOutStructure *chain = pCreateInfo->pNext;
-    while (chain) {
-        if (chain->sType == VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_LIST_LUNARG) {
-            ddl_list = (VkDirectDriverLoadingListLUNARG *)chain;
+    const void *pNext = pCreateInfo->pNext;
+    while (pNext) {
+        VkBaseInStructure out_structure = {0};
+        memcpy(&out_structure, pNext, sizeof(VkBaseInStructure));
+        if (out_structure.sType == VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_LIST_LUNARG) {
+            ddl_list = (VkDirectDriverLoadingListLUNARG *)pNext;
             break;
         }
-        chain = (const VkBaseOutStructure *)chain->pNext;
+        pNext = out_structure.pNext;
     }
     if (NULL == ddl_list) {
         if (direct_driver_loading_enabled) {
@@ -5853,7 +5855,9 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
     {
         const void *pNext = localCreateInfo.pNext;
         while (pNext != NULL) {
-            switch (*(VkStructureType *)pNext) {
+            VkBaseInStructure pNext_in_structure = {0};
+            memcpy(&pNext_in_structure, pNext, sizeof(VkBaseInStructure));
+            switch (pNext_in_structure.sType) {
                 case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2: {
                     const VkPhysicalDeviceFeatures2KHR *features = pNext;
 
@@ -5905,8 +5909,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
                 // Multiview properties are also allowed, but since VK_KHX_multiview is a device extension, we'll just let the
                 // ICD handle that error when the user enables the extension here
                 default: {
-                    const VkBaseInStructure *header = pNext;
-                    pNext = header->pNext;
+                    pNext = pNext_in_structure.pNext;
                     break;
                 }
             }
@@ -5918,7 +5921,9 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
     {
         const void *pNext = localCreateInfo.pNext;
         while (pNext != NULL) {
-            switch (*(VkStructureType *)pNext) {
+            VkBaseInStructure pNext_in_structure = {0};
+            memcpy(&pNext_in_structure, pNext, sizeof(VkBaseInStructure));
+            switch (pNext_in_structure.sType) {
                 case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR: {
                     const VkPhysicalDeviceMaintenance5FeaturesKHR *maintenance_features = pNext;
                     if (maintenance_features->maintenance5 == VK_TRUE) {
@@ -5929,8 +5934,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
                 }
 
                 default: {
-                    const VkBaseInStructure *header = pNext;
-                    pNext = header->pNext;
+                    pNext = pNext_in_structure.pNext;
                     break;
                 }
             }

--- a/loader/loader_linux.c
+++ b/loader/loader_linux.c
@@ -292,8 +292,8 @@ VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32
             if (sorted_device_info[index].has_pci_bus_info) {
                 VkPhysicalDevicePCIBusInfoPropertiesEXT pci_props = (VkPhysicalDevicePCIBusInfoPropertiesEXT){
                     .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT};
-                VkPhysicalDeviceProperties2 dev_props2 = (VkPhysicalDeviceProperties2){
-                    .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, .pNext = (VkBaseInStructure *)&pci_props};
+                VkPhysicalDeviceProperties2 dev_props2 =
+                    (VkPhysicalDeviceProperties2){.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, .pNext = &pci_props};
 
                 PFN_vkGetPhysicalDeviceProperties2 GetPhysDevProps2 = NULL;
                 if (app_is_vulkan_1_1 && device_is_1_1_capable) {
@@ -394,8 +394,8 @@ VkResult linux_sort_physical_device_groups(struct loader_instance *inst, uint32_
             if (sorted_group_term[group].internal_device_info[gpu].has_pci_bus_info) {
                 VkPhysicalDevicePCIBusInfoPropertiesEXT pci_props = (VkPhysicalDevicePCIBusInfoPropertiesEXT){
                     .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT};
-                VkPhysicalDeviceProperties2 dev_props2 = (VkPhysicalDeviceProperties2){
-                    .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, .pNext = (VkBaseInStructure *)&pci_props};
+                VkPhysicalDeviceProperties2 dev_props2 =
+                    (VkPhysicalDeviceProperties2){.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, .pNext = &pci_props};
 
                 PFN_vkGetPhysicalDeviceProperties2 GetPhysDevProps2 = NULL;
                 if (app_is_vulkan_1_1 && device_is_1_1_capable) {

--- a/loader/terminator.c
+++ b/loader/terminator.c
@@ -156,9 +156,11 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceFeatures2(VkPhysicalDevic
         // Write to the VkPhysicalDeviceFeatures2 struct
         icd_term->dispatch.GetPhysicalDeviceFeatures(phys_dev_term->phys_dev, &pFeatures->features);
 
-        const VkBaseInStructure *pNext = pFeatures->pNext;
+        void *pNext = pFeatures->pNext;
         while (pNext != NULL) {
-            switch (pNext->sType) {
+            VkBaseOutStructure pNext_in_structure = {0};
+            memcpy(&pNext_in_structure, pNext, sizeof(VkBaseOutStructure));
+            switch (pNext_in_structure.sType) {
                 case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES: {
                     // Skip the check if VK_KHR_multiview is enabled because it's a device extension
                     // Write to the VkPhysicalDeviceMultiviewFeaturesKHR struct
@@ -175,7 +177,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceFeatures2(VkPhysicalDevic
                                "vkGetPhysicalDeviceFeatures2: Emulation found unrecognized structure type in pFeatures->pNext - "
                                "this struct will be ignored");
 
-                    pNext = pNext->pNext;
+                    pNext = pNext_in_structure.pNext;
                     break;
                 }
             }
@@ -212,9 +214,11 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceProperties2(VkPhysicalDev
         // Write to the VkPhysicalDeviceProperties2 struct
         icd_term->dispatch.GetPhysicalDeviceProperties(phys_dev_term->phys_dev, &pProperties->properties);
 
-        const VkBaseInStructure *pNext = pProperties->pNext;
+        void *pNext = pProperties->pNext;
         while (pNext != NULL) {
-            switch (pNext->sType) {
+            VkBaseOutStructure pNext_in_structure = {0};
+            memcpy(&pNext_in_structure, pNext, sizeof(VkBaseOutStructure));
+            switch (pNext_in_structure.sType) {
                 case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES: {
                     VkPhysicalDeviceIDPropertiesKHR *id_properties = (VkPhysicalDeviceIDPropertiesKHR *)pNext;
 
@@ -238,7 +242,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceProperties2(VkPhysicalDev
                                "vkGetPhysicalDeviceProperties2KHR: Emulation found unrecognized structure type in "
                                "pProperties->pNext - this struct will be ignored");
 
-                    pNext = pNext->pNext;
+                    pNext = pNext_in_structure.pNext;
                     break;
                 }
             }

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -2454,15 +2454,17 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2K
     }
 
     if (icd_term->dispatch.GetPhysicalDeviceSurfaceCapabilities2KHR != NULL) {
-        VkBaseOutStructure *pNext = (VkBaseOutStructure *)pSurfaceCapabilities->pNext;
+        void *pNext = pSurfaceCapabilities->pNext;
         while (pNext != NULL) {
-            if ((int)pNext->sType == VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR) {
+            VkBaseOutStructure pNext_out_structure = {0};
+            memcpy(&pNext_out_structure, pNext, sizeof(VkBaseOutStructure));
+            if (pNext_out_structure.sType == VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR) {
                 // Not all ICDs may be supporting VK_KHR_surface_protected_capabilities
                 // Initialize VkSurfaceProtectedCapabilitiesKHR.supportsProtected to false and
                 // if an ICD supports protected surfaces, it will reset it to true accordingly.
                 ((VkSurfaceProtectedCapabilitiesKHR *)pNext)->supportsProtected = VK_FALSE;
             }
-            pNext = (VkBaseOutStructure *)pNext->pNext;
+            pNext = pNext_out_structure.pNext;
         }
 
         // Pass the call to the driver, possibly unwrapping the ICD surface


### PR DESCRIPTION
Replaces dubious type punning to VkBaseIn/OutStructure into correct mempcy to a local VkBaseIn/OutStructure in order to access the sType safely.

This commit changes only the simple locations of the type punning. The more difficult situations aren't being tackled here, since those situations insert elements into the pNext chain, modifying it in the process.