### PR TITLE
Correctly check if settings file exists on windows

### DIFF
--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -1194,12 +1194,15 @@ VkResult get_settings_path_if_exists_in_registry_key(const struct loader_instanc
             }
         }
 
-        // Make sure the path exists first
-        if (*out_path && !loader_platform_file_exists(name)) {
-            return VK_ERROR_INITIALIZATION_FAILED;
-        }
-
         if (strcmp(VK_LOADER_SETTINGS_FILENAME, &(name[start_of_path_filename])) == 0) {
+            // Make sure the path exists first
+            if (!loader_platform_file_exists(name)) {
+                loader_log(
+                    inst, VULKAN_LOADER_DEBUG_BIT, 0,
+                    "Registry contained entry to vk_loader_settings.json but the corresponding file does not exist, ignoring");
+                return VK_ERROR_INITIALIZATION_FAILED;
+            }
+
             *out_path = loader_instance_heap_calloc(inst, name_size + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
             if (*out_path == NULL) {
                 return VK_ERROR_OUT_OF_HOST_MEMORY;

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -315,12 +315,16 @@ VkResult get_loader_settings(const struct loader_instance* inst, loader_settings
 #if defined(WIN32)
     res = windows_get_loader_settings_file_path(inst, &settings_file_path);
     if (res != VK_SUCCESS) {
+        loader_log(inst, VULKAN_LOADER_INFO_BIT, 0,
+                   "No valid vk_loader_settings.json file found, no loader settings will be active");
         goto out;
     }
 
 #elif COMMON_UNIX_PLATFORMS
     res = get_unix_settings_path(inst, &settings_file_path);
     if (res != VK_SUCCESS) {
+        loader_log(inst, VULKAN_LOADER_INFO_BIT, 0,
+                   "No valid vk_loader_settings.json file found, no loader settings will be active");
         goto out;
     }
 #else


### PR DESCRIPTION
While there was logic to check if the vk_loader_settings.json file existed, it was not being run at an appropriate time and with another expression that caused the check to never happen.

This commit also logs that the loader fails to find the loader settings file, and if it finds a registry entry, if the file doesn't exist.

Fixes #1600 