### PR TITLE
loader: Explicitly specify argument types

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2003,7 +2003,7 @@ void loader_initialize(void) {
 #endif
 }
 
-void loader_release() {
+void loader_release(void) {
     // Guarantee release of the preloaded ICD libraries. This may have already been called in vkDestroyInstance.
     loader_unload_preloaded_icds();
 

--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -38,7 +38,7 @@
 // Environment variables
 #if COMMON_UNIX_PLATFORMS
 
-bool is_high_integrity() { return geteuid() != getuid() || getegid() != getgid(); }
+bool is_high_integrity(void) { return geteuid() != getuid() || getegid() != getgid(); }
 
 char *loader_getenv(const char *name, const struct loader_instance *inst) {
     if (NULL == name) return NULL;

--- a/loader/loader_environment.h
+++ b/loader/loader_environment.h
@@ -37,7 +37,7 @@ void loader_free_getenv(char *val, const struct loader_instance *inst);
 
 #if defined(WIN32) || COMMON_UNIX_PLATFORMS
 
-bool is_high_integrity();
+bool is_high_integrity(void);
 
 char *loader_secure_getenv(const char *name, const struct loader_instance *inst);
 


### PR DESCRIPTION
Function definitions / declarations without specifying the argument types are deprecated in all C versions and may trigger compiler warnings (-Wstrict-prototypes).

This change replaces all `function()` definitions and declarations with `function(void)`.

Test: Vulkan-Loader builds on Fuchsia with Wstrict-prototypes enabled.

Bug: https://fxbug.dev/378964821
