### PR TITLE
Only call surface creation functions on supported drivers 

### DIFF
--- a/loader/debug_utils.c
+++ b/loader/debug_utils.c
@@ -612,16 +612,6 @@ VkResult add_debug_extensions_to_ext_list(const struct loader_instance *inst, st
                                   debug_utils_extension_info);
 }
 
-void check_for_enabled_debug_extensions(struct loader_instance *ptr_instance, const VkInstanceCreateInfo *pCreateInfo) {
-    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_DEBUG_REPORT_EXTENSION_NAME) == 0) {
-            ptr_instance->enabled_known_extensions.ext_debug_report = 1;
-        } else if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0) {
-            ptr_instance->enabled_known_extensions.ext_debug_utils = 1;
-        }
-    }
-}
-
 bool debug_extensions_InstanceGpa(struct loader_instance *ptr_instance, const char *name, void **addr) {
     bool ret_type = false;
 

--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -12169,58 +12169,77 @@ bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *na
     return false;
 }
 
-// A function that can be used to query enabled extensions during a vkCreateInstance call
-void extensions_create_instance(struct loader_instance *ptr_instance, const VkInstanceCreateInfo *pCreateInfo) {
-    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
-
-    // ---- VK_KHR_get_physical_device_properties2 extension commands
-        if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.khr_get_physical_device_properties2 = 1;
-
-    // ---- VK_KHR_device_group_creation extension commands
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.khr_device_group_creation = 1;
-
-    // ---- VK_KHR_external_memory_capabilities extension commands
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.khr_external_memory_capabilities = 1;
-
-    // ---- VK_KHR_external_semaphore_capabilities extension commands
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.khr_external_semaphore_capabilities = 1;
-
-    // ---- VK_KHR_external_fence_capabilities extension commands
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.khr_external_fence_capabilities = 1;
-
-    // ---- VK_NV_external_memory_capabilities extension commands
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NV_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.nv_external_memory_capabilities = 1;
-
-    // ---- VK_EXT_direct_mode_display extension commands
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.ext_direct_mode_display = 1;
-
-    // ---- VK_EXT_acquire_xlib_display extension commands
+void fill_out_enabled_instance_extensions(uint32_t extension_count, const char *const * extension_list, struct loader_instance_extension_enables* enables) {
+    for(uint32_t i = 0; i < extension_count; i++) {
+        if (strcmp(extension_list[i], VK_KHR_SURFACE_EXTENSION_NAME) == 0) { enables->khr_surface = true; }
+        if (strcmp(extension_list[i], VK_KHR_DISPLAY_EXTENSION_NAME) == 0) { enables->khr_display = true; }
+#if defined(VK_USE_PLATFORM_XLIB_KHR)
+        if (strcmp(extension_list[i], VK_KHR_XLIB_SURFACE_EXTENSION_NAME) == 0) { enables->khr_xlib_surface = true; }
+#endif // defined(VK_USE_PLATFORM_XLIB_KHR)
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+        if (strcmp(extension_list[i], VK_KHR_XCB_SURFACE_EXTENSION_NAME) == 0) { enables->khr_xcb_surface = true; }
+#endif // defined(VK_USE_PLATFORM_XCB_KHR)
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+        if (strcmp(extension_list[i], VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) == 0) { enables->khr_wayland_surface = true; }
+#endif // defined(VK_USE_PLATFORM_WAYLAND_KHR)
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+        if (strcmp(extension_list[i], VK_KHR_ANDROID_SURFACE_EXTENSION_NAME) == 0) { enables->khr_android_surface = true; }
+#endif // defined(VK_USE_PLATFORM_ANDROID_KHR)
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+        if (strcmp(extension_list[i], VK_KHR_WIN32_SURFACE_EXTENSION_NAME) == 0) { enables->khr_win32_surface = true; }
+#endif // defined(VK_USE_PLATFORM_WIN32_KHR)
+        if (strcmp(extension_list[i], VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) == 0) { enables->khr_get_physical_device_properties2 = true; }
+        if (strcmp(extension_list[i], VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME) == 0) { enables->khr_device_group_creation = true; }
+        if (strcmp(extension_list[i], VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME) == 0) { enables->khr_external_memory_capabilities = true; }
+        if (strcmp(extension_list[i], VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME) == 0) { enables->khr_external_semaphore_capabilities = true; }
+        if (strcmp(extension_list[i], VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME) == 0) { enables->khr_external_fence_capabilities = true; }
+        if (strcmp(extension_list[i], VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME) == 0) { enables->khr_get_surface_capabilities2 = true; }
+        if (strcmp(extension_list[i], VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME) == 0) { enables->khr_get_display_properties2 = true; }
+        if (strcmp(extension_list[i], VK_KHR_SURFACE_PROTECTED_CAPABILITIES_EXTENSION_NAME) == 0) { enables->khr_surface_protected_capabilities = true; }
+        if (strcmp(extension_list[i], VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0) { enables->khr_portability_enumeration = true; }
+        if (strcmp(extension_list[i], VK_EXT_DEBUG_REPORT_EXTENSION_NAME) == 0) { enables->ext_debug_report = true; }
+#if defined(VK_USE_PLATFORM_GGP)
+        if (strcmp(extension_list[i], VK_GGP_STREAM_DESCRIPTOR_SURFACE_EXTENSION_NAME) == 0) { enables->ggp_stream_descriptor_surface = true; }
+#endif // defined(VK_USE_PLATFORM_GGP)
+        if (strcmp(extension_list[i], VK_NV_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME) == 0) { enables->nv_external_memory_capabilities = true; }
+        if (strcmp(extension_list[i], VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME) == 0) { enables->ext_validation_flags = true; }
+#if defined(VK_USE_PLATFORM_VI_NN)
+        if (strcmp(extension_list[i], VK_NN_VI_SURFACE_EXTENSION_NAME) == 0) { enables->nn_vi_surface = true; }
+#endif // defined(VK_USE_PLATFORM_VI_NN)
+        if (strcmp(extension_list[i], VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME) == 0) { enables->ext_direct_mode_display = true; }
 #if defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_ACQUIRE_XLIB_DISPLAY_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.ext_acquire_xlib_display = 1;
-#endif // VK_USE_PLATFORM_XLIB_XRANDR_EXT
-
-    // ---- VK_EXT_display_surface_counter extension commands
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.ext_display_surface_counter = 1;
-
-    // ---- VK_EXT_debug_utils extension commands
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.ext_debug_utils = 1;
-
-    // ---- VK_EXT_acquire_drm_display extension commands
-        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME)) {
-            ptr_instance->enabled_known_extensions.ext_acquire_drm_display = 1;
-        }
+        if (strcmp(extension_list[i], VK_EXT_ACQUIRE_XLIB_DISPLAY_EXTENSION_NAME) == 0) { enables->ext_acquire_xlib_display = true; }
+#endif // defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
+        if (strcmp(extension_list[i], VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME) == 0) { enables->ext_display_surface_counter = true; }
+        if (strcmp(extension_list[i], VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME) == 0) { enables->ext_swapchain_colorspace = true; }
+#if defined(VK_USE_PLATFORM_IOS_MVK)
+        if (strcmp(extension_list[i], VK_MVK_IOS_SURFACE_EXTENSION_NAME) == 0) { enables->mvk_ios_surface = true; }
+#endif // defined(VK_USE_PLATFORM_IOS_MVK)
+#if defined(VK_USE_PLATFORM_MACOS_MVK)
+        if (strcmp(extension_list[i], VK_MVK_MACOS_SURFACE_EXTENSION_NAME) == 0) { enables->mvk_macos_surface = true; }
+#endif // defined(VK_USE_PLATFORM_MACOS_MVK)
+        if (strcmp(extension_list[i], VK_EXT_DEBUG_UTILS_EXTENSION_NAME) == 0) { enables->ext_debug_utils = true; }
+#if defined(VK_USE_PLATFORM_FUCHSIA)
+        if (strcmp(extension_list[i], VK_FUCHSIA_IMAGEPIPE_SURFACE_EXTENSION_NAME) == 0) { enables->fuchsia_imagepipe_surface = true; }
+#endif // defined(VK_USE_PLATFORM_FUCHSIA)
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+        if (strcmp(extension_list[i], VK_EXT_METAL_SURFACE_EXTENSION_NAME) == 0) { enables->ext_metal_surface = true; }
+#endif // defined(VK_USE_PLATFORM_METAL_EXT)
+        if (strcmp(extension_list[i], VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME) == 0) { enables->ext_validation_features = true; }
+        if (strcmp(extension_list[i], VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME) == 0) { enables->ext_headless_surface = true; }
+        if (strcmp(extension_list[i], VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME) == 0) { enables->ext_surface_maintenance1 = true; }
+        if (strcmp(extension_list[i], VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME) == 0) { enables->ext_acquire_drm_display = true; }
+#if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
+        if (strcmp(extension_list[i], VK_EXT_DIRECTFB_SURFACE_EXTENSION_NAME) == 0) { enables->ext_directfb_surface = true; }
+#endif // defined(VK_USE_PLATFORM_DIRECTFB_EXT)
+#if defined(VK_USE_PLATFORM_SCREEN_QNX)
+        if (strcmp(extension_list[i], VK_QNX_SCREEN_SURFACE_EXTENSION_NAME) == 0) { enables->qnx_screen_surface = true; }
+#endif // defined(VK_USE_PLATFORM_SCREEN_QNX)
+        if (strcmp(extension_list[i], VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME) == 0) { enables->google_surfaceless_query = true; }
+        if (strcmp(extension_list[i], VK_LUNARG_DIRECT_DRIVER_LOADING_EXTENSION_NAME) == 0) { enables->lunarg_direct_driver_loading = true; }
+        if (strcmp(extension_list[i], VK_EXT_LAYER_SETTINGS_EXTENSION_NAME) == 0) { enables->ext_layer_settings = true; }
     }
-}
+};
 
 // Some device commands still need a terminator because the loader needs to unwrap something about them.
 // In many cases, the item needing unwrapping is a VkPhysicalDevice or VkSurfaceKHR object.  But there may be other items
@@ -12581,6 +12600,9 @@ const char *const LOADER_INSTANCE_EXTENSIONS[] = {
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
                                                   VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME,
 #endif // VK_USE_PLATFORM_WAYLAND_KHR
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+                                                  VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,
+#endif // VK_USE_PLATFORM_ANDROID_KHR
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
                                                   VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
 #endif // VK_USE_PLATFORM_WIN32_KHR

--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -46,10 +46,12 @@ VKAPI_ATTR VkResult VKAPI_CALL vkDevExtError(VkDevice dev);
 // the appropriate information for any instance extensions we know about.
 bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *name, void **addr);
 
+struct loader_instance_extension_enables; // Forward declaration
 // Extension interception for vkCreateInstance function, so we can properly
 // detect and enable any instance extension information for extensions we know
 // about.
-void extensions_create_instance(struct loader_instance *ptr_instance, const VkInstanceCreateInfo *pCreateInfo);
+void fill_out_enabled_instance_extensions(uint32_t extension_count, const char *const * extension_list, struct loader_instance_extension_enables* enables);
+
 
 // Extension interception for vkGetDeviceProcAddr function, so we can return
 // an appropriate terminator if this is one of those few device commands requiring
@@ -479,18 +481,73 @@ struct loader_icd_term_dispatch {
 };
 
 struct loader_instance_extension_enables {
+    uint8_t khr_surface;
+    uint8_t khr_display;
+#if defined(VK_USE_PLATFORM_XLIB_KHR)
+    uint8_t khr_xlib_surface;
+#endif // defined(VK_USE_PLATFORM_XLIB_KHR)
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+    uint8_t khr_xcb_surface;
+#endif // defined(VK_USE_PLATFORM_XCB_KHR)
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+    uint8_t khr_wayland_surface;
+#endif // defined(VK_USE_PLATFORM_WAYLAND_KHR)
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+    uint8_t khr_android_surface;
+#endif // defined(VK_USE_PLATFORM_ANDROID_KHR)
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+    uint8_t khr_win32_surface;
+#endif // defined(VK_USE_PLATFORM_WIN32_KHR)
     uint8_t khr_get_physical_device_properties2;
     uint8_t khr_device_group_creation;
     uint8_t khr_external_memory_capabilities;
     uint8_t khr_external_semaphore_capabilities;
     uint8_t khr_external_fence_capabilities;
+    uint8_t khr_get_surface_capabilities2;
+    uint8_t khr_get_display_properties2;
+    uint8_t khr_surface_protected_capabilities;
+    uint8_t khr_portability_enumeration;
     uint8_t ext_debug_report;
+#if defined(VK_USE_PLATFORM_GGP)
+    uint8_t ggp_stream_descriptor_surface;
+#endif // defined(VK_USE_PLATFORM_GGP)
     uint8_t nv_external_memory_capabilities;
+    uint8_t ext_validation_flags;
+#if defined(VK_USE_PLATFORM_VI_NN)
+    uint8_t nn_vi_surface;
+#endif // defined(VK_USE_PLATFORM_VI_NN)
     uint8_t ext_direct_mode_display;
+#if defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
     uint8_t ext_acquire_xlib_display;
+#endif // defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
     uint8_t ext_display_surface_counter;
+    uint8_t ext_swapchain_colorspace;
+#if defined(VK_USE_PLATFORM_IOS_MVK)
+    uint8_t mvk_ios_surface;
+#endif // defined(VK_USE_PLATFORM_IOS_MVK)
+#if defined(VK_USE_PLATFORM_MACOS_MVK)
+    uint8_t mvk_macos_surface;
+#endif // defined(VK_USE_PLATFORM_MACOS_MVK)
     uint8_t ext_debug_utils;
+#if defined(VK_USE_PLATFORM_FUCHSIA)
+    uint8_t fuchsia_imagepipe_surface;
+#endif // defined(VK_USE_PLATFORM_FUCHSIA)
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+    uint8_t ext_metal_surface;
+#endif // defined(VK_USE_PLATFORM_METAL_EXT)
+    uint8_t ext_validation_features;
+    uint8_t ext_headless_surface;
+    uint8_t ext_surface_maintenance1;
     uint8_t ext_acquire_drm_display;
+#if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
+    uint8_t ext_directfb_surface;
+#endif // defined(VK_USE_PLATFORM_DIRECTFB_EXT)
+#if defined(VK_USE_PLATFORM_SCREEN_QNX)
+    uint8_t qnx_screen_surface;
+#endif // defined(VK_USE_PLATFORM_SCREEN_QNX)
+    uint8_t google_surfaceless_query;
+    uint8_t lunarg_direct_driver_loading;
+    uint8_t ext_layer_settings;
 };
 
 // Functions that required a terminator need to have a separate dispatch table which contains their corresponding

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -265,8 +265,8 @@ struct loader_icd_term {
     struct loader_icd_term *next;
 
     PFN_PhysDevExt phys_dev_ext[MAX_NUM_UNKNOWN_EXTS];
-    bool supports_get_dev_prop_2;
-    bool supports_ext_surface_maintenance_1;
+
+    struct loader_instance_extension_enables enabled_instance_extensions;
 
     uint32_t physical_device_count;
 
@@ -371,49 +371,6 @@ struct loader_instance {
     bool portability_enumeration_flag_bit_set;
     bool portability_enumeration_extension_enabled;
 
-    bool wsi_surface_enabled;
-#if defined(VK_USE_PLATFORM_WIN32_KHR)
-    bool wsi_win32_surface_enabled;
-#endif
-#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-    bool wsi_wayland_surface_enabled;
-#endif
-#if defined(VK_USE_PLATFORM_XCB_KHR)
-    bool wsi_xcb_surface_enabled;
-#endif
-#if defined(VK_USE_PLATFORM_XLIB_KHR)
-    bool wsi_xlib_surface_enabled;
-#endif
-#if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
-    bool wsi_directfb_surface_enabled;
-#endif
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-    bool wsi_android_surface_enabled;
-#endif
-#if defined(VK_USE_PLATFORM_MACOS_MVK)
-    bool wsi_macos_surface_enabled;
-#endif
-#if defined(VK_USE_PLATFORM_IOS_MVK)
-    bool wsi_ios_surface_enabled;
-#endif
-#if defined(VK_USE_PLATFORM_GGP)
-    bool wsi_ggp_surface_enabled;
-#endif
-    bool wsi_headless_surface_enabled;
-#if defined(VK_USE_PLATFORM_METAL_EXT)
-    bool wsi_metal_surface_enabled;
-#endif
-#if defined(VK_USE_PLATFORM_FUCHSIA)
-    bool wsi_imagepipe_surface_enabled;
-#endif
-#if defined(VK_USE_PLATFORM_SCREEN_QNX)
-    bool wsi_screen_surface_enabled;
-#endif
-#if defined(VK_USE_PLATFORM_VI_NN)
-    bool wsi_vi_surface_enabled;
-#endif
-    bool wsi_display_enabled;
-    bool wsi_display_props2_enabled;
     bool create_terminator_invalid_extension;
     bool supports_get_dev_prop_2;
 };

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -738,9 +738,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         // are enabled than what's down in the terminator.
         // This is why we don't clear inside of these function calls.
         // The clearing should actually be handled by the overall memset of the pInstance structure above.
-        wsi_create_instance(ptr_instance, &ici);
-        check_for_enabled_debug_extensions(ptr_instance, &ici);
-        extensions_create_instance(ptr_instance, &ici);
+        fill_out_enabled_instance_extensions(ici.enabledExtensionCount, ici.ppEnabledExtensionNames,
+                                             &ptr_instance->enabled_known_extensions);
 
         *pInstance = (VkInstance)ptr_instance;
 

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -39,105 +39,6 @@
 // the ICDs.
 #define ICD_VER_SUPPORTS_ICD_SURFACE_KHR 3
 
-void wsi_create_instance(struct loader_instance *loader_inst, const VkInstanceCreateInfo *pCreateInfo) {
-    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_surface_enabled = true;
-            continue;
-        }
-#if defined(VK_USE_PLATFORM_WIN32_KHR)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_WIN32_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_win32_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_WIN32_KHR
-#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_wayland_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_WAYLAND_KHR
-#if defined(VK_USE_PLATFORM_XCB_KHR)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_XCB_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_xcb_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_XCB_KHR
-#if defined(VK_USE_PLATFORM_XLIB_KHR)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_XLIB_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_xlib_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_XLIB_KHR
-#if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_DIRECTFB_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_directfb_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_DIRECTFB_EXT
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_ANDROID_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_android_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_ANDROID_KHR
-#if defined(VK_USE_PLATFORM_MACOS_MVK)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_MVK_MACOS_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_macos_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_MACOS_MVK
-#if defined(VK_USE_PLATFORM_IOS_MVK)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_MVK_IOS_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_ios_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_IOS_MVK
-#if defined(VK_USE_PLATFORM_GGP)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_GGP_STREAM_DESCRIPTOR_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_ggp_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_GGP
-#if defined(VK_USE_PLATFORM_FUCHSIA)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_FUCHSIA_IMAGEPIPE_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_imagepipe_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_FUCHSIA
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_headless_surface_enabled = true;
-            continue;
-        }
-#if defined(VK_USE_PLATFORM_METAL_EXT)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_METAL_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_metal_surface_enabled = true;
-            continue;
-        }
-#endif
-#if defined(VK_USE_PLATFORM_SCREEN_QNX)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_QNX_SCREEN_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_screen_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_SCREEN_QNX
-#if defined(VK_USE_PLATFORM_VI_NN)
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NN_VI_SURFACE_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_vi_surface_enabled = true;
-            continue;
-        }
-#endif  // VK_USE_PLATFORM_VI_NN
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_DISPLAY_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_display_enabled = true;
-            continue;
-        }
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME) == 0) {
-            loader_inst->wsi_display_props2_enabled = true;
-            continue;
-        }
-    }
-}
-
 // Linux WSI surface extensions are not always compiled into the loader. (Assume
 // for Windows the KHR_win32_surface is always compiled into loader). A given
 // Linux build environment might not have the headers required for building one
@@ -232,7 +133,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceSupportKHR(VkP
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_surface extension not enabled. vkGetPhysicalDeviceSurfaceSupportKHR not executed!");
         return VK_SUCCESS;
@@ -288,7 +189,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilitiesKH
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_surface extension not enabled. vkGetPhysicalDeviceSurfaceCapabilitiesKHR not executed!");
         return VK_SUCCESS;
@@ -346,7 +247,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormatsKHR(VkP
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_surface extension not enabled. vkGetPhysicalDeviceSurfaceFormatsKHR not executed!");
         return VK_SUCCESS;
@@ -405,7 +306,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfacePresentModesKH
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_surface extension not enabled. vkGetPhysicalDeviceSurfacePresentModesKHR not executed!");
         return VK_SUCCESS;
@@ -645,7 +546,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateWin32SurfaceKHR(VkInstance insta
     *pSurface = VK_NULL_HANDLE;
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_win32_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_win32_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_win32_surface extension not enabled. vkCreateWin32SurfaceKHR not executed!");
         result = VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -703,7 +604,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceWin32PresentationSupp
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_win32_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_win32_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_win32_surface extension not enabled. vkGetPhysicalDeviceWin32PresentationSupportKHR not executed!");
         return VK_FALSE;
@@ -746,7 +647,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateWaylandSurfaceKHR(VkInstance ins
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_wayland_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_wayland_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_wayland_surface extension not enabled. vkCreateWaylandSurfaceKHR not executed!");
         result = VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -807,7 +708,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceWaylandPresentationSu
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_wayland_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_wayland_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_wayland_surface extension not enabled. vkGetPhysicalDeviceWaylandPresentationSupportKHR not executed!");
         return VK_FALSE;
@@ -851,7 +752,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateXcbSurfaceKHR(VkInstance instanc
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_xcb_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_xcb_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_xcb_surface extension not enabled. vkCreateXcbSurfaceKHR not executed!");
         result = VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -914,7 +815,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceXcbPresentationSuppor
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_xcb_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_xcb_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_xcb_surface extension not enabled. vkGetPhysicalDeviceXcbPresentationSupportKHR not executed!");
         return VK_FALSE;
@@ -959,7 +860,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateXlibSurfaceKHR(VkInstance instan
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_xlib_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_xlib_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_xlib_surface extension not enabled. vkCreateXlibSurfaceKHR not executed!");
         result = VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -1020,7 +921,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceXlibPresentationSuppo
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_xlib_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_xlib_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_xlib_surface extension not enabled. vkGetPhysicalDeviceXlibPresentationSupportKHR not executed!");
         return VK_FALSE;
@@ -1066,7 +967,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDirectFBSurfaceEXT(VkInstance in
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_directfb_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.ext_directfb_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_EXT_directfb_surface extension not enabled. vkCreateDirectFBSurfaceEXT not executed!");
         result = VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -1127,7 +1028,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceDirectFBPresentationS
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_directfb_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.ext_directfb_surface) {
         loader_log(
             loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
             "VK_EXT_directfb_surface extension not enabled. vkGetPhysicalDeviceDirectFBPresentationSupportKHR not executed!");
@@ -1170,7 +1071,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateAndroidSurfaceKHR(VkInstance ins
                                                                   const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_display_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_display) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_display extension not enabled. vkCreateAndroidSurfaceKHR not executed!");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -1218,7 +1119,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateHeadlessSurfaceEXT(VkInstance in
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_headless_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.ext_headless_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_EXT_headless_surface extension not enabled.  "
                    "vkCreateHeadlessSurfaceEXT not executed!");
@@ -1307,7 +1208,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateMacOSSurfaceMVK(VkInstance insta
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_macos_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.mvk_macos_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_MVK_macos_surface extension not enabled. vkCreateMacOSSurfaceMVK not executed!");
         result = VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -1369,7 +1270,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateIOSSurfaceMVK(VkInstance instanc
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_ios_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.mvk_ios_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_MVK_ios_surface extension not enabled. vkCreateIOSSurfaceMVK not executed!");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -1421,7 +1322,7 @@ terminator_CreateStreamDescriptorSurfaceGGP(VkInstance instance, const VkStreamD
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_ggp_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.wsi_ggp_surface_enabled) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_GGP_stream_descriptor_surface extension not enabled. vkCreateStreamDescriptorSurfaceGGP not executed!");
         result = VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -1481,7 +1382,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateMetalSurfaceEXT(VkInstance insta
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_metal_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.ext_metal_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_EXT_metal_surface extension not enabled. vkCreateMetalSurfaceEXT will not be executed.");
     }
@@ -1541,7 +1442,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateScreenSurfaceQNX(VkInstance inst
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_screen_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.qnx_screen_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_QNX_screen_surface extension not enabled. vkCreateScreenSurfaceQNX not executed!");
         result = VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -1602,7 +1503,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL terminator_GetPhysicalDeviceScreenPresentationSup
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_screen_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.qnx_screen_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_QNX_screen_surface extension not enabled. vkGetPhysicalDeviceScreenPresentationSupportQNX not executed!");
         return VK_FALSE;
@@ -1644,7 +1545,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateViSurfaceNN(VkInstance instance,
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_vi_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.nn_vi_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_NN_vi_surface extension not enabled. vkCreateViSurfaceNN not executed!");
         result = VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -1705,7 +1606,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceDisplayPropertiesKHR(
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_display_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_display) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_display extension not enabled. vkGetPhysicalDeviceDisplayPropertiesKHR not executed!");
         return VK_SUCCESS;
@@ -1746,7 +1647,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceDisplayPlanePropertie
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_display_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_display) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_display extension not enabled. vkGetPhysicalDeviceDisplayPlanePropertiesKHR not executed!");
         return VK_SUCCESS;
@@ -1787,7 +1688,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayPlaneSupportedDisplaysKHR(Vk
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_display_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_display) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_display extension not enabled. vkGetDisplayPlaneSupportedDisplaysKHR not executed!");
         return VK_SUCCESS;
@@ -1829,7 +1730,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayModePropertiesKHR(VkPhysical
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_display_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_display) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_display extension not enabled. vkGetDisplayModePropertiesKHR not executed!");
         return VK_SUCCESS;
@@ -1872,7 +1773,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDisplayModeKHR(VkPhysicalDevice 
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_display_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_display) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_display extension not enabled. vkCreateDisplayModeKHR not executed!");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -1911,7 +1812,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDisplayPlaneCapabilitiesKHR(VkPhysi
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    if (!loader_inst->wsi_display_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_display) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_display extension not enabled. vkGetDisplayPlaneCapabilitiesKHR not executed!");
         return VK_SUCCESS;
@@ -1954,7 +1855,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDisplayPlaneSurfaceKHR(VkInstanc
 
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_display_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_display) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_surface extension not enabled. vkCreateDisplayPlaneSurfaceKHR not executed!");
         result = VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -1971,10 +1872,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDisplayPlaneSurfaceKHR(VkInstanc
     for (struct loader_icd_term *icd_term = loader_inst->icd_terms; icd_term != NULL; icd_term = icd_term->next) {
         if (icd_term->scanned_icd->interface_version >= ICD_VER_SUPPORTS_ICD_SURFACE_KHR) {
             if (NULL != icd_term->dispatch.CreateDisplayPlaneSurfaceKHR) {
-                result = icd_term->dispatch.CreateDisplayPlaneSurfaceKHR(icd_term->instance, pCreateInfo, pAllocator,
-                                                                         &icd_term->surface_list.list[icd_surface->surface_index]);
-                if (VK_SUCCESS != result) {
-                    goto out;
+            result = icd_term->dispatch.CreateDisplayPlaneSurfaceKHR(icd_term->instance, pCreateInfo, pAllocator,
+                                                                     &icd_term->surface_list.list[icd_surface->surface_index]);
+            if (VK_SUCCESS != result) {
+                goto out;
                 }
             }
         }
@@ -2389,7 +2290,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateImagePipeSurfaceFUCHSIA(VkInstan
     *pSurface = VK_NULL_HANDLE;
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->wsi_imagepipe_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.fuchsia_imagepipe_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_FUCHSIA_imagepipe_surface extension not enabled.  "
                    "vkCreateImagePipeSurfaceFUCHSIA not executed!");
@@ -2444,7 +2345,7 @@ void emulate_VK_EXT_surface_maintenance1(struct loader_icd_term *icd_term, const
                                          VkSurfaceCapabilities2KHR *pSurfaceCapabilities) {
     // Because VK_EXT_surface_maintenance1 is an instance extension, applications will use it to query info on drivers which do
     // not support the extension. Thus we need to emulate the driver filling out the structs in that case.
-    if (!icd_term->supports_ext_surface_maintenance_1) {
+    if (!icd_term->enabled_instance_extensions.ext_surface_maintenance1) {
         VkPresentModeKHR present_mode = VK_PRESENT_MODE_MAX_ENUM_KHR;
         const void *void_pNext = pSurfaceInfo->pNext;
         while (void_pNext) {
@@ -2507,7 +2408,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2K
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
     VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)pSurfaceInfo->surface;
 
-    if (!loader_inst->wsi_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_surface extension not enabled. vkGetPhysicalDeviceSurfaceCapabilities2KHR not executed!");
         return VK_SUCCESS;
@@ -2544,7 +2445,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2K
 
         // Because VK_EXT_surface_maintenance1 is an instance extension, applications will use it to query info on drivers which do
         // not support the extension. Thus we need to emulate the driver filling out the structs in that case.
-        if (!icd_term->supports_ext_surface_maintenance_1) {
+        if (!icd_term->enabled_instance_extensions.ext_surface_maintenance1) {
             emulate_VK_EXT_surface_maintenance1(icd_term, pSurfaceInfo, pSurfaceCapabilities);
         }
 
@@ -2602,7 +2503,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormats2KHR(Vk
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
 
-    if (!loader_inst->wsi_surface_enabled) {
+    if (!loader_inst->enabled_known_extensions.khr_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_KHR_surface extension not enabled. vkGetPhysicalDeviceSurfaceFormats2KHR not executed!");
         return VK_SUCCESS;
@@ -2682,49 +2583,49 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_KHR_surface extension:
     if (!strcmp("vkDestroySurfaceKHR", name)) {
-        *addr = loader_inst->wsi_surface_enabled ? (void *)vkDestroySurfaceKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_surface ? (void *)vkDestroySurfaceKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceSurfaceSupportKHR", name)) {
-        *addr = loader_inst->wsi_surface_enabled ? (void *)vkGetPhysicalDeviceSurfaceSupportKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_surface ? (void *)vkGetPhysicalDeviceSurfaceSupportKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceSurfaceCapabilitiesKHR", name)) {
-        *addr = loader_inst->wsi_surface_enabled ? (void *)vkGetPhysicalDeviceSurfaceCapabilitiesKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_surface ? (void *)vkGetPhysicalDeviceSurfaceCapabilitiesKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceSurfaceFormatsKHR", name)) {
-        *addr = loader_inst->wsi_surface_enabled ? (void *)vkGetPhysicalDeviceSurfaceFormatsKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_surface ? (void *)vkGetPhysicalDeviceSurfaceFormatsKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceSurfacePresentModesKHR", name)) {
-        *addr = loader_inst->wsi_surface_enabled ? (void *)vkGetPhysicalDeviceSurfacePresentModesKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_surface ? (void *)vkGetPhysicalDeviceSurfacePresentModesKHR : NULL;
         return true;
     }
 
     if (!strcmp("vkGetDeviceGroupPresentCapabilitiesKHR", name)) {
-        *addr = loader_inst->wsi_surface_enabled ? (void *)vkGetDeviceGroupPresentCapabilitiesKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_surface ? (void *)vkGetDeviceGroupPresentCapabilitiesKHR : NULL;
         return true;
     }
 
     if (!strcmp("vkGetDeviceGroupSurfacePresentModesKHR", name)) {
-        *addr = loader_inst->wsi_surface_enabled ? (void *)vkGetDeviceGroupSurfacePresentModesKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_surface ? (void *)vkGetDeviceGroupSurfacePresentModesKHR : NULL;
         return true;
     }
 
     if (!strcmp("vkGetPhysicalDevicePresentRectanglesKHR", name)) {
-        *addr = loader_inst->wsi_surface_enabled ? (void *)vkGetPhysicalDevicePresentRectanglesKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_surface ? (void *)vkGetPhysicalDevicePresentRectanglesKHR : NULL;
         return true;
     }
 
     // Functions for VK_KHR_get_surface_capabilities2 extension:
     if (!strcmp("vkGetPhysicalDeviceSurfaceCapabilities2KHR", name)) {
-        *addr = loader_inst->wsi_surface_enabled ? (void *)vkGetPhysicalDeviceSurfaceCapabilities2KHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_surface ? (void *)vkGetPhysicalDeviceSurfaceCapabilities2KHR : NULL;
         return true;
     }
 
     if (!strcmp("vkGetPhysicalDeviceSurfaceFormats2KHR", name)) {
-        *addr = loader_inst->wsi_surface_enabled ? (void *)vkGetPhysicalDeviceSurfaceFormats2KHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_surface ? (void *)vkGetPhysicalDeviceSurfaceFormats2KHR : NULL;
         return true;
     }
 
@@ -2763,11 +2664,12 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_KHR_win32_surface extension:
     if (!strcmp("vkCreateWin32SurfaceKHR", name)) {
-        *addr = loader_inst->wsi_win32_surface_enabled ? (void *)vkCreateWin32SurfaceKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_win32_surface ? (void *)vkCreateWin32SurfaceKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceWin32PresentationSupportKHR", name)) {
-        *addr = loader_inst->wsi_win32_surface_enabled ? (void *)vkGetPhysicalDeviceWin32PresentationSupportKHR : NULL;
+        *addr =
+            loader_inst->enabled_known_extensions.khr_win32_surface ? (void *)vkGetPhysicalDeviceWin32PresentationSupportKHR : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
@@ -2775,11 +2677,12 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_KHR_wayland_surface extension:
     if (!strcmp("vkCreateWaylandSurfaceKHR", name)) {
-        *addr = loader_inst->wsi_wayland_surface_enabled ? (void *)vkCreateWaylandSurfaceKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_wayland_surface ? (void *)vkCreateWaylandSurfaceKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceWaylandPresentationSupportKHR", name)) {
-        *addr = loader_inst->wsi_wayland_surface_enabled ? (void *)vkGetPhysicalDeviceWaylandPresentationSupportKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_wayland_surface ? (void *)vkGetPhysicalDeviceWaylandPresentationSupportKHR
+                                                                          : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
@@ -2787,11 +2690,11 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_KHR_xcb_surface extension:
     if (!strcmp("vkCreateXcbSurfaceKHR", name)) {
-        *addr = loader_inst->wsi_xcb_surface_enabled ? (void *)vkCreateXcbSurfaceKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_xcb_surface ? (void *)vkCreateXcbSurfaceKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceXcbPresentationSupportKHR", name)) {
-        *addr = loader_inst->wsi_xcb_surface_enabled ? (void *)vkGetPhysicalDeviceXcbPresentationSupportKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_xcb_surface ? (void *)vkGetPhysicalDeviceXcbPresentationSupportKHR : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_XCB_KHR
@@ -2799,11 +2702,12 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_KHR_xlib_surface extension:
     if (!strcmp("vkCreateXlibSurfaceKHR", name)) {
-        *addr = loader_inst->wsi_xlib_surface_enabled ? (void *)vkCreateXlibSurfaceKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_xlib_surface ? (void *)vkCreateXlibSurfaceKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceXlibPresentationSupportKHR", name)) {
-        *addr = loader_inst->wsi_xlib_surface_enabled ? (void *)vkGetPhysicalDeviceXlibPresentationSupportKHR : NULL;
+        *addr =
+            loader_inst->enabled_known_extensions.khr_xlib_surface ? (void *)vkGetPhysicalDeviceXlibPresentationSupportKHR : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_XLIB_KHR
@@ -2811,11 +2715,13 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_EXT_directfb_surface extension:
     if (!strcmp("vkCreateDirectFBSurfaceEXT", name)) {
-        *addr = loader_inst->wsi_directfb_surface_enabled ? (void *)vkCreateDirectFBSurfaceEXT : NULL;
+        *addr = loader_inst->enabled_known_extensions.ext_directfb_surface ? (void *)vkCreateDirectFBSurfaceEXT : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceDirectFBPresentationSupportEXT", name)) {
-        *addr = loader_inst->wsi_directfb_surface_enabled ? (void *)vkGetPhysicalDeviceDirectFBPresentationSupportEXT : NULL;
+        *addr = loader_inst->enabled_known_extensions.ext_directfb_surface
+                    ? (void *)vkGetPhysicalDeviceDirectFBPresentationSupportEXT
+                    : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_DIRECTFB_EXT
@@ -2823,7 +2729,7 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_KHR_android_surface extension:
     if (!strcmp("vkCreateAndroidSurfaceKHR", name)) {
-        *addr = loader_inst->wsi_android_surface_enabled ? (void *)vkCreateAndroidSurfaceKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_android_surface ? (void *)vkCreateAndroidSurfaceKHR : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
@@ -2832,7 +2738,7 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_MVK_macos_surface extension:
     if (!strcmp("vkCreateMacOSSurfaceMVK", name)) {
-        *addr = loader_inst->wsi_macos_surface_enabled ? (void *)vkCreateMacOSSurfaceMVK : NULL;
+        *addr = loader_inst->enabled_known_extensions.mvk_macos_surface ? (void *)vkCreateMacOSSurfaceMVK : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_MACOS_MVK
@@ -2840,7 +2746,7 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_MVK_ios_surface extension:
     if (!strcmp("vkCreateIOSSurfaceMVK", name)) {
-        *addr = loader_inst->wsi_ios_surface_enabled ? (void *)vkCreateIOSSurfaceMVK : NULL;
+        *addr = loader_inst->enabled_known_extensions.mvk_ios_surface ? (void *)vkCreateIOSSurfaceMVK : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_IOS_MVK
@@ -2848,7 +2754,7 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_GGP_stream_descriptor_surface extension:
     if (!strcmp("vkCreateStreamDescriptorSurfaceGGP", name)) {
-        *addr = loader_inst->wsi_ggp_surface_enabled ? (void *)vkCreateStreamDescriptorSurfaceGGP : NULL;
+        *addr = loader_inst->enabled_known_extensions.wsi_ggp_surface_enabled ? (void *)vkCreateStreamDescriptorSurfaceGGP : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_GGP
@@ -2856,7 +2762,7 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_FUCHSIA_imagepipe_surface extension:
     if (!strcmp("vkCreateImagePipeSurfaceFUCHSIA", name)) {
-        *addr = loader_inst->wsi_imagepipe_surface_enabled ? (void *)vkCreateImagePipeSurfaceFUCHSIA : NULL;
+        *addr = loader_inst->enabled_known_extensions.fuchsia_imagepipe_surface ? (void *)vkCreateImagePipeSurfaceFUCHSIA : NULL;
         return true;
     }
 
@@ -2864,14 +2770,14 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_EXT_headless_surface extension:
     if (!strcmp("vkCreateHeadlessSurfaceEXT", name)) {
-        *addr = loader_inst->wsi_headless_surface_enabled ? (void *)vkCreateHeadlessSurfaceEXT : NULL;
+        *addr = loader_inst->enabled_known_extensions.ext_headless_surface ? (void *)vkCreateHeadlessSurfaceEXT : NULL;
         return true;
     }
 
 #if defined(VK_USE_PLATFORM_METAL_EXT)
     // Functions for the VK_MVK_macos_surface extension:
     if (!strcmp("vkCreateMetalSurfaceEXT", name)) {
-        *addr = loader_inst->wsi_metal_surface_enabled ? (void *)vkCreateMetalSurfaceEXT : NULL;
+        *addr = loader_inst->enabled_known_extensions.ext_metal_surface ? (void *)vkCreateMetalSurfaceEXT : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_METAL_EXT
@@ -2880,11 +2786,12 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_QNX_screen_surface extension:
     if (!strcmp("vkCreateScreenSurfaceQNX", name)) {
-        *addr = loader_inst->wsi_screen_surface_enabled ? (void *)vkCreateScreenSurfaceQNX : NULL;
+        *addr = loader_inst->enabled_known_extensions.qnx_screen_surface ? (void *)vkCreateScreenSurfaceQNX : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceScreenPresentationSupportQNX", name)) {
-        *addr = loader_inst->wsi_screen_surface_enabled ? (void *)vkGetPhysicalDeviceScreenPresentationSupportQNX : NULL;
+        *addr = loader_inst->enabled_known_extensions.qnx_screen_surface ? (void *)vkGetPhysicalDeviceScreenPresentationSupportQNX
+                                                                         : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
@@ -2893,38 +2800,38 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for the VK_NN_vi_surface extension:
     if (!strcmp("vkCreateViSurfaceNN", name)) {
-        *addr = loader_inst->wsi_vi_surface_enabled ? (void *)vkCreateViSurfaceNN : NULL;
+        *addr = loader_inst->enabled_known_extensions.nn_vi_surface ? (void *)vkCreateViSurfaceNN : NULL;
         return true;
     }
 #endif  // VK_USE_PLATFORM_VI_NN
 
     // Functions for VK_KHR_display extension:
     if (!strcmp("vkGetPhysicalDeviceDisplayPropertiesKHR", name)) {
-        *addr = loader_inst->wsi_display_enabled ? (void *)vkGetPhysicalDeviceDisplayPropertiesKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_display ? (void *)vkGetPhysicalDeviceDisplayPropertiesKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", name)) {
-        *addr = loader_inst->wsi_display_enabled ? (void *)vkGetPhysicalDeviceDisplayPlanePropertiesKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_display ? (void *)vkGetPhysicalDeviceDisplayPlanePropertiesKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetDisplayPlaneSupportedDisplaysKHR", name)) {
-        *addr = loader_inst->wsi_display_enabled ? (void *)vkGetDisplayPlaneSupportedDisplaysKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_display ? (void *)vkGetDisplayPlaneSupportedDisplaysKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetDisplayModePropertiesKHR", name)) {
-        *addr = loader_inst->wsi_display_enabled ? (void *)vkGetDisplayModePropertiesKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_display ? (void *)vkGetDisplayModePropertiesKHR : NULL;
         return true;
     }
     if (!strcmp("vkCreateDisplayModeKHR", name)) {
-        *addr = loader_inst->wsi_display_enabled ? (void *)vkCreateDisplayModeKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_display ? (void *)vkCreateDisplayModeKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetDisplayPlaneCapabilitiesKHR", name)) {
-        *addr = loader_inst->wsi_display_enabled ? (void *)vkGetDisplayPlaneCapabilitiesKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_display ? (void *)vkGetDisplayPlaneCapabilitiesKHR : NULL;
         return true;
     }
     if (!strcmp("vkCreateDisplayPlaneSurfaceKHR", name)) {
-        *addr = loader_inst->wsi_display_enabled ? (void *)vkCreateDisplayPlaneSurfaceKHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_display ? (void *)vkCreateDisplayPlaneSurfaceKHR : NULL;
         return true;
     }
 
@@ -2936,19 +2843,23 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *loader_inst, const char 
 
     // Functions for KHR_get_display_properties2
     if (!strcmp("vkGetPhysicalDeviceDisplayProperties2KHR", name)) {
-        *addr = loader_inst->wsi_display_props2_enabled ? (void *)vkGetPhysicalDeviceDisplayProperties2KHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_get_display_properties2 ? (void *)vkGetPhysicalDeviceDisplayProperties2KHR
+                                                                                  : NULL;
         return true;
     }
     if (!strcmp("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", name)) {
-        *addr = loader_inst->wsi_display_props2_enabled ? (void *)vkGetPhysicalDeviceDisplayPlaneProperties2KHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_get_display_properties2
+                    ? (void *)vkGetPhysicalDeviceDisplayPlaneProperties2KHR
+                    : NULL;
         return true;
     }
     if (!strcmp("vkGetDisplayModeProperties2KHR", name)) {
-        *addr = loader_inst->wsi_display_props2_enabled ? (void *)vkGetDisplayModeProperties2KHR : NULL;
+        *addr = loader_inst->enabled_known_extensions.khr_get_display_properties2 ? (void *)vkGetDisplayModeProperties2KHR : NULL;
         return true;
     }
     if (!strcmp("vkGetDisplayPlaneCapabilities2KHR", name)) {
-        *addr = loader_inst->wsi_display_props2_enabled ? (void *)vkGetDisplayPlaneCapabilities2KHR : NULL;
+        *addr =
+            loader_inst->enabled_known_extensions.khr_get_display_properties2 ? (void *)vkGetDisplayPlaneCapabilities2KHR : NULL;
         return true;
     }
 

--- a/loader/wsi.h
+++ b/loader/wsi.h
@@ -30,7 +30,6 @@ typedef struct {
 
 bool wsi_swapchain_instance_gpa(struct loader_instance *ptr_instance, const char *name, void **addr);
 
-void wsi_create_instance(struct loader_instance *ptr_instance, const VkInstanceCreateInfo *pCreateInfo);
 bool wsi_unsupported_instance_extension(const VkExtensionProperties *ext_prop);
 
 VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateHeadlessSurfaceEXT(VkInstance instance,


### PR DESCRIPTION
Make sure that the surface extension is supported by a driver and
enabled before calling down on each surface creation function. This
fixes crashes where a driver on the system doesn't support a surface
extension that the application is using but still exposes the function
pointer.

Also in this PR: Loader now generates a struct that contains of bools for each instance
extension and a function to set the bool to true if the extension is in
the list passed in. This consolidates that logic into one place rather
than having it spread out across the codebase. It also enable further
changes that will require each drivers list of supported instance
extensions.