### PR TITLE
Fix layers with pre-inst funcs from being loaded erroneously

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3979,6 +3979,17 @@ VkResult loader_scan_for_implicit_layers(struct loader_instance *inst, struct lo
         goto out;
     }
 
+    // Remove layers from settings file that are off, are implicit, or are implicit layers that aren't active
+    for (uint32_t i = 0; i < settings_layers.count; ++i) {
+        if (settings_layers.list[i].settings_control_value == LOADER_SETTINGS_LAYER_CONTROL_OFF ||
+            settings_layers.list[i].settings_control_value == LOADER_SETTINGS_LAYER_UNORDERED_LAYER_LOCATION ||
+            (settings_layers.list[i].type_flags & VK_LAYER_TYPE_FLAG_EXPLICIT_LAYER) == VK_LAYER_TYPE_FLAG_EXPLICIT_LAYER ||
+            !loader_implicit_layer_is_enabled(inst, layer_filters, &settings_layers.list[i])) {
+            loader_remove_layer_in_list(inst, &settings_layers, i);
+            i--;
+        }
+    }
+
     // If we should not look for layers using other mechanisms, assign settings_layers to instance_layers and jump to the
     // output
     if (!should_search_for_other_layers) {

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -172,6 +172,7 @@ VkResult loader_get_icd_loader_instance_extensions(const struct loader_instance 
                                                    struct loader_extension_list *inst_exts);
 struct loader_icd_term *loader_get_icd_and_device(const void *device, struct loader_device **found_dev);
 struct loader_instance *loader_get_instance(const VkInstance instance);
+loader_platform_dl_handle loader_open_layer_file(const struct loader_instance *inst, struct loader_layer_properties *prop);
 struct loader_device *loader_create_logical_device(const struct loader_instance *inst, const VkAllocationCallbacks *pAllocator);
 void loader_add_logical_device(struct loader_icd_term *icd_term, struct loader_device *found_dev);
 void loader_remove_logical_device(struct loader_icd_term *icd_term, struct loader_device *found_dev,

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -184,8 +184,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
 
     // Get the implicit layers
     struct loader_layer_list layers = {0};
-    loader_platform_dl_handle *libs = NULL;
-    size_t lib_count = 0;
     memset(&layers, 0, sizeof(layers));
     struct loader_envvar_all_filters layer_filters = {0};
 
@@ -199,11 +197,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
         return res;
     }
 
-    res = loader_init_library_list(&layers, &libs);
-    if (VK_SUCCESS != res) {
-        return res;
-    }
-
     // Prepend layers onto the chain if they implement this entry point
     for (uint32_t i = 0; i < layers.count; ++i) {
         // Skip this layer if it doesn't expose the entry-point
@@ -211,15 +204,12 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
             continue;
         }
 
-        loader_platform_dl_handle layer_lib = loader_platform_open_library(layers.list[i].lib_name);
-        if (layer_lib == NULL) {
-            loader_log(NULL, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0,
-                       "%s: Unable to load implicit layer library \"%s\"", __FUNCTION__, layers.list[i].lib_name);
+        loader_open_layer_file(NULL, &layers.list[i]);
+        if (layers.list[i].lib_handle == NULL) {
             continue;
         }
 
-        libs[lib_count++] = layer_lib;
-        void *pfn = loader_platform_get_proc_address(layer_lib,
+        void *pfn = loader_platform_get_proc_address(layers.list[i].lib_handle,
                                                      layers.list[i].pre_instance_functions.enumerate_instance_extension_properties);
         if (pfn == NULL) {
             loader_log(NULL, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0,
@@ -259,12 +249,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
         loader_free(NULL, holder);
     }
 
-    // Close the dl handles
-    for (size_t i = 0; i < lib_count; ++i) {
-        loader_platform_close_library(libs[i]);
-    }
-    loader_free(NULL, libs);
-
     return res;
 }
 
@@ -290,8 +274,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
 
     // Get the implicit layers
     struct loader_layer_list layers;
-    loader_platform_dl_handle *libs = NULL;
-    size_t lib_count = 0;
     memset(&layers, 0, sizeof(layers));
     struct loader_envvar_all_filters layer_filters = {0};
 
@@ -305,11 +287,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
         return res;
     }
 
-    res = loader_init_library_list(&layers, &libs);
-    if (VK_SUCCESS != res) {
-        return res;
-    }
-
     // Prepend layers onto the chain if they implement this entry point
     for (uint32_t i = 0; i < layers.count; ++i) {
         // Skip this layer if it doesn't expose the entry-point
@@ -317,16 +294,13 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
             continue;
         }
 
-        loader_platform_dl_handle layer_lib = loader_platform_open_library(layers.list[i].lib_name);
-        if (layer_lib == NULL) {
-            loader_log(NULL, VULKAN_LOADER_WARN_BIT, 0, "%s: Unable to load implicit layer library \"%s\"", __FUNCTION__,
-                       layers.list[i].lib_name);
+        loader_open_layer_file(NULL, &layers.list[i]);
+        if (layers.list[i].lib_handle == NULL) {
             continue;
         }
 
-        libs[lib_count++] = layer_lib;
-        void *pfn =
-            loader_platform_get_proc_address(layer_lib, layers.list[i].pre_instance_functions.enumerate_instance_layer_properties);
+        void *pfn = loader_platform_get_proc_address(layers.list[i].lib_handle,
+                                                     layers.list[i].pre_instance_functions.enumerate_instance_layer_properties);
         if (pfn == NULL) {
             loader_log(NULL, VULKAN_LOADER_WARN_BIT, 0, "%s: Unable to resolve symbol \"%s\" in implicit layer library \"%s\"",
                        __FUNCTION__, layers.list[i].pre_instance_functions.enumerate_instance_layer_properties,
@@ -365,12 +339,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
         loader_free(NULL, holder);
     }
 
-    // Close the dl handles
-    for (size_t i = 0; i < lib_count; ++i) {
-        loader_platform_close_library(libs[i]);
-    }
-    loader_free(NULL, libs);
-
     return res;
 }
 
@@ -403,8 +371,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
 
     // Get the implicit layers
     struct loader_layer_list layers;
-    loader_platform_dl_handle *libs = NULL;
-    size_t lib_count = 0;
     memset(&layers, 0, sizeof(layers));
     struct loader_envvar_all_filters layer_filters = {0};
 
@@ -418,11 +384,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
         return res;
     }
 
-    res = loader_init_library_list(&layers, &libs);
-    if (VK_SUCCESS != res) {
-        return res;
-    }
-
     // Prepend layers onto the chain if they implement this entry point
     for (uint32_t i = 0; i < layers.count; ++i) {
         // Skip this layer if it doesn't expose the entry-point
@@ -430,15 +391,13 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
             continue;
         }
 
-        loader_platform_dl_handle layer_lib = loader_platform_open_library(layers.list[i].lib_name);
-        if (layer_lib == NULL) {
-            loader_log(NULL, VULKAN_LOADER_WARN_BIT, 0, "%s: Unable to load implicit layer library \"%s\"", __FUNCTION__,
-                       layers.list[i].lib_name);
+        loader_open_layer_file(NULL, &layers.list[i]);
+        if (layers.list[i].lib_handle == NULL) {
             continue;
         }
 
-        libs[lib_count++] = layer_lib;
-        void *pfn = loader_platform_get_proc_address(layer_lib, layers.list[i].pre_instance_functions.enumerate_instance_version);
+        void *pfn = loader_platform_get_proc_address(layers.list[i].lib_handle,
+                                                     layers.list[i].pre_instance_functions.enumerate_instance_version);
         if (pfn == NULL) {
             loader_log(NULL, VULKAN_LOADER_WARN_BIT, 0, "%s: Unable to resolve symbol \"%s\" in implicit layer library \"%s\"",
                        __FUNCTION__, layers.list[i].pre_instance_functions.enumerate_instance_version, layers.list[i].lib_name);
@@ -475,12 +434,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceVersion(uint32_t
         chain_head = (VkEnumerateInstanceVersionChain *)chain_head->pNextLink;
         loader_free(NULL, holder);
     }
-
-    // Close the dl handles
-    for (size_t i = 0; i < lib_count; ++i) {
-        loader_platform_close_library(libs[i]);
-    }
-    loader_free(NULL, libs);
 
     return res;
 }

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -2143,6 +2143,220 @@ TEST(SettingsFile, ImplicitLayersNotAccidentallyEnabled) {
         ASSERT_TRUE(string_eq(layers.at(0).layerName, layer_names.at(9)));
     }
 }
+
+TEST(SettingsFile, ImplicitLayersPreInstanceEnumInstLayerProps) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
+
+    env.add_implicit_layer(
+        ManifestLayer{}.set_file_format_version({1, 1, 2}).add_layer(
+            ManifestLayer::LayerDescription{}
+                .set_name(implicit_layer_name)
+                .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                .set_disable_environment("DISABLE_ME")
+                .add_pre_instance_function(ManifestLayer::LayerDescription::FunctionOverride{}
+                                               .set_vk_func("vkEnumerateInstanceLayerProperties")
+                                               .set_override_name("test_preinst_vkEnumerateInstanceLayerProperties"))),
+        "implicit_test_layer.json");
+
+    env.update_loader_settings(
+        env.loader_settings.add_app_specific_setting(AppSpecificSettings{}.add_stderr_log_filter("all").add_layer_configuration(
+            LoaderSettingsLayerConfiguration{}
+                .set_name(implicit_layer_name)
+                .set_path(env.get_shimmed_layer_manifest_path(0))
+                .set_control("auto")
+                .set_treat_as_implicit_manifest(true))));
+
+    uint32_t layer_props = 43;
+    auto& layer = env.get_test_layer(0);
+    layer.set_reported_layer_props(layer_props);
+
+    uint32_t count = 0;
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, layer_props);
+}
+
+TEST(SettingsFile, EnableEnvironmentImplicitLayersPreInstanceEnumInstLayerProps) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
+
+    env.add_implicit_layer(
+        ManifestLayer{}.set_file_format_version({1, 1, 2}).add_layer(
+            ManifestLayer::LayerDescription{}
+                .set_name(implicit_layer_name)
+                .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                .set_disable_environment("DISABLE_ME")
+                .set_enable_environment("ENABLE_ME")
+                .add_pre_instance_function(ManifestLayer::LayerDescription::FunctionOverride{}
+                                               .set_vk_func("vkEnumerateInstanceLayerProperties")
+                                               .set_override_name("test_preinst_vkEnumerateInstanceLayerProperties"))),
+        "implicit_test_layer.json");
+
+    env.update_loader_settings(
+        env.loader_settings.add_app_specific_setting(AppSpecificSettings{}.add_stderr_log_filter("all").add_layer_configuration(
+            LoaderSettingsLayerConfiguration{}
+                .set_name(implicit_layer_name)
+                .set_path(env.get_shimmed_layer_manifest_path(0))
+                .set_control("auto")
+                .set_treat_as_implicit_manifest(true))));
+
+    uint32_t layer_props = 43;
+    auto& layer = env.get_test_layer(0);
+    layer.set_reported_layer_props(layer_props);
+
+    uint32_t count = 0;
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, nullptr));
+    ASSERT_EQ(count, 1U);
+    std::array<VkLayerProperties, 1> layers{};
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceLayerProperties(&count, layers.data()));
+    ASSERT_EQ(count, 1U);
+    ASSERT_TRUE(string_eq(layers.at(0).layerName, implicit_layer_name));
+}
+
+TEST(SettingsFile, ImplicitLayersPreInstanceEnumInstExtProps) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
+
+    env.add_implicit_layer(
+        ManifestLayer{}.set_file_format_version({1, 1, 2}).add_layer(
+            ManifestLayer::LayerDescription{}
+                .set_name(implicit_layer_name)
+                .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                .set_disable_environment("DISABLE_ME")
+                .add_pre_instance_function(ManifestLayer::LayerDescription::FunctionOverride{}
+                                               .set_vk_func("vkEnumerateInstanceExtensionProperties")
+                                               .set_override_name("test_preinst_vkEnumerateInstanceExtensionProperties"))),
+        "implicit_test_layer.json");
+
+    env.update_loader_settings(
+        env.loader_settings.add_app_specific_setting(AppSpecificSettings{}.add_stderr_log_filter("all").add_layer_configuration(
+            LoaderSettingsLayerConfiguration{}
+                .set_name(implicit_layer_name)
+                .set_path(env.get_shimmed_layer_manifest_path(0))
+                .set_control("auto")
+                .set_treat_as_implicit_manifest(true))));
+
+    uint32_t ext_props = 52;
+    auto& layer = env.get_test_layer(0);
+    layer.set_reported_extension_props(ext_props);
+
+    uint32_t count = 0;
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr));
+    ASSERT_EQ(count, ext_props);
+}
+
+TEST(SettingsFile, EnableEnvironmentImplicitLayersPreInstanceEnumInstExtProps) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
+
+    env.add_implicit_layer(
+        ManifestLayer{}.set_file_format_version({1, 1, 2}).add_layer(
+            ManifestLayer::LayerDescription{}
+                .set_name(implicit_layer_name)
+                .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                .set_disable_environment("DISABLE_ME")
+                .set_enable_environment("ENABLE_ME")
+                .add_pre_instance_function(ManifestLayer::LayerDescription::FunctionOverride{}
+                                               .set_vk_func("vkEnumerateInstanceExtensionProperties")
+                                               .set_override_name("test_preinst_vkEnumerateInstanceExtensionProperties"))),
+        "implicit_test_layer.json");
+
+    env.update_loader_settings(
+        env.loader_settings.add_app_specific_setting(AppSpecificSettings{}.add_stderr_log_filter("all").add_layer_configuration(
+            LoaderSettingsLayerConfiguration{}
+                .set_name(implicit_layer_name)
+                .set_path(env.get_shimmed_layer_manifest_path(0))
+                .set_control("auto")
+                .set_treat_as_implicit_manifest(true))));
+
+    uint32_t ext_props = 52;
+    auto& layer = env.get_test_layer(0);
+    layer.set_reported_extension_props(ext_props);
+
+    auto extensions = env.GetInstanceExtensions(4);
+    EXPECT_TRUE(string_eq(extensions.at(0).extensionName, VK_EXT_DEBUG_REPORT_EXTENSION_NAME));
+    EXPECT_TRUE(string_eq(extensions.at(1).extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME));
+    EXPECT_TRUE(string_eq(extensions.at(2).extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME));
+    EXPECT_TRUE(string_eq(extensions.at(3).extensionName, VK_LUNARG_DIRECT_DRIVER_LOADING_EXTENSION_NAME));
+}
+
+TEST(SettingsFile, ImplicitLayersPreInstanceVersion) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA))
+        .add_physical_device({})
+        .set_icd_api_version(VK_MAKE_API_VERSION(0, 1, 2, 3));
+
+    const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
+
+    env.add_implicit_layer(ManifestLayer{}.set_file_format_version({1, 1, 2}).add_layer(
+                               ManifestLayer::LayerDescription{}
+                                   .set_name(implicit_layer_name)
+                                   .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                   .set_api_version(VK_MAKE_API_VERSION(0, 1, 2, 3))
+                                   .set_disable_environment("DISABLE_ME")
+                                   .add_pre_instance_function(ManifestLayer::LayerDescription::FunctionOverride{}
+                                                                  .set_vk_func("vkEnumerateInstanceVersion")
+                                                                  .set_override_name("test_preinst_vkEnumerateInstanceVersion"))),
+                           "implicit_test_layer.json");
+
+    env.update_loader_settings(
+        env.loader_settings.add_app_specific_setting(AppSpecificSettings{}.add_stderr_log_filter("all").add_layer_configuration(
+            LoaderSettingsLayerConfiguration{}
+                .set_name(implicit_layer_name)
+                .set_path(env.get_shimmed_layer_manifest_path(0))
+                .set_control("auto")
+                .set_treat_as_implicit_manifest(true))));
+
+    uint32_t layer_version = VK_MAKE_API_VERSION(1, 2, 3, 4);
+    auto& layer = env.get_test_layer(0);
+    layer.set_reported_instance_version(layer_version);
+
+    uint32_t version = 0;
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceVersion(&version));
+    ASSERT_EQ(version, layer_version);
+}
+
+TEST(SettingsFile, EnableEnvironmentImplicitLayersPreInstanceVersion) {
+    FrameworkEnvironment env;
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA))
+        .add_physical_device({})
+        .set_icd_api_version(VK_MAKE_API_VERSION(0, 1, 2, 3));
+
+    const char* implicit_layer_name = "VK_LAYER_ImplicitTestLayer";
+
+    env.add_implicit_layer(ManifestLayer{}.set_file_format_version({1, 1, 2}).add_layer(
+                               ManifestLayer::LayerDescription{}
+                                   .set_name(implicit_layer_name)
+                                   .set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)
+                                   .set_api_version(VK_MAKE_API_VERSION(0, 1, 2, 3))
+                                   .set_disable_environment("DISABLE_ME")
+                                   .set_enable_environment("ENABLE_ME")
+                                   .add_pre_instance_function(ManifestLayer::LayerDescription::FunctionOverride{}
+                                                                  .set_vk_func("vkEnumerateInstanceVersion")
+                                                                  .set_override_name("test_preinst_vkEnumerateInstanceVersion"))),
+                           "implicit_test_layer.json");
+
+    env.update_loader_settings(
+        env.loader_settings.add_app_specific_setting(AppSpecificSettings{}.add_stderr_log_filter("all").add_layer_configuration(
+            LoaderSettingsLayerConfiguration{}
+                .set_name(implicit_layer_name)
+                .set_path(env.get_shimmed_layer_manifest_path(0))
+                .set_control("auto")
+                .set_treat_as_implicit_manifest(true))));
+
+    uint32_t layer_version = VK_MAKE_API_VERSION(1, 2, 3, 4);
+    auto& layer = env.get_test_layer(0);
+    layer.set_reported_instance_version(layer_version);
+
+    uint32_t version = 0;
+    ASSERT_EQ(VK_SUCCESS, env.vulkan_functions.vkEnumerateInstanceVersion(&version));
+    ASSERT_EQ(version, VK_HEADER_VERSION_COMPLETE);
+}
+
 // Settings can say which filters to use - make sure those are propagated & treated correctly
 TEST(SettingsFile, StderrLogFilters) {
     FrameworkEnvironment env{FrameworkSettings{}.set_log_filter("")};


### PR DESCRIPTION
The loader_scan_for_implicit_layers function was not removing inactive layers
from the list of layers gotten from the loader settings file. This caused
layers with pre-instance functions to loaded and executed.
For example, layers with an enable-environment field shouldn't be
loaded unless their respective env-var was set.
This lack of filtering didn't change the list of layers active during
vkCreateInstance, but does cause adverse side effects during pre-instance
API function calls.

Also: Reuse library loading code in pre-instance functions

The functions vkEnumerateInstanceExtensionProperties,
vkEnumerateInstanceVersion, and vkEnumerateInstanceLayerProperties have no
strong reason for duplicating the the logic to load and unload libraries.
This commit re-uses existing facilities to handle library loading, which has
the side benefit of adding logging to the loading and unloading of layer
libraries.