### PR TITLE
Add armv7l/armv8l support to loader/CMakeLists.txt

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -286,7 +286,7 @@ elseif(UNIX OR MINGW OR (WIN32 AND USE_GAS)) # i.e.: Linux & Apple & MinGW & Win
             if(ASSEMBLER_WORKS)
                 set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas_aarch.S)
             endif()
-        elseif (${SYSTEM_PROCESSOR} MATCHES "aarch32|armhf")
+        elseif (${SYSTEM_PROCESSOR} MATCHES "aarch32|armhf|armv7l|armv8l")
             try_compile(ASSEMBLER_WORKS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/asm_test_aarch32.S OUTPUT_VARIABLE TRY_COMPILE_OUTPUT)
             if(ASSEMBLER_WORKS)
                 set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas_aarch.S)


### PR DESCRIPTION
This fixes this error message appearing when building on linux/armv7l or linux/armv8l:
```
CMake Warning at loader/CMakeLists.txt:368 (message):                                                                         
  Could not find working armv8l GAS assembler                                                                                 

Support for unknown physical device and device functions is disabled due to missing the required assembly support code.
To support unknown functions, assembly must be added for the platform.
```

(Noticed this issue building 1.3.300 on linux Chromebrew/armv7l.)