### PR TITLE
In chromium official builds remove dev build marking from vulkan-1.dll

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -144,6 +144,23 @@ if (!is_android) {
     }
   }
 
+  if (is_win) {
+    action("gen_loader_rc") {
+      script = "scripts/generate_loader_rc.py"
+      inputs = [
+        "loader/loader.rc",
+      ]
+      args = [
+        rebase_path("loader/loader.rc", root_build_dir),
+        rebase_path("$target_gen_dir/loader.rc", root_build_dir),
+      ]
+      if (is_official_build) {
+        args += [ "--is_official" ]
+      }
+      outputs = [ "$target_gen_dir/loader.rc" ]
+    }
+  }
+
   target(library_type, "libvulkan") {
     sources = [
       "loader/adapters.h",
@@ -199,13 +216,14 @@ if (!is_android) {
       }
     }
 
+    deps = []
     if (is_win) {
       sources += [
         "loader/dirent_on_windows.c",
         "loader/dirent_on_windows.h",
         "loader/loader_windows.c",
         "loader/loader_windows.h",
-        "loader/loader.rc",
+        "$target_gen_dir/loader.rc",
         "loader/vulkan-1.def",
       ]
       if (!is_clang) {
@@ -228,6 +246,7 @@ if (!is_android) {
         cflags = [ "-Wno-incompatible-pointer-types" ]
       }
       libs = [ "Cfgmgr32.lib" ]
+      deps += [ ":gen_loader_rc" ]
     }
     if (is_linux || is_chromeos) {
       sources += [
@@ -252,7 +271,7 @@ if (!is_android) {
       # which can be obtained separately from the loader implementation itself.
       no_headers = true
 
-      deps = [
+      deps += [
         ":dlopen_fuchsia",
         "//sdk/lib/fdio",
       ]

--- a/scripts/generate_loader_rc.py
+++ b/scripts/generate_loader_rc.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright 2023 The Khronos Group Inc.
+# Copyright 2023 Valve Corporation
+# Copyright 2023 LunarG, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import sys
+
+def main(argv):
+    parser = argparse.ArgumentParser(description='Update Loader.rc for official builds')
+    parser.add_argument('src')
+    parser.add_argument('dst')
+    parser.add_argument('--is_official', action='store_true')
+    parser.set_defaults(is_official=False)
+    args = parser.parse_args(argv)
+    with open(args.src, 'r') as src:
+        with open(args.dst, 'w') as dst:
+            for line in src:
+                if args.is_official:
+                    if line.startswith('#define VER_FILE_DESCRIPTION_STR'):
+                        dst.write(line.replace('Dev Build', '0'))
+                    elif line.startswith('#define VER_FILE_VERSION_STR'):
+                        dst.write(line.replace(' - Dev Build', ''))
+                    else:
+                        dst.write(line)
+                else:
+                    dst.write(line)
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
This is a fix to issue #1571 , Vulkan-Loader/Loader/Loader.rc lists dll as dev build.

In this change, a new loader.rc file is created based on the checked in one and "Dev Build" suffixes are removed for official builds. This makes it so that all chromium based browsers don't ship a vulkan-1.dll with properties that show it to be dev builds.
