### PR TITLE
cjson: add NULL check prior to strcmp

### DIFF
--- a/loader/cJSON.c
+++ b/loader/cJSON.c
@@ -951,7 +951,7 @@ cJSON *loader_cJSON_GetArrayItem(cJSON *array, int item) {
 }
 cJSON *loader_cJSON_GetObjectItem(cJSON *object, const char *string) {
     cJSON *c = object->child;
-    while (c && strcmp(c->string, string)) c = c->next;
+    while (c && NULL != c->string && strcmp(c->string, string)) c = c->next;
     return c;
 }
 


### PR DESCRIPTION
This fixes an issue found by OSS-Fuzz: https://issues.oss-fuzz.com/issues/42529964

I noticed that there are no maintainer emails in the OSS-Fuzz `project.yaml`. https://github.com/google/oss-fuzz/blob/master/projects/vulkan-loader/project.yaml -- I'm happy to add any maintainer emails as that would give access to the bugs found/reported by OSS-Fuzz. Let me know if you'd like any emails in the `project.yaml` and I'll add them.