### PR TITLE
Fix CMake 3.31 builds for WIN32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,35 +161,41 @@ option(BUILD_WERROR "Enable warnings as errors")
 # Note that clang-cl.exe should use MSVC flavor flags, not GNU
 if (CMAKE_C_COMPILER_ID STREQUAL "MSVC" OR (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))
     if (BUILD_WERROR)
-        target_compile_options(loader_common_options INTERFACE /WX)
+        target_compile_options(loader_common_options INTERFACE $<$<COMPILE_LANGUAGE::CXX,C>:/WX>)
     endif()
-    target_compile_options(loader_common_options INTERFACE /W4)
+    target_compile_options(loader_common_options INTERFACE $<$<COMPILE_LANGUAGE::CXX,C>:/W4>)
 elseif(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     # using GCC or Clang with the regular front end
     if (BUILD_WERROR)
-        target_compile_options(loader_common_options INTERFACE -Werror)
+        target_compile_options(loader_common_options INTERFACE $<$<COMPILE_LANGUAGE::CXX,C>:-Werror>)
     endif()
-    target_compile_options(loader_common_options INTERFACE -Wall -Wextra)
+    target_compile_options(loader_common_options INTERFACE
+        $<$<COMPILE_LANGUAGE::CXX,C>:-Wall>
+        $<$<COMPILE_LANGUAGE::CXX,C>:-Wextra>
+    )
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
-    target_compile_options(loader_common_options INTERFACE -Wno-missing-field-initializers)
+    target_compile_options(loader_common_options INTERFACE $<$<COMPILE_LANGUAGE::CXX,C>:-Wno-missing-field-initializers>)
 
     # need to prepend /clang: to compiler arguments when using clang-cl
     if (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_C_COMPILER_FRONTEND_VARIANT}" MATCHES "MSVC")
-        target_compile_options(loader_common_options INTERFACE /clang:-fno-strict-aliasing)
+        target_compile_options(loader_common_options INTERFACE $<$<COMPILE_LANGUAGE::CXX,C>:/clang:-fno-strict-aliasing>)
     else()
-        target_compile_options(loader_common_options INTERFACE -fno-strict-aliasing)
+        target_compile_options(loader_common_options INTERFACE $<$<COMPILE_LANGUAGE::CXX,C>:-fno-strict-aliasing>)
     endif()
 
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(loader_common_options INTERFACE -Wno-stringop-truncation -Wno-stringop-overflow)
+        target_compile_options(loader_common_options INTERFACE
+            $<$<COMPILE_LANGUAGE::CXX,C>:-Wno-stringop-truncation>
+            $<$<COMPILE_LANGUAGE::CXX,C>:-Wno-stringop-overflow>
+        )
         if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 7.1)
-            target_compile_options(loader_common_options INTERFACE -Wshadow=local) #only added in GCC 7
+            target_compile_options(loader_common_options INTERFACE $<$<COMPILE_LANGUAGE::CXX,C>:-Wshadow=local>) #only added in GCC 7
         endif()
     endif()
 
-    target_compile_options(loader_common_options INTERFACE -Wpointer-arith)
+    target_compile_options(loader_common_options INTERFACE $<$<COMPILE_LANGUAGE::CXX,C>:-Wpointer-arith>)
 
     # Force GLIBC to use the 64 bit interface for file operations instead of 32 bit - More info in issue #1551
     if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4")
@@ -203,7 +209,13 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC" OR (CMAKE_C_COMPILER_ID STREQUAL "Clang" A
     # /guard:cf: Enable control flow guard
     # /wd4152: Disable warning on conversion of a function pointer to a data pointer
     # /wd4201: Disable warning on anonymous struct/unions
-    target_compile_options(loader_common_options INTERFACE /sdl /GR- /guard:cf /wd4152 /wd4201)
+    target_compile_options(loader_common_options INTERFACE
+        $<$<COMPILE_LANGUAGE::CXX,C>:/sdl>
+        $<$<COMPILE_LANGUAGE::CXX,C>:/GR->
+        $<$<COMPILE_LANGUAGE::CXX,C>:/guard:cf>
+        $<$<COMPILE_LANGUAGE::CXX,C>:/wd4152>
+        $<$<COMPILE_LANGUAGE::CXX,C>:/wd4201>
+    )
 
     # Enable control flow guard
     target_link_options(loader_common_options INTERFACE "LINKER:/guard:cf")

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -236,22 +236,11 @@ end
         set_target_properties(loader_asm_gen_files PROPERTIES FOLDER ${LOADER_HELPER_FOLDER})
 
         if(SYSTEM_PROCESSOR MATCHES "arm")
-            add_library(loader-unknown-chain STATIC unknown_ext_chain_marmasm.asm)
+            list(APPEND OPT_LOADER_SRCS unknown_ext_chain_marmasm.asm)
         else()
-            add_library(loader-unknown-chain STATIC unknown_ext_chain_masm.asm)
+            list(APPEND OPT_LOADER_SRCS unknown_ext_chain_masm.asm)
         endif()
-        target_include_directories(loader-unknown-chain PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
-        add_dependencies(loader-unknown-chain loader_asm_gen_files)
         set(UNKNOWN_FUNCTIONS_SUPPORTED ON)
-
-        # Work around bug in CMake Ninja + MSVC/clang-cl, see https://discourse.cmake.org/t/building-lib-file-from-asm-cmake-bug/1959
-        if (CMAKE_C_COMPILER_ID STREQUAL "MSVC" OR (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))
-            if(SYSTEM_PROCESSOR MATCHES "arm")
-                set(CMAKE_ASM_MARMASM_CREATE_STATIC_LIBRARY "<CMAKE_AR> /OUT:<TARGET> <LINK_FLAGS> <OBJECTS>")
-            else()
-                set(CMAKE_ASM_MASM_CREATE_STATIC_LIBRARY "<CMAKE_AR> /OUT:<TARGET> <LINK_FLAGS> <OBJECTS>")
-            endif()
-        endif()
     else()
         message(WARNING "Could not find working ${} assembler\n${ASM_FAILURE_MSG}")
     endif()
@@ -279,17 +268,17 @@ elseif(UNIX OR MINGW OR (WIN32 AND USE_GAS)) # i.e.: Linux & Apple & MinGW & Win
             endif()
 
             if(ASSEMBLER_WORKS)
-                set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas_aarch.S)
+                list(APPEND OPT_LOADER_SRCS unknown_ext_chain_gas_aarch.S)
             endif()
         elseif (${SYSTEM_PROCESSOR} MATCHES "aarch64|arm64")
             try_compile(ASSEMBLER_WORKS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/asm_test_aarch64.S OUTPUT_VARIABLE TRY_COMPILE_OUTPUT)
             if(ASSEMBLER_WORKS)
-                set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas_aarch.S)
+                list(APPEND OPT_LOADER_SRCS unknown_ext_chain_gas_aarch.S)
             endif()
         elseif (${SYSTEM_PROCESSOR} MATCHES "aarch32|armhf|armv7l|armv8l")
             try_compile(ASSEMBLER_WORKS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/asm_test_aarch32.S OUTPUT_VARIABLE TRY_COMPILE_OUTPUT)
             if(ASSEMBLER_WORKS)
-                set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas_aarch.S)
+                list(APPEND OPT_LOADER_SRCS unknown_ext_chain_gas_aarch.S)
             endif()
         # Covers x86_64, amd64, x86, i386, i686, I386, I686
         elseif(${SYSTEM_PROCESSOR} MATCHES "amd64|86")
@@ -300,7 +289,7 @@ elseif(UNIX OR MINGW OR (WIN32 AND USE_GAS)) # i.e.: Linux & Apple & MinGW & Win
 
             try_compile(ASSEMBLER_WORKS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/asm_test_x86.S)
             if(ASSEMBLER_WORKS)
-                set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain_gas_x86.S)
+                list(APPEND OPT_LOADER_SRCS unknown_ext_chain_gas_x86.S)
             endif()
         endif()
     endif()
@@ -390,10 +379,6 @@ if(WIN32)
                 ${RC_FILE_LOCATION})
 
     target_link_libraries(vulkan PRIVATE loader_specific_options)
-
-    if(UNKNOWN_FUNCTIONS_SUPPORTED AND TARGET loader-unknown-chain)
-        target_link_libraries(vulkan PRIVATE loader-unknown-chain)
-    endif()
 
     # when adding the suffix the import and runtime library names must be consistent
     # mingw: libvulkan-1.dll.a / vulkan-1.dll


### PR DESCRIPTION
A recent fix to CMake for ASM static libraries on Windows broke the existing build.

Easiest solution I found is to remove the usage of ASM static libraries from the loader.

This is already what the UNIX build does.

This required using generator expressions to NOT pass along compiler options that aren't needed for assembly files.