### PR TITLE
Make emulate_VK_EXT_surface_maintenance1 more comply to vk spec

### DIFF
--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -2469,9 +2469,13 @@ void emulate_VK_EXT_surface_maintenance1(struct loader_icd_term *icd_term, const
                 VkSurfacePresentModeCompatibilityEXT *surface_present_mode_compatibility =
                     (VkSurfacePresentModeCompatibilityEXT *)void_pNext;
                 if (surface_present_mode_compatibility->pPresentModes) {
-                    surface_present_mode_compatibility->pPresentModes[0] = present_mode;
+                    if (surface_present_mode_compatibility->presentModeCount != 0) {
+                        surface_present_mode_compatibility->pPresentModes[0] = present_mode;
+                        surface_present_mode_compatibility->presentModeCount = 1;
+                    }
+                } else {
+                    surface_present_mode_compatibility->presentModeCount = 1;
                 }
-                surface_present_mode_compatibility->presentModeCount = 1;
 
             } else if (out_structure.sType == VK_STRUCTURE_TYPE_SURFACE_PRESENT_SCALING_CAPABILITIES_EXT) {
                 // Because there is no way to fill out the information faithfully, set scaled max/min image extent to the


### PR DESCRIPTION
The emulation function does not comply with specifications. The spec asks ```The implementation must include the present mode passed to VkSurfacePresentModeEXT in pPresentModes, unless presentModeCount is zero.``` But now the implementation here will always include the present mode regardless of whether presentModeCount is zero.
According to spec ```If the value of presentModeCount is less than the number of compatible present modes that are supported, at most presentModeCount values will be written to pPresentModes.``` When presentModeCount is 0, at most 0 values will be written to pPresentModes, in other words the implementation should do nothing in this situation.
This commit fixed the above issue.