### PR TITLE
Loader settings bug fixes and expanded test coverage

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -82,6 +82,8 @@ struct activated_layer_info {
     char *library;
     bool is_implicit;
     char *disable_env;
+    char *enable_name_env;
+    char *enable_value_env;
 };
 
 // thread safety lock for accessing global data structures such as "loader"
@@ -4695,6 +4697,8 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
             activated_layers[num_activated_layers].is_implicit = !(layer_prop->type_flags & VK_LAYER_TYPE_FLAG_EXPLICIT_LAYER);
             if (activated_layers[num_activated_layers].is_implicit) {
                 activated_layers[num_activated_layers].disable_env = layer_prop->disable_env_var.name;
+                activated_layers[num_activated_layers].enable_name_env = layer_prop->enable_env_var.name;
+                activated_layers[num_activated_layers].enable_value_env = layer_prop->enable_env_var.value;
             }
 
             loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_LAYER_BIT, 0, "Insert instance layer \"%s\" (%s)",
@@ -4809,6 +4813,11 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
             if (activated_layers[index].is_implicit) {
                 loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "               Disable Env Var:  %s",
                            activated_layers[index].disable_env);
+                if (activated_layers[index].enable_name_env) {
+                    loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0,
+                               "               This layer was enabled because Env Var %s was set to Value %s",
+                               activated_layers[index].enable_name_env, activated_layers[index].enable_value_env);
+                }
             }
             loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Manifest: %s", activated_layers[index].manifest);
             loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "           Library:  %s", activated_layers[index].library);

--- a/loader/log.c
+++ b/loader/log.c
@@ -143,9 +143,11 @@ void loader_log(const struct loader_instance *inst, VkFlags msg_type, int32_t ms
 
     // Always log to stderr if this is a fatal error
     if (0 == (msg_type & VULKAN_LOADER_FATAL_ERROR_BIT)) {
-        // Exit early if the current instance settings do not ask for logging to stderr
-        if (inst && inst->settings.settings_active && 0 == (msg_type & inst->settings.debug_level)) {
-            return;
+        if (inst && inst->settings.settings_active && inst->settings.debug_level > 0) {
+            // Exit early if the current instance settings have some debugging options but do match the current msg_type
+            if (0 == (msg_type & inst->settings.debug_level)) {
+                return;
+            }
             // Check the global settings and if that doesn't say to skip, check the environment variable
         } else if (0 == (msg_type & g_loader_debug)) {
             return;

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -726,6 +726,7 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
     if (vk_instance_layers_env != NULL) {
         vk_instance_layers_env_len = strlen(vk_instance_layers_env) + 1;
         vk_instance_layers_env_copy = loader_stack_alloc(vk_instance_layers_env_len);
+        memset(vk_instance_layers_env_copy, 0, vk_instance_layers_env_len);
 
         loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0, "env var \'%s\' defined and adding layers: %s",
                    ENABLED_LAYERS_ENV, vk_instance_layers_env);
@@ -761,13 +762,14 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
             loader_strncpy(vk_instance_layers_env_copy, vk_instance_layers_env_len, vk_instance_layers_env,
                            vk_instance_layers_env_len);
 
-            while (vk_instance_layers_env_copy && *vk_instance_layers_env_copy) {
-                char* next = loader_get_next_path(vk_instance_layers_env_copy);
-                if (0 == strcmp(vk_instance_layers_env_copy, props->info.layerName)) {
+            char* instance_layers_env_iter = vk_instance_layers_env_copy;
+            while (instance_layers_env_iter && *instance_layers_env_iter) {
+                char* next = loader_get_next_path(instance_layers_env_iter);
+                if (0 == strcmp(instance_layers_env_iter, props->info.layerName)) {
                     enable_layer = true;
                     break;
                 }
-                vk_instance_layers_env_copy = next;
+                instance_layers_env_iter = next;
             }
         }
 

--- a/tests/framework/shim/shim.h
+++ b/tests/framework/shim/shim.h
@@ -134,11 +134,14 @@ struct FrameworkEnvironment;  // forward declaration
 // Necessary to have inline definitions as shim is a dll and thus functions
 // defined in the .cpp wont be found by the rest of the application
 struct PlatformShim {
-    PlatformShim() = default;
-    PlatformShim(std::vector<fs::FolderManager>* folders) : folders(folders) {}
+    PlatformShim() { fputs_stderr_log.reserve(65536); }
+    PlatformShim(std::vector<fs::FolderManager>* folders) : folders(folders) { fputs_stderr_log.reserve(65536); }
 
     // Used to get info about which drivers & layers have been added to folders
     std::vector<fs::FolderManager>* folders;
+
+    // Captures the output to stderr from fputs & fputc - aka the output of loader_log()
+    std::string fputs_stderr_log;
 
     // Test Framework interface
     void reset();
@@ -155,6 +158,9 @@ struct PlatformShim {
 
     void add_manifest(ManifestCategory category, std::filesystem::path const& path);
     void add_unsecured_manifest(ManifestCategory category, std::filesystem::path const& path);
+
+    void clear_logs() { fputs_stderr_log.clear(); }
+    bool find_in_log(std::string const& search_text) const { return fputs_stderr_log.find(search_text) != std::string::npos; }
 
 // platform specific shim interface
 #if defined(WIN32)

--- a/tests/framework/shim/unix_shim.cpp
+++ b/tests/framework/shim/unix_shim.cpp
@@ -397,8 +397,7 @@ struct Interposer {
 };
 
 __attribute__((used)) static Interposer _interpose_opendir MACOS_ATTRIB = {VOIDP_CAST(my_opendir), VOIDP_CAST(opendir)};
-// don't intercept readdir as it crashes when using ASAN with macOS
-// __attribute__((used)) static Interposer _interpose_readdir MACOS_ATTRIB = {VOIDP_CAST(my_readdir), VOIDP_CAST(readdir)};
+__attribute__((used)) static Interposer _interpose_readdir MACOS_ATTRIB = {VOIDP_CAST(my_readdir), VOIDP_CAST(readdir)};
 __attribute__((used)) static Interposer _interpose_closedir MACOS_ATTRIB = {VOIDP_CAST(my_closedir), VOIDP_CAST(closedir)};
 __attribute__((used)) static Interposer _interpose_access MACOS_ATTRIB = {VOIDP_CAST(my_access), VOIDP_CAST(access)};
 __attribute__((used)) static Interposer _interpose_fopen MACOS_ATTRIB = {VOIDP_CAST(my_fopen), VOIDP_CAST(fopen)};

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -198,11 +198,13 @@ InstWrapper& InstWrapper::operator=(InstWrapper&& other) noexcept {
 }
 
 void InstWrapper::CheckCreate(VkResult result_to_check) {
+    handle_assert_null(inst);
     ASSERT_EQ(result_to_check, functions->vkCreateInstance(create_info.get(), callbacks, &inst));
     functions->load_instance_functions(inst);
 }
 
 void InstWrapper::CheckCreateWithInfo(InstanceCreateInfo& create_info, VkResult result_to_check) {
+    handle_assert_null(inst);
     ASSERT_EQ(result_to_check, functions->vkCreateInstance(create_info.get(), callbacks, &inst));
     functions->load_instance_functions(inst);
 }
@@ -297,10 +299,12 @@ DeviceWrapper& DeviceWrapper::operator=(DeviceWrapper&& other) noexcept {
 }
 
 void DeviceWrapper::CheckCreate(VkPhysicalDevice phys_dev, VkResult result_to_check) {
+    handle_assert_null(dev);
     ASSERT_EQ(result_to_check, functions->vkCreateDevice(phys_dev, create_info.get(), callbacks, &dev));
 }
 
 VkResult CreateDebugUtilsMessenger(DebugUtilsWrapper& debug_utils) {
+    handle_assert_null(debug_utils.messenger);
     return debug_utils.local_vkCreateDebugUtilsMessengerEXT(debug_utils.inst, debug_utils.get(), debug_utils.callbacks,
                                                             &debug_utils.messenger);
 }

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -268,7 +268,13 @@ inline loader_platform_dl_handle loader_platform_open_library(const char* libPat
 inline void loader_platform_open_library_print_error(std::filesystem::path const& libPath) {
     std::wcerr << "Unable to open library: " << libPath << " due to: " << dlerror() << "\n";
 }
-inline void loader_platform_close_library(loader_platform_dl_handle library) { dlclose(library); }
+inline void loader_platform_close_library(loader_platform_dl_handle library) {
+    char* loader_disable_dynamic_library_unloading_env_var = getenv("VK_LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING");
+    if (NULL == loader_disable_dynamic_library_unloading_env_var ||
+        0 != strncmp(loader_disable_dynamic_library_unloading_env_var, "1", 2)) {
+    }
+    dlclose(library);
+}
 inline void* loader_platform_get_proc_address(loader_platform_dl_handle library, const char* name) {
     assert(library);
     assert(name);

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -1893,154 +1893,153 @@ TEST(SettingsFile, StderrLogFilters) {
                 LoaderSettingsLayerConfiguration{}.set_name("VK_LAYER_missing").set_path("/road/to/nowhere").set_control("on"))));
 
     std::string expected_output_verbose;
-    expected_output_verbose += "Layer Configurations count = 2\n";
-    expected_output_verbose += "---- Layer Configuration [0] ----\n";
-    expected_output_verbose += std::string("Name: ") + explicit_layer_name + "\n";
-    expected_output_verbose += "Path: " + env.get_shimmed_layer_manifest_path().string() + "\n";
-    expected_output_verbose += "Control: on\n";
-    expected_output_verbose += "---- Layer Configuration [1] ----\n";
-    expected_output_verbose += "Name: VK_LAYER_missing\n";
-    expected_output_verbose += "Path: /road/to/nowhere\n";
-    expected_output_verbose += "Control: on\n";
-    expected_output_verbose += "---------------------------------\n";
+    expected_output_verbose += "DEBUG:             Layer Configurations count = 2\n";
+    expected_output_verbose += "DEBUG:             ---- Layer Configuration [0] ----\n";
+    expected_output_verbose += std::string("DEBUG:             Name: ") + explicit_layer_name + "\n";
+    expected_output_verbose += "DEBUG:             Path: " + env.get_shimmed_layer_manifest_path().string() + "\n";
+    expected_output_verbose += "DEBUG:             Control: on\n";
+    expected_output_verbose += "DEBUG:             ---- Layer Configuration [1] ----\n";
+    expected_output_verbose += "DEBUG:             Name: VK_LAYER_missing\n";
+    expected_output_verbose += "DEBUG:             Path: /road/to/nowhere\n";
+    expected_output_verbose += "DEBUG:             Control: on\n";
+    expected_output_verbose += "DEBUG:             ---------------------------------\n";
 
-    std::string expected_output_info = get_settings_location_log_message(env) + "\n";
+    std::string expected_output_info = std::string("INFO:              ") + get_settings_location_log_message(env) + "\n";
 
     std::string expected_output_warning =
-        "Layer name Regular_TestLayer1 does not conform to naming standard (Policy #LLP_LAYER_3)\n";
+        "WARNING:           Layer name Regular_TestLayer1 does not conform to naming standard (Policy #LLP_LAYER_3)\n";
 
-    std::string expected_output_error = "loader_get_json: Failed to open JSON file /road/to/nowhere\n";
+    std::string expected_output_error = "ERROR:             loader_get_json: Failed to open JSON file /road/to/nowhere\n";
 
     env.loader_settings.app_specific_settings.at(0).stderr_log = {"all"};
     env.update_loader_settings(env.loader_settings);
     {
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
 
-        ASSERT_TRUE(env.debug_log.find(expected_output_verbose));
-        ASSERT_TRUE(env.debug_log.find(expected_output_info));
-        ASSERT_TRUE(env.debug_log.find(expected_output_warning));
-        ASSERT_TRUE(env.debug_log.find(expected_output_error));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_error));
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
     }
-    env.debug_log.clear();
-    env.debug_log.create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
+    env.platform_shim->clear_logs();
     env.loader_settings.app_specific_settings.at(0).stderr_log = {"error", "warn", "info", "debug"};
     env.update_loader_settings(env.loader_settings);
     {
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
 
-        ASSERT_TRUE(env.debug_log.find(expected_output_verbose));
-        ASSERT_TRUE(env.debug_log.find(expected_output_info));
-        ASSERT_TRUE(env.debug_log.find(expected_output_warning));
-        ASSERT_TRUE(env.debug_log.find(expected_output_error));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_error));
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
     }
-    env.debug_log.clear();
-    env.debug_log.create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+    env.platform_shim->clear_logs();
     env.loader_settings.app_specific_settings.at(0).stderr_log = {"warn", "info", "debug"};
     env.update_loader_settings(env.loader_settings);
     {
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
 
-        ASSERT_TRUE(env.debug_log.find(expected_output_verbose));
-        ASSERT_TRUE(env.debug_log.find(expected_output_info));
-        ASSERT_TRUE(env.debug_log.find(expected_output_warning));
-        ASSERT_FALSE(env.debug_log.find(expected_output_error));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_error));
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
     }
-    env.debug_log.clear();
-    env.debug_log.create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+    env.platform_shim->clear_logs();
     env.loader_settings.app_specific_settings.at(0).stderr_log = {"debug"};
     env.update_loader_settings(env.loader_settings);
     {
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
 
-        ASSERT_TRUE(env.debug_log.find(expected_output_verbose));
-        ASSERT_FALSE(env.debug_log.find(expected_output_info));
-        ASSERT_FALSE(env.debug_log.find(expected_output_warning));
-        ASSERT_FALSE(env.debug_log.find(expected_output_error));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_error));
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
     }
-    env.debug_log.clear();
-    env.debug_log.create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+    env.platform_shim->clear_logs();
     env.loader_settings.app_specific_settings.at(0).stderr_log = {"info"};
     env.update_loader_settings(env.loader_settings);
     {
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
 
-        ASSERT_FALSE(env.debug_log.find(expected_output_verbose));
-        ASSERT_TRUE(env.debug_log.find(expected_output_info));
-        ASSERT_FALSE(env.debug_log.find(expected_output_warning));
-        ASSERT_FALSE(env.debug_log.find(expected_output_error));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_error));
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
     }
-    env.debug_log.clear();
-    env.debug_log.create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+    env.platform_shim->clear_logs();
     env.loader_settings.app_specific_settings.at(0).stderr_log = {"warn"};
     env.update_loader_settings(env.loader_settings);
     {
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
 
-        ASSERT_FALSE(env.debug_log.find(expected_output_verbose));
-        ASSERT_FALSE(env.debug_log.find(expected_output_info));
-        ASSERT_TRUE(env.debug_log.find(expected_output_warning));
-        ASSERT_FALSE(env.debug_log.find(expected_output_error));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_error));
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
     }
-    env.debug_log.clear();
-    env.debug_log.create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+    env.platform_shim->clear_logs();
     env.loader_settings.app_specific_settings.at(0).stderr_log = {"error"};
     env.update_loader_settings(env.loader_settings);
     {
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
 
-        ASSERT_FALSE(env.debug_log.find(expected_output_verbose));
-        ASSERT_FALSE(env.debug_log.find(expected_output_info));
-        ASSERT_FALSE(env.debug_log.find(expected_output_warning));
-        ASSERT_TRUE(env.debug_log.find(expected_output_error));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
+        ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_error));
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
     }
-    env.debug_log.clear();
-    env.debug_log.create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-    env.loader_settings.app_specific_settings.at(0).stderr_log = {""};
+    env.platform_shim->clear_logs();
+    env.loader_settings.app_specific_settings.at(0).stderr_log = {""};  // Empty string shouldn't be misinterpreted
     env.update_loader_settings(env.loader_settings);
     {
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
 
-        ASSERT_FALSE(env.debug_log.find(expected_output_verbose));
-        ASSERT_FALSE(env.debug_log.find(expected_output_info));
-        ASSERT_FALSE(env.debug_log.find(expected_output_warning));
-        ASSERT_TRUE(env.debug_log.find(expected_output_error));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_error));
+        auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
+        EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
+    }
+    env.platform_shim->clear_logs();
+    env.loader_settings.app_specific_settings.at(0).stderr_log = {};  // No string in the log
+    env.update_loader_settings(env.loader_settings);
+    {
+        InstWrapper inst{env.vulkan_functions};
+        inst.CheckCreate();
+
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
+        ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_error));
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
     }
 }
 
 // Settings can say which filters to use - make sure the lack of this filter works correctly with VK_LOADER_DEBUG
-TEST(SettingsFile, StderrLog_VK_LOADER_DEBUG) {
+TEST(SettingsFile, StderrLog_NoOutput) {
     FrameworkEnvironment env{FrameworkSettings{}.set_log_filter("")};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device({});
     const char* explicit_layer_name = "Regular_TestLayer1";
@@ -2061,9 +2060,8 @@ TEST(SettingsFile, StderrLog_VK_LOADER_DEBUG) {
 
     {
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
-        EXPECT_TRUE(env.debug_log.returned_output.empty());
+        EXPECT_TRUE(env.platform_shim->fputs_stderr_log.empty());
 
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 0);
         EXPECT_TRUE(active_layer_props.size() == 0);
@@ -2073,10 +2071,9 @@ TEST(SettingsFile, StderrLog_VK_LOADER_DEBUG) {
     env.update_loader_settings(env.loader_settings);
     {
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
 
-        EXPECT_TRUE(env.debug_log.returned_output.empty());
+        EXPECT_TRUE(env.platform_shim->fputs_stderr_log.empty());
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 0);
         EXPECT_TRUE(active_layer_props.size() == 0);
     }
@@ -2087,9 +2084,8 @@ TEST(SettingsFile, StderrLog_VK_LOADER_DEBUG) {
         EnvVarWrapper instance_layers{"VK_INSTANCE_LAYERS", explicit_layer_name};
 
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
-        EXPECT_TRUE(env.debug_log.returned_output.empty());
+        EXPECT_TRUE(env.platform_shim->fputs_stderr_log.empty());
 
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
@@ -2099,10 +2095,9 @@ TEST(SettingsFile, StderrLog_VK_LOADER_DEBUG) {
         EnvVarWrapper instance_layers{"VK_LOADER_LAYERS_ENABLE", explicit_layer_name};
 
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
 
-        EXPECT_TRUE(env.debug_log.returned_output.empty());
+        EXPECT_TRUE(env.platform_shim->fputs_stderr_log.empty());
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
     }
@@ -2112,9 +2107,8 @@ TEST(SettingsFile, StderrLog_VK_LOADER_DEBUG) {
         EnvVarWrapper instance_layers{"VK_INSTANCE_LAYERS", explicit_layer_name};
 
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
-        EXPECT_TRUE(env.debug_log.returned_output.empty());
+        EXPECT_TRUE(env.platform_shim->fputs_stderr_log.empty());
 
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
@@ -2124,10 +2118,9 @@ TEST(SettingsFile, StderrLog_VK_LOADER_DEBUG) {
         EnvVarWrapper instance_layers{"VK_LOADER_LAYERS_ENABLE", explicit_layer_name};
 
         InstWrapper inst{env.vulkan_functions};
-        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
         inst.CheckCreate();
 
-        EXPECT_TRUE(env.debug_log.returned_output.empty());
+        EXPECT_TRUE(env.platform_shim->fputs_stderr_log.empty());
         auto active_layer_props = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         EXPECT_TRUE(string_eq(active_layer_props.at(0).layerName, explicit_layer_name));
     }

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -1357,13 +1357,20 @@ TEST(SettingsFile, EnvVarsWork_VK_INSTANCE_LAYERS_multiple_layers) {
             ManifestLayer::LayerDescription{}.set_name(explicit_layer_name2).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
         "explicit_test_layer2.json"});
 
+    const char* explicit_layer_name3 = "VK_LAYER_Regular_TestLayer3";
+    env.add_explicit_layer(TestLayerDetails{
+        ManifestLayer{}.add_layer(
+            ManifestLayer::LayerDescription{}.set_name(explicit_layer_name3).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)),
+        "explicit_test_layer3.json"});
+
     EnvVarWrapper vk_instance_layers{"VK_INSTANCE_LAYERS"};
     vk_instance_layers.add_to_list(explicit_layer_name2);
     vk_instance_layers.add_to_list(explicit_layer_name1);
     {
-        auto layer_props = env.GetLayerProperties(2);
+        auto layer_props = env.GetLayerProperties(3);
         ASSERT_TRUE(string_eq(layer_props.at(0).layerName, explicit_layer_name1));
         ASSERT_TRUE(string_eq(layer_props.at(1).layerName, explicit_layer_name2));
+        ASSERT_TRUE(string_eq(layer_props.at(2).layerName, explicit_layer_name3));
 
         InstWrapper inst{env.vulkan_functions};
         FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
@@ -1381,10 +1388,15 @@ TEST(SettingsFile, EnvVarsWork_VK_INSTANCE_LAYERS_multiple_layers) {
          LoaderSettingsLayerConfiguration{}
              .set_name(explicit_layer_name2)
              .set_control("off")
-             .set_path(env.get_shimmed_layer_manifest_path(1))}));
+             .set_path(env.get_shimmed_layer_manifest_path(1)),
+         LoaderSettingsLayerConfiguration{}
+             .set_name(explicit_layer_name3)
+             .set_control("auto")
+             .set_path(env.get_shimmed_layer_manifest_path(2))}));
     env.update_loader_settings(env.loader_settings);
     {
-        ASSERT_NO_FATAL_FAILURE(env.GetLayerProperties(0));
+        auto layer_props = env.GetLayerProperties(1);
+        ASSERT_TRUE(string_eq(layer_props.at(0).layerName, explicit_layer_name3));
 
         InstWrapper inst{env.vulkan_functions};
         FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
@@ -1395,8 +1407,9 @@ TEST(SettingsFile, EnvVarsWork_VK_INSTANCE_LAYERS_multiple_layers) {
     env.loader_settings.app_specific_settings.at(0).layer_configurations.at(0).control = "auto";
     env.update_loader_settings(env.loader_settings);
     {
-        auto layer_props = env.GetLayerProperties(1);
+        auto layer_props = env.GetLayerProperties(2);
         ASSERT_TRUE(string_eq(layer_props.at(0).layerName, explicit_layer_name1));
+        ASSERT_TRUE(string_eq(layer_props.at(1).layerName, explicit_layer_name3));
 
         InstWrapper inst{env.vulkan_functions};
         FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
@@ -1408,8 +1421,9 @@ TEST(SettingsFile, EnvVarsWork_VK_INSTANCE_LAYERS_multiple_layers) {
     env.loader_settings.app_specific_settings.at(0).layer_configurations.at(0).control = "on";
     env.update_loader_settings(env.loader_settings);
     {
-        auto layer_props = env.GetLayerProperties(1);
+        auto layer_props = env.GetLayerProperties(2);
         ASSERT_TRUE(string_eq(layer_props.at(0).layerName, explicit_layer_name1));
+        ASSERT_TRUE(string_eq(layer_props.at(1).layerName, explicit_layer_name3));
 
         InstWrapper inst{env.vulkan_functions};
         FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
@@ -1421,8 +1435,9 @@ TEST(SettingsFile, EnvVarsWork_VK_INSTANCE_LAYERS_multiple_layers) {
     env.loader_settings.app_specific_settings.at(0).layer_configurations.at(1).control = "auto";
     env.update_loader_settings(env.loader_settings);
     {
-        auto layer_props = env.GetLayerProperties(1);
+        auto layer_props = env.GetLayerProperties(2);
         ASSERT_TRUE(string_eq(layer_props.at(0).layerName, explicit_layer_name2));
+        ASSERT_TRUE(string_eq(layer_props.at(1).layerName, explicit_layer_name3));
 
         InstWrapper inst{env.vulkan_functions};
         FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
@@ -1434,8 +1449,9 @@ TEST(SettingsFile, EnvVarsWork_VK_INSTANCE_LAYERS_multiple_layers) {
     env.loader_settings.app_specific_settings.at(0).layer_configurations.at(1).control = "on";
     env.update_loader_settings(env.loader_settings);
     {
-        auto layer_props = env.GetLayerProperties(1);
+        auto layer_props = env.GetLayerProperties(2);
         ASSERT_TRUE(string_eq(layer_props.at(0).layerName, explicit_layer_name2));
+        ASSERT_TRUE(string_eq(layer_props.at(1).layerName, explicit_layer_name3));
 
         InstWrapper inst{env.vulkan_functions};
         FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
@@ -1443,12 +1459,12 @@ TEST(SettingsFile, EnvVarsWork_VK_INSTANCE_LAYERS_multiple_layers) {
         auto layers = inst.GetActiveLayers(inst.GetPhysDev(), 1);
         ASSERT_TRUE(string_eq(layers.at(0).layerName, explicit_layer_name2));
     }
-    env.loader_settings.app_specific_settings.at(0).layer_configurations.at(0).control = "auto";
+    env.loader_settings.app_specific_settings.at(0).layer_configurations.at(1).control = "auto";
     env.update_loader_settings(env.loader_settings);
     {
         auto layer_props = env.GetLayerProperties(2);
-        ASSERT_TRUE(string_eq(layer_props.at(0).layerName, explicit_layer_name1));
-        ASSERT_TRUE(string_eq(layer_props.at(1).layerName, explicit_layer_name2));
+        ASSERT_TRUE(string_eq(layer_props.at(0).layerName, explicit_layer_name2));
+        ASSERT_TRUE(string_eq(layer_props.at(1).layerName, explicit_layer_name3));
 
         InstWrapper inst{env.vulkan_functions};
         FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
@@ -1459,9 +1475,10 @@ TEST(SettingsFile, EnvVarsWork_VK_INSTANCE_LAYERS_multiple_layers) {
     env.loader_settings.app_specific_settings.at(0).layer_configurations.at(0).control = "on";
     env.update_loader_settings(env.loader_settings);
     {
-        auto layer_props = env.GetLayerProperties(2);
+        auto layer_props = env.GetLayerProperties(3);
         ASSERT_TRUE(string_eq(layer_props.at(0).layerName, explicit_layer_name1));
         ASSERT_TRUE(string_eq(layer_props.at(1).layerName, explicit_layer_name2));
+        ASSERT_TRUE(string_eq(layer_props.at(2).layerName, explicit_layer_name3));
 
         InstWrapper inst{env.vulkan_functions};
         FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);


### PR DESCRIPTION
* Fix VK_INSTANCE_LAYERS bug when using vk_loader_settings.json - stack allocated variable would be indexed past the end of the array if more than 1 layer was present in the settings file, causing garbage to be read as a string.

* Make vkEnumerateInstanceExtensionProperties return VK_INCOMPLETE correctly - When some layers are turned "off" in the settings file, the count of layers would be correct but VK_INCOMPLETE would be returned by mistake.

* Intercept loader_log in Test Framework - allows seeing the output of VK_LOADER_DEBUG & the loader settings file log settings output directly, rather than going through the Debug Utils Messenger.

* Re-enable readdir interception on MacOS which was disabled so address sanitizer could work, which no longer seems to be needed.