### PR TITLE
gn: Add _GNU_SOURCE definition to Linux builds

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -81,8 +81,11 @@ config("vulkan_loader_config") {
     cflags = [ "/wd4201" ]
   }
   if (is_linux || is_chromeos) {
-    # assume secure_getenv() is available
     defines += [
+      # Enables `readlink()` and `strtok_r()`.
+      "_GNU_SOURCE",
+
+      # assume secure_getenv() is available
       "HAVE_SECURE_GETENV",
       "LOADER_ENABLE_LINUX_SORT",
     ]


### PR DESCRIPTION
On GN-based linux-x64 builds, with the _GNU_SOURCE definition, the compiler will now have readlink() and strtok_r() declared.

This is consistent with the build configurations defined in loader/CMakeLists.txt.
