### PR TITLE
Log what caused each layer to be enabled

### DIFF
--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -163,6 +163,16 @@ enum layer_type_flags {
     VK_LAYER_TYPE_FLAG_META_LAYER = 0x4,      // If not set, indicates standard layer
 };
 
+enum loader_layer_enabled_by_what {
+    ENABLED_BY_WHAT_UNSET,  // default value indicates this field hasn't been filled in
+    ENABLED_BY_WHAT_LOADER_SETTINGS_FILE,
+    ENABLED_BY_WHAT_IMPLICIT_LAYER,
+    ENABLED_BY_WHAT_VK_INSTANCE_LAYERS,
+    ENABLED_BY_WHAT_VK_LOADER_LAYERS_ENABLE,
+    ENABLED_BY_WHAT_IN_APPLICATION_API,
+    ENABLED_BY_WHAT_META_LAYER,
+};
+
 struct loader_layer_properties {
     VkLayerProperties info;
     enum layer_type_flags type_flags;
@@ -172,6 +182,7 @@ struct loader_layer_properties {
     char *manifest_file_name;
     char *lib_name;
     enum loader_layer_library_status lib_status;
+    enum loader_layer_enabled_by_what enabled_by_what;
     loader_platform_dl_handle lib_handle;
     struct loader_layer_functions functions;
     struct loader_extension_list instance_extension_list;

--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -480,6 +480,7 @@ VkResult loader_add_environment_layers(struct loader_instance *inst, const enum 
                             // Only add it if it doesn't already appear in the layer list
                             if (!loader_find_layer_name_in_list(source_prop->info.layerName, target_list)) {
                                 if (0 == (source_prop->type_flags & VK_LAYER_TYPE_FLAG_META_LAYER)) {
+                                    source_prop->enabled_by_what = ENABLED_BY_WHAT_VK_INSTANCE_LAYERS;
                                     res = loader_add_layer_properties_to_list(inst, target_list, source_prop);
                                     if (res == VK_ERROR_OUT_OF_HOST_MEMORY) goto out;
                                     res = loader_add_layer_properties_to_list(inst, expanded_target_list, source_prop);
@@ -546,6 +547,7 @@ VkResult loader_add_environment_layers(struct loader_instance *inst, const enum 
 
         // If not a meta-layer, simply add it.
         if (0 == (source_prop->type_flags & VK_LAYER_TYPE_FLAG_META_LAYER)) {
+            source_prop->enabled_by_what = ENABLED_BY_WHAT_VK_LOADER_LAYERS_ENABLE;
             res = loader_add_layer_properties_to_list(inst, target_list, source_prop);
             if (res == VK_ERROR_OUT_OF_HOST_MEMORY) goto out;
             res = loader_add_layer_properties_to_list(inst, expanded_target_list, source_prop);

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -774,6 +774,7 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
         // Force enable it based on settings
         if (props->settings_control_value == LOADER_SETTINGS_LAYER_CONTROL_ON) {
             enable_layer = true;
+            props->enabled_by_what = ENABLED_BY_WHAT_LOADER_SETTINGS_FILE;
         } else {
             // Check if disable filter needs to skip the layer
             if ((filters->disable_filter.disable_all || filters->disable_filter.disable_all_implicit ||
@@ -785,6 +786,7 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
         // Check the enable filter
         if (!enable_layer && check_name_matches_filter_environment_var(props->info.layerName, &filters->enable_filter)) {
             enable_layer = true;
+            props->enabled_by_what = ENABLED_BY_WHAT_VK_LOADER_LAYERS_ENABLE;
         }
 
         // First look for the old-fashion layers forced on with VK_INSTANCE_LAYERS
@@ -799,6 +801,7 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
                 char* next = loader_get_next_path(instance_layers_env_iter);
                 if (0 == strcmp(instance_layers_env_iter, props->info.layerName)) {
                     enable_layer = true;
+                    props->enabled_by_what = ENABLED_BY_WHAT_VK_INSTANCE_LAYERS;
                     break;
                 }
                 instance_layers_env_iter = next;
@@ -810,6 +813,7 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
             for (uint32_t j = 0; j < app_enabled_name_count; j++) {
                 if (strcmp(props->info.layerName, app_enabled_names[j]) == 0) {
                     enable_layer = true;
+                    props->enabled_by_what = ENABLED_BY_WHAT_IN_APPLICATION_API;
                     break;
                 }
             }
@@ -819,6 +823,7 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
         if (!enable_layer && (0 == (props->type_flags & VK_LAYER_TYPE_FLAG_EXPLICIT_LAYER)) &&
             loader_implicit_layer_is_enabled(inst, filters, props)) {
             enable_layer = true;
+            props->enabled_by_what = ENABLED_BY_WHAT_IMPLICIT_LAYER;
         }
 
         if (enable_layer) {


### PR DESCRIPTION
Adds information about how each layer was enabled, useful for debugging when you are not sure *what* caused a layer to be enabled (in-application API, different environment variables, vkconfig, implicit layer, etc).