### PR TITLE
cmake: Update minimum version to 3.22.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
               if: ${{ matrix.os == 'ubuntu-20.04' }}
               uses: lukka/get-cmake@latest
               with:
-                cmakeVersion: 3.17.2
+                cmakeVersion: 3.22.1
             - run: sudo apt update
             - run: sudo apt install --yes --no-install-recommends libwayland-dev libxrandr-dev
             # This is to combat a bug when using 6.6 linux kernels with thread/address sanitizer
@@ -115,7 +115,7 @@ jobs:
                 python-version: '3.11'
             - uses: lukka/get-cmake@latest
               with:
-                cmakeVersion: 3.17.2
+                cmakeVersion: 3.22.1
             - name: Enable 32 bit
               run: sudo dpkg --add-architecture i386
             - run: sudo apt-get update
@@ -152,7 +152,7 @@ jobs:
                 python-version: '3.11'
             - uses: lukka/get-cmake@latest
               with:
-                cmakeVersion: 3.17.2
+                cmakeVersion: 3.22.1
             - name: Enable 32 bit
               run: sudo dpkg --add-architecture i386
             - run: sudo apt-get update

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,7 +77,7 @@ jobs:
     - uses: lukka/get-cmake@latest
       if: matrix.language == 'cpp'
       with:
-        cmakeVersion: 3.17.2
+        cmakeVersion: 3.22.1
     - name: Install Dependencies
       if: matrix.language == 'cpp'
       run: |

--- a/BUILD.md
+++ b/BUILD.md
@@ -81,7 +81,7 @@ indicated by *install_dir*:
 ## Build Requirements
 
 1. `C99` capable compiler
-2. `CMake` version 3.17.2 or greater
+2. `CMake` version 3.22.1 or greater
 3. `Git`
 
 ### Test Requirements
@@ -271,7 +271,7 @@ These variables should be set using the `-D` option when invoking CMake to gener
     - [2019](https://www.visualstudio.com/vs/older-downloads/)
   - The Community Edition of each of the above versions is sufficient, as
     well as any more capable edition.
-- [CMake 3.17.2](https://cmake.org/files/v3.17/cmake-3.17.2-win64-x64.zip) is recommended.
+- [CMake 3.22.1](https://cmake.org/files/v3.22.1/cmake-3.22.1-win64-x64.zip) is recommended.
   - Use the installer option to add CMake to the system PATH
 - Git Client Support
   - [Git for Windows](http://git-scm.com/download/win) is a popular solution
@@ -382,7 +382,7 @@ This repository has been built and tested on the two most recent Ubuntu LTS
 versions, although earlier versions may work.
 It is be straightforward to adapt this repository to other Linux distributions.
 
-[CMake 3.17.2](https://cmake.org/files/v3.17/cmake-3.17.2-Linux-x86_64.tar.gz) is recommended.
+[CMake 3.22.1](https://cmake.org/files/v3.22.1/cmake-3.22.1-Linux-x86_64.tar.gz) is recommended.
 
 #### Required Package List
 
@@ -561,7 +561,7 @@ Clone the Vulkan-Loader repository:
 
 ### MacOS build
 
-[CMake 3.17.2](https://cmake.org/files/v3.17/cmake-3.17.2-Darwin-x86_64.tar.gz) is recommended.
+[CMake 3.22.1](https://cmake.org/files/v3.22.1/cmake-3.22.1-Darwin-x86_64.tar.gz) is recommended.
 
 #### Building with the Unix Makefiles Generator
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ~~~
-cmake_minimum_required(VERSION 3.17.2)
+cmake_minimum_required(VERSION 3.22.1)
 
 project(VULKAN_LOADER VERSION 1.4.307 LANGUAGES C)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,11 +23,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Make sure tests uses the dynamic runtime instead
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
-# For MSVC/Windows, replace /GR with an empty string, this prevents warnings of /GR being overriden by /GR-
-# Newer CMake versions (3.20) have better solutions for this through policy - using the old
-# way while waiting for when updating can occur
-string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-
 if (IS_DIRECTORY "${GOOGLETEST_INSTALL_DIR}/googletest")
     set(BUILD_GTEST ON)
     set(BUILD_GMOCK OFF)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ~~~
-cmake_minimum_required(VERSION 3.17.2)
+cmake_minimum_required(VERSION 3.22.1)
 
 project(INTEGRATION LANGUAGES C)
 


### PR DESCRIPTION
Matches Vulkan Validation Layers and SPIRV-Tools.