### PR TITLE
Support VK_GOOGLE_surfaceless_query 

### DIFF
--- a/loader/extension_manual.c
+++ b/loader/extension_manual.c
@@ -274,16 +274,18 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfacePresentModes2E
                    "ICD associated with VkPhysicalDevice does not support GetPhysicalDeviceSurfacePresentModes2EXT");
         abort();
     }
-    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)(pSurfaceInfo->surface);
-    if (NULL != icd_term->surface_list.list &&
-        icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
-        icd_term->surface_list.list[icd_surface->surface_index]) {
-        VkPhysicalDeviceSurfaceInfo2KHR surface_info_copy;
-        surface_info_copy.sType = pSurfaceInfo->sType;
-        surface_info_copy.pNext = pSurfaceInfo->pNext;
-        surface_info_copy.surface = icd_term->surface_list.list[icd_surface->surface_index];
-        return icd_term->dispatch.GetPhysicalDeviceSurfacePresentModes2EXT(phys_dev_term->phys_dev, &surface_info_copy,
-                                                                           pPresentModeCount, pPresentModes);
+    if (VK_NULL_HANDLE != pSurfaceInfo->surface) {
+        VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)(pSurfaceInfo->surface);
+        if (NULL != icd_surface && NULL != icd_term->surface_list.list &&
+            icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
+            icd_term->surface_list.list[icd_surface->surface_index]) {
+            VkPhysicalDeviceSurfaceInfo2KHR surface_info_copy;
+            surface_info_copy.sType = pSurfaceInfo->sType;
+            surface_info_copy.pNext = pSurfaceInfo->pNext;
+            surface_info_copy.surface = icd_term->surface_list.list[icd_surface->surface_index];
+            return icd_term->dispatch.GetPhysicalDeviceSurfacePresentModes2EXT(phys_dev_term->phys_dev, &surface_info_copy,
+                                                                               pPresentModeCount, pPresentModes);
+        }
     }
     return icd_term->dispatch.GetPhysicalDeviceSurfacePresentModes2EXT(phys_dev_term->phys_dev, pSurfaceInfo, pPresentModeCount,
                                                                        pPresentModes);
@@ -321,16 +323,18 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetDeviceGroupSurfacePresentModes2EXT(
                    "[VUID-vkGetDeviceGroupSurfacePresentModes2EXT-pSurfaceInfo-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
-    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)(pSurfaceInfo->surface);
-    if (NULL != icd_term->surface_list.list &&
-        icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
-        icd_term->surface_list.list[icd_surface->surface_index]) {
-        VkPhysicalDeviceSurfaceInfo2KHR surface_info_copy;
-        surface_info_copy.sType = pSurfaceInfo->sType;
-        surface_info_copy.pNext = pSurfaceInfo->pNext;
-        surface_info_copy.surface = icd_term->surface_list.list[icd_surface->surface_index];
-        return dev->loader_dispatch.extension_terminator_dispatch.GetDeviceGroupSurfacePresentModes2EXT(device, &surface_info_copy,
-                                                                                                        pModes);
+    if (VK_NULL_HANDLE != pSurfaceInfo->surface) {
+        VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)(pSurfaceInfo->surface);
+        if (NULL != icd_surface && NULL != icd_term->surface_list.list &&
+            icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
+            icd_term->surface_list.list[icd_surface->surface_index]) {
+            VkPhysicalDeviceSurfaceInfo2KHR surface_info_copy;
+            surface_info_copy.sType = pSurfaceInfo->sType;
+            surface_info_copy.pNext = pSurfaceInfo->pNext;
+            surface_info_copy.surface = icd_term->surface_list.list[icd_surface->surface_index];
+            return dev->loader_dispatch.extension_terminator_dispatch.GetDeviceGroupSurfacePresentModes2EXT(
+                device, &surface_info_copy, pModes);
+        }
     }
     return dev->loader_dispatch.extension_terminator_dispatch.GetDeviceGroupSurfacePresentModes2EXT(device, pSurfaceInfo, pModes);
 }

--- a/loader/loader.rc
+++ b/loader/loader.rc
@@ -1,7 +1,7 @@
 //
-// Copyright (c) 2014-2024 The Khronos Group Inc.
-// Copyright (c) 2014-2024 Valve Corporation
-// Copyright (c) 2014-2024 LunarG, Inc.
+// Copyright (c) 2014-2025 The Khronos Group Inc.
+// Copyright (c) 2014-2025 Valve Corporation
+// Copyright (c) 2014-2025 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 #define VER_FILE_VERSION 1, 4, 304, 0
 #define VER_FILE_DESCRIPTION_STR "1.4.304.Dev Build"
 #define VER_FILE_VERSION_STR "Vulkan Loader - Dev Build"
-#define VER_COPYRIGHT_STR "Copyright (C) 2015-2024"
+#define VER_COPYRIGHT_STR "Copyright (C) 2015-2025"
 
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION VER_FILE_VERSION

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -362,7 +362,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormatsKHR(VkP
         // Zero out the format count as this driver doesn't support WSI functionality
         *pSurfaceFormatCount = 0;
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "ICD for selected physical device does not export vkGetPhysicalDeviceSurfaceCapabilitiesKHR!");
+                   "ICD for selected physical device does not export vkGetPhysicalDeviceSurfaceFormatsKHR!");
         return VK_SUCCESS;
     }
 

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -366,15 +366,16 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormatsKHR(VkP
         return VK_SUCCESS;
     }
 
-    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
-    if (NULL != phys_dev_term->this_icd_term->surface_list.list &&
-        phys_dev_term->this_icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
-        phys_dev_term->this_icd_term->surface_list.list[icd_surface->surface_index]) {
-        return icd_term->dispatch.GetPhysicalDeviceSurfaceFormatsKHR(
-            phys_dev_term->phys_dev, phys_dev_term->this_icd_term->surface_list.list[icd_surface->surface_index],
-            pSurfaceFormatCount, pSurfaceFormats);
+    if (VK_NULL_HANDLE != surface) {
+        VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
+        if (NULL != phys_dev_term->this_icd_term->surface_list.list &&
+            phys_dev_term->this_icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
+            phys_dev_term->this_icd_term->surface_list.list[icd_surface->surface_index]) {
+            return icd_term->dispatch.GetPhysicalDeviceSurfaceFormatsKHR(
+                phys_dev_term->phys_dev, phys_dev_term->this_icd_term->surface_list.list[icd_surface->surface_index],
+                pSurfaceFormatCount, pSurfaceFormats);
+        }
     }
-
     return icd_term->dispatch.GetPhysicalDeviceSurfaceFormatsKHR(phys_dev_term->phys_dev, surface, pSurfaceFormatCount,
                                                                  pSurfaceFormats);
 }
@@ -424,16 +425,17 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfacePresentModesKH
                    "ICD for selected physical device does not export vkGetPhysicalDeviceSurfacePresentModesKHR!");
         return VK_SUCCESS;
     }
+    if (VK_NULL_HANDLE != surface) {
+        VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
 
-    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)surface;
-    if (NULL != phys_dev_term->this_icd_term->surface_list.list &&
-        phys_dev_term->this_icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
-        phys_dev_term->this_icd_term->surface_list.list[icd_surface->surface_index]) {
-        return icd_term->dispatch.GetPhysicalDeviceSurfacePresentModesKHR(
-            phys_dev_term->phys_dev, phys_dev_term->this_icd_term->surface_list.list[icd_surface->surface_index], pPresentModeCount,
-            pPresentModes);
+        if (icd_surface != NULL && NULL != phys_dev_term->this_icd_term->surface_list.list &&
+            phys_dev_term->this_icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
+            phys_dev_term->this_icd_term->surface_list.list[icd_surface->surface_index]) {
+            return icd_term->dispatch.GetPhysicalDeviceSurfacePresentModesKHR(
+                phys_dev_term->phys_dev, phys_dev_term->this_icd_term->surface_list.list[icd_surface->surface_index],
+                pPresentModeCount, pPresentModes);
+        }
     }
-
     return icd_term->dispatch.GetPhysicalDeviceSurfacePresentModesKHR(phys_dev_term->phys_dev, surface, pPresentModeCount,
                                                                       pPresentModes);
 }
@@ -2497,7 +2499,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2K
     struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)physicalDevice;
     struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;
     struct loader_instance *loader_inst = (struct loader_instance *)icd_term->this_instance;
-    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)pSurfaceInfo->surface;
+    VkIcdSurface *icd_surface = NULL;
+    if (pSurfaceInfo->surface) {
+        icd_surface = (VkIcdSurface *)(uintptr_t)pSurfaceInfo->surface;
+    }
 
     if (!loader_inst->wsi_surface_enabled) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
@@ -2522,7 +2527,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2K
         VkResult res = VK_SUCCESS;
 
         // Pass the call to the driver, possibly unwrapping the ICD surface
-        if (NULL != icd_term->surface_list.list &&
+        if (NULL != icd_surface && NULL != icd_term->surface_list.list &&
             icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
             icd_term->surface_list.list[icd_surface->surface_index]) {
             VkPhysicalDeviceSurfaceInfo2KHR info_copy = *pSurfaceInfo;
@@ -2549,8 +2554,8 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2K
                    icd_term->scanned_icd->lib_name);
 
         // Write to the VkSurfaceCapabilities2KHR struct
-        VkSurfaceKHR surface = pSurfaceInfo->surface;
-        if (NULL != icd_term->surface_list.list &&
+        VkSurfaceKHR surface = VK_NULL_HANDLE;
+        if (NULL != icd_surface && NULL != icd_term->surface_list.list &&
             icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
             icd_term->surface_list.list[icd_surface->surface_index]) {
             surface = icd_term->surface_list.list[icd_surface->surface_index];
@@ -2600,11 +2605,14 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormats2KHR(Vk
         return VK_SUCCESS;
     }
 
-    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)(pSurfaceInfo->surface);
+    VkIcdSurface *icd_surface = NULL;
+    if (VK_NULL_HANDLE != pSurfaceInfo->surface) {
+        icd_surface = (VkIcdSurface *)(uintptr_t)(pSurfaceInfo->surface);
+    }
 
     if (icd_term->dispatch.GetPhysicalDeviceSurfaceFormats2KHR != NULL) {
         // Pass the call to the driver, possibly unwrapping the ICD surface
-        if (NULL != icd_term->surface_list.list &&
+        if (NULL != icd_surface && NULL != icd_term->surface_list.list &&
             icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
             icd_term->surface_list.list[icd_surface->surface_index]) {
             VkPhysicalDeviceSurfaceInfo2KHR info_copy = *pSurfaceInfo;
@@ -2628,7 +2636,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormats2KHR(Vk
         }
 
         VkSurfaceKHR surface = pSurfaceInfo->surface;
-        if (NULL != icd_term->surface_list.list &&
+        if (NULL != icd_surface && NULL != icd_term->surface_list.list &&
             icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) &&
             icd_term->surface_list.list[icd_surface->surface_index]) {
             surface = icd_term->surface_list.list[icd_surface->surface_index];

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -1277,8 +1277,11 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     funcs += '    }\n'
 
                     if has_surface == 1:
-                        funcs += f'    VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t)({surface_var_name});\n'
-                        funcs += '    if (NULL != icd_term->surface_list.list && icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) && icd_term->surface_list[icd_surface->surface_index]) {\n'
+                        funcs += '    VkIcdSurface *icd_surface = NULL;\n'
+                        funcs += f'    if (NULL != {surface_var_name}) {{\n'
+                        funcs += f'        icd_surface = (VkIcdSurface *)(uintptr_t)({surface_var_name});\n'
+                        funcs += '    }\n'
+                        funcs += '    if (NULL != icd_surface && NULL != icd_term->surface_list.list && icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) && icd_term->surface_list[icd_surface->surface_index]) {\n'
 
                         # If there's a structure with a surface, we need to update its internals with the correct surface for the ICD
                         if update_structure_surface == 1:

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -140,7 +140,6 @@ void init_vulkan_functions(VulkanFunctions& funcs) {
     funcs.vkCreateWin32SurfaceKHR = GPA(vkCreateWin32SurfaceKHR);
     funcs.vkGetPhysicalDeviceWin32PresentationSupportKHR = GPA(vkGetPhysicalDeviceWin32PresentationSupportKHR);
 #endif  // VK_USE_PLATFORM_WIN32_KHR
-
     funcs.vkDestroyDevice = GPA(vkDestroyDevice);
     funcs.vkGetDeviceQueue = GPA(vkGetDeviceQueue);
 #undef GPA


### PR DESCRIPTION
Requires bypassing the logic which dereferences VkSurfaceKHR in
vkGetPhysicalDeviceSurfaceFormatsKHR and
vkGetPhysicalDeviceSurfacePresentModesKHR. This should have been done
closer to the release of VK_GOOGLE_surfaceless_query, but because that
extension was meant for Android, which isn't supported by this loader,
it was not done. That said, SwiftShader can support the extension, so
support is now being added in this commit.