### PR TITLE
loader: Use "const char*" for string literals

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3126,8 +3126,8 @@ VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enu
     char *cur_path_ptr = NULL;
     bool use_first_found_manifest = false;
 #if COMMON_UNIX_PLATFORMS
-    char *relative_location = NULL;  // Only used on unix platforms
-    size_t rel_size = 0;             // unused in windows, dont declare so no compiler warnings are generated
+    const char *relative_location = NULL;  // Only used on unix platforms
+    size_t rel_size = 0;                   // unused in windows, dont declare so no compiler warnings are generated
 #endif
 
 #if defined(_WIN32)

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -207,7 +207,8 @@ out:
     return res;
 }
 
-VkResult check_if_settings_path_exists(const struct loader_instance* inst, char* base, char* suffix, char** settings_file_path) {
+VkResult check_if_settings_path_exists(const struct loader_instance* inst, const char* base, const char* suffix,
+                                       char** settings_file_path) {
     if (NULL == base || NULL == suffix) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }


### PR DESCRIPTION
Previously in the loader code, there were some function arguments and variables of `char *` type that stores string literals. This triggers compiler warnings when `-Wwrite-strings` is enabled (which is enabled by default if compiling C++).

This change replaces `char*` with `const char*` for such variables and arguments.

Bug: https://fxbug.dev/378964821
