### PR TITLE
Settings takes priority over layers disable env var

### DIFF
--- a/loader/log.h
+++ b/loader/log.h
@@ -54,6 +54,10 @@ void loader_init_global_debug_level(void);
 // Sets the global debug level - used by global settings files
 void loader_set_global_debug_level(uint32_t new_loader_debug);
 
+// Writes a stringified version of enum vulkan_loader_debug_flags into cmd_line_msg, and writes the number of characters written in
+// num_used
+void generate_debug_flag_str(VkFlags msg_type, size_t cmd_line_size, char *cmd_line_msg, size_t *num_used);
+
 // The asm declaration prevents name mangling which is necessary for macOS
 #if defined(MODIFY_UNKNOWN_FUNCTION_DECLS)
 #define ASM_NAME(name) __asm(name)

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -285,9 +285,9 @@ void log_settings(const struct loader_instance* inst, loader_settings* settings)
     cmd_line_msg[0] = '\0';
 
     generate_debug_flag_str(settings->debug_level, cmd_line_size, cmd_line_msg, &num_used);
-if (num_used > 0) {
-    loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Loader Settings Filters for Logging to Standard Error: %s", cmd_line_msg);
-}
+    if (num_used > 0) {
+        loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Loader Settings Filters for Logging to Standard Error: %s", cmd_line_msg);
+    }
 
     loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Layer Configurations count = %d", settings->layer_configuration_count);
     for (uint32_t i = 0; i < settings->layer_configuration_count; i++) {
@@ -770,13 +770,13 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
         // Force enable it based on settings
         if (props->settings_control_value == LOADER_SETTINGS_LAYER_CONTROL_ON) {
             enable_layer = true;
-        }
-
-        // Check if disable filter needs to skip the layer
-        if ((filters->disable_filter.disable_all || filters->disable_filter.disable_all_implicit ||
-             check_name_matches_filter_environment_var(props->info.layerName, &filters->disable_filter.additional_filters)) &&
-            !check_name_matches_filter_environment_var(props->info.layerName, &filters->allow_filter)) {
-            continue;
+        } else {
+            // Check if disable filter needs to skip the layer
+            if ((filters->disable_filter.disable_all || filters->disable_filter.disable_all_implicit ||
+                 check_name_matches_filter_environment_var(props->info.layerName, &filters->disable_filter.additional_filters)) &&
+                !check_name_matches_filter_environment_var(props->info.layerName, &filters->allow_filter)) {
+                continue;
+            }
         }
         // Check the enable filter
         if (!enable_layer && check_name_matches_filter_environment_var(props->info.layerName, &filters->enable_filter)) {

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -278,12 +278,25 @@ void log_settings(const struct loader_instance* inst, loader_settings* settings)
     loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "Using layer configurations found in loader settings from %s",
                settings->settings_file_path);
 
+    char cmd_line_msg[64];
+    size_t cmd_line_size = sizeof(cmd_line_msg);
+    size_t num_used = 0;
+
+    cmd_line_msg[0] = '\0';
+
+    generate_debug_flag_str(settings->debug_level, cmd_line_size, cmd_line_msg, &num_used);
+if (num_used > 0) {
+    loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Loader Settings Filters for Logging to Standard Error: %s", cmd_line_msg);
+}
+
     loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Layer Configurations count = %d", settings->layer_configuration_count);
     for (uint32_t i = 0; i < settings->layer_configuration_count; i++) {
         loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "---- Layer Configuration [%d] ----", i);
         if (settings->layer_configurations[i].control != LOADER_SETTINGS_LAYER_UNORDERED_LAYER_LOCATION) {
             loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Name: %s", settings->layer_configurations[i].name);
             loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Path: %s", settings->layer_configurations[i].path);
+            loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Layer Type: %s",
+                       settings->layer_configurations[i].treat_as_implicit_manifest ? "Implicit" : "Explicit");
         }
         loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Control: %s",
                    loader_settings_layer_control_to_string(settings->layer_configurations[i].control));

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -2380,10 +2380,12 @@ TEST(SettingsFile, StderrLogFilters) {
     expected_output_verbose += "DEBUG:             ---- Layer Configuration [0] ----\n";
     expected_output_verbose += std::string("DEBUG:             Name: ") + explicit_layer_name + "\n";
     expected_output_verbose += "DEBUG:             Path: " + env.get_shimmed_layer_manifest_path().string() + "\n";
+    expected_output_verbose += "DEBUG:             Layer Type: Explicit\n";
     expected_output_verbose += "DEBUG:             Control: on\n";
     expected_output_verbose += "DEBUG:             ---- Layer Configuration [1] ----\n";
     expected_output_verbose += "DEBUG:             Name: VK_LAYER_missing\n";
     expected_output_verbose += "DEBUG:             Path: /road/to/nowhere\n";
+    expected_output_verbose += "DEBUG:             Layer Type: Explicit\n";
     expected_output_verbose += "DEBUG:             Control: on\n";
     expected_output_verbose += "DEBUG:             ---------------------------------\n";
 
@@ -2400,6 +2402,9 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
+        ASSERT_TRUE(
+            env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error: ERROR | "
+                                           "WARNING | INFO | DEBUG | PERF | DRIVER | LAYER\n"));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2414,6 +2419,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
+        ASSERT_TRUE(env.platform_shim->find_in_log(
+            "DEBUG:             Loader Settings Filters for Logging to Standard Error: ERROR | WARNING | INFO | DEBUG\n"));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2428,6 +2435,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
+        ASSERT_TRUE(env.platform_shim->find_in_log(
+            "DEBUG:             Loader Settings Filters for Logging to Standard Error: WARNING | INFO | DEBUG\n"));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2442,6 +2451,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
+        ASSERT_TRUE(
+            env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error: DEBUG\n"));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2456,6 +2467,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
+        ASSERT_FALSE(
+            env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error: INFO\n"));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2470,6 +2483,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
+        ASSERT_FALSE(
+            env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error: WARNING\n"));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2484,6 +2499,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
+        ASSERT_FALSE(
+            env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error: ERROR\n"));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2498,6 +2515,7 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
+        ASSERT_FALSE(env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error:"));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2512,6 +2530,7 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
+        ASSERT_FALSE(env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error:"));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2637,10 +2656,12 @@ TEST(SettingsFile, NoStderr_log_but_VK_LOADER_DEBUG) {
     expected_output_verbose += "DEBUG:             ---- Layer Configuration [0] ----\n";
     expected_output_verbose += std::string("DEBUG:             Name: ") + explicit_layer_name + "\n";
     expected_output_verbose += "DEBUG:             Path: " + env.get_shimmed_layer_manifest_path().string() + "\n";
+    expected_output_verbose += "DEBUG:             Layer Type: Explicit\n";
     expected_output_verbose += "DEBUG:             Control: auto\n";
     expected_output_verbose += "DEBUG:             ---- Layer Configuration [1] ----\n";
     expected_output_verbose += "DEBUG:             Name: VK_LAYER_missing\n";
     expected_output_verbose += "DEBUG:             Path: /road/to/nowhere\n";
+    expected_output_verbose += "DEBUG:             Layer Type: Explicit\n";
     expected_output_verbose += "DEBUG:             Control: auto\n";
     expected_output_verbose += "DEBUG:             ---------------------------------\n";
 

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -1749,7 +1749,8 @@ TEST(SettingsFile, EnvVarsWork_VK_LOADER_LAYERS_DISABLE) {
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate();
     ASSERT_TRUE(env.debug_log.find(get_settings_location_log_message(env)));
-    ASSERT_NO_FATAL_FAILURE(inst.GetActiveLayers(inst.GetPhysDev(), 0));
+    auto layers = inst.GetActiveLayers(inst.GetPhysDev(), 1);
+    ASSERT_TRUE(string_eq(layers.at(0).layerName, explicit_layer_name));
 }
 
 #if defined(WIN32)


### PR DESCRIPTION
* Log Settings file Stderr Log Filters

This commit also pulls out the logic that loader_log uses to create the
ERROR | WARNING | <etc> string so that it can be reused in the logging
of the settings file stderr filters. To accomplish this, the logic was
changed slightly to assume that all debug masks are possible. This also
means adding an assert to make sure loader_log isn't called with
multiple flags set, just as a heads up that it isn't desireable.

The logging only occurs if any filters are set.

The settings file also now includes the type of layer in the log, either
explicit or implicit (based solely on the loader settings file value of
treat_as_implicit_layer).

* Make Settings file "ON" take priority over disable env-var

The VK_LOADER_LAYERS_DISABLE env-var was disabling layers even if the
settings file was turning them on. The fix is a simple change in logic
to only check for the layer disable if the layer wasn't set to "ON".
Checking for "OFF" isn't needed since that happens above this check.

* Add test which enables most layer env-vars at once

Makes sure the various combinations of environment variables and
settings file interacts according to expectations.