### PR TITLE
Silence warnings for wrong manifest type

### DIFF
--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -697,7 +697,7 @@ void FrameworkEnvironment::add_layer_impl(TestLayerDetails layer_details, Manife
         }
 #if defined(_WIN32)
         if (layer_details.discovery_type == ManifestDiscoveryType::windows_app_package) {
-            platform_shim->set_app_package_path(layer_manifest_loc);
+            platform_shim->set_app_package_path(folder.location());
         }
 #endif
         for (size_t i = new_layers_start; i < layers.size(); i++) {


### PR DESCRIPTION
If the loader happens upon a layer/ICD manifest while searching for manifests of the opposite type, do not emit warnings. These are spurious and only cause users to think something is wrong with the installation when it is actually fine.