### PR TITLE
Fix out-of-memory case in cJSON

### DIFF
--- a/loader/cJSON.c
+++ b/loader/cJSON.c
@@ -914,6 +914,7 @@ static unsigned char *print(const cJSON *const item, cJSON_bool format, bool *ou
     buffer->format = format;
     buffer->pAllocator = item->pAllocator;
     if (buffer->buffer == NULL) {
+        *out_of_memory = true;
         goto fail;
     }
 


### PR DESCRIPTION
If the initial calloc failed then NULL was being returned but the out_of_memory flag was not being set, so callers did not understand the returned value correctly. Set the flag.