### PR TITLE
Fix bug in wrap/unwrap physical device object

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5915,10 +5915,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
 
                     // Before calling down, replace the incoming physical device values (which are really loader terminator
                     // physical devices) with the ICDs physical device values.
-                    struct loader_physical_device_term *cur_term;
+                    struct loader_physical_device_tramp *cur_tramp;
                     for (uint32_t phys_dev = 0; phys_dev < cur_struct->physicalDeviceCount; phys_dev++) {
-                        cur_term = (struct loader_physical_device_term *)cur_struct->pPhysicalDevices[phys_dev];
-                        phys_dev_array[phys_dev] = cur_term->phys_dev;
+                        cur_tramp = (struct loader_physical_device_tramp *)cur_struct->pPhysicalDevices[phys_dev];
+                        phys_dev_array[phys_dev] = cur_tramp->phys_dev;
                     }
                     temp_struct->pPhysicalDevices = phys_dev_array;
 


### PR DESCRIPTION
The Vulkan loader wraps VKPhysicalDevice into a loader_physical_device_tramp structure and returns it to the application. This is done by the function setup_loader_tramp_phys_devs.
When the application passes a VKPhysicalDevice to the Vulkan loader, it is internally treated as a pointer of loader_physical_device_tramp. The loader then extracts the actual VKPhysicalDevice and forwards it to the ICD driver.

However, there is an issue in the function terminator_CreateDevice. Instead of converting the VKPhysicalDevice back into a loader_physical_device_tramp, it incorrectly converts it to a loader_physical_device_term.

This mismatch causes a crash in Vulkan CTS during the test case 'dEQP-VK.api.object_management.single.device_group'.