### PR TITLE
scripts: Make generate_source.py look harder for vk.xml

### DIFF
--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -44,8 +44,15 @@ def main(argv):
     group.add_argument('-v', '--verify', action='store_true', help='verify repo files match generator output')
     args = parser.parse_args(argv)
 
+    registry = os.path.abspath(os.path.join(args.registry,  'vk.xml'))
+    if not os.path.isfile(registry):
+        registry = os.path.abspath(os.path.join(args.registry, 'Vulkan-Headers/registry/vk.xml'))
+        if not os.path.isfile(registry):
+            print(f'cannot find vk.xml in {args.registry}')
+            return -1
+
     gen_cmds = [[common_codegen.repo_relative('scripts/loader_genvk.py'),
-                 '-registry', os.path.abspath(os.path.join(args.registry,  'vk.xml')),
+                 '-registry', registry,
                  '-quiet',
                  filename] for filename in ['vk_layer_dispatch_table.h',
                                             'vk_loader_extensions.h',


### PR DESCRIPTION
Allow the registry path argument to also be the base directory containing the Vulkan-Headers repo (eg. ./external) to save redundant typing.