### PR TITLE
Prepend [Vulkan Loader] to stderr log output 

### DIFF
--- a/docs/LoaderDebugging.md
+++ b/docs/LoaderDebugging.md
@@ -99,57 +99,59 @@ For example, the output of the loader looking for implicit layers may look like
 the following:
 
 ```
-LAYER: Searching for layer manifest files
-LAYER:  In following locations:
-LAYER:   /home/${USER}/.config/vulkan/implicit_layer.d
-LAYER:   /etc/xdg/vulkan/implicit_layer.d
-LAYER:   /usr/local/etc/vulkan/implicit_layer.d
-LAYER:   /etc/vulkan/implicit_layer.d
-LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d
-LAYER:   /home/${USER}/.local/share/flatpak/exports/share/vulkan/implicit_layer.d
-LAYER:   /var/lib/flatpak/exports/share/vulkan/implicit_layer.d
-LAYER:   /usr/local/share/vulkan/implicit_layer.d
-LAYER:   /usr/share/vulkan/implicit_layer.d
-LAYER:  Found the following files:
-LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d/renderdoc_capture.json
-LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d/steamfossilize_i386.json
-LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d/steamfossilize_x86_64.json
-LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d/steamoverlay_i386.json
-LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d/steamoverlay_x86_64.json
-LAYER:   /usr/share/vulkan/implicit_layer.d/nvidia_layers.json
-LAYER:   /usr/share/vulkan/implicit_layer.d/VkLayer_MESA_device_select.json
+[Vulkan Loader] LAYER: Searching for implicit layer manifest files
+[Vulkan Loader] LAYER:  In following locations:
+[Vulkan Loader] LAYER:   /home/${USER}/.config/vulkan/implicit_layer.d
+[Vulkan Loader] LAYER:   /etc/xdg/vulkan/implicit_layer.d
+[Vulkan Loader] LAYER:   /usr/local/etc/vulkan/implicit_layer.d
+[Vulkan Loader] LAYER:   /etc/vulkan/implicit_layer.d
+[Vulkan Loader] LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d
+[Vulkan Loader] LAYER:   /home/${USER}/.local/share/flatpak/exports/share/vulkan/implicit_layer.d
+[Vulkan Loader] LAYER:   /var/lib/flatpak/exports/share/vulkan/implicit_layer.d
+[Vulkan Loader] LAYER:   /usr/local/share/vulkan/implicit_layer.d
+[Vulkan Loader] LAYER:   /usr/share/vulkan/implicit_layer.d
+[Vulkan Loader] LAYER:  Found the following files:
+[Vulkan Loader] LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d/renderdoc_capture.json
+[Vulkan Loader] LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d/steamfossilize_i386.json
+[Vulkan Loader] LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d/steamfossilize_x86_64.json
+[Vulkan Loader] LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d/steamoverlay_i386.json
+[Vulkan Loader] LAYER:   /home/${USER}/.local/share/vulkan/implicit_layer.d/steamoverlay_x86_64.json
+[Vulkan Loader] LAYER:   /usr/share/vulkan/implicit_layer.d/nvidia_layers.json
+[Vulkan Loader] LAYER:   /usr/share/vulkan/implicit_layer.d/VkLayer_MESA_device_select.json
 ```
 
 Then, the loading of layer libraries is reported similar to this:
 
 ```
-LAYER | DEBUG: Loading layer library libVkLayer_khronos_validation.so
-LAYER | INFO: Insert instance layer VK_LAYER_KHRONOS_validation (libVkLayer_khronos_validation.so)
-LAYER | DEBUG: Loading layer library libVkLayer_MESA_device_select.so
-LAYER | INFO: Insert instance layer VK_LAYER_MESA_device_select (libVkLayer_MESA_device_select.so)
+[Vulkan Loader] DEBUG | LAYER : Loading layer library libVkLayer_khronos_validation.so
+[Vulkan Loader] INFO | LAYER : Insert instance layer VK_LAYER_KHRONOS_validation (libVkLayer_khronos_validation.so)
+[Vulkan Loader] DEBUG | LAYER : Loading layer library libVkLayer_MESA_device_select.so
+[Vulkan Loader] INFO | LAYER : Insert instance layer VK_LAYER_MESA_device_select (libVkLayer_MESA_device_select.so)
 ```
 
 Finally, when the Vulkan instance is created, you can see the full instance
 call-chain from a functional standpoint with output like this:
 
 ```
-LAYER: vkCreateInstance layer callstack setup to:
-LAYER:  <Application>
-LAYER:    ||
-LAYER:  <Loader>
-LAYER:    ||
-LAYER:  VK_LAYER_MESA_device_select
-LAYER:      Type: Implicit
-LAYER:         Disable Env Var:  NODEVICE_SELECT
-LAYER:      Manifest: /usr/share/vulkan/implicit_layer.d/VkLayer_MESA_device_select.json
-LAYER:      Library:  libVkLayer_MESA_device_select.so
-LAYER:    ||
-LAYER:  VK_LAYER_KHRONOS_validation
-LAYER:      Type: Explicit
-LAYER:      Manifest: /usr/share/vulkan/explicit_layer.d/VkLayer_khronos_validation.json
-LAYER:      Library:  libVkLayer_khronos_validation.so
-LAYER:    ||
-LAYER:  <Drivers>
+[Vulkan Loader] LAYER: vkCreateInstance layer callstack setup to:
+[Vulkan Loader] LAYER:  <Application>
+[Vulkan Loader] LAYER:    ||
+[Vulkan Loader] LAYER:  <Loader>
+[Vulkan Loader] LAYER:    ||
+[Vulkan Loader] LAYER:  VK_LAYER_MESA_device_select
+[Vulkan Loader] LAYER:      Type: Implicit
+[Vulkan Loader] LAYER:      Enabled By: Implicit Layer
+[Vulkan Loader] LAYER:         Disable Env Var:  NODEVICE_SELECT
+[Vulkan Loader] LAYER:      Manifest: /usr/share/vulkan/implicit_layer.d/VkLayer_MESA_device_select.json
+[Vulkan Loader] LAYER:      Library:  libVkLayer_MESA_device_select.so
+[Vulkan Loader] LAYER:    ||
+[Vulkan Loader] LAYER:  VK_LAYER_KHRONOS_validation
+[Vulkan Loader] LAYER:      Type: Explicit
+[Vulkan Loader] LAYER:      Enabled By: By the Application
+[Vulkan Loader] LAYER:      Manifest: /usr/share/vulkan/explicit_layer.d/VkLayer_khronos_validation.json
+[Vulkan Loader] LAYER:      Library:  libVkLayer_khronos_validation.so
+[Vulkan Loader] LAYER:    ||
+[Vulkan Loader] LAYER:  <Drivers>
 ```
 
 In this scenario, two layers were used (the same two that were loaded earlier):
@@ -186,9 +188,9 @@ This will disable all implicit layers and the loader will report any disabled
 layers to the logging output when layer logging is enabled in the following way:
 
 ```
-WARNING | LAYER:  Implicit layer "VK_LAYER_MESA_device_select" forced disabled because name matches filter of env var 'VK_LOADER_LAYERS_DISABLE'.
-WARNING | LAYER:  Implicit layer "VK_LAYER_AMD_switchable_graphics_64" forced disabled because name matches filter of env var 'VK_LOADER_LAYERS_DISABLE'.
-WARNING | LAYER:  Implicit layer "VK_LAYER_Twitch_Overlay" forced disabled because name matches filter of env var 'VK_LOADER_LAYERS_DISABLE'.
+[Vulkan Loader] WARNING | LAYER:  Implicit layer "VK_LAYER_MESA_device_select" forced disabled because name matches filter of env var 'VK_LOADER_LAYERS_DISABLE'.
+[Vulkan Loader] WARNING | LAYER:  Implicit layer "VK_LAYER_AMD_switchable_graphics_64" forced disabled because name matches filter of env var 'VK_LOADER_LAYERS_DISABLE'.
+[Vulkan Loader] WARNING | LAYER:  Implicit layer "VK_LAYER_Twitch_Overlay" forced disabled because name matches filter of env var 'VK_LOADER_LAYERS_DISABLE'.
 ```
 
 ### Selectively Re-enable Layers
@@ -283,34 +285,34 @@ look like the following (NOTE: additional spaces have been removed from the
 output for easier reading):
 
 ```
-DRIVER: Searching for driver manifest files
-DRIVER:    In following folders:
-DRIVER:       /home/$(USER)/.config/vulkan/icd.d
-DRIVER:       /etc/xdg/vulkan/icd.d
-DRIVER:       /etc/vulkan/icd.d
-DRIVER:       /home/$(USER)/.local/share/vulkan/icd.d
-DRIVER:       /home/$(USER)/.local/share/flatpak/exports/share/vulkan/icd.d
-DRIVER:       /var/lib/flatpak/exports/share/vulkan/icd.d
-DRIVER:       /usr/local/share/vulkan/icd.d
-DRIVER:       /usr/share/vulkan/icd.d
-DRIVER:    Found the following files:
-DRIVER:       /usr/share/vulkan/icd.d/intel_icd.x86_64.json
-DRIVER:       /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
-DRIVER:       /usr/share/vulkan/icd.d/radeon_icd.x86_64.json
-DRIVER:       /usr/share/vulkan/icd.d/lvp_icd.i686.json
-DRIVER:       /usr/share/vulkan/icd.d/radeon_icd.i686.json
-DRIVER:       /usr/share/vulkan/icd.d/intel_icd.i686.json
-DRIVER:       /usr/share/vulkan/icd.d/nvidia_icd.json
-DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/intel_icd.x86_64.json, version "1.0.0"
-DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/lvp_icd.x86_64.json, version "1.0.0"
-DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/radeon_icd.x86_64.json, version "1.0.0"
-DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/lvp_icd.i686.json, version "1.0.0"
-DRIVER: Requested driver /usr/lib/libvulkan_lvp.so was wrong bit-type. Ignoring this JSON
-DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/radeon_icd.i686.json, version "1.0.0"
-DRIVER: Requested driver /usr/lib/libvulkan_radeon.so was wrong bit-type. Ignoring this JSON
-DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/intel_icd.i686.json, version "1.0.0"
-DRIVER: Requested driver /usr/lib/libvulkan_intel.so was wrong bit-type. Ignoring this JSON
-DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/nvidia_icd.json, version "1.0.0"
+[Vulkan Loader] DRIVER: Searching for driver manifest files
+[Vulkan Loader] DRIVER:    In following folders:
+[Vulkan Loader] DRIVER:       /home/$(USER)/.config/vulkan/icd.d
+[Vulkan Loader] DRIVER:       /etc/xdg/vulkan/icd.d
+[Vulkan Loader] DRIVER:       /etc/vulkan/icd.d
+[Vulkan Loader] DRIVER:       /home/$(USER)/.local/share/vulkan/icd.d
+[Vulkan Loader] DRIVER:       /home/$(USER)/.local/share/flatpak/exports/share/vulkan/icd.d
+[Vulkan Loader] DRIVER:       /var/lib/flatpak/exports/share/vulkan/icd.d
+[Vulkan Loader] DRIVER:       /usr/local/share/vulkan/icd.d
+[Vulkan Loader] DRIVER:       /usr/share/vulkan/icd.d
+[Vulkan Loader] DRIVER:    Found the following files:
+[Vulkan Loader] DRIVER:       /usr/share/vulkan/icd.d/intel_icd.x86_64.json
+[Vulkan Loader] DRIVER:       /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
+[Vulkan Loader] DRIVER:       /usr/share/vulkan/icd.d/radeon_icd.x86_64.json
+[Vulkan Loader] DRIVER:       /usr/share/vulkan/icd.d/lvp_icd.i686.json
+[Vulkan Loader] DRIVER:       /usr/share/vulkan/icd.d/radeon_icd.i686.json
+[Vulkan Loader] DRIVER:       /usr/share/vulkan/icd.d/intel_icd.i686.json
+[Vulkan Loader] DRIVER:       /usr/share/vulkan/icd.d/nvidia_icd.json
+[Vulkan Loader] DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/intel_icd.x86_64.json, version "1.0.0"
+[Vulkan Loader] DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/lvp_icd.x86_64.json, version "1.0.0"
+[Vulkan Loader] DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/radeon_icd.x86_64.json, version "1.0.0"
+[Vulkan Loader] DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/lvp_icd.i686.json, version "1.0.0"
+[Vulkan Loader] DRIVER: Requested driver /usr/lib/libvulkan_lvp.so was wrong bit-type. Ignoring this JSON
+[Vulkan Loader] DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/radeon_icd.i686.json, version "1.0.0"
+[Vulkan Loader] DRIVER: Requested driver /usr/lib/libvulkan_radeon.so was wrong bit-type. Ignoring this JSON
+[Vulkan Loader] DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/intel_icd.i686.json, version "1.0.0"
+[Vulkan Loader] DRIVER: Requested driver /usr/lib/libvulkan_intel.so was wrong bit-type. Ignoring this JSON
+[Vulkan Loader] DRIVER: Found ICD manifest file /usr/share/vulkan/icd.d/nvidia_icd.json, version "1.0.0"
 ```
 
 Then when the application selects the device to use, you will see the Vulkan
@@ -318,13 +320,13 @@ device call chain reported in the following way (NOTE: additional spaces have
 been removed from the output for easier reading):
 
 ```
-DRIVER: vkCreateDevice layer callstack setup to:
-DRIVER:    <Application>
-DRIVER:      ||
-DRIVER:    <Loader>
-DRIVER:      ||
-DRIVER:    <Device>
-DRIVER:        Using "Intel(R) UHD Graphics 630 (CFL GT2)" with driver: "/usr/lib64/libvulkan_intel.so"
+[Vulkan Loader] DRIVER: vkCreateDevice layer callstack setup to:
+[Vulkan Loader] DRIVER:    <Application>
+[Vulkan Loader] DRIVER:      ||
+[Vulkan Loader] DRIVER:    <Loader>
+[Vulkan Loader] DRIVER:      ||
+[Vulkan Loader] DRIVER:    <Device>
+[Vulkan Loader] DRIVER:        Using "Intel(R) UHD Graphics 630 (CFL GT2)" with driver: "/usr/lib64/libvulkan_intel.so"
 ```
 
 
@@ -351,8 +353,8 @@ The loader outputs messages like the following when the environment variables
 are used:
 
 ```
-WARNING | DRIVER: Driver "intel_icd.x86_64.json" ignored because not selected by env var 'VK_LOADER_DRIVERS_SELECT'
-WARNING | DRIVER: Driver "radeon_icd.x86_64.json" ignored because it was disabled by env var 'VK_LOADER_DRIVERS_DISABLE'
+[Vulkan Loader] WARNING | DRIVER: Driver "intel_icd.x86_64.json" ignored because not selected by env var 'VK_LOADER_DRIVERS_SELECT'
+[Vulkan Loader] WARNING | DRIVER: Driver "radeon_icd.x86_64.json" ignored because it was disabled by env var 'VK_LOADER_DRIVERS_DISABLE'
 ```
 
 For more info on how to use the filtering environment variables, refer to the

--- a/docs/LoaderDriverInterface.md
+++ b/docs/LoaderDriverInterface.md
@@ -172,7 +172,7 @@ message will show for each driver that has been ignored.
 This message will look like the following:
 
 ```
-WARNING | DRIVER: Driver "intel_icd.x86_64.json" ignored because not selected by env var 'VK_LOADER_DRIVERS_SELECT'
+[Vulkan Loader] WARNING | DRIVER: Driver "intel_icd.x86_64.json" ignored because not selected by env var 'VK_LOADER_DRIVERS_SELECT'
 ```
 
 If no drivers are found with a manifest filename that matches any of the
@@ -190,7 +190,7 @@ will show for each driver that has been forcibly disabled.
 This message will look like the following:
 
 ```
-WARNING | DRIVER: Driver "radeon_icd.x86_64.json" ignored because it was disabled by env var 'VK_LOADER_DRIVERS_DISABLE'
+[Vulkan Loader] WARNING | DRIVER: Driver "radeon_icd.x86_64.json" ignored because it was disabled by env var 'VK_LOADER_DRIVERS_DISABLE'
 ```
 
 If no drivers are found with a manifest filename that matches any of the

--- a/docs/LoaderLayerInterface.md
+++ b/docs/LoaderLayerInterface.md
@@ -486,7 +486,7 @@ will show for each layer that has been forced on.
 This message will look like the following:
 
 ```
-WARNING | LAYER:  Layer "VK_LAYER_LUNARG_wrap_objects" force enabled due to env var 'VK_LOADER_LAYERS_ENABLE'
+[Vulkan Loader] WARNING | LAYER:  Layer "VK_LAYER_LUNARG_wrap_objects" force enabled due to env var 'VK_LOADER_LAYERS_ENABLE'
 ```
 
 #### Layer Disable Filtering
@@ -508,7 +508,7 @@ will show for each layer that has been forcibly disabled.
 This message will look like the following:
 
 ```
-WARNING | LAYER:  Layer "VK_LAYER_LUNARG_wrap_objects" disabled because name matches filter of env var 'VK_LOADER_LAYERS_DISABLE'
+[Vulkan Loader] WARNING | LAYER:  Layer "VK_LAYER_LUNARG_wrap_objects" disabled because name matches filter of env var 'VK_LOADER_LAYERS_DISABLE'
 ```
 
 #### Layer Special Case Disable

--- a/loader/log.h
+++ b/loader/log.h
@@ -54,9 +54,8 @@ void loader_init_global_debug_level(void);
 // Sets the global debug level - used by global settings files
 void loader_set_global_debug_level(uint32_t new_loader_debug);
 
-// Writes a stringified version of enum vulkan_loader_debug_flags into cmd_line_msg, and writes the number of characters written in
-// num_used
-void generate_debug_flag_str(VkFlags msg_type, size_t cmd_line_size, char *cmd_line_msg, size_t *num_used);
+// Writes a stringified version of enum vulkan_loader_debug_flags into a char array cmd_line_msg of length cmd_line_size
+void generate_debug_flag_str(VkFlags msg_type, size_t cmd_line_size, char *cmd_line_msg);
 
 // The asm declaration prevents name mangling which is necessary for macOS
 #if defined(MODIFY_UNKNOWN_FUNCTION_DECLS)

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -279,14 +279,13 @@ void log_settings(const struct loader_instance* inst, loader_settings* settings)
     loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "Using layer configurations found in loader settings from %s",
                settings->settings_file_path);
 
-    char cmd_line_msg[64];
+    char cmd_line_msg[64] = {0};
     size_t cmd_line_size = sizeof(cmd_line_msg);
-    size_t num_used = 0;
 
     cmd_line_msg[0] = '\0';
 
-    generate_debug_flag_str(settings->debug_level, cmd_line_size, cmd_line_msg, &num_used);
-    if (num_used > 0) {
+    generate_debug_flag_str(settings->debug_level, cmd_line_size, cmd_line_msg);
+    if (strlen(cmd_line_msg)) {
         loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Loader Settings Filters for Logging to Standard Error: %s", cmd_line_msg);
     }
 

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -2377,25 +2377,27 @@ TEST(SettingsFile, StderrLogFilters) {
                 LoaderSettingsLayerConfiguration{}.set_name("VK_LAYER_missing").set_path("/road/to/nowhere").set_control("on"))));
 
     std::string expected_output_verbose;
-    expected_output_verbose += "DEBUG:             Layer Configurations count = 2\n";
-    expected_output_verbose += "DEBUG:             ---- Layer Configuration [0] ----\n";
-    expected_output_verbose += std::string("DEBUG:             Name: ") + explicit_layer_name + "\n";
-    expected_output_verbose += "DEBUG:             Path: " + env.get_shimmed_layer_manifest_path().string() + "\n";
-    expected_output_verbose += "DEBUG:             Layer Type: Explicit\n";
-    expected_output_verbose += "DEBUG:             Control: on\n";
-    expected_output_verbose += "DEBUG:             ---- Layer Configuration [1] ----\n";
-    expected_output_verbose += "DEBUG:             Name: VK_LAYER_missing\n";
-    expected_output_verbose += "DEBUG:             Path: /road/to/nowhere\n";
-    expected_output_verbose += "DEBUG:             Layer Type: Explicit\n";
-    expected_output_verbose += "DEBUG:             Control: on\n";
-    expected_output_verbose += "DEBUG:             ---------------------------------\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Layer Configurations count = 2\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          ---- Layer Configuration [0] ----\n";
+    expected_output_verbose += std::string("[Vulkan Loader] DEBUG:          Name: ") + explicit_layer_name + "\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Path: " + env.get_shimmed_layer_manifest_path().string() + "\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Layer Type: Explicit\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Control: on\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          ---- Layer Configuration [1] ----\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Name: VK_LAYER_missing\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Path: /road/to/nowhere\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Layer Type: Explicit\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Control: on\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          ---------------------------------\n";
 
-    std::string expected_output_info = std::string("INFO:              ") + get_settings_location_log_message(env) + "\n";
+    std::string expected_output_info =
+        std::string("[Vulkan Loader] INFO:           ") + get_settings_location_log_message(env) + "\n";
 
-    std::string expected_output_warning = "WARNING:           Layer name " + std::string(explicit_layer_name) +
+    std::string expected_output_warning = "[Vulkan Loader] WARNING:        Layer name " + std::string(explicit_layer_name) +
                                           " does not conform to naming standard (Policy #LLP_LAYER_3)\n";
 
-    std::string expected_output_error = "ERROR:             loader_get_json: Failed to open JSON file /road/to/nowhere\n";
+    std::string expected_output_error =
+        "[Vulkan Loader] ERROR:          loader_get_json: Failed to open JSON file /road/to/nowhere\n";
 
     env.loader_settings.app_specific_settings.at(0).stderr_log = {"all"};
     env.update_loader_settings(env.loader_settings);
@@ -2403,9 +2405,9 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
-        ASSERT_TRUE(
-            env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error: ERROR | "
-                                           "WARNING | INFO | DEBUG | PERF | DRIVER | LAYER\n"));
+        ASSERT_TRUE(env.platform_shim->find_in_log(
+            "[Vulkan Loader] DEBUG:          Loader Settings Filters for Logging to Standard Error: ERROR | "
+            "WARNING | INFO | DEBUG | PERF | DRIVER | LAYER\n"));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2420,8 +2422,9 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
-        ASSERT_TRUE(env.platform_shim->find_in_log(
-            "DEBUG:             Loader Settings Filters for Logging to Standard Error: ERROR | WARNING | INFO | DEBUG\n"));
+        ASSERT_TRUE(
+            env.platform_shim->find_in_log("[Vulkan Loader] DEBUG:          Loader Settings Filters for Logging to Standard "
+                                           "Error: ERROR | WARNING | INFO | DEBUG\n"));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2437,7 +2440,7 @@ TEST(SettingsFile, StderrLogFilters) {
         inst.CheckCreate();
 
         ASSERT_TRUE(env.platform_shim->find_in_log(
-            "DEBUG:             Loader Settings Filters for Logging to Standard Error: WARNING | INFO | DEBUG\n"));
+            "[Vulkan Loader] DEBUG:          Loader Settings Filters for Logging to Standard Error: WARNING | INFO | DEBUG\n"));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2452,8 +2455,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
-        ASSERT_TRUE(
-            env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error: DEBUG\n"));
+        ASSERT_TRUE(env.platform_shim->find_in_log(
+            "[Vulkan Loader] DEBUG:          Loader Settings Filters for Logging to Standard Error: DEBUG\n"));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2468,8 +2471,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
-        ASSERT_FALSE(
-            env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error: INFO\n"));
+        ASSERT_FALSE(env.platform_shim->find_in_log(
+            "[Vulkan Loader] DEBUG:          Loader Settings Filters for Logging to Standard Error: INFO\n"));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2484,8 +2487,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
-        ASSERT_FALSE(
-            env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error: WARNING\n"));
+        ASSERT_FALSE(env.platform_shim->find_in_log(
+            "[Vulkan Loader] DEBUG:          Loader Settings Filters for Logging to Standard Error: WARNING\n"));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_TRUE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2500,8 +2503,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
-        ASSERT_FALSE(
-            env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error: ERROR\n"));
+        ASSERT_FALSE(env.platform_shim->find_in_log(
+            "[Vulkan Loader] DEBUG:          Loader Settings Filters for Logging to Standard Error: ERROR\n"));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2516,7 +2519,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
-        ASSERT_FALSE(env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error:"));
+        ASSERT_FALSE(env.platform_shim->find_in_log(
+            "[Vulkan Loader] DEBUG:          Loader Settings Filters for Logging to Standard Error:"));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2531,7 +2535,8 @@ TEST(SettingsFile, StderrLogFilters) {
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
 
-        ASSERT_FALSE(env.platform_shim->find_in_log("DEBUG:             Loader Settings Filters for Logging to Standard Error:"));
+        ASSERT_FALSE(env.platform_shim->find_in_log(
+            "[Vulkan Loader] DEBUG:          Loader Settings Filters for Logging to Standard Error:"));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_verbose));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_info));
         ASSERT_FALSE(env.platform_shim->find_in_log(expected_output_warning));
@@ -2653,25 +2658,27 @@ TEST(SettingsFile, NoStderr_log_but_VK_LOADER_DEBUG) {
     env.update_loader_settings(env.loader_settings);
 
     std::string expected_output_verbose;
-    expected_output_verbose += "DEBUG:             Layer Configurations count = 2\n";
-    expected_output_verbose += "DEBUG:             ---- Layer Configuration [0] ----\n";
-    expected_output_verbose += std::string("DEBUG:             Name: ") + explicit_layer_name + "\n";
-    expected_output_verbose += "DEBUG:             Path: " + env.get_shimmed_layer_manifest_path().string() + "\n";
-    expected_output_verbose += "DEBUG:             Layer Type: Explicit\n";
-    expected_output_verbose += "DEBUG:             Control: auto\n";
-    expected_output_verbose += "DEBUG:             ---- Layer Configuration [1] ----\n";
-    expected_output_verbose += "DEBUG:             Name: VK_LAYER_missing\n";
-    expected_output_verbose += "DEBUG:             Path: /road/to/nowhere\n";
-    expected_output_verbose += "DEBUG:             Layer Type: Explicit\n";
-    expected_output_verbose += "DEBUG:             Control: auto\n";
-    expected_output_verbose += "DEBUG:             ---------------------------------\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Layer Configurations count = 2\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          ---- Layer Configuration [0] ----\n";
+    expected_output_verbose += std::string("[Vulkan Loader] DEBUG:          Name: ") + explicit_layer_name + "\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Path: " + env.get_shimmed_layer_manifest_path().string() + "\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Layer Type: Explicit\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Control: auto\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          ---- Layer Configuration [1] ----\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Name: VK_LAYER_missing\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Path: /road/to/nowhere\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Layer Type: Explicit\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Control: auto\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          ---------------------------------\n";
 
-    std::string expected_output_info = std::string("INFO:              ") + get_settings_location_log_message(env) + "\n";
+    std::string expected_output_info =
+        std::string("[Vulkan Loader] INFO:           ") + get_settings_location_log_message(env) + "\n";
 
     std::string expected_output_warning =
-        "WARNING:           Layer name Regular_TestLayer1 does not conform to naming standard (Policy #LLP_LAYER_3)\n";
+        "[Vulkan Loader] WARNING:        Layer name Regular_TestLayer1 does not conform to naming standard (Policy #LLP_LAYER_3)\n";
 
-    std::string expected_output_error = "ERROR:             loader_get_json: Failed to open JSON file /road/to/nowhere\n";
+    std::string expected_output_error =
+        "[Vulkan Loader] ERROR:          loader_get_json: Failed to open JSON file /road/to/nowhere\n";
 
     env.platform_shim->clear_logs();
     {


### PR DESCRIPTION
This makes it clear *who* is creating log messages, which wasn't as clear
before.

This branch refactors the logging code to be easier to understand.

Also, updates docs to reflect changes in log output.

Example output with changes:
```
[Vulkan Loader] INFO:           Vulkan Loader Version 1.4.307
[Vulkan Loader] INFO:           [Vulkan Loader Git - Tag: improve_debug_log_messages, Branch/Commit: v1.4.307-6-gd9c615ac8]
[Vulkan Loader] INFO:           No valid vk_loader_settings.json file found, no loader settings will be active
[Vulkan Loader] INFO:           Found manifest file /etc/vulkan/implicit_layer.d/renderdoc_capture.json (file version 1.1.2)
```