### PR TITLE
build: Fix Chromium-specific configs in BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -260,8 +260,10 @@ if (!is_android) {
       frameworks = [ "CoreFoundation.framework" ]
     }
     public_deps = [ "$vulkan_headers_dir:vulkan_headers" ]
-    configs -= [ "//build/config/compiler:chromium_code" ]
-    configs += [ "//build/config/compiler:no_chromium_code" ]
+    if (build_with_chromium) {
+      configs -= [ "//build/config/compiler:chromium_code" ]
+      configs += [ "//build/config/compiler:no_chromium_code" ]
+    }
     configs += [ ":vulkan_internal_config" ]
     public_configs = [ ":vulkan_loader_config" ]
     configs -= vulkan_undefine_configs


### PR DESCRIPTION
`chromium_code` and `no_chromium_code` are GN config targets defined in the chromium repository. Non-Chromium GN builds don't have these targets and GN will fail parsing them.

This change modifies Chromium-specific configs so that they are only applied on Chromium builds.

Test: Vulkan-Loader builds on Fuchsia (also with other changes)
Bug: https://fxbug.dev/378964821
