### PR TITLE
gn: Disable function UBsan check to support new vulkan.hpp function pointers

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -77,8 +77,9 @@ config("vulkan_loader_config") {
     "LOADER_USE_UNSAFE_FILE_SEARCH=1",
   ]
 
+  cflags = []
   if (is_win) {
-    cflags = [ "/wd4201" ]
+    cflags += [ "/wd4201" ]
   }
   if (is_linux || is_chromeos) {
     defines += [
@@ -89,6 +90,18 @@ config("vulkan_loader_config") {
       "HAVE_SECURE_GETENV",
       "LOADER_ENABLE_LINUX_SORT",
     ]
+  }
+  if (is_clang) {
+    # Vulkan-Hpp uses `vk::PFN_...` function pointer types, which are different
+    # from the C-styled `PFN_...` function pointers.
+    # 
+    # These types are guaranteed to be identical during Vulkan-Hpp compile time.
+    # However, UBsan's function sanitizer treats them as different types and
+    # triggers a runtime error when these functions are called.
+    #
+    # Thus, we need to disable the function sanitizer so that Vulkan
+    # applications created using Vulkan-Hpp can run correctly.
+    cflags += [ "-fno-sanitize=function" ]
   }
 }
 


### PR DESCRIPTION
KhronosGroup/Vulkan-Hpp#2020 added `vk::PFN_...` function pointer types as the preferred function pointers used in vulkan.hpp structs and functions.

These function pointer types use C++-styled types for the function arguments and return values, so the compiler treats them as types different from the C-styled "PFN_...` function pointers types. Vulkan-Hpp guarantees that they are binary identical during compile time, but UBsan's function sanitizer trigger a "function pointer type different" runtime error when these function pointers are invoked in the Vulkan-Loader (for example, debug_utils.c and allocation.c) -- see KhronosGroup/Vulkan-Hpp#2082 for example.

This change disables the function sanitizer from the Vulkan-Loader (where the function pointers are invoked) so that Vulkan applications created using Vulkan-Hpp can run correctly when UBsan is enabled.

Test: Vulkan example [vkcontext](https://fuchsia.googlesource.com/fuchsia/+/main/src/graphics/tests/common/test_vkcontext.cc) with change  https://fuchsia-review.googlesource.com/c/fuchsia/+/1208145 didn't crash on Fuchsia core.x64-asan build.

Bug: https://fxbug.dev/378964821
