### PR TITLE
Only set global debug level from settings if above 0

### DIFF
--- a/loader/settings.c
+++ b/loader/settings.c
@@ -487,7 +487,7 @@ VkResult update_global_loader_settings(void) {
         }
 
         memcpy(&global_loader_settings, &settings, sizeof(loader_settings));
-        if (global_loader_settings.settings_active) {
+        if (global_loader_settings.settings_active && global_loader_settings.debug_level > 0) {
             loader_set_global_debug_level(global_loader_settings.debug_level);
         }
     }


### PR DESCRIPTION
This prevents VK_LOADER_DEBUG from being ignored when the settings file lacks stderr_log.

Fixes #1601