### PR TITLE
Refactor codegen scripts to use vulkan_object.py

### DIFF
--- a/loader/generated/vk_layer_dispatch_table.h
+++ b/loader/generated/vk_layer_dispatch_table.h
@@ -2,9 +2,9 @@
 // See loader_extension_generator.py for modifications
 
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) 2023-2023 RasterGrid Kft.
  *
@@ -22,6 +22,7 @@
  *
  * Author: Mark Lobodzinski <mark@lunarg.com>
  * Author: Mark Young <marky@lunarg.com>
+ * Author: Charles Giessen <charles@lunarg.com>
  */
 
 // clang-format off
@@ -858,7 +859,11 @@ typedef struct VkLayerDispatchTable_ {
     PFN_vkCmdCopyAccelerationStructureNV CmdCopyAccelerationStructureNV;
     PFN_vkCmdTraceRaysNV CmdTraceRaysNV;
     PFN_vkCreateRayTracingPipelinesNV CreateRayTracingPipelinesNV;
+
+    // ---- VK_KHR_ray_tracing_pipeline extension commands
     PFN_vkGetRayTracingShaderGroupHandlesKHR GetRayTracingShaderGroupHandlesKHR;
+
+    // ---- VK_NV_ray_tracing extension commands
     PFN_vkGetRayTracingShaderGroupHandlesNV GetRayTracingShaderGroupHandlesNV;
     PFN_vkGetAccelerationStructureHandleNV GetAccelerationStructureHandleNV;
     PFN_vkCmdWriteAccelerationStructuresPropertiesNV CmdWriteAccelerationStructuresPropertiesNV;

--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -2,9 +2,9 @@
 // See loader_extension_generator.py for modifications
 
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) 2023-2023 RasterGrid Kft.
  *
@@ -22,6 +22,7 @@
  *
  * Author: Mark Lobodzinski <mark@lunarg.com>
  * Author: Mark Young <marky@lunarg.com>
+ * Author: Charles Giessen <charles@lunarg.com>
  */
 
 // clang-format off
@@ -896,7 +897,11 @@ VKAPI_ATTR void VKAPI_CALL loader_init_device_extension_dispatch_table(struct lo
     table->CmdCopyAccelerationStructureNV = (PFN_vkCmdCopyAccelerationStructureNV)gdpa(dev, "vkCmdCopyAccelerationStructureNV");
     table->CmdTraceRaysNV = (PFN_vkCmdTraceRaysNV)gdpa(dev, "vkCmdTraceRaysNV");
     table->CreateRayTracingPipelinesNV = (PFN_vkCreateRayTracingPipelinesNV)gdpa(dev, "vkCreateRayTracingPipelinesNV");
+
+    // ---- VK_KHR_ray_tracing_pipeline extension commands
     table->GetRayTracingShaderGroupHandlesKHR = (PFN_vkGetRayTracingShaderGroupHandlesKHR)gdpa(dev, "vkGetRayTracingShaderGroupHandlesKHR");
+
+    // ---- VK_NV_ray_tracing extension commands
     table->GetRayTracingShaderGroupHandlesNV = (PFN_vkGetRayTracingShaderGroupHandlesNV)gdpa(dev, "vkGetRayTracingShaderGroupHandlesNV");
     table->GetAccelerationStructureHandleNV = (PFN_vkGetAccelerationStructureHandleNV)gdpa(dev, "vkGetAccelerationStructureHandleNV");
     table->CmdWriteAccelerationStructuresPropertiesNV = (PFN_vkCmdWriteAccelerationStructuresPropertiesNV)gdpa(dev, "vkCmdWriteAccelerationStructuresPropertiesNV");
@@ -1540,19 +1545,23 @@ VKAPI_ATTR void VKAPI_CALL loader_init_instance_extension_dispatch_table(VkLayer
 void init_extension_device_proc_terminator_dispatch(struct loader_device *dev) {
     struct loader_device_terminator_dispatch* dispatch = &dev->loader_dispatch.extension_terminator_dispatch;
     PFN_vkGetDeviceProcAddr gpda = (PFN_vkGetDeviceProcAddr)dev->phys_dev_term->this_icd_term->dispatch.GetDeviceProcAddr;
+
     // ---- VK_KHR_swapchain extension commands
     if (dev->driver_extensions.khr_swapchain_enabled)
        dispatch->CreateSwapchainKHR = (PFN_vkCreateSwapchainKHR)gpda(dev->icd_device, "vkCreateSwapchainKHR");
     if (dev->driver_extensions.khr_swapchain_enabled)
        dispatch->GetDeviceGroupSurfacePresentModesKHR = (PFN_vkGetDeviceGroupSurfacePresentModesKHR)gpda(dev->icd_device, "vkGetDeviceGroupSurfacePresentModesKHR");
+
     // ---- VK_KHR_display_swapchain extension commands
     if (dev->driver_extensions.khr_display_swapchain_enabled)
        dispatch->CreateSharedSwapchainsKHR = (PFN_vkCreateSharedSwapchainsKHR)gpda(dev->icd_device, "vkCreateSharedSwapchainsKHR");
+
     // ---- VK_EXT_debug_marker extension commands
     if (dev->driver_extensions.ext_debug_marker_enabled)
        dispatch->DebugMarkerSetObjectTagEXT = (PFN_vkDebugMarkerSetObjectTagEXT)gpda(dev->icd_device, "vkDebugMarkerSetObjectTagEXT");
     if (dev->driver_extensions.ext_debug_marker_enabled)
        dispatch->DebugMarkerSetObjectNameEXT = (PFN_vkDebugMarkerSetObjectNameEXT)gpda(dev->icd_device, "vkDebugMarkerSetObjectNameEXT");
+
     // ---- VK_EXT_debug_utils extension commands
     if (dev->driver_extensions.ext_debug_utils_enabled)
        dispatch->SetDebugUtilsObjectNameEXT = (PFN_vkSetDebugUtilsObjectNameEXT)gpda(dev->icd_device, "vkSetDebugUtilsObjectNameEXT");
@@ -1571,6 +1580,7 @@ void init_extension_device_proc_terminator_dispatch(struct loader_device *dev) {
     if (dev->driver_extensions.ext_debug_utils_enabled)
        dispatch->CmdInsertDebugUtilsLabelEXT = (PFN_vkCmdInsertDebugUtilsLabelEXT)gpda(dev->icd_device, "vkCmdInsertDebugUtilsLabelEXT");
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
+
     // ---- VK_EXT_full_screen_exclusive extension commands
     if (dev->driver_extensions.ext_full_screen_exclusive_enabled && (dev->driver_extensions.khr_device_group_enabled || dev->driver_extensions.version_1_1_enabled))
        dispatch->GetDeviceGroupSurfacePresentModes2EXT = (PFN_vkGetDeviceGroupSurfacePresentModes2EXT)gpda(dev->icd_device, "vkGetDeviceGroupSurfacePresentModes2EXT");
@@ -1579,6 +1589,7 @@ void init_extension_device_proc_terminator_dispatch(struct loader_device *dev) {
 
 // These are prototypes for functions that need their trampoline called in all circumstances.
 // They are used in loader_lookup_device_dispatch_table but are defined afterwards.
+
     // ---- VK_EXT_debug_marker extension commands
 VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
     VkDevice                                    device,
@@ -1586,6 +1597,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
 VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(
     VkDevice                                    device,
     const VkDebugMarkerObjectNameInfoEXT*       pNameInfo);
+
     // ---- VK_EXT_debug_utils extension commands
 VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
     VkDevice                                    device,
@@ -2778,7 +2790,11 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
     if (!strcmp(name, "CmdCopyAccelerationStructureNV")) return (void *)table->CmdCopyAccelerationStructureNV;
     if (!strcmp(name, "CmdTraceRaysNV")) return (void *)table->CmdTraceRaysNV;
     if (!strcmp(name, "CreateRayTracingPipelinesNV")) return (void *)table->CreateRayTracingPipelinesNV;
+
+    // ---- VK_KHR_ray_tracing_pipeline extension commands
     if (!strcmp(name, "GetRayTracingShaderGroupHandlesKHR")) return (void *)table->GetRayTracingShaderGroupHandlesKHR;
+
+    // ---- VK_NV_ray_tracing extension commands
     if (!strcmp(name, "GetRayTracingShaderGroupHandlesNV")) return (void *)table->GetRayTracingShaderGroupHandlesNV;
     if (!strcmp(name, "GetAccelerationStructureHandleNV")) return (void *)table->GetAccelerationStructureHandleNV;
     if (!strcmp(name, "CmdWriteAccelerationStructuresPropertiesNV")) return (void *)table->CmdWriteAccelerationStructuresPropertiesNV;
@@ -6713,6 +6729,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(
     return disp->CreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
 }
 
+
+// ---- VK_KHR_ray_tracing_pipeline extension trampoline/terminators
+
 VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesKHR(
     VkDevice                                    device,
     VkPipeline                                  pipeline,
@@ -6729,6 +6748,9 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesKHR(
     }
     return disp->GetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
 }
+
+
+// ---- VK_NV_ray_tracing extension trampoline/terminators
 
 VKAPI_ATTR VkResult VKAPI_CALL GetRayTracingShaderGroupHandlesNV(
     VkDevice                                    device,
@@ -11467,10 +11489,14 @@ bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *na
         *addr = (void *)CreateRayTracingPipelinesNV;
         return true;
     }
+
+    // ---- VK_KHR_ray_tracing_pipeline extension commands
     if (!strcmp("vkGetRayTracingShaderGroupHandlesKHR", name)) {
         *addr = (void *)GetRayTracingShaderGroupHandlesKHR;
         return true;
     }
+
+    // ---- VK_NV_ray_tracing extension commands
     if (!strcmp("vkGetRayTracingShaderGroupHandlesNV", name)) {
         *addr = (void *)GetRayTracingShaderGroupHandlesNV;
         return true;
@@ -13006,6 +13032,9 @@ const char *const LOADER_INSTANCE_EXTENSIONS[] = {
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
                                                   VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME,
 #endif // VK_USE_PLATFORM_WAYLAND_KHR
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+                                                  VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,
+#endif // VK_USE_PLATFORM_ANDROID_KHR
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
                                                   VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
 #endif // VK_USE_PLATFORM_WIN32_KHR

--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -2,9 +2,9 @@
 // See loader_extension_generator.py for modifications
 
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) 2023-2023 RasterGrid Kft.
  *
@@ -22,6 +22,7 @@
  *
  * Author: Mark Lobodzinski <mark@lunarg.com>
  * Author: Mark Young <marky@lunarg.com>
+ * Author: Charles Giessen <charles@lunarg.com>
  */
 
 // clang-format off
@@ -502,14 +503,18 @@ struct loader_instance_extension_enables {
 // Functions that required a terminator need to have a separate dispatch table which contains their corresponding
 // device function. This is used in the terminators themselves.
 struct loader_device_terminator_dispatch {
+
     // ---- VK_KHR_swapchain extension commands
     PFN_vkCreateSwapchainKHR CreateSwapchainKHR;
     PFN_vkGetDeviceGroupSurfacePresentModesKHR GetDeviceGroupSurfacePresentModesKHR;
+
     // ---- VK_KHR_display_swapchain extension commands
     PFN_vkCreateSharedSwapchainsKHR CreateSharedSwapchainsKHR;
+
     // ---- VK_EXT_debug_marker extension commands
     PFN_vkDebugMarkerSetObjectTagEXT DebugMarkerSetObjectTagEXT;
     PFN_vkDebugMarkerSetObjectNameEXT DebugMarkerSetObjectNameEXT;
+
     // ---- VK_EXT_debug_utils extension commands
     PFN_vkSetDebugUtilsObjectNameEXT SetDebugUtilsObjectNameEXT;
     PFN_vkSetDebugUtilsObjectTagEXT SetDebugUtilsObjectTagEXT;
@@ -520,6 +525,7 @@ struct loader_device_terminator_dispatch {
     PFN_vkCmdEndDebugUtilsLabelEXT CmdEndDebugUtilsLabelEXT;
     PFN_vkCmdInsertDebugUtilsLabelEXT CmdInsertDebugUtilsLabelEXT;
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
+
     // ---- VK_EXT_full_screen_exclusive extension commands
     PFN_vkGetDeviceGroupSurfacePresentModes2EXT GetDeviceGroupSurfacePresentModes2EXT;
 #endif // VK_USE_PLATFORM_WIN32_KHR

--- a/loader/generated/vk_object_types.h
+++ b/loader/generated/vk_object_types.h
@@ -5,9 +5,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2017 The Khronos Group Inc.
- * Copyright (c) 2015-2017 Valve Corporation
- * Copyright (c) 2015-2017 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  * Copyright (c) 2015-2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
  * Author: Tobin Ehlis <tobine@google.com>
  * Author: Chris Forbes <chrisforbes@google.com>
  * Author: John Zulauf<jzulauf@lunarg.com>
+ * Author: Charles Giessen<charles@lunarg.com>
  *
  ****************************************************************************/
 
@@ -346,12 +347,8 @@ static inline VkObjectType convertDebugReportObjectToCoreObject(VkDebugReportObj
         return VK_OBJECT_TYPE_CU_MODULE_NVX;
     } else if (debug_report_obj == VK_DEBUG_REPORT_OBJECT_TYPE_CU_FUNCTION_NVX_EXT) {
         return VK_OBJECT_TYPE_CU_FUNCTION_NVX;
-    } else if (debug_report_obj == VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR_EXT) {
-        return VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR;
     } else if (debug_report_obj == VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT) {
         return VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR;
-    } else if (debug_report_obj == VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_KHR_EXT) {
-        return VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_KHR;
     } else if (debug_report_obj == VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT) {
         return VK_OBJECT_TYPE_VALIDATION_CACHE_EXT;
     } else if (debug_report_obj == VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT) {
@@ -440,12 +437,8 @@ static inline VkDebugReportObjectTypeEXT convertCoreObjectToDebugReportObject(Vk
         return VK_DEBUG_REPORT_OBJECT_TYPE_CU_MODULE_NVX_EXT;
     } else if (core_report_obj == VK_OBJECT_TYPE_CU_FUNCTION_NVX) {
         return VK_DEBUG_REPORT_OBJECT_TYPE_CU_FUNCTION_NVX_EXT;
-    } else if (core_report_obj == VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR) {
-        return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR_EXT;
     } else if (core_report_obj == VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR) {
         return VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT;
-    } else if (core_report_obj == VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_KHR) {
-        return VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_KHR_EXT;
     } else if (core_report_obj == VK_OBJECT_TYPE_VALIDATION_CACHE_EXT) {
         return VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT;
     } else if (core_report_obj == VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV) {

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -18,219 +18,84 @@
 # limitations under the License.
 #
 # Author: Mark Lobodzinski <mark@lunarg.com>
+# Author: Charles Giessen <charles@lunarg.com>
 
-import os,re,sys
-import xml.etree.ElementTree as etree
-from generator import *
-from collections import namedtuple
-from common_codegen import *
+from base_generator import BaseGenerator
 
-return_type_table = {"VkResult": "VK_SUCCESS",
-                     "uint32_t": "0",
-                     "uint64_t": "0L",
-                     "VkDeviceAddress": "0L",
-                     "VkDeviceSize": "0L"}
+class DispatchTableHelperGenerator(BaseGenerator):
+    def __init__(self):
+        BaseGenerator.__init__(self)
 
-#
-# DispatchTableHelperOutputGeneratorOptions - subclass of GeneratorOptions.
-class DispatchTableHelperOutputGeneratorOptions(GeneratorOptions):
-    def __init__(self,
-                 conventions = None,
-                 filename = None,
-                 directory = '.',
-                 genpath = None,
-                 apiname = None,
-                 profile = None,
-                 versions = '.*',
-                 emitversions = '.*',
-                 defaultExtensions = None,
-                 addExtensions = None,
-                 removeExtensions = None,
-                 emitExtensions = None,
-                 sortProcedure = regSortFeatures,
-                 prefixText = "",
-                 genFuncPointers = True,
-                 apicall = '',
-                 apientry = '',
-                 apientryp = '',
-                 alignFuncParam = 0,
-                 expandEnumerants = True):
-        GeneratorOptions.__init__(self,
-                conventions = conventions,
-                filename = filename,
-                directory = directory,
-                genpath = genpath,
-                apiname = apiname,
-                profile = profile,
-                versions = versions,
-                emitversions = emitversions,
-                defaultExtensions = defaultExtensions,
-                addExtensions = addExtensions,
-                removeExtensions = removeExtensions,
-                emitExtensions = emitExtensions,
-                sortProcedure = sortProcedure)
-        self.prefixText      = prefixText
-        self.genFuncPointers = genFuncPointers
-        self.prefixText      = None
-        self.apicall         = apicall
-        self.apientry        = apientry
-        self.apientryp       = apientryp
-        self.alignFuncParam  = alignFuncParam
-#
-# DispatchTableHelperOutputGenerator - subclass of OutputGenerator.
-# Generates dispatch table helper header files for LVL
-class DispatchTableHelperOutputGenerator(OutputGenerator):
-    """Generate dispatch table helper header based on XML element attributes"""
-    def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
-        OutputGenerator.__init__(self, errFile, warnFile, diagFile)
-        # Internal state - accumulators for different inner block text
-        self.instance_dispatch_list = []      # List of entries for instance dispatch list
-        self.device_dispatch_list = []        # List of entries for device dispatch list
-        self.dev_ext_stub_list = []           # List of stub functions for device extension functions
-        self.device_extension_list = []       # List of device extension functions
-        self.extension_type = ''
-    #
-    # Called once at the beginning of each run
-    def beginFile(self, genOpts):
-        OutputGenerator.beginFile(self, genOpts)
-        write("#pragma once", file=self.outFile)
-        # User-supplied prefix text, if any (list of strings)
-        if (genOpts.prefixText):
-            for s in genOpts.prefixText:
-                write(s, file=self.outFile)
-        # File Comment
-        file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See dispatch_table_helper_generator.py for modifications\n'
-        write(file_comment, file=self.outFile)
+    def generate(self):
+        out = []
+
+        out.append('#pragma once\n')
+        out.append('// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n')
+        out.append('// See dispatch_table_helper_generator.py for modifications\n')
+        out.append('\n')
         # Copyright Notice
-        copyright =  '/*\n'
-        copyright += ' * Copyright (c) 2015-2021 The Khronos Group Inc.\n'
-        copyright += ' * Copyright (c) 2015-2021 Valve Corporation\n'
-        copyright += ' * Copyright (c) 2015-2021 LunarG, Inc.\n'
-        copyright += ' *\n'
-        copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
-        copyright += ' * you may not use this file except in compliance with the License.\n'
-        copyright += ' * You may obtain a copy of the License at\n'
-        copyright += ' *\n'
-        copyright += ' *     http://www.apache.org/licenses/LICENSE-2.0\n'
-        copyright += ' *\n'
-        copyright += ' * Unless required by applicable law or agreed to in writing, software\n'
-        copyright += ' * distributed under the License is distributed on an "AS IS" BASIS,\n'
-        copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
-        copyright += ' * See the License for the specific language governing permissions and\n'
-        copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>\n'
-        copyright += ' * Author: Jon Ashburn <jon@lunarg.com>\n'
-        copyright += ' * Author: Mark Lobodzinski <mark@lunarg.com>\n'
-        copyright += ' */\n'
+        out.append('/*\n')
+        out.append(' * Copyright (c) 2015-2025 The Khronos Group Inc.\n')
+        out.append(' * Copyright (c) 2015-2025 Valve Corporation\n')
+        out.append(' * Copyright (c) 2015-2025 LunarG, Inc.\n')
+        out.append(' *\n')
+        out.append(' * Licensed under the Apache License, Version 2.0 (the "License");\n')
+        out.append(' * you may not use this file except in compliance with the License.\n')
+        out.append(' * You may obtain a copy of the License at\n')
+        out.append(' *\n')
+        out.append(' *     http://www.apache.org/licenses/LICENSE-2.0\n')
+        out.append(' *\n')
+        out.append(' * Unless required by applicable law or agreed to in writing, software\n')
+        out.append(' * distributed under the License is distributed on an "AS IS" BASIS,\n')
+        out.append(' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n')
+        out.append(' * See the License for the specific language governing permissions and\n')
+        out.append(' * limitations under the License.\n')
+        out.append(' *\n')
+        out.append(' * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>\n')
+        out.append(' * Author: Jon Ashburn <jon@lunarg.com>\n')
+        out.append(' * Author: Mark Lobodzinski <mark@lunarg.com>\n')
+        out.append(' * Author: Charles Giessen <charles@lunarg.com>\n')
+        out.append(' */\n')
+        out.append('\n')
+        out.append('#include <vulkan/vulkan.h>\n')
+        out.append('#include <vulkan/vk_layer.h>\n')
+        out.append('#include <string.h>\n')
+        out.append('#include "loader/generated/vk_layer_dispatch_table.h"\n')
+        out.append('\n')
 
-        preamble = ''
-        preamble += '#include <vulkan/vulkan.h>\n'
-        preamble += '#include <vulkan/vk_layer.h>\n'
-        preamble += '#include <string.h>\n'
-        preamble += '#include "loader/generated/vk_layer_dispatch_table.h"\n'
+        self.OutputDispatchTableHelper(out, 'device')
+        out.append('\n\n')
+        self.OutputDispatchTableHelper(out, 'instance')
 
-        write(copyright, file=self.outFile)
-        write(preamble, file=self.outFile)
-    #
-    # Write generate and write dispatch tables to output file
-    def endFile(self):
-        device_table = ''
-        instance_table = ''
+        self.write(''.join(out))
 
-        device_table += self.OutputDispatchTableHelper('device')
-        instance_table += self.OutputDispatchTableHelper('instance')
-
-        for stub in self.dev_ext_stub_list:
-            write(stub, file=self.outFile)
-        write("\n\n", file=self.outFile)
-        write(device_table, file=self.outFile);
-        write("\n", file=self.outFile)
-        write(instance_table, file=self.outFile);
-
-        # Finish processing in superclass
-        OutputGenerator.endFile(self)
-    #
-    # Processing at beginning of each feature or extension
-    def beginFeature(self, interface, emit):
-        OutputGenerator.beginFeature(self, interface, emit)
-        self.featureExtraProtect = GetFeatureProtect(interface)
-        self.extension_type = interface.get('type')
-
-    #
-    # Process commands, adding to appropriate dispatch tables
-    def genCmd(self, cmdinfo, name, alias):
-        OutputGenerator.genCmd(self, cmdinfo, name, alias)
-
-        avoid_entries = ['vkCreateInstance',
-                         'vkCreateDevice']
-        # Get first param type
-        params = cmdinfo.elem.findall('param')
-        info = self.getTypeNameTuple(params[0])
-
-        if name not in avoid_entries:
-            self.AddCommandToDispatchList(name, info[0], self.featureExtraProtect, cmdinfo)
-
-    #
-    # Determine if this API should be ignored or added to the instance or device dispatch table
-    def AddCommandToDispatchList(self, name, handle_type, protect, cmdinfo):
-        handle = self.registry.tree.find("types/type/[name='" + handle_type + "'][@category='handle']")
-        if handle is None:
-            return
-        if handle_type != 'VkInstance' and handle_type != 'VkPhysicalDevice' and name != 'vkGetInstanceProcAddr':
-            self.device_dispatch_list.append((name, self.featureExtraProtect))
-        else:
-            self.instance_dispatch_list.append((name, self.featureExtraProtect))
-        return
-    #
-    # Retrieve the type and name for a parameter
-    def getTypeNameTuple(self, param):
-        type = ''
-        name = ''
-        for elem in param:
-            if elem.tag == 'type':
-                type = noneStr(elem.text)
-            elif elem.tag == 'name':
-                name = noneStr(elem.text)
-        return (type, name)
-    #
-    # Create a dispatch table from the appropriate list and return it as a string
-    def OutputDispatchTableHelper(self, table_type):
-        entries = []
-        table = ''
+    # Create a dispatch table from the corresponding table_type and append it to out
+    def OutputDispatchTableHelper(self, out: list, table_type: str):
         if table_type == 'device':
-            entries = self.device_dispatch_list
-            table += 'static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDispatchTable *table, PFN_vkGetDeviceProcAddr gpa) {\n'
-            table += '    memset(table, 0, sizeof(*table));\n'
-            table += '    table->magic = DEVICE_DISP_TABLE_MAGIC_NUMBER;\n\n'
-            table += '    // Device function pointers\n'
+            out.append('static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDispatchTable *table, PFN_vkGetDeviceProcAddr gpa) {\n')
+            out.append('    memset(table, 0, sizeof(*table));\n')
+            out.append('    table->magic = DEVICE_DISP_TABLE_MAGIC_NUMBER;\n\n')
+            out.append('    // Device function pointers\n')
         else:
-            entries = self.instance_dispatch_list
-            table += 'static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa) {\n'
-            table += '    memset(table, 0, sizeof(*table));\n\n'
-            table += '    // Instance function pointers\n'
+            out.append('static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa) {\n')
+            out.append('    memset(table, 0, sizeof(*table));\n\n')
+            out.append('    // Instance function pointers\n')
 
-        for item in entries:
-            # Remove 'vk' from proto name
-            base_name = item[0][2:]
+        for command_name, command in self.vk.commands.items():
+            if (table_type == 'device' and not command.device) or (table_type == 'instance' and command.device):
+                continue
 
-            if item[1] is not None:
-                table += '#if defined(%s)\n' % item[1]
+            if command.protect is not None:
+                out.append( f'#if defined({command.protect})\n')
 
             # If we're looking for the proc we are passing in, just point the table to it.  This fixes the issue where
             # a layer overrides the function name for the loader.
-            if (table_type == 'device' and base_name == 'GetDeviceProcAddr'):
-                table += '    table->GetDeviceProcAddr = gpa;\n'
-            elif (table_type != 'device' and base_name == 'GetInstanceProcAddr'):
-                table += '    table->GetInstanceProcAddr = gpa;\n'
+            if (table_type == 'device' and command_name == 'vkGetDeviceProcAddr'):
+                out.append( '    table->GetDeviceProcAddr = gpa;\n')
+            elif (table_type != 'device' and command_name == 'vkGetInstanceProcAddr'):
+                out.append( '    table->GetInstanceProcAddr = gpa;\n')
             else:
-                table += '    table->%s = (PFN_%s) gpa(%s, "%s");\n' % (base_name, item[0], table_type, item[0])
-            if item[1] is not None:
-                table += '#endif // %s\n' % item[1]
-
-        table += '}'
-        return table
+                out.append( f'    table->{command_name[2:]} = (PFN_{command_name})gpa({table_type}, "{command_name}");\n')
+            if command.protect is not None:
+                out.append( f'#endif  // {command.protect}\n')
+        out.append('}')

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -25,11 +25,115 @@ import common_codegen
 import filecmp
 import os
 import shutil
-import subprocess
 import sys
 import tempfile
 import datetime
 import re
+
+from xml.etree import ElementTree
+
+def RunGenerators(api: str, registry: str, directory: str, targetFilter: str, caching: bool):
+
+    # These live in the Vulkan-Docs repo, but are pulled in via the
+    # Vulkan-Headers/registry folder
+    # At runtime we inject python path to find these helper scripts
+    scripts = os.path.dirname(registry)
+    scripts_directory_path = os.path.dirname(os.path.abspath(__file__))
+    registry_headers_path = os.path.join(scripts_directory_path, scripts)
+    sys.path.insert(0, registry_headers_path)
+    try:
+        from reg import Registry
+    except:
+        print("ModuleNotFoundError: No module named 'reg'") # normal python error message
+        print(f'{registry_headers_path} is not pointing to the Vulkan-Headers registry directory.')
+        print("Inside Vulkan-Headers there is a registry/reg.py file that is used.")
+        sys.exit(1) # Return without call stack so easy to spot error
+
+    from base_generator import BaseGeneratorOptions
+    from dispatch_table_helper_generator import DispatchTableHelperGenerator
+    from helper_file_generator import HelperFileGenerator
+    from loader_extension_generator import LoaderExtensionGenerator
+
+    # These set fields that are needed by both OutputGenerator and BaseGenerator,
+    # but are uniform and don't need to be set at a per-generated file level
+    from base_generator import (SetTargetApiName, SetMergedApiNames)
+    SetTargetApiName(api)
+
+    generators = {
+        'vk_layer_dispatch_table.h': {
+            'generator' : LoaderExtensionGenerator,
+            'genCombined': True,
+            'directory' : 'loader/generated',
+        },
+        'vk_loader_extensions.c': {
+            'generator' : LoaderExtensionGenerator,
+            'genCombined': True,
+            'directory' : 'loader/generated',
+        },
+        'vk_loader_extensions.h': {
+            'generator' : LoaderExtensionGenerator,
+            'genCombined': True,
+            'directory' : 'loader/generated',
+        },
+        'vk_object_types.h': {
+            'generator' : HelperFileGenerator,
+            'genCombined': True,
+            'directory' : 'loader/generated',
+        },
+        'vk_dispatch_table_helper.h': {
+            'generator' : DispatchTableHelperGenerator,
+            'genCombined': True,
+            'directory' : 'tests/framework/layer',
+        }
+    }
+
+    unknownTargets = [x for x in (targetFilter if targetFilter else []) if x not in generators.keys()]
+    if unknownTargets:
+        print(f'ERROR: No generator options for unknown target(s): {", ".join(unknownTargets)}', file=sys.stderr)
+        return 1
+
+    # Filter if --target is passed in
+    targets = [x for x in generators.keys() if not targetFilter or x in targetFilter]
+
+    for index, target in enumerate(targets, start=1):
+        print(f'[{index}|{len(targets)}] Generating {target}')
+
+        # First grab a class contructor object and create an instance
+        generator = generators[target]['generator']
+        gen = generator()
+
+        # This code and the 'genCombined' generator metadata is used by downstream
+        # users to generate code with all Vulkan APIs merged into the target API variant
+        # (e.g. Vulkan SC) when needed. The constructed apiList is also used to filter
+        # out non-applicable extensions later below.
+        apiList = [api]
+        if api != 'vulkan' and generators[target]['genCombined']:
+            SetMergedApiNames('vulkan')
+            apiList.append('vulkan')
+        else:
+            SetMergedApiNames(None)
+
+        outDirectory = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', generators[target]['directory']))
+        options = BaseGeneratorOptions(
+            customFileName  = target,
+            customDirectory = outDirectory)
+
+        # Create the registry object with the specified generator and generator
+        # options. The options are set before XML loading as they may affect it.
+        reg = Registry(gen, options)
+
+        # Parse the specified registry XML into an ElementTree object
+        tree = ElementTree.parse(registry)
+
+        # Filter out extensions that are not on the API list
+        [exts.remove(e) for exts in tree.findall('extensions') for e in exts.findall('extension') if (sup := e.get('supported')) is not None and all(api not in sup.split(',') for api in apiList)]
+
+        # Load the XML tree into the registry object
+        reg.loadElementTree(tree)
+
+        # Finally, use the output generator to create the requested target
+        reg.apiGen()
+
 
 def main(argv):
     parser = argparse.ArgumentParser(description='Generate source code for this repository')
@@ -40,9 +144,13 @@ def main(argv):
                         help='Specify API name to generate')
     parser.add_argument('--generated-version', help='sets the header version used to generate the repo')
     group = parser.add_mutually_exclusive_group()
+    group.add_argument('--target', nargs='+', help='only generate file names passed in')
     group.add_argument('-i', '--incremental', action='store_true', help='only update repo files that change')
     group.add_argument('-v', '--verify', action='store_true', help='verify repo files match generator output')
+    group.add_argument('--no-caching', action='store_true', help='Do not try to cache generator objects')
     args = parser.parse_args(argv)
+
+    repo_dir = common_codegen.repo_relative(f'loader/{args.api}/generated')
 
     registry = os.path.abspath(os.path.join(args.registry,  'vk.xml'))
     if not os.path.isfile(registry):
@@ -51,13 +159,6 @@ def main(argv):
             print(f'cannot find vk.xml in {args.registry}')
             return -1
 
-    gen_cmds = [[common_codegen.repo_relative('scripts/loader_genvk.py'),
-                 '-registry', registry,
-                 '-quiet',
-                 filename] for filename in ['vk_layer_dispatch_table.h',
-                                            'vk_loader_extensions.h',
-                                            'vk_loader_extensions.c',
-                                            'vk_object_types.h']]
 
     repo_dir = common_codegen.repo_relative('loader/generated')
 
@@ -71,17 +172,8 @@ def main(argv):
         # generate directly in the repo
         gen_dir = repo_dir
 
-    # run each code generator
-    for cmd in gen_cmds:
-        print(' '.join(cmd))
-        try:
-            subprocess.check_call([sys.executable] + cmd,
-                                  # ignore generator output, vk_validation_stats.py is especially noisy
-                                  stdout=subprocess.DEVNULL,
-                                  cwd=gen_dir)
-        except Exception as e:
-            print('ERROR:', str(e))
-            return 1
+    caching = not args.no_caching
+    RunGenerators(args.api, registry, gen_dir, args.target, caching)
 
     # optional post-generation steps
     if args.verify:

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -20,482 +20,184 @@
 # Author: Mark Lobodzinski <mark@lunarg.com>
 # Author: Tobin Ehlis <tobine@google.com>
 # Author: John Zulauf <jzulauf@lunarg.com>
+# Author: Charles Giessen <charles@lunarg.com>
 
-import os,re,sys
-import xml.etree.ElementTree as etree
-from generator import *
-from collections import namedtuple
-from common_codegen import *
+import re
+from base_generator import BaseGenerator
 
-#
-# HelperFileOutputGeneratorOptions - subclass of GeneratorOptions.
-class HelperFileOutputGeneratorOptions(GeneratorOptions):
-    def __init__(self,
-                 conventions = None,
-                 filename = None,
-                 directory = '.',
-                 genpath = None,
-                 apiname = None,
-                 profile = None,
-                 versions = '.*',
-                 emitversions = '.*',
-                 defaultExtensions = None,
-                 addExtensions = None,
-                 removeExtensions = None,
-                 emitExtensions = None,
-                 sortProcedure = regSortFeatures,
-                 prefixText = "",
-                 genFuncPointers = True,
-                 protectFile = True,
-                 protectFeature = True,
-                 apicall = '',
-                 apientry = '',
-                 apientryp = '',
-                 alignFuncParam = 0,
-                 library_name = '',
-                 expandEnumerants = True,
-                 helper_file_type = ''):
-        GeneratorOptions.__init__(self,
-                conventions = conventions,
-                filename = filename,
-                directory = directory,
-                genpath = genpath,
-                apiname = apiname,
-                profile = profile,
-                versions = versions,
-                emitversions = emitversions,
-                defaultExtensions = defaultExtensions,
-                addExtensions = addExtensions,
-                removeExtensions = removeExtensions,
-                emitExtensions = emitExtensions,
-                sortProcedure = sortProcedure)
-        self.prefixText       = prefixText
-        self.genFuncPointers  = genFuncPointers
-        self.protectFile      = protectFile
-        self.protectFeature   = protectFeature
-        self.apicall          = apicall
-        self.apientry         = apientry
-        self.apientryp        = apientryp
-        self.alignFuncParam   = alignFuncParam
-        self.library_name     = library_name
-        self.helper_file_type = helper_file_type
-#
-# HelperFileOutputGenerator - subclass of OutputGenerator. Outputs Vulkan helper files
-class HelperFileOutputGenerator(OutputGenerator):
-    """Generate helper file based on XML element attributes"""
-    def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
-        OutputGenerator.__init__(self, errFile, warnFile, diagFile)
-        # Internal state - accumulators for different inner block text
-        self.enum_output = ''                             # string built up of enum string routines
-        # Internal state - accumulators for different inner block text
-        self.structNames = []                             # List of Vulkan struct typenames
-        self.structTypes = dict()                         # Map of Vulkan struct typename to required VkStructureType
-        self.structMembers = []                           # List of StructMemberData records for all Vulkan structs
-        self.object_types = []                            # List of all handle types
-        self.object_type_aliases = []                     # Aliases to handles types (for handles that were extensions)
-        self.debug_report_object_types = []               # Handy copy of debug_report_object_type enum data
-        self.core_object_types = []                       # Handy copy of core_object_type enum data
-        self.device_extension_info = dict()               # Dict of device extension name defines and ifdef values
-        self.instance_extension_info = dict()             # Dict of instance extension name defines and ifdef values
+class HelperFileGenerator(BaseGenerator):
+    def __init__(self):
+        BaseGenerator.__init__(self)
 
-        # Named tuples to store struct and command data
-        self.StructType = namedtuple('StructType', ['name', 'value'])
-        self.CommandParam = namedtuple('CommandParam', ['type', 'name', 'ispointer', 'isstaticarray', 'isconst', 'iscount', 'len', 'extstructs', 'cdecl'])
-        self.StructMemberData = namedtuple('StructMemberData', ['name', 'members', 'ifdef_protect'])
+        # Helper for VkDebugReportObjectTypeEXT
+        # Maps [ 'VkBuffer' : 'VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT' ]
+        # Will be 'VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT' if no type
+        self.debugReportObject = dict()
+        # Maps [ 'VkBuffer' : 'VK_OBJECT_TYPE_BUFFER' ]
+        self.objectType = dict()
 
-        self.custom_construct_params = {
-            # safe_VkGraphicsPipelineCreateInfo needs to know if subpass has color and\or depth\stencil attachments to use its pointers
-            'VkGraphicsPipelineCreateInfo' :
-                ', const bool uses_color_attachment, const bool uses_depthstencil_attachment',
-            # safe_VkPipelineViewportStateCreateInfo needs to know if viewport and scissor is dynamic to use its pointers
-            'VkPipelineViewportStateCreateInfo' :
-                ', const bool is_dynamic_viewports, const bool is_dynamic_scissors',
-        }
-    #
-    # Called once at the beginning of each run
-    def beginFile(self, genOpts):
-        OutputGenerator.beginFile(self, genOpts)
-        # User-supplied prefix text, if any (list of strings)
-        self.helper_file_type = genOpts.helper_file_type
-        self.library_name = genOpts.library_name
-
-        write("// clang-format off", file=self.outFile)
-
-        # File Comment
-        file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See helper_file_generator.py for modifications\n'
-        write(file_comment, file=self.outFile)
-        # Copyright Notice
-        copyright = ''
-        copyright += '\n'
-        copyright += '/***************************************************************************\n'
-        copyright += ' *\n'
-        copyright += ' * Copyright (c) 2015-2017 The Khronos Group Inc.\n'
-        copyright += ' * Copyright (c) 2015-2017 Valve Corporation\n'
-        copyright += ' * Copyright (c) 2015-2017 LunarG, Inc.\n'
-        copyright += ' * Copyright (c) 2015-2017 Google Inc.\n'
-        copyright += ' *\n'
-        copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
-        copyright += ' * you may not use this file except in compliance with the License.\n'
-        copyright += ' * You may obtain a copy of the License at\n'
-        copyright += ' *\n'
-        copyright += ' *     http://www.apache.org/licenses/LICENSE-2.0\n'
-        copyright += ' *\n'
-        copyright += ' * Unless required by applicable law or agreed to in writing, software\n'
-        copyright += ' * distributed under the License is distributed on an "AS IS" BASIS,\n'
-        copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
-        copyright += ' * See the License for the specific language governing permissions and\n'
-        copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Mark Lobodzinski <mark@lunarg.com>\n'
-        copyright += ' * Author: Courtney Goeltzenleuchter <courtneygo@google.com>\n'
-        copyright += ' * Author: Tobin Ehlis <tobine@google.com>\n'
-        copyright += ' * Author: Chris Forbes <chrisforbes@google.com>\n'
-        copyright += ' * Author: John Zulauf<jzulauf@lunarg.com>\n'
-        copyright += ' *\n'
-        copyright += ' ****************************************************************************/\n'
-        write(copyright, file=self.outFile)
-    #
-    # Write generated file content to output file
-    def endFile(self):
-        dest_file = ''
-        dest_file += self.OutputDestFile()
-        # Remove blank lines at EOF
-        if dest_file.endswith('\n'):
-            dest_file = dest_file[:-1]
-        write(dest_file, file=self.outFile)
-        write("// clang-format on", file=self.outFile)
-        # Finish processing in superclass
-        OutputGenerator.endFile(self)
-    #
-    # Override parent class to be notified of the beginning of an extension
-    def beginFeature(self, interface, emit):
-        # Start processing in superclass
-        OutputGenerator.beginFeature(self, interface, emit)
-        self.featureExtraProtect = GetFeatureProtect(interface)
-
-        if interface.tag != 'extension':
-            return
-        name = self.featureName
-        name_define = next(enum.get('name') for enum in interface.findall('require/enum') if enum.get('name').endswith('_EXTENSION_NAME'))
-        requires = interface.get('requires')
-        if requires is not None:
-            required_extensions = requires.split(',')
+    # Takes a VK_OBJECT_TYPE_THE_TYP_EXT and turns it into TheTypeEXT
+    def get_kVulkanObjectName(self, str_to_process):
+        removed_prefix = str_to_process.split('_')[3:]
+        if ''.join(removed_prefix[-1:]) in self.vk.vendorTags:
+            return ''.join(str_to_process.title().split('_')[3:-1] + removed_prefix[-1:])
         else:
-            required_extensions = list()
-        info = { 'define': name_define, 'ifdef':self.featureExtraProtect, 'reqs':required_extensions }
-        if interface.get('type') == 'instance':
-            self.instance_extension_info[name] = info
-        else:
-            self.device_extension_info[name] = info
+            return ''.join(str_to_process.title().split('_')[3:])
 
-    #
-    # Override parent class to be notified of the end of an extension
-    def endFeature(self):
-        # Finish processing in superclass
-        OutputGenerator.endFeature(self)
-    #
-    # Grab group (e.g. C "enum" type) info to output for enum-string conversion helper
-    def genGroup(self, groupinfo, groupName, alias):
-        OutputGenerator.genGroup(self, groupinfo, groupName, alias)
-        groupElem = groupinfo.elem
-        # For enum_string_header
-        if self.helper_file_type == 'enum_string_header':
-            value_set = set()
-            for elem in groupElem.findall('enum'):
-                if elem.get('supported') != 'disabled' and elem.get('alias') is None:
-                    value_set.add(elem.get('name'))
-            self.enum_output += self.GenerateEnumStringConversion(groupName, value_set)
-        elif self.helper_file_type == 'object_types_header':
-            if groupName == 'VkDebugReportObjectTypeEXT':
-                for elem in groupElem.findall('enum'):
-                    if elem.get('supported') != 'disabled':
-                        item_name = elem.get('name')
-                        self.debug_report_object_types.append(item_name)
-            elif groupName == 'VkObjectType':
-                for elem in groupElem.findall('enum'):
-                    if elem.get('supported') != 'disabled':
-                        item_name = elem.get('name')
-                        self.core_object_types.append(item_name)
+    def split_handle_by_capital_case(self, str_to_split):
+        name = str_to_split[2:]
+        name = name.replace('NVX', 'Nvx')
+        # Force vendor tags to be title case so we can split by capital letter
+        for tag in self.vk.vendorTags:
+            name = name.replace(tag, tag.title())
+        # Split by capital letters so we can concoct a VK_DEBUG_REPORT_<>_EXT string out of it
+        return re.split('(?<=.)(?=[A-Z])', f'{name}')
 
-    #
-    # Called for each type -- if the type is a struct/union, grab the metadata
-    def genType(self, typeinfo, name, alias):
-        OutputGenerator.genType(self, typeinfo, name, alias)
-        typeElem = typeinfo.elem
-        # If the type is a struct type, traverse the imbedded <member> tags generating a structure.
-        # Otherwise, emit the tag text.
-        category = typeElem.get('category')
-        if category == 'handle':
-            if alias:
-                self.object_type_aliases.append((name,alias))
+
+    def convert_to_VK_OBJECT_TYPE(self, str_to_convert):
+        return '_'.join(['VK', 'OBJECT', 'TYPE'] + self.split_handle_by_capital_case(str_to_convert)).upper()
+
+    def convert_to_VK_DEBUG_REPORT_OBJECT_TYPE(self, str_to_convert):
+        return '_'.join(['VK', 'DEBUG', 'REPORT', 'OBJECT', 'TYPE'] + self.split_handle_by_capital_case(str_to_convert) + ['EXT']).upper()
+
+    def generate(self):
+        # Search all fields of the Enum to see if has a DEBUG_REPORT_OBJECT
+        for handle in self.vk.handles.values():
+            debugObjects = ([enum.name for enum in self.vk.enums['VkDebugReportObjectTypeEXT'].fields if f'{handle.type[3:]}_EXT' in enum.name])
+            object = 'VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT' if len(debugObjects) == 0 else debugObjects[0]
+            self.debugReportObject[handle.name] = object
+
+
+
+        out = []
+        out.append('''// clang-format off
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See helper_file_generator.py for modifications
+
+
+/***************************************************************************
+ *
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
+ * Author: Tobin Ehlis <tobine@google.com>
+ * Author: Chris Forbes <chrisforbes@google.com>
+ * Author: John Zulauf<jzulauf@lunarg.com>
+ * Author: Charles Giessen<charles@lunarg.com>
+ *
+ ****************************************************************************/
+
+
+#pragma once
+
+#include <vulkan/vulkan.h>
+
+''')
+
+        # Get the list of field names from VkDebugReportObjectTypeEXT
+        VkDebugReportObjectTypeEXT_field_names = []
+        for field in self.vk.enums['VkDebugReportObjectTypeEXT'].fields:
+            VkDebugReportObjectTypeEXT_field_names.append(field.name)
+
+        # Create a list with the needed information so that when we print, we print in the exact same order, as we are printing arrays where external code may index into it
+        object_types = []
+        enum_num = 1 # start at one since the zero place is manually printed with the UNKNOWN value
+        for handle in self.vk.handles.values():
+            debug_report_object_name = self.convert_to_VK_DEBUG_REPORT_OBJECT_TYPE(handle.name)
+            if debug_report_object_name in VkDebugReportObjectTypeEXT_field_names:
+                object_types.append((f'{handle.name[2:]}', enum_num, debug_report_object_name))
             else:
-                self.object_types.append(name)
-        elif (category == 'struct' or category == 'union'):
-            self.structNames.append(name)
-            self.genStruct(typeinfo, name, alias)
-    #
-    # Generate a VkStructureType based on a structure typename
-    def genVkStructureType(self, typename):
-        # Add underscore between lowercase then uppercase
-        value = re.sub('([a-z0-9])([A-Z])', r'\1_\2', typename)
-        # Change to uppercase
-        value = value.upper()
-        # Add STRUCTURE_TYPE_
-        return re.sub('VK_', 'VK_STRUCTURE_TYPE_', value)
-    #
-    # Check if the parameter passed in is a pointer
-    def paramIsPointer(self, param):
-        ispointer = False
-        for elem in param:
-            if ((elem.tag != 'type') and (elem.tail is not None)) and '*' in elem.tail:
-                ispointer = True
-        return ispointer
-    #
-    # Check if the parameter passed in is a static array
-    def paramIsStaticArray(self, param):
-        isstaticarray = 0
-        paramname = param.find('name')
-        if (paramname.tail is not None) and ('[' in paramname.tail):
-            isstaticarray = paramname.tail.count('[')
-        return isstaticarray
-    #
-    # Retrieve the type and name for a parameter
-    def getTypeNameTuple(self, param):
-        type = ''
-        name = ''
-        for elem in param:
-            if elem.tag == 'type':
-                type = noneStr(elem.text)
-            elif elem.tag == 'name':
-                name = noneStr(elem.text)
-        return (type, name)
-    #
-    # Retrieve the value of the len tag
-    def getLen(self, param):
-        result = None
-        len = param.attrib.get('len')
-        if len and len != 'null-terminated':
-            # For string arrays, 'len' can look like 'count,null-terminated', indicating that we
-            # have a null terminated array of strings.  We strip the null-terminated from the
-            # 'len' field and only return the parameter specifying the string count
-            if 'null-terminated' in len:
-                result = len.split(',')[0]
-            else:
-                result = len
-            if 'altlen' in param.attrib:
-                # Elements with latexmath 'len' also contain a C equivalent 'altlen' attribute
-                # Use indexing operator instead of get() so we fail if the attribute is missing
-                result = param.attrib['altlen']
-            # Spec has now notation for len attributes, using :: instead of platform specific pointer symbol
-            result = str(result).replace('::', '->')
-        return result
-    #
-    # Check if a structure is or contains a dispatchable (dispatchable = True) or
-    # non-dispatchable (dispatchable = False) handle
-    def TypeContainsObjectHandle(self, handle_type, dispatchable):
-        if dispatchable:
-            type_key = 'VK_DEFINE_HANDLE'
-        else:
-            type_key = 'VK_DEFINE_NON_DISPATCHABLE_HANDLE'
-        handle = self.registry.tree.find("types/type/[name='" + handle_type + "'][@category='handle']")
-        if handle is not None and handle.find('type').text == type_key:
-            return True
-        # if handle_type is a struct, search its members
-        if handle_type in self.structNames:
-            member_index = next((i for i, v in enumerate(self.structMembers) if v[0] == handle_type), None)
-            if member_index is not None:
-                for item in self.structMembers[member_index].members:
-                    handle = self.registry.tree.find("types/type/[name='" + item.type + "'][@category='handle']")
-                    if handle is not None and handle.find('type').text == type_key:
-                        return True
-        return False
-    #
-    # Generate local ready-access data describing Vulkan structures and unions from the XML metadata
-    def genStruct(self, typeinfo, typeName, alias):
-        OutputGenerator.genStruct(self, typeinfo, typeName, alias)
-        members = typeinfo.elem.findall('.//member')
-        # Iterate over members once to get length parameters for arrays
-        lens = set()
-        for member in members:
-            len = self.getLen(member)
-            if len:
-                lens.add(len)
-        # Generate member info
-        membersInfo = []
-        for member in members:
-            # Get the member's type and name
-            info = self.getTypeNameTuple(member)
-            type = info[0]
-            name = info[1]
-            cdecl = self.makeCParamDecl(member, 1)
-            # Process VkStructureType
-            if type == 'VkStructureType':
-                # Extract the required struct type value from the comments
-                # embedded in the original text defining the 'typeinfo' element
-                rawXml = etree.tostring(typeinfo.elem).decode('ascii')
-                result = re.search(r'VK_STRUCTURE_TYPE_\w+', rawXml)
-                if result:
-                    value = result.group(0)
-                else:
-                    value = self.genVkStructureType(typeName)
-                # Store the required type value
-                self.structTypes[typeName] = self.StructType(name=name, value=value)
-            # Store pointer/array/string info
-            isstaticarray = self.paramIsStaticArray(member)
-            membersInfo.append(self.CommandParam(type=type,
-                                                 name=name,
-                                                 ispointer=self.paramIsPointer(member),
-                                                 isstaticarray=isstaticarray,
-                                                 isconst=True if 'const' in cdecl else False,
-                                                 iscount=True if name in lens else False,
-                                                 len=self.getLen(member),
-                                                 extstructs=self.registry.validextensionstructs[typeName] if name == 'pNext' else None,
-                                                 cdecl=cdecl))
-        self.structMembers.append(self.StructMemberData(name=typeName, members=membersInfo, ifdef_protect=self.featureExtraProtect))
-    #
-    # Enum_string_header: Create a routine to convert an enumerated value into a string
-    def GenerateEnumStringConversion(self, groupName, value_list):
-        outstring = '\n'
-        outstring += 'static inline const char* string_%s(%s input_value)\n' % (groupName, groupName)
-        outstring += '{\n'
-        outstring += '    switch ((%s)input_value)\n' % groupName
-        outstring += '    {\n'
-        for item in value_list:
-            outstring += '        case %s:\n' % item
-            outstring += '            return "%s";\n' % item
-        outstring += '        default:\n'
-        outstring += '            return "Unhandled %s";\n' % groupName
-        outstring += '    }\n'
-        outstring += '}\n'
-        return outstring
-    #
-    # Combine object types helper header file preamble with body text and return
-    def GenerateObjectTypesHelperHeader(self):
-        object_types_helper_header = '\n'
-        object_types_helper_header += '#pragma once\n'
-        object_types_helper_header += '\n'
-        object_types_helper_header += '#include <vulkan/vulkan.h>\n\n'
-        object_types_helper_header += self.GenerateObjectTypesHeader()
-        return object_types_helper_header
-    #
-    # Object types header: create object enum type header file
-    def GenerateObjectTypesHeader(self):
-        object_types_header = ''
-        object_types_header += '// Object Type enum for validation layer internal object handling\n'
-        object_types_header += 'typedef enum VulkanObjectType {\n'
-        object_types_header += '    kVulkanObjectTypeUnknown = 0,\n'
-        enum_num = 1
-        type_list = [];
-        enum_entry_map = {}
-
-        # Output enum definition as each handle is processed, saving the names to use for the conversion routine
-        for item in self.object_types:
-            fixup_name = item[2:]
-            enum_entry = 'kVulkanObjectType%s' % fixup_name
-            enum_entry_map[item] = enum_entry
-            object_types_header += '    ' + enum_entry
-            object_types_header += ' = %d,\n' % enum_num
+                object_types.append((f'{handle.name[2:]}', enum_num, 'VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT'))
             enum_num += 1
-            type_list.append(enum_entry)
-        object_types_header += '    kVulkanObjectTypeMax = %d,\n' % enum_num
-        object_types_header += '    // Aliases for backwards compatibilty of "promoted" types\n'
-        for (name, alias) in self.object_type_aliases:
-            fixup_name = name[2:]
-            object_types_header += '    kVulkanObjectType{} = {},\n'.format(fixup_name, enum_entry_map[alias])
-        object_types_header += '} VulkanObjectType;\n\n'
 
-        # Output name string helper
-        object_types_header += '// Array of object name strings for OBJECT_TYPE enum conversion\n'
-        object_types_header += 'static const char * const object_string[kVulkanObjectTypeMax] = {\n'
-        object_types_header += '    "Unknown",\n'
-        for item in self.object_types:
-            fixup_name = item[2:]
-            object_types_header += '    "%s",\n' % fixup_name
-        object_types_header += '};\n'
 
-        # Key creation helper for map comprehensions that convert between k<Name> and VK<Name> symbols
-        def to_key(regex, raw_key): return re.search(regex, raw_key).group(1).lower().replace("_","")
+        out.append('// Object Type enum for validation layer internal object handling\n')
+        out.append('typedef enum VulkanObjectType {\n')
+        out.append('    kVulkanObjectTypeUnknown = 0,\n')
+        for name, number, debug_report in object_types:
+            out.append(f'    kVulkanObjectType{name} = {number},\n')
+        out.append(f'    kVulkanObjectTypeMax = {enum_num},\n')
 
-        # Output a conversion routine from the layer object definitions to the debug report definitions
-        # As the VK_DEBUG_REPORT types are not being updated, specify UNKNOWN for unmatched types
-        object_types_header += '\n'
-        object_types_header += '// Helper array to get Vulkan VK_EXT_debug_report object type enum from the internal layers version\n'
-        object_types_header += 'const VkDebugReportObjectTypeEXT get_debug_report_enum[] = {\n'
-        object_types_header += '    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, // kVulkanObjectTypeUnknown\n'
+        # Hardcode the alises as Vulkan Object lacks this information currently
+        out.append('    // Aliases for backwards compatibilty of "promoted" types\n')
+        out.append('    kVulkanObjectTypeDescriptorUpdateTemplateKHR = kVulkanObjectTypeDescriptorUpdateTemplate,\n')
+        out.append('    kVulkanObjectTypeSamplerYcbcrConversionKHR = kVulkanObjectTypeSamplerYcbcrConversion,\n')
+        out.append('    kVulkanObjectTypePrivateDataSlotEXT = kVulkanObjectTypePrivateDataSlot,\n')
 
-        dbg_re = '^VK_DEBUG_REPORT_OBJECT_TYPE_(.*?)(_EXT)?$'
-        dbg_map = {to_key(dbg_re, dbg) : dbg for dbg in self.debug_report_object_types}
-        dbg_default = 'VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT'
-        for object_type in type_list:
-            vk_object_type = dbg_map.get(object_type.replace("kVulkanObjectType", "").lower(), dbg_default)
-            object_types_header += '    %s,   // %s\n' % (vk_object_type, object_type)
-        object_types_header += '};\n'
+        out.append('} VulkanObjectType;\n')
+        out.append('\n')
 
-        # Output a conversion routine from the layer object definitions to the core object type definitions
-        # This will intentionally *fail* for unmatched types as the VK_OBJECT_TYPE list should match the kVulkanObjectType list
-        object_types_header += '\n'
-        object_types_header += '// Helper array to get Official Vulkan VkObjectType enum from the internal layers version\n'
-        object_types_header += 'const VkObjectType get_object_type_enum[] = {\n'
-        object_types_header += '    VK_OBJECT_TYPE_UNKNOWN, // kVulkanObjectTypeUnknown\n'
+        out.append('// Array of object name strings for OBJECT_TYPE enum conversion\n')
+        out.append('static const char * const object_string[kVulkanObjectTypeMax] = {\n')
+        out.append('    \"Unknown\",\n')
+        for name, number, debug_report in object_types:
+            out.append(f'    \"{name}\",\n')
+        out.append('};\n')
+        out.append('\n')
 
-        vko_re = '^VK_OBJECT_TYPE_(.*)'
-        vko_map = {to_key(vko_re, vko) : vko for vko in self.core_object_types}
-        for object_type in type_list:
-            vk_object_type = vko_map[object_type.replace("kVulkanObjectType", "").lower()]
-            object_types_header += '    %s,   // %s\n' % (vk_object_type, object_type)
-        object_types_header += '};\n'
+        out.append('// Helper array to get Vulkan VK_EXT_debug_report object type enum from the internal layers version\n')
+        out.append('const VkDebugReportObjectTypeEXT get_debug_report_enum[] = {\n')
+        out.append('    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, // kVulkanObjectTypeUnknown\n')
+        for name, number, debug_report in object_types:
+            out.append(f'    {debug_report},   // kVulkanObjectType{name}\n')
+        out.append('};\n')
+        out.append('\n')
 
-        # Create a function to convert from VkDebugReportObjectTypeEXT to VkObjectType
-        object_types_header += '\n'
-        object_types_header += '// Helper function to convert from VkDebugReportObjectTypeEXT to VkObjectType\n'
-        object_types_header += 'static inline VkObjectType convertDebugReportObjectToCoreObject(VkDebugReportObjectTypeEXT debug_report_obj){\n'
-        object_types_header += '    if (debug_report_obj == VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT) {\n'
-        object_types_header += '        return VK_OBJECT_TYPE_UNKNOWN;\n'
-        for core_object_type in self.core_object_types:
-            core_target_type = core_object_type.replace("VK_OBJECT_TYPE_", "").lower()
-            core_target_type = core_target_type.replace("_", "")
-            for dr_object_type in self.debug_report_object_types:
-                dr_target_type = dr_object_type.replace("VK_DEBUG_REPORT_OBJECT_TYPE_", "").lower()
-                dr_target_type = dr_target_type[:-4]
-                dr_target_type = dr_target_type.replace("_", "")
-                if core_target_type == dr_target_type:
-                    object_types_header += '    } else if (debug_report_obj == %s) {\n' % dr_object_type
-                    object_types_header += '        return %s;\n' % core_object_type
+        out.append('// Helper array to get Official Vulkan VkObjectType enum from the internal layers version\n')
+        out.append('const VkObjectType get_object_type_enum[] = {\n')
+        out.append('    VK_OBJECT_TYPE_UNKNOWN, // kVulkanObjectTypeUnknown\n')
+        for handle in self.vk.handles.values():
+            object_name = self.convert_to_VK_OBJECT_TYPE(handle.name)
+            out.append(f'    {object_name},   // kVulkanObjectType{handle.name[2:]}\n')
+        out.append('};\n')
+        out.append('\n')
+
+        out.append('// Helper function to convert from VkDebugReportObjectTypeEXT to VkObjectType\n')
+        out.append('static inline VkObjectType convertDebugReportObjectToCoreObject(VkDebugReportObjectTypeEXT debug_report_obj){\n')
+        out.append('    if (debug_report_obj == VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT) {\n')
+        out.append('        return VK_OBJECT_TYPE_UNKNOWN;\n')
+        for field in self.vk.enums['VkObjectType'].fields:
+            enum_field_name = f'VK_DEBUG_REPORT_{field.name[3:]}_EXT'
+            for debug_report_field in self.vk.enums['VkDebugReportObjectTypeEXT'].fields:
+                if enum_field_name == debug_report_field.name:
+                    out.append(f'    }} else if (debug_report_obj == VK_DEBUG_REPORT_{field.name[3:]}_EXT) {{\n')
+                    out.append(f'        return {field.name};\n')
                     break
-        object_types_header += '    }\n'
-        object_types_header += '    return VK_OBJECT_TYPE_UNKNOWN;\n'
-        object_types_header += '}\n'
+        out.append('    }\n')
+        out.append('    return VK_OBJECT_TYPE_UNKNOWN;\n')
+        out.append('}\n')
+        out.append('\n')
 
-        # Create a function to convert from VkObjectType to VkDebugReportObjectTypeEXT
-        object_types_header += '\n'
-        object_types_header += '// Helper function to convert from VkDebugReportObjectTypeEXT to VkObjectType\n'
-        object_types_header += 'static inline VkDebugReportObjectTypeEXT convertCoreObjectToDebugReportObject(VkObjectType core_report_obj){\n'
-        object_types_header += '    if (core_report_obj == VK_OBJECT_TYPE_UNKNOWN) {\n'
-        object_types_header += '        return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;\n'
-        for core_object_type in self.core_object_types:
-            core_target_type = core_object_type.replace("VK_OBJECT_TYPE_", "").lower()
-            core_target_type = core_target_type.replace("_", "")
-            for dr_object_type in self.debug_report_object_types:
-                dr_target_type = dr_object_type.replace("VK_DEBUG_REPORT_OBJECT_TYPE_", "").lower()
-                dr_target_type = dr_target_type[:-4]
-                dr_target_type = dr_target_type.replace("_", "")
-                if core_target_type == dr_target_type:
-                    object_types_header += '    } else if (core_report_obj == %s) {\n' % core_object_type
-                    object_types_header += '        return %s;\n' % dr_object_type
+        out.append('// Helper function to convert from VkDebugReportObjectTypeEXT to VkObjectType\n')
+        out.append('static inline VkDebugReportObjectTypeEXT convertCoreObjectToDebugReportObject(VkObjectType core_report_obj){\n')
+        out.append('    if (core_report_obj == VK_OBJECT_TYPE_UNKNOWN) {\n')
+        out.append('        return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;\n')
+        for field in self.vk.enums['VkObjectType'].fields:
+            enum_field_name = f'VK_DEBUG_REPORT_{field.name[3:]}_EXT'
+            for debug_report_field in self.vk.enums['VkDebugReportObjectTypeEXT'].fields:
+                if enum_field_name == debug_report_field.name:
+                    out.append(f'    }} else if (core_report_obj == {field.name}) {{\n')
+                    out.append(f'        return VK_DEBUG_REPORT_{field.name[3:]}_EXT;\n')
                     break
-        object_types_header += '    }\n'
-        object_types_header += '    return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;\n'
-        object_types_header += '}\n'
-        return object_types_header
+        out.append('    }\n')
+        out.append('    return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;\n')
+        out.append('}\n')
 
-    #
-    # Create a helper file and return it as a string
-    def OutputDestFile(self):
-        if self.helper_file_type == 'object_types_header':
-            return self.GenerateObjectTypesHelperHeader()
-        else:
-            return 'Bad Helper File Generator Option %s' % self.helper_file_type
+        out.append('// clang-format on')
+        self.write("".join(out))

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -21,13 +21,10 @@
 #
 # Author: Mark Young <marky@lunarg.com>
 # Author: Mark Lobodzinski <mark@lunarg.com>
+# Author: Charles Giessen <charles@lunarg.com>
 
 import re
-import sys
-from collections import namedtuple
-from generator import *
-from common_codegen import *
-
+from base_generator import BaseGenerator
 
 WSI_EXT_NAMES = ['VK_KHR_surface',
                  'VK_KHR_display',
@@ -105,382 +102,115 @@ PRE_INSTANCE_FUNCTIONS = ['vkEnumerateInstanceExtensionProperties',
                           'vkEnumerateInstanceLayerProperties',
                           'vkEnumerateInstanceVersion']
 
-#
-# API Version
-class APIVersion:
-    def __init__(self, token, apiname = 'Vulkan', supported = True):
-        self.token = token
-        self.constant = token.replace('_VERSION_', '_API_VERSION_')
-        self.number = token[token.find('_VERSION_') + len('_VERSION_'):].replace('_', '.')
-        self.name = f'{apiname} {self.number}'
-        self.supported = supported
+class LoaderExtensionGenerator(BaseGenerator):
+    def __init__(self):
+        BaseGenerator.__init__(self)
 
-#
-# LoaderExtensionGeneratorOptions - subclass of GeneratorOptions.
-class LoaderExtensionGeneratorOptions(GeneratorOptions):
-    def __init__(self,
-                 conventions = None,
-                 filename = None,
-                 directory = '.',
-                 genpath = None,
-                 apiname = None,
-                 profile = None,
-                 versions = '.*',
-                 emitversions = '.*',
-                 defaultExtensions = None,
-                 addExtensions = None,
-                 removeExtensions = None,
-                 emitExtensions = None,
-                 sortProcedure = regSortFeatures,
-                 prefixText = "",
-                 genFuncPointers = True,
-                 protectFile = True,
-                 protectFeature = True,
-                 apicall = '',
-                 apientry = '',
-                 apientryp = '',
-                 indentFuncProto = True,
-                 indentFuncPointer = False,
-                 alignFuncParam = 0,
-                 expandEnumerants = True):
-        GeneratorOptions.__init__(self,
-                conventions = conventions,
-                filename = filename,
-                directory = directory,
-                genpath = genpath,
-                apiname = apiname,
-                profile = profile,
-                versions = versions,
-                emitversions = emitversions,
-                defaultExtensions = defaultExtensions,
-                addExtensions = addExtensions,
-                removeExtensions = removeExtensions,
-                emitExtensions = emitExtensions,
-                sortProcedure = sortProcedure)
-        self.prefixText      = prefixText
-        self.prefixText      = None
-        self.apicall         = apicall
-        self.apientry        = apientry
-        self.apientryp       = apientryp
-        self.alignFuncParam  = alignFuncParam
-        self.expandEnumerants = expandEnumerants
+        self.core_commands = []
+        self.extension_commands = []
+        self.instance_extensions = []
 
-#
-# LoaderExtensionOutputGenerator - subclass of OutputGenerator.
-# Generates dispatch table helper header files for LVL
-class LoaderExtensionOutputGenerator(OutputGenerator):
-    """Generate dispatch table helper header based on XML element attributes"""
-    def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
-        OutputGenerator.__init__(self, errFile, warnFile, diagFile)
+    def generate(self):
 
-        # Internal state - accumulators for different inner block text
-        self.ext_instance_dispatch_list = []  # List of extension entries for instance dispatch list
-        self.ext_device_dispatch_list = []    # List of extension entries for device dispatch list
-        self.core_commands = []               # List of CommandData records for core Vulkan commands
-        self.ext_commands = []                # List of CommandData records for extension Vulkan commands
-        self.CommandParam = namedtuple('CommandParam', ['type', 'name', 'cdecl'])
-        self.CommandData = namedtuple('CommandData', ['name', 'ext_name', 'ext_type', 'require', 'protect', 'return_type', 'handle_type', 'params', 'cdecl'])
-        self.instanceExtensions = []
-        self.ExtensionData = namedtuple('ExtensionData', ['name', 'type', 'protect', 'define', 'num_commands'])
+        self.core_commands = [x for x in self.vk.commands.values() if len(x.extensions) == 0]
+        self.extension_commands = [x for x in self.vk.commands.values() if len(x.extensions) > 0]
 
-    #
-    # Called once at the beginning of each run
-    def beginFile(self, genOpts):
-        OutputGenerator.beginFile(self, genOpts)
+        self.instance_extensions = [x for x in self.vk.extensions.values() if x.instance]
 
-        # User-supplied prefix text, if any (list of strings)
-        if genOpts.prefixText:
-            for s in genOpts.prefixText:
-                write(s, file=self.outFile)
+        out = []
+        self.add_preamble(out)
 
-        # File Comment
-        file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See loader_extension_generator.py for modifications\n'
-        write(file_comment, file=self.outFile)
+        if self.filename == 'vk_loader_extensions.h':
+            self.print_vk_loader_extensions_h(out)
+        elif self.filename == 'vk_loader_extensions.c':
+            self.print_vk_loader_extensions_c(out)
+        elif self.filename == 'vk_layer_dispatch_table.h':
+            self.print_vk_layer_dispatch_table(out)
 
-        # Copyright Notice
-        copyright =  '/*\n'
-        copyright += ' * Copyright (c) 2015-2022 The Khronos Group Inc.\n'
-        copyright += ' * Copyright (c) 2015-2022 Valve Corporation\n'
-        copyright += ' * Copyright (c) 2015-2022 LunarG, Inc.\n'
-        copyright += ' * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n'
-        copyright += ' * Copyright (c) 2023-2023 RasterGrid Kft.\n'
-        copyright += ' *\n'
-        copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
-        copyright += ' * you may not use this file except in compliance with the License.\n'
-        copyright += ' * You may obtain a copy of the License at\n'
-        copyright += ' *\n'
-        copyright += ' *     http://www.apache.org/licenses/LICENSE-2.0\n'
-        copyright += ' *\n'
-        copyright += ' * Unless required by applicable law or agreed to in writing, software\n'
-        copyright += ' * distributed under the License is distributed on an "AS IS" BASIS,\n'
-        copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
-        copyright += ' * See the License for the specific language governing permissions and\n'
-        copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Mark Lobodzinski <mark@lunarg.com>\n'
-        copyright += ' * Author: Mark Young <marky@lunarg.com>\n'
-        copyright += ' */\n'
+        out.append('// clang-format on')
 
-        preamble = ''
+        self.write(''.join(out))
 
-        preamble += '// clang-format off\n'
+    def add_preamble(self, out):
+        out.append('''// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See loader_extension_generator.py for modifications
 
-        if self.genOpts.filename == 'vk_loader_extensions.h':
-            preamble += '#pragma once\n'
-            preamble += '\n'
-            preamble += '#include <stdbool.h>\n'
-            preamble += '#include <vulkan/vulkan.h>\n'
-            preamble += '#include <vulkan/vk_layer.h>\n'
-            preamble += '#include "vk_layer_dispatch_table.h"\n'
-            preamble += '\n'
+/*
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2023-2023 RasterGrid Kft.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: Mark Young <marky@lunarg.com>
+ * Author: Charles Giessen <charles@lunarg.com>
+ */
+
+// clang-format off
+''')
+
+    def print_vk_loader_extensions_h(self, out):
+        out.append('#pragma once\n')
+        out.append('\n')
+        out.append('#include <stdbool.h>\n')
+        out.append('#include <vulkan/vulkan.h>\n')
+        out.append('#include <vulkan/vk_layer.h>\n')
+        out.append('#include "vk_layer_dispatch_table.h"\n')
+        out.append('\n\n')
+
+        self.OutputPrototypesInHeader(out)
+        self.OutputLoaderTerminators(out)
+        self.OutputIcdDispatchTable(out)
+        self.OutputIcdExtensionEnableUnion(out)
+        self.OutputDeviceFunctionTerminatorDispatchTable(out)
 
 
-        elif self.genOpts.filename == 'vk_loader_extensions.c':
-            preamble += '#include <stdio.h>\n'
-            preamble += '#include <stdlib.h>\n'
-            preamble += '#include <string.h>\n'
-            preamble += '#include "loader.h"\n'
-            preamble += '#include "vk_loader_extensions.h"\n'
-            preamble += '#include <vulkan/vk_icd.h>\n'
-            preamble += '#include "wsi.h"\n'
-            preamble += '#include "debug_utils.h"\n'
-            preamble += '#include "extension_manual.h"\n'
+    def print_vk_loader_extensions_c(self, out):
+        out.append('#include <stdio.h>\n')
+        out.append('#include <stdlib.h>\n')
+        out.append('#include <string.h>\n')
+        out.append('#include "loader.h"\n')
+        out.append('#include "vk_loader_extensions.h"\n')
+        out.append('#include <vulkan/vk_icd.h>\n')
+        out.append('#include "wsi.h"\n')
+        out.append('#include "debug_utils.h"\n')
+        out.append('#include "extension_manual.h"\n')
+        self.OutputUtilitiesInSource(out)
+        self.OutputIcdDispatchTableInit(out)
+        self.OutputLoaderDispatchTables(out)
+        self.InitDeviceFunctionTerminatorDispatchTable(out)
+        self.OutputDeviceFunctionTrampolinePrototypes(out)
+        self.OutputLoaderLookupFunc(out)
+        self.CreateTrampTermFuncs(out)
+        self.InstExtensionGPA(out)
+        self.InstantExtensionCreate(out)
+        self.DeviceExtensionGetTerminator(out)
+        self.InitInstLoaderExtensionDispatchTable(out)
+        self.OutputInstantExtensionWhitelistArray(out)
 
-        elif self.genOpts.filename == 'vk_layer_dispatch_table.h':
-            preamble += '#pragma once\n'
-            preamble += '\n'
-            preamble += '#include <vulkan/vulkan.h>\n'
-            preamble += '\n'
-            preamble += '#if !defined(PFN_GetPhysicalDeviceProcAddr)\n'
-            preamble += 'typedef PFN_vkVoidFunction (VKAPI_PTR *PFN_GetPhysicalDeviceProcAddr)(VkInstance instance, const char* pName);\n'
-            preamble += '#endif\n'
-
-        write(copyright, file=self.outFile)
-        write(preamble, file=self.outFile)
-
-    #
-    # Write generate and write dispatch tables to output file
-    def endFile(self):
-        file_data = ''
-
-        if self.genOpts.filename == 'vk_loader_extensions.h':
-            file_data += self.OutputPrototypesInHeader()
-            file_data += self.OutputLoaderTerminators()
-            file_data += self.OutputIcdDispatchTable()
-            file_data += self.OutputIcdExtensionEnableUnion()
-            file_data += self.OutputDeviceFunctionTerminatorDispatchTable()
-
-        elif self.genOpts.filename == 'vk_loader_extensions.c':
-            file_data += self.OutputUtilitiesInSource()
-            file_data += self.OutputIcdDispatchTableInit()
-            file_data += self.OutputLoaderDispatchTables()
-            file_data += self.InitDeviceFunctionTerminatorDispatchTable()
-            file_data += self.OutputDeviceFunctionTrampolinePrototypes()
-            file_data += self.OutputLoaderLookupFunc()
-            file_data += self.CreateTrampTermFuncs()
-            file_data += self.InstExtensionGPA()
-            file_data += self.InstantExtensionCreate()
-            file_data += self.DeviceExtensionGetTerminator()
-            file_data += self.InitInstLoaderExtensionDispatchTable()
-            file_data += self.OutputInstantExtensionWhitelistArray()
-
-        elif self.genOpts.filename == 'vk_layer_dispatch_table.h':
-            file_data += self.OutputLayerInstanceDispatchTable()
-            file_data += self.OutputLayerDeviceDispatchTable()
-
-        file_data += '// clang-format on'
-
-        write(file_data, file=self.outFile)
-
-        # Finish processing in superclass
-        OutputGenerator.endFile(self)
-
-    def beginFeature(self, interface, emit):
-        # Start processing in superclass
-        OutputGenerator.beginFeature(self, interface, emit)
-        self.featureExtraProtect = GetFeatureProtect(interface)
-
-        enums = interface[0].findall('enum')
-        self.currentExtension = ''
-        self.name_definition = ''
-
-        for item in enums:
-            name_definition = item.get('name')
-            if 'EXTENSION_NAME' in name_definition:
-                self.name_definition = name_definition
-
-        self.type = interface.get('type')
-        self.num_commands = 0
-        name = interface.get('name')
-        self.currentExtension = name
-
-    #
-    # Process commands, adding to appropriate dispatch tables
-    def genCmd(self, cmdinfo, name, alias):
-        OutputGenerator.genCmd(self, cmdinfo, name, alias)
-
-        # Get first param type
-        params = cmdinfo.elem.findall('param')
-        info = self.getTypeNameTuple(params[0])
-
-        self.num_commands += 1
-
-        if 'android' not in name:
-            self.AddCommandToDispatchList(self.currentExtension, self.type, name, cmdinfo, info[0])
-
-    def endFeature(self):
-
-        if 'android' not in self.currentExtension:
-            self.instanceExtensions.append(self.ExtensionData(name=self.currentExtension,
-                                                              type=self.type,
-                                                              protect=self.featureExtraProtect,
-                                                              define=self.name_definition,
-                                                              num_commands=self.num_commands))
-
-        # Finish processing in superclass
-        OutputGenerator.endFeature(self)
-
-    #
-    # Retrieve the value of the len tag
-    def getLen(self, param):
-        result = None
-        length = param.attrib.get('len')
-        if length and length != 'null-terminated':
-            # For string arrays, 'len' can look like 'count,null-terminated',
-            # indicating that we have a null terminated array of strings.  We
-            # strip the null-terminated from the 'len' field and only return
-            # the parameter specifying the string count
-            if 'null-terminated' in length:
-                result = length.split(',')[0]
-            else:
-                result = length
-            result = str(result).replace('::', '->')
-        return result
-
-    #
-    # Returns an APIVersion object corresponding to the specified version token or None
-    def getAPIVersion(self, token):
-        if self.genOpts.apiname == 'vulkansc':
-            if token in ['VK_VERSION_1_0', 'VK_VERSION_1_1', 'VK_VERSION_1_2']:
-                # Vulkan 1.0-1.2 is included in Vulkan SC 1.0
-                token = 'VKSC_VERSION_1_0'
-
-            if token.startswith('VKSC_VERSION_'):
-                return APIVersion(token, 'Vulkan SC', True)
-            elif token.startswith('VK_VERSION_'):
-                # Unsupported Vulkan version
-                return APIVersion(token, 'Vulkan', False)
-            else:
-                return None
-
-        if token.startswith('VK_VERSION_'):
-            return APIVersion(token)
-        return None
-
-    #
-    # Determine if this API should be ignored or added to the instance or device dispatch table
-    def AddCommandToDispatchList(self, extension_name, extension_type, name, cmdinfo, handle_type):
-        handle = self.registry.tree.find("types/type/[name='" + handle_type + "'][@category='handle']")
-
-        return_type =  cmdinfo.elem.find('proto/type')
-        if (return_type is not None and return_type.text == 'void'):
-            return_type = None
-
-        require = None
-        if name == 'vkGetDeviceGroupSurfacePresentModes2EXT':
-            require_node = self.registry.tree.find(f"./extensions/extension[@name='{extension_name}']/require/command[@name='{name}']/..")
-            if 'depends' in require_node.attrib:
-                require = require_node.attrib['depends']
-
-        cmd_params = []
-
-        # Generate a list of commands for use in printing the necessary
-        # core instance terminator prototypes
-        params = cmdinfo.elem.findall('param')
-        lens = set()
-        for param in params:
-            length = self.getLen(param)
-            if length:
-                lens.add(length)
-
-        for param in params:
-            paramInfo = self.getTypeNameTuple(param)
-            param_type = paramInfo[0]
-            param_name = paramInfo[1]
-            param_cdecl = self.makeCParamDecl(param, 0)
-            cmd_params.append(self.CommandParam(type=param_type, name=param_name,
-                                                cdecl=param_cdecl))
-
-        version = self.getAPIVersion(extension_name)
-        if version and not version.supported:
-            # Skip commands in unsupported versions
-            return
-
-        if handle is not None and handle_type != 'VkInstance' and handle_type != 'VkPhysicalDevice':
-            # The Core Vulkan code will be wrapped in a feature called VK_VERSION_#_#
-            # For example: VK_VERSION_1_0 wraps the core 1.0 Vulkan functionality
-            if version:
-                self.core_commands.append(
-                    self.CommandData(name=name, ext_name=version.token,
-                                     ext_type='device',
-                                     require=require,
-                                     protect=self.featureExtraProtect,
-                                     return_type = return_type,
-                                     handle_type = handle_type,
-                                     params = cmd_params,
-                                     cdecl=self.makeCDecls(cmdinfo.elem)[0]))
-            else:
-                self.ext_device_dispatch_list.append((name, self.featureExtraProtect))
-                self.ext_commands.append(
-                    self.CommandData(name=name, ext_name=extension_name,
-                                     ext_type=extension_type,
-                                     require=require,
-                                     protect=self.featureExtraProtect,
-                                     return_type = return_type,
-                                     handle_type = handle_type,
-                                     params = cmd_params,
-                                     cdecl=self.makeCDecls(cmdinfo.elem)[0]))
-        else:
-            # The Core Vulkan code will be wrapped in a feature called VK_VERSION_#_#
-            # For example: VK_VERSION_1_0 wraps the core 1.0 Vulkan functionality
-            if version:
-                self.core_commands.append(
-                    self.CommandData(name=name, ext_name=version.token,
-                                     ext_type='instance',
-                                     require=require,
-                                     protect=self.featureExtraProtect,
-                                     return_type = return_type,
-                                     handle_type = handle_type,
-                                     params = cmd_params,
-                                     cdecl=self.makeCDecls(cmdinfo.elem)[0]))
-
-            else:
-                self.ext_instance_dispatch_list.append((name, self.featureExtraProtect))
-                self.ext_commands.append(
-                    self.CommandData(name=name, ext_name=extension_name,
-                                     ext_type=extension_type,
-                                     require=require,
-                                     protect=self.featureExtraProtect,
-                                     return_type = return_type,
-                                     handle_type = handle_type,
-                                     params = cmd_params,
-                                     cdecl=self.makeCDecls(cmdinfo.elem)[0]))
-
-    #
-    # Retrieve the type and name for a parameter
-    def getTypeNameTuple(self, param):
-        t = ''
-        n = ''
-        for elem in param:
-            if elem.tag == 'type':
-                t = noneStr(elem.text)
-            elif elem.tag == 'name':
-                n = noneStr(elem.text)
-        return (t, n)
+    def print_vk_layer_dispatch_table(self, out):
+        out.append('#pragma once\n')
+        out.append('\n')
+        out.append('#include <vulkan/vulkan.h>\n')
+        out.append('\n')
+        out.append('#if !defined(PFN_GetPhysicalDeviceProcAddr)\n')
+        out.append('typedef PFN_vkVoidFunction (VKAPI_PTR *PFN_GetPhysicalDeviceProcAddr)(VkInstance instance, const char* pName);\n')
+        out.append('#endif\n\n')
+        self.OutputLayerInstanceDispatchTable(out)
+        self.OutputLayerDeviceDispatchTable(out)
 
     # Convert an XML dependency expression to a C expression, taking a callback to replace extension names
     # See https://registry.khronos.org/vulkan/specs/1.4/registry.html#depends-expressions
@@ -492,246 +222,264 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
         expr = re.sub(r'\w+', lambda match: replace_func(match.group()), expr)
         return expr
 
-    def OutputPrototypesInHeader(self):
-        protos = ''
-        protos += '// Structures defined externally, but used here\n'
-        protos += 'struct loader_instance;\n'
-        protos += 'struct loader_device;\n'
-        protos += 'struct loader_icd_term;\n'
-        protos += 'struct loader_dev_dispatch_table;\n'
-        protos += '\n'
-        protos += '// Device extension error function\n'
-        protos += 'VKAPI_ATTR VkResult VKAPI_CALL vkDevExtError(VkDevice dev);\n'
-        protos += '\n'
-        protos += '// Extension interception for vkGetInstanceProcAddr function, so we can return\n'
-        protos += '// the appropriate information for any instance extensions we know about.\n'
-        protos += 'bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *name, void **addr);\n'
-        protos += '\n'
-        protos += '// Extension interception for vkCreateInstance function, so we can properly\n'
-        protos += '// detect and enable any instance extension information for extensions we know\n'
-        protos += '// about.\n'
-        protos += 'void extensions_create_instance(struct loader_instance *ptr_instance, const VkInstanceCreateInfo *pCreateInfo);\n'
-        protos += '\n'
-        protos += '// Extension interception for vkGetDeviceProcAddr function, so we can return\n'
-        protos += '// an appropriate terminator if this is one of those few device commands requiring\n'
-        protos += '// a terminator.\n'
-        protos += 'PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *dev, const char *name, bool* found_name);\n'
-        protos += '\n'
-        protos += '// Dispatch table properly filled in with appropriate terminators for the\n'
-        protos += '// supported extensions.\n'
-        protos += 'extern const VkLayerInstanceDispatchTable instance_disp;\n'
-        protos += '\n'
-        protos += '// Array of extension strings for instance extensions we support.\n'
-        protos += 'extern const char *const LOADER_INSTANCE_EXTENSIONS[];\n'
-        protos += '\n'
-        protos += 'VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_instance* inst, struct loader_icd_term *icd_term);\n'
-        protos += '\n'
-        protos += '// Init Device function pointer dispatch table with core commands\n'
-        protos += 'VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_dispatch_table *dev_table, PFN_vkGetDeviceProcAddr gpa,\n'
-        protos += '                                                             VkDevice dev);\n'
-        protos += '\n'
-        protos += '// Init Device function pointer dispatch table with extension commands\n'
-        protos += 'VKAPI_ATTR void VKAPI_CALL loader_init_device_extension_dispatch_table(struct loader_dev_dispatch_table *dev_table,\n'
-        protos += '                                                                       PFN_vkGetInstanceProcAddr gipa,\n'
-        protos += '                                                                       PFN_vkGetDeviceProcAddr gdpa,\n'
-        protos += '                                                                       VkInstance inst,\n'
-        protos += '                                                                       VkDevice dev);\n'
-        protos += '\n'
-        protos += '// Init Instance function pointer dispatch table with core commands\n'
-        protos += 'VKAPI_ATTR void VKAPI_CALL loader_init_instance_core_dispatch_table(VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa,\n'
-        protos += '                                                                    VkInstance inst);\n'
-        protos += '\n'
-        protos += '// Init Instance function pointer dispatch table with core commands\n'
-        protos += 'VKAPI_ATTR void VKAPI_CALL loader_init_instance_extension_dispatch_table(VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa,\n'
-        protos += '                                                                         VkInstance inst);\n'
-        protos += '\n'
-        protos += '// Device command lookup function\n'
-        protos += 'VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDispatchTable *table, const char *name, bool* name_found);\n'
-        protos += '\n'
-        protos += '// Instance command lookup function\n'
-        protos += 'VKAPI_ATTR void* VKAPI_CALL loader_lookup_instance_dispatch_table(const VkLayerInstanceDispatchTable *table, const char *name,\n'
-        protos += '                                                                  bool *found_name);\n'
-        protos += '\n'
-        return protos
-
-    def OutputUtilitiesInSource(self):
-        protos = ''
-        protos += '// Device extension error function\n'
-        protos += 'VKAPI_ATTR VkResult VKAPI_CALL vkDevExtError(VkDevice dev) {\n'
-        protos += '    struct loader_device *found_dev;\n'
-        protos += '    // The device going in is a trampoline device\n'
-        protos += '    struct loader_icd_term *icd_term = loader_get_icd_and_device(dev, &found_dev);\n'
-        protos += '\n'
-        protos += '    if (icd_term)\n'
-        protos += '        loader_log(icd_term->this_instance, VULKAN_LOADER_ERROR_BIT, 0,\n'
-        protos += '                   "Bad destination in loader trampoline dispatch,"\n'
-        protos += '                   "Are layers and extensions that you are calling enabled?");\n'
-        protos += '    return VK_ERROR_EXTENSION_NOT_PRESENT;\n'
-        protos += '}\n\n'
-        return protos
-
-    #
-    # Create a layer instance dispatch table from the appropriate list and return it as a string
-    def OutputLayerInstanceDispatchTable(self):
-        commands = []
-        table = ''
-        cur_extension_name = ''
-
-        table += '// Instance function pointer dispatch table\n'
-        table += 'typedef struct VkLayerInstanceDispatchTable_ {\n'
-
-        # First add in an entry for GetPhysicalDeviceProcAddr.  This will not
-        # ever show up in the XML or header, so we have to manually add it.
-        table += '    // Manually add in GetPhysicalDeviceProcAddr entry\n'
-        table += '    PFN_GetPhysicalDeviceProcAddr GetPhysicalDeviceProcAddr;\n'
-
-        for x in range(0, 2):
-            if x == 0:
-                commands = self.core_commands
+    def DescribeBlock(self, command, current_block, out, custom_commands_string = ' commands', indent = '    '):
+        if command.extensions != current_block and command.version != current_block:
+            if command.version is None and len(command.extensions) == 0: # special case for 1.0
+                out.append(f'\n{indent}// ---- Core Vulkan 1.0{custom_commands_string}\n')
+                return None
+            elif command.version is not None:
+                if command.version != current_block:
+                    out.append(f'\n{indent}// ---- Core Vulkan 1.{command.version.name.split('_')[-1]}{custom_commands_string}\n')
+                return command.version
             else:
-                commands = self.ext_commands
+                # don't repeat unless the first extension is different (while rest can vary)
+                if not isinstance(current_block, list) or current_block[0].name != command.extensions[0].name:
+                    out.append(f'\n{indent}// ---- {command.extensions[0].name if len(command.extensions) > 0 else ''} extension{custom_commands_string}\n')
+                return command.extensions
+        else:
+            return current_block
 
-            for cur_cmd in commands:
-                version = self.getAPIVersion(cur_cmd.ext_name)
-                is_inst_handle_type = cur_cmd.name in ADD_INST_CMDS or cur_cmd.handle_type == 'VkInstance' or cur_cmd.handle_type == 'VkPhysicalDevice'
-                if is_inst_handle_type:
+    def OutputPrototypesInHeader(self, out: list):
+        out.append('''// Structures defined externally, but used here
+struct loader_instance;
+struct loader_device;
+struct loader_icd_term;
+struct loader_dev_dispatch_table;
 
-                    if cur_cmd.ext_name != cur_extension_name:
-                        if version:
-                            table += f'\n    // ---- Core {version.name} commands\n'
-                        else:
-                            table += f'\n    // ---- {cur_cmd.ext_name} extension commands\n'
-                        cur_extension_name = cur_cmd.ext_name
+// Device extension error function
+VKAPI_ATTR VkResult VKAPI_CALL vkDevExtError(VkDevice dev);
 
-                    # Remove 'vk' from proto name
-                    base_name = cur_cmd.name[2:]
+// Extension interception for vkGetInstanceProcAddr function, so we can return
+// the appropriate information for any instance extensions we know about.
+bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *name, void **addr);
 
-                    if cur_cmd.protect is not None:
-                        table += f'#if defined({cur_cmd.protect})\n'
+// Extension interception for vkCreateInstance function, so we can properly
+// detect and enable any instance extension information for extensions we know
+// about.
+void extensions_create_instance(struct loader_instance *ptr_instance, const VkInstanceCreateInfo *pCreateInfo);
 
-                    table += f'    PFN_{cur_cmd.name} {base_name};\n'
+// Extension interception for vkGetDeviceProcAddr function, so we can return
+// an appropriate terminator if this is one of those few device commands requiring
+// a terminator.
+PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *dev, const char *name, bool* found_name);
 
-                    if cur_cmd.protect is not None:
-                        table += f'#endif // {cur_cmd.protect}\n'
+// Dispatch table properly filled in with appropriate terminators for the
+// supported extensions.
+extern const VkLayerInstanceDispatchTable instance_disp;
 
-        table += '} VkLayerInstanceDispatchTable;\n\n'
-        return table
+// Array of extension strings for instance extensions we support.
+extern const char *const LOADER_INSTANCE_EXTENSIONS[];
 
-    #
-    # Create a layer device dispatch table from the appropriate list and return it as a string
-    def OutputLayerDeviceDispatchTable(self):
-        commands = []
-        table = ''
-        cur_extension_name = ''
+VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_instance* inst, struct loader_icd_term *icd_term);
 
-        table += '// Device function pointer dispatch table\n'
-        table += '#define DEVICE_DISP_TABLE_MAGIC_NUMBER 0x10ADED040410ADEDUL\n'
-        table += 'typedef struct VkLayerDispatchTable_ {\n'
-        table += '    uint64_t magic; // Should be DEVICE_DISP_TABLE_MAGIC_NUMBER\n'
+// Init Device function pointer dispatch table with core commands
+VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_dispatch_table *dev_table, PFN_vkGetDeviceProcAddr gpa,
+                                                             VkDevice dev);
 
-        for x in range(0, 2):
-            if x == 0:
-                commands = self.core_commands
-            else:
-                commands = self.ext_commands
+// Init Device function pointer dispatch table with extension commands
+VKAPI_ATTR void VKAPI_CALL loader_init_device_extension_dispatch_table(struct loader_dev_dispatch_table *dev_table,
+                                                                       PFN_vkGetInstanceProcAddr gipa,
+                                                                       PFN_vkGetDeviceProcAddr gdpa,
+                                                                       VkInstance inst,
+                                                                       VkDevice dev);
 
-            for cur_cmd in commands:
-                version = self.getAPIVersion(cur_cmd.ext_name)
-                is_inst_handle_type = cur_cmd.name in ADD_INST_CMDS or cur_cmd.handle_type == 'VkInstance' or cur_cmd.handle_type == 'VkPhysicalDevice'
-                if not is_inst_handle_type:
+// Init Instance function pointer dispatch table with core commands
+VKAPI_ATTR void VKAPI_CALL loader_init_instance_core_dispatch_table(VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa,
+                                                                    VkInstance inst);
 
-                    if cur_cmd.ext_name != cur_extension_name:
-                        if version:
-                            table += f'\n    // ---- Core {version.name} commands\n'
-                        else:
-                            table += f'\n    // ---- {cur_cmd.ext_name} extension commands\n'
-                        cur_extension_name = cur_cmd.ext_name
+// Init Instance function pointer dispatch table with core commands
+VKAPI_ATTR void VKAPI_CALL loader_init_instance_extension_dispatch_table(VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa,
+                                                                         VkInstance inst);
 
-                    # Remove 'vk' from proto name
-                    base_name = cur_cmd.name[2:]
+// Device command lookup function
+VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDispatchTable *table, const char *name, bool* name_found);
 
-                    if cur_cmd.protect is not None:
-                        table += f'#if defined({cur_cmd.protect})\n'
+// Instance command lookup function
+VKAPI_ATTR void* VKAPI_CALL loader_lookup_instance_dispatch_table(const VkLayerInstanceDispatchTable *table, const char *name,
+                                                                  bool *found_name);
 
-                    table += f'    PFN_{cur_cmd.name} {base_name};\n'
-                    if cur_cmd.protect is not None:
-                        table += f'#endif // {cur_cmd.protect}\n'
+''')
 
-        table += '} VkLayerDispatchTable;\n\n'
-        return table
+    # Creates the prototypes for the loader's core instance command terminators
+    def OutputLoaderTerminators(self, out):
+        out.append('// Loader core instance terminators\n')
 
-    #
-    # Common code between the dispatch table struct and the function filling out said struct
-    def ShouldPrintInIcdDispatchTable(self, cur_cmd, skip_list):
-        return cur_cmd.name == 'vkGetDeviceProcAddr' or \
-            (cur_cmd.handle_type not in ['VkDevice', 'VkCommandBuffer', 'VkQueue'] and cur_cmd.name not in skip_list)
+        for command in self.vk.commands.values():
+            if len(command.extensions) > 0:
+                continue
+            if not (command.name in ADD_INST_CMDS) and not (command.params[0].type in ['VkInstance', 'VkPhysicalDevice']):
+                continue
 
-    #
-    # Create a dispatch table from the appropriate list and return it as a string
-    def OutputIcdDispatchTable(self):
-        commands = []
-        table = ''
-        cur_extension_name = ''
+            mod_string = ''
+            new_terminator = command.cPrototype
+            mod_string = new_terminator.replace("VKAPI_CALL vk", "VKAPI_CALL terminator_")
 
+            if command.name in PRE_INSTANCE_FUNCTIONS:
+                pre_instance_basic_version = mod_string
+                mod_string = mod_string.replace("terminator_", "terminator_pre_instance_")
+                mod_string = mod_string.replace(command.name[2:] + '(\n', command.name[2:] + '(\n    const Vk' + command.name[2:] + 'Chain* chain,\n')
+
+            if command.protect is not None:
+                out.append(f'#if defined({command.protect})\n')
+
+            if command.name in PRE_INSTANCE_FUNCTIONS:
+                out.append(pre_instance_basic_version)
+                out.append('\n')
+
+            out.append(mod_string)
+            out.append('\n')
+
+            if command.protect is not None:
+                out.append(f'#endif // {command.protect}\n')
+
+        out.append('\n')
+
+    # Create a dispatch table from the appropriate list
+    def OutputIcdDispatchTable(self, out):
         skip_commands = ['vkGetInstanceProcAddr',
                          'vkEnumerateDeviceLayerProperties',
                         ]
 
-        table += '// ICD function pointer dispatch table\n'
-        table += 'struct loader_icd_term_dispatch {\n'
+        out.append('// ICD function pointer dispatch table\n')
+        out.append('struct loader_icd_term_dispatch {\n')
 
-        for x in range(0, 2):
-            if x == 0:
-                commands = self.core_commands
-            else:
-                commands = self.ext_commands
+        current_block = ''
+        for command in self.vk.commands.values():
+            if (command.name in skip_commands or command.device )and command.name != 'vkGetDeviceProcAddr':
+                continue
 
-            for cur_cmd in commands:
-                version = self.getAPIVersion(cur_cmd.ext_name)
-                if self.ShouldPrintInIcdDispatchTable(cur_cmd, skip_commands):
-                    if cur_cmd.ext_name != cur_extension_name:
-                        if version:
-                            table += f'\n    // ---- Core {version.name} commands\n'
-                        else:
-                            table += f'\n    // ---- {cur_cmd.ext_name} extension commands\n'
-                        cur_extension_name = cur_cmd.ext_name
+            current_block = self.DescribeBlock(command, current_block, out)
 
-                    # Remove 'vk' from proto name
-                    base_name = cur_cmd.name[2:]
+            if command.protect:
+                out.append(f'#if defined({command.protect})\n')
 
-                    if cur_cmd.protect is not None:
-                        table += f'#if defined({cur_cmd.protect})\n'
+            out.append(f'    PFN_{command.name} {command.name[2:]};\n')
 
-                    table += f'    PFN_{cur_cmd.name} {base_name};\n'
+            if command.protect:
+                out.append(f'#endif // {command.protect}\n')
+        out.append('};\n\n')
 
-                    if cur_cmd.protect is not None:
-                        table += f'#endif // {cur_cmd.protect}\n'
+    # Create the extension enable union
+    def OutputIcdExtensionEnableUnion(self, out):
 
-        table += '};\n\n'
-        return table
+        out.append( 'struct loader_instance_extension_enables {\n')
+        for extension in self.instance_extensions:
+            if len(extension.commands) == 0 or extension.name in WSI_EXT_NAMES:
+                continue
+            out.append( f'    uint8_t {extension.name[3:].lower()};\n')
 
-    #
-    # Init a dispatch table from the appropriate list and return it as a string
-    def OutputIcdDispatchTableInit(self):
-        commands = []
-        cur_extension_name = ''
+        out.append( '};\n\n')
 
-        table = ''
-        table += 'VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_instance* inst, struct loader_icd_term *icd_term) {\n'
-        table += '    const PFN_vkGetInstanceProcAddr fp_gipa = icd_term->scanned_icd->GetInstanceProcAddr;\n'
-        table += '\n'
-        table += '#define LOOKUP_GIPA(func) icd_term->dispatch.func = (PFN_vk##func)fp_gipa(icd_term->instance, "vk" #func);\n'
-        table += '\n'
-        table += '#define LOOKUP_REQUIRED_GIPA(func)                                                      \\\n'
-        table += '    do {                                                                                \\\n'
-        table += '        LOOKUP_GIPA(func);                                                              \\\n'
-        table += '        if (!icd_term->dispatch.func) {                                                 \\\n'
-        table += '            loader_log(inst, VULKAN_LOADER_WARN_BIT, 0, "Unable to load %s from ICD %s",\\\n'
-        table += '                       "vk"#func, icd_term->scanned_icd->lib_name);                     \\\n'
-        table += '            return false;                                                               \\\n'
-        table += '        }                                                                               \\\n'
-        table += '    } while (0)\n'
-        table += '\n'
+    # Create a dispatch table solely for device functions which have custom terminators
+    def OutputDeviceFunctionTerminatorDispatchTable(self, out):
+        out.append('// Functions that required a terminator need to have a separate dispatch table which contains their corresponding\n')
+        out.append('// device function. This is used in the terminators themselves.\n')
+        out.append('struct loader_device_terminator_dispatch {\n')
+
+        # last_protect = None
+        current_block = ''
+        for command in self.vk.commands.values():
+            if len(command.extensions) == 0:
+                continue
+            if command.name in DEVICE_CMDS_NEED_TERM:
+                if command.protect is not None:
+                    out.append( f'#if defined({command.protect})\n')
+
+                current_block = self.DescribeBlock(command, current_block, out)
+
+                out.append( f'    PFN_{command.name} {command.name[2:]};\n')
+
+                if command.protect is not None:
+                    out.append( f'#endif // {command.protect}\n')
+
+        out.append( '};\n\n')
+
+
+    # Create a layer instance dispatch table from the appropriate list
+    def OutputLayerInstanceDispatchTable(self, out):
+
+        out.append('// Instance function pointer dispatch table\n')
+        out.append('typedef struct VkLayerInstanceDispatchTable_ {\n')
+
+        # First add in an entry for GetPhysicalDeviceProcAddr.  This will not
+        # ever show up in the XML or header, so we have to manually add it.
+        out.append('    // Manually add in GetPhysicalDeviceProcAddr entry\n')
+        out.append('    PFN_GetPhysicalDeviceProcAddr GetPhysicalDeviceProcAddr;\n')
+
+        current_block = ''
+        for command_name, command in self.vk.commands.items():
+            if not command.instance:
+                continue
+
+            current_block = self.DescribeBlock(command, current_block, out)
+
+            if command.protect:
+                out.append(f'#if defined({command.protect})\n')
+
+            out.append(f'    PFN_{command_name} {command_name[2:]};\n')
+
+            if command.protect:
+                out.append(f'#endif // {command.protect}\n')
+
+        out.append('} VkLayerInstanceDispatchTable;\n\n')
+
+    # Create a layer device dispatch table from the appropriate list
+    def OutputLayerDeviceDispatchTable(self, out):
+
+        out.append('// Device function pointer dispatch table\n')
+        out.append('#define DEVICE_DISP_TABLE_MAGIC_NUMBER 0x10ADED040410ADEDUL\n')
+        out.append('typedef struct VkLayerDispatchTable_ {\n')
+        out.append('    uint64_t magic; // Should be DEVICE_DISP_TABLE_MAGIC_NUMBER\n')
+
+        current_block = ''
+        for command in [x for x in self.vk.commands.values() if x.device]:
+
+            current_block = self.DescribeBlock(command, current_block, out)
+
+            if command.protect:
+                out.append(f'#if defined({command.protect})\n')
+
+            out.append(f'    PFN_{command.name} {command.name[2:]};\n')
+
+            if command.protect:
+                out.append(f'#endif // {command.protect}\n')
+        out.append('} VkLayerDispatchTable;\n\n')
+
+    def OutputUtilitiesInSource(self, out):
+        out.append('''
+// Device extension error function
+VKAPI_ATTR VkResult VKAPI_CALL vkDevExtError(VkDevice dev) {
+    struct loader_device *found_dev;
+    // The device going in is a trampoline device
+    struct loader_icd_term *icd_term = loader_get_icd_and_device(dev, &found_dev);
+
+    if (icd_term)
+        loader_log(icd_term->this_instance, VULKAN_LOADER_ERROR_BIT, 0,
+                   "Bad destination in loader trampoline dispatch,"
+                   "Are layers and extensions that you are calling enabled?");
+    return VK_ERROR_EXTENSION_NOT_PRESENT;
+}
+
+''')
+
+
+    # Init a dispatch table from the appropriate list
+    def OutputIcdDispatchTableInit(self, out):
+        out.append('VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_instance* inst, struct loader_icd_term *icd_term) {\n')
+        out.append('    const PFN_vkGetInstanceProcAddr fp_gipa = icd_term->scanned_icd->GetInstanceProcAddr;\n')
+        out.append('\n')
+        out.append('#define LOOKUP_GIPA(func) icd_term->dispatch.func = (PFN_vk##func)fp_gipa(icd_term->instance, "vk" #func);\n')
+        out.append('\n')
+        out.append('#define LOOKUP_REQUIRED_GIPA(func)                                                      \\\n')
+        out.append('    do {                                                                                \\\n')
+        out.append('        LOOKUP_GIPA(func);                                                              \\\n')
+        out.append('        if (!icd_term->dispatch.func) {                                                 \\\n')
+        out.append('            loader_log(inst, VULKAN_LOADER_WARN_BIT, 0, "Unable to load %s from ICD %s",\\\n')
+        out.append('                       "vk"#func, icd_term->scanned_icd->lib_name);                     \\\n')
+        out.append('            return false;                                                               \\\n')
+        out.append('        }                                                                               \\\n')
+        out.append('    } while (0)\n')
+        out.append('\n')
 
 
         skip_gipa_commands = ['vkGetInstanceProcAddr',
@@ -742,108 +490,39 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                               'vkEnumerateInstanceVersion',
                              ]
 
-        for x in range(0, 2):
-            if x == 0:
-                commands = self.core_commands
-            else:
-                commands = self.ext_commands
-
-            required = False
-            for cur_cmd in commands:
-                version = self.getAPIVersion(cur_cmd.ext_name)
-                if self.ShouldPrintInIcdDispatchTable(cur_cmd, skip_gipa_commands):
-
-                    if cur_cmd.ext_name != cur_extension_name:
-                        if version:
-                            table += f'\n    // ---- Core {version.name}\n'
-                            required = version.number == '1.0'
-                        else:
-                            table += f'\n    // ---- {cur_cmd.ext_name} extension commands\n'
-                            required = False
-                        cur_extension_name = cur_cmd.ext_name
-
-                    # Remove 'vk' from proto name
-                    base_name = cur_cmd.name[2:]
-
-                    if cur_cmd.protect is not None:
-                        table += f'#if defined({cur_cmd.protect})\n'
-
-                    if required:
-                        # The Core Vulkan code will be wrapped in a feature called VK_VERSION_#_#
-                        # For example: VK_VERSION_1_0 wraps the core 1.0 Vulkan functionality
-                        table += f'    LOOKUP_REQUIRED_GIPA({base_name});\n'
-                    else:
-                        table += f'    LOOKUP_GIPA({base_name});\n'
-                    if cur_cmd.protect is not None:
-                        table += f'#endif // {cur_cmd.protect}\n'
-
-        table += '\n'
-        table += '#undef LOOKUP_REQUIRED_GIPA\n'
-        table += '#undef LOOKUP_GIPA\n'
-        table += '\n'
-        table += '    return true;\n'
-        table += '};\n\n'
-        return table
-
-    #
-    # Create the extension enable union
-    def OutputIcdExtensionEnableUnion(self):
-        extensions = self.instanceExtensions
-
-        union = ''
-        union += 'struct loader_instance_extension_enables {\n'
-        for ext in extensions:
-            if (self.getAPIVersion(ext.name) or ext.name in WSI_EXT_NAMES or
-                ext.type == 'device' or ext.num_commands == 0):
+        current_block = ''
+        for command in [x for x in self.vk.commands.values() if x.instance or x.name == 'vkGetDeviceProcAddr']:
+            if command.name in skip_gipa_commands:
                 continue
+            custom_commands_string= ' commands' if len(command.extensions) > 0 else ''
+            current_block = self.DescribeBlock(command, current_block, out, custom_commands_string=custom_commands_string)
 
-            union += f'    uint8_t {ext.name[3:].lower()};\n'
+            if command.protect is not None:
+                out.append( f'#if defined({command.protect})\n')
 
-        union += '};\n\n'
-        return union
+            if command.version is None and len(command.extensions) == 0:
+                # The Core Vulkan code will be wrapped in a feature called VK_VERSION_#_#
+                # For example: VK_VERSION_1_0 wraps the core 1.0 Vulkan functionality
+                out.append(f'    LOOKUP_REQUIRED_GIPA({command.name[2:]});\n')
+            else:
+                out.append( f'    LOOKUP_GIPA({command.name[2:]});\n')
 
-    #
-    # Creates the prototypes for the loader's core instance command terminators
-    def OutputLoaderTerminators(self):
-        terminators = ''
-        terminators += '// Loader core instance terminators\n'
+            if command.protect is not None:
+                out.append(f'#endif // {command.protect}\n')
 
-        for cur_cmd in self.core_commands:
-            is_inst_handle_type = cur_cmd.name in ADD_INST_CMDS or cur_cmd.handle_type == 'VkInstance' or cur_cmd.handle_type == 'VkPhysicalDevice'
-            if is_inst_handle_type:
-                mod_string = ''
-                new_terminator = cur_cmd.cdecl
-                mod_string = new_terminator.replace("VKAPI_CALL vk", "VKAPI_CALL terminator_")
+        out.append('\n')
+        out.append('#undef LOOKUP_REQUIRED_GIPA\n')
+        out.append('#undef LOOKUP_GIPA\n')
+        out.append('\n')
+        out.append('    return true;\n')
+        out.append('};\n\n')
 
-                if cur_cmd.name in PRE_INSTANCE_FUNCTIONS:
-                    pre_instance_basic_version = mod_string
-                    mod_string = mod_string.replace("terminator_", "terminator_pre_instance_")
-                    mod_string = mod_string.replace(cur_cmd.name[2:] + '(\n', cur_cmd.name[2:] + '(\n    const Vk' + cur_cmd.name[2:] + 'Chain* chain,\n')
 
-                if cur_cmd.protect is not None:
-                    terminators += f'#if defined({cur_cmd.protect})\n'
-
-                if cur_cmd.name in PRE_INSTANCE_FUNCTIONS:
-                    terminators += pre_instance_basic_version
-                    terminators += '\n'
-
-                terminators += mod_string
-                terminators += '\n'
-
-                if cur_cmd.protect is not None:
-                    terminators += f'#endif // {cur_cmd.protect}\n'
-
-        terminators += '\n'
-        return terminators
-
-    #
     # Creates code to initialize the various dispatch tables
-    def OutputLoaderDispatchTables(self):
+    def OutputLoaderDispatchTables(self, out):
         commands = []
-        tables = ''
         gpa_param = ''
         cur_type = ''
-        cur_extension_name = ''
 
         for x in range(0, 4):
             if x == 0:
@@ -851,58 +530,54 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                 gpa_param = 'dev'
                 commands = self.core_commands
 
-                tables += '// Init Device function pointer dispatch table with core commands\n'
-                tables += 'VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_dispatch_table *dev_table, PFN_vkGetDeviceProcAddr gpa,\n'
-                tables += '                                                             VkDevice dev) {\n'
-                tables += '    VkLayerDispatchTable *table = &dev_table->core_dispatch;\n'
-                tables += '    if (table->magic != DEVICE_DISP_TABLE_MAGIC_NUMBER) { abort(); }\n'
-                tables += '    for (uint32_t i = 0; i < MAX_NUM_UNKNOWN_EXTS; i++) dev_table->ext_dispatch[i] = (PFN_vkDevExt)vkDevExtError;\n'
+                out.append('// Init Device function pointer dispatch table with core commands\n')
+                out.append('VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_dispatch_table *dev_table, PFN_vkGetDeviceProcAddr gpa,\n')
+                out.append('                                                             VkDevice dev) {\n')
+                out.append('    VkLayerDispatchTable *table = &dev_table->core_dispatch;\n')
+                out.append('    if (table->magic != DEVICE_DISP_TABLE_MAGIC_NUMBER) { abort(); }\n')
+                out.append('    for (uint32_t i = 0; i < MAX_NUM_UNKNOWN_EXTS; i++) dev_table->ext_dispatch[i] = (PFN_vkDevExt)vkDevExtError;\n')
 
             elif x == 1:
                 cur_type = 'device'
                 gpa_param = 'dev'
-                commands = self.ext_commands
+                commands = self.extension_commands
 
-                tables += '// Init Device function pointer dispatch table with extension commands\n'
-                tables += 'VKAPI_ATTR void VKAPI_CALL loader_init_device_extension_dispatch_table(struct loader_dev_dispatch_table *dev_table,\n'
-                tables += '                                                                       PFN_vkGetInstanceProcAddr gipa,\n'
-                tables += '                                                                       PFN_vkGetDeviceProcAddr gdpa,\n'
-                tables += '                                                                       VkInstance inst,\n'
-                tables += '                                                                       VkDevice dev) {\n'
-                tables += '    VkLayerDispatchTable *table = &dev_table->core_dispatch;\n'
-                tables += '    table->magic = DEVICE_DISP_TABLE_MAGIC_NUMBER;\n'
+                out.append('// Init Device function pointer dispatch table with extension commands\n')
+                out.append('VKAPI_ATTR void VKAPI_CALL loader_init_device_extension_dispatch_table(struct loader_dev_dispatch_table *dev_table,\n')
+                out.append('                                                                       PFN_vkGetInstanceProcAddr gipa,\n')
+                out.append('                                                                       PFN_vkGetDeviceProcAddr gdpa,\n')
+                out.append('                                                                       VkInstance inst,\n')
+                out.append('                                                                       VkDevice dev) {\n')
+                out.append('    VkLayerDispatchTable *table = &dev_table->core_dispatch;\n')
+                out.append('    table->magic = DEVICE_DISP_TABLE_MAGIC_NUMBER;\n')
 
             elif x == 2:
                 cur_type = 'instance'
                 gpa_param = 'inst'
                 commands = self.core_commands
 
-                tables += '// Init Instance function pointer dispatch table with core commands\n'
-                tables += 'VKAPI_ATTR void VKAPI_CALL loader_init_instance_core_dispatch_table(VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa,\n'
-                tables += '                                                                    VkInstance inst) {\n'
+                out.append('// Init Instance function pointer dispatch table with core commands\n')
+                out.append('VKAPI_ATTR void VKAPI_CALL loader_init_instance_core_dispatch_table(VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa,\n')
+                out.append('                                                                    VkInstance inst) {\n')
 
             else:
                 cur_type = 'instance'
                 gpa_param = 'inst'
-                commands = self.ext_commands
+                commands = self.extension_commands
 
-                tables += '// Init Instance function pointer dispatch table with core commands\n'
-                tables += 'VKAPI_ATTR void VKAPI_CALL loader_init_instance_extension_dispatch_table(VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa,\n'
-                tables += '                                                                        VkInstance inst) {\n'
+                out.append('// Init Instance function pointer dispatch table with core commands\n')
+                out.append('VKAPI_ATTR void VKAPI_CALL loader_init_instance_extension_dispatch_table(VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa,\n')
+                out.append('                                                                        VkInstance inst) {\n')
 
-            for cur_cmd in commands:
-                version = self.getAPIVersion(cur_cmd.ext_name)
-                is_inst_handle_type = cur_cmd.handle_type == 'VkInstance' or cur_cmd.handle_type == 'VkPhysicalDevice'
+            current_block = ''
+            for command in commands:
+                is_inst_handle_type = command.params[0].type in ['VkInstance', 'VkPhysicalDevice']
                 if ((cur_type == 'instance' and is_inst_handle_type) or (cur_type == 'device' and not is_inst_handle_type)):
-                    if cur_cmd.ext_name != cur_extension_name:
-                        if version:
-                            tables += f'\n    // ---- Core {version.name} commands\n'
-                        else:
-                            tables += f'\n    // ---- {cur_cmd.ext_name} extension commands\n'
-                        cur_extension_name = cur_cmd.ext_name
+
+                    current_block = self.DescribeBlock(command, current_block, out)
 
                     # Remove 'vk' from proto name
-                    base_name = cur_cmd.name[2:]
+                    base_name = command.name[2:]
 
                     # Names to skip
                     if (base_name == 'CreateInstance' or base_name == 'CreateDevice' or
@@ -911,95 +586,134 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                         base_name == 'EnumerateInstanceVersion'):
                         continue
 
-                    if cur_cmd.protect is not None:
-                        tables += f'#if defined({cur_cmd.protect})\n'
+                    if command.protect is not None:
+                        out.append(f'#if defined({command.protect})\n')
 
                     # If we're looking for the proc we are passing in, just point the table to it.  This fixes the issue where
                     # a layer overrides the function name for the loader.
                     if x == 1:
                         if base_name == 'GetDeviceProcAddr':
-                            tables += '    table->GetDeviceProcAddr = gdpa;\n'
-                        elif cur_cmd.ext_type == 'instance':
-                            tables += f'    table->{base_name} = (PFN_{cur_cmd.name})gipa(inst, "{cur_cmd.name}");\n'
+                            out.append('    table->GetDeviceProcAddr = gdpa;\n')
+                        elif len(command.extensions) > 0 and command.extensions[0].instance:
+                            out.append(f'    table->{base_name} = (PFN_{command.name})gipa(inst, "{command.name}");\n')
                         else:
-                            tables += f'    table->{base_name} = (PFN_{cur_cmd.name})gdpa(dev, "{cur_cmd.name}");\n'
+                            out.append(f'    table->{base_name} = (PFN_{command.name})gdpa(dev, "{command.name}");\n')
                     elif (x < 1 and base_name == 'GetDeviceProcAddr'):
-                        tables += '    table->GetDeviceProcAddr = gpa;\n'
+                        out.append('    table->GetDeviceProcAddr = gpa;\n')
                     elif (x > 1 and base_name == 'GetInstanceProcAddr'):
-                        tables += '    table->GetInstanceProcAddr = gpa;\n'
+                        out.append('    table->GetInstanceProcAddr = gpa;\n')
                     else:
-                        tables += f'    table->{base_name} = (PFN_{cur_cmd.name})gpa({gpa_param}, "{cur_cmd.name}");\n'
+                        out.append(f'    table->{base_name} = (PFN_{command.name})gpa({gpa_param}, "{command.name}");\n')
 
-                    if cur_cmd.protect is not None:
-                        tables += f'#endif // {cur_cmd.protect}\n'
+                    if command.protect is not None:
+                        out.append(f'#endif // {command.protect}\n')
 
-            tables += '}\n\n'
-        return tables
+            out.append('}\n\n')
+
+#
+    # Create code to initialize a dispatch table from the appropriate list of extension entrypoints
+    def InitDeviceFunctionTerminatorDispatchTable(self, out):
+        out.append('// Functions that required a terminator need to have a separate dispatch table which contains their corresponding\n')
+        out.append('// device function. This is used in the terminators themselves.\n')
+        out.append('void init_extension_device_proc_terminator_dispatch(struct loader_device *dev) {\n')
+        out.append('    struct loader_device_terminator_dispatch* dispatch = &dev->loader_dispatch.extension_terminator_dispatch;\n')
+        out.append('    PFN_vkGetDeviceProcAddr gpda = (PFN_vkGetDeviceProcAddr)dev->phys_dev_term->this_icd_term->dispatch.GetDeviceProcAddr;\n')
+        current_block = ''
+        for command in [x for x in self.vk.commands.values() if x.extensions or x.version]:
+            if command.name in DEVICE_CMDS_NEED_TERM:
+                if command.protect is not None:
+                    out.append(f'#if defined({command.protect})\n')
+
+                current_block = self.DescribeBlock(command, current_block, out)
+                if command.name == 'vkGetDeviceGroupSurfacePresentModes2EXT': # command.extensions[0].depends in [x for x in self.vk.commands.values() if x.device]:
+                    # Hardcode the dependency expression as vulkan_object.py doesn't expose this information
+                    dep_expr = self.ConvertDependencyExpression('VK_KHR_device_group,VK_VERSION_1_1', lambda ext_name: f'dev->driver_extensions.{ext_name[3:].lower()}_enabled')
+                    out.append(f'    if (dev->driver_extensions.{command.extensions[0].name[3:].lower()}_enabled && ({dep_expr}))\n')
+                    out.append(f'       dispatch->{command.name[2:]} = (PFN_{(command.name)})gpda(dev->icd_device, "{(command.name)}");\n')
+                else:
+                    out.append(f'    if (dev->driver_extensions.{command.extensions[0].name[3:].lower()}_enabled)\n')
+                    out.append(f'       dispatch->{command.name[2:]} = (PFN_{(command.name)})gpda(dev->icd_device, "{(command.name)}");\n')
+
+                if command.protect is not None:
+                    out.append(f'#endif // {command.protect}\n')
+
+        out.append('}\n\n')
+
+
+    def OutputDeviceFunctionTrampolinePrototypes(self, out):
+        out.append('// These are prototypes for functions that need their trampoline called in all circumstances.\n')
+        out.append('// They are used in loader_lookup_device_dispatch_table but are defined afterwards.\n')
+        current_block = ''
+        for command in self.vk.commands.values():
+            if command.name in DEVICE_CMDS_MUST_USE_TRAMP:
+
+                if command.protect is not None:
+                    out.append(f'#if defined({command.protect})\n')
+                current_block = self.DescribeBlock(command, current_block, out)
+
+                out.append(f'{command.cPrototype.replace("VKAPI_CALL vk", "VKAPI_CALL ")}\n')
+
+                if command.protect is not None:
+                    out.append(f'#endif // {command.protect}\n')
+        out.append('\n')
+
 
     #
-    # Create a lookup table function from the appropriate list of entrypoints and
-    # return it as a string
-    def OutputLoaderLookupFunc(self):
+    # Create a lookup table function from the appropriate list of entrypoints
+    def OutputLoaderLookupFunc(self, out):
         commands = []
-        tables = ''
         cur_type = ''
-        cur_extension_name = ''
 
         for x in range(0, 2):
             if x == 0:
                 cur_type = 'device'
 
-                tables += '// Device command lookup function\n'
-                tables += 'VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDispatchTable *table, const char *name, bool* found_name) {\n'
-                tables += '    if (!name || name[0] != \'v\' || name[1] != \'k\') {\n'
-                tables += '        *found_name = false;\n'
-                tables += '        return NULL;\n'
-                tables += '    }\n'
-                tables += '\n'
-                tables += '    name += 2;\n'
-                tables += '    *found_name = true;\n'
-                tables += '    struct loader_device* dev = (struct loader_device *)table;\n'
-                tables += '    const struct loader_instance* inst = dev->phys_dev_term->this_icd_term->this_instance;\n'
-                tables += '    uint32_t api_version = VK_MAKE_API_VERSION(0, inst->app_api_version.major, inst->app_api_version.minor, inst->app_api_version.patch);\n'
-                tables += '\n'
+                out.append('// Device command lookup function\n')
+                out.append('VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDispatchTable *table, const char *name, bool* found_name) {\n')
+                out.append('    if (!name || name[0] != \'v\' || name[1] != \'k\') {\n')
+                out.append('        *found_name = false;\n')
+                out.append('        return NULL;\n')
+                out.append('    }\n')
+                out.append('\n')
+                out.append('    name += 2;\n')
+                out.append('    *found_name = true;\n')
+                out.append('    struct loader_device* dev = (struct loader_device *)table;\n')
+                out.append('    const struct loader_instance* inst = dev->phys_dev_term->this_icd_term->this_instance;\n')
+                out.append('    uint32_t api_version = VK_MAKE_API_VERSION(0, inst->app_api_version.major, inst->app_api_version.minor, inst->app_api_version.patch);\n')
+                out.append('\n')
             else:
                 cur_type = 'instance'
 
-                tables += '// Instance command lookup function\n'
-                tables += 'VKAPI_ATTR void* VKAPI_CALL loader_lookup_instance_dispatch_table(const VkLayerInstanceDispatchTable *table, const char *name,\n'
-                tables += '                                                                 bool *found_name) {\n'
-                tables += '    if (!name || name[0] != \'v\' || name[1] != \'k\') {\n'
-                tables += '        *found_name = false;\n'
-                tables += '        return NULL;\n'
-                tables += '    }\n'
-                tables += '\n'
-                tables += '    *found_name = true;\n'
-                tables += '    name += 2;\n'
+                out.append('// Instance command lookup function\n')
+                out.append('VKAPI_ATTR void* VKAPI_CALL loader_lookup_instance_dispatch_table(const VkLayerInstanceDispatchTable *table, const char *name,\n')
+                out.append('                                                                 bool *found_name) {\n')
+                out.append('    if (!name || name[0] != \'v\' || name[1] != \'k\') {\n')
+                out.append('        *found_name = false;\n')
+                out.append('        return NULL;\n')
+                out.append('    }\n')
+                out.append('\n')
+                out.append('    *found_name = true;\n')
+                out.append('    name += 2;\n')
 
 
-            for y in range(0, 2):
-                if y == 0:
-                    commands = self.core_commands
-                else:
-                    commands = self.ext_commands
+            for command_list in [self.core_commands, self.extension_commands]:
+                commands = command_list
 
-                for cur_cmd in commands:
-                    version = self.getAPIVersion(cur_cmd.ext_name)
-                    is_inst_handle_type = cur_cmd.handle_type == 'VkInstance' or cur_cmd.handle_type == 'VkPhysicalDevice'
+                version_check = ''
+                current_block = ''
+                for command in commands:
+                    is_inst_handle_type = command.params[0].type in ['VkInstance', 'VkPhysicalDevice']
                     if ((cur_type == 'instance' and is_inst_handle_type) or (cur_type == 'device' and not is_inst_handle_type)):
-                        if cur_cmd.ext_name != cur_extension_name:
-                            if version:
-                                tables += f'\n    // ---- Core {version.name} commands\n'
-                                if cur_type == 'device':
-                                    version_check = f'        if (dev->should_ignore_device_commands_from_newer_version && api_version < {version.constant}) return NULL;\n'
-                            else:
 
-                                tables += f'\n    // ---- {cur_cmd.ext_name} extension commands\n'
+                        current_block = self.DescribeBlock(command, current_block, out)
+                        if len(command.extensions) == 0:
+                            if cur_type == 'device':
+                                version_check = f'        if (dev->should_ignore_device_commands_from_newer_version && api_version < {command.version.nameApi if command.version else 'VK_API_VERSION_1_0'}) return NULL;\n'
+                            else:
                                 version_check = ''
-                            cur_extension_name = cur_cmd.ext_name
 
                         # Remove 'vk' from proto name
-                        base_name = cur_cmd.name[2:]
+                        base_name = command.name[2:]
 
                         if (base_name == 'CreateInstance' or base_name == 'CreateDevice' or
                             base_name == 'EnumerateInstanceExtensionProperties' or
@@ -1007,37 +721,34 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                             base_name == 'EnumerateInstanceVersion'):
                             continue
 
-                        if cur_cmd.protect is not None:
-                            tables += f'#if defined({cur_cmd.protect})\n'
+                        if command.protect is not None:
+                            out.append(f'#if defined({command.protect})\n')
 
-                        tables += f'    if (!strcmp(name, "{base_name}")) '
-                        if cur_cmd.name in DEVICE_CMDS_MUST_USE_TRAMP:
+                        out.append(f'    if (!strcmp(name, "{base_name}")) ')
+                        if command.name in DEVICE_CMDS_MUST_USE_TRAMP:
                             if version_check != '':
-                                tables += f'{{\n{version_check}        return dev->layer_extensions.{cur_cmd.ext_name[3:].lower()}_enabled ? (void *){base_name} : NULL;\n    }}\n'
+                                out.append(f'{{\n{version_check}        return dev->layer_extensions.{command.extensions[0].name[3:].lower()}_enabled ? (void *){base_name} : NULL;\n    }}\n')
                             else:
-                                tables += f'return dev->layer_extensions.{cur_cmd.ext_name[3:].lower()}_enabled ? (void *){base_name} : NULL;\n'
+                                out.append(f'return dev->layer_extensions.{command.extensions[0].name[3:].lower()}_enabled ? (void *){base_name} : NULL;\n')
 
                         else:
                             if version_check != '':
-                                tables += f'{{\n{version_check}        return (void *)table->{base_name};\n    }}\n'
+                                out.append(f'{{\n{version_check}        return (void *)table->{base_name};\n    }}\n')
                             else:
-                                tables += f'return (void *)table->{base_name};\n'
+                                out.append(f'return (void *)table->{base_name};\n')
 
-                        if cur_cmd.protect is not None:
-                            tables += f'#endif // {cur_cmd.protect}\n'
+                        if command.protect is not None:
+                            out.append(f'#endif // {command.protect}\n')
 
-            tables += '\n'
-            tables += '    *found_name = false;\n'
-            tables += '    return NULL;\n'
-            tables += '}\n\n'
-        return tables
+            out.append('\n')
+            out.append('    *found_name = false;\n')
+            out.append('    return NULL;\n')
+            out.append('}\n\n')
+
 
     #
     # Create the appropriate trampoline (and possibly terminator) functions
-    def CreateTrampTermFuncs(self):
-        funcs = ''
-        cur_extension_name = ''
-
+    def CreateTrampTermFuncs(self, out):
         # Some extensions have to be manually added.  Skip those in the automatic
         # generation.  They will be manually added later.
         manual_ext_commands = ['vkEnumeratePhysicalDeviceGroupsKHR',
@@ -1066,28 +777,23 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                                'vkGetDeviceGroupSurfacePresentModes2EXT',
                                'vkGetPhysicalDeviceToolPropertiesEXT']
 
-        for ext_cmd in self.ext_commands:
-            if (ext_cmd.ext_name in WSI_EXT_NAMES or
-                ext_cmd.ext_name in AVOID_EXT_NAMES or
-                ext_cmd.name in AVOID_CMD_NAMES or
-                ext_cmd.name in manual_ext_commands):
+        current_block = ''
+        for command in [x for x in self.vk.commands.values() if x.extensions]:
+            if (command.extensions[0].name in WSI_EXT_NAMES or
+                command.extensions[0].name in AVOID_EXT_NAMES or
+                command.name in AVOID_CMD_NAMES or
+                command.name in manual_ext_commands):
                 continue
 
-            version = self.getAPIVersion(ext_cmd.ext_name)
-            if ext_cmd.ext_name != cur_extension_name:
-                if version:
-                    funcs += f'\n// ---- Core {version.name} trampoline/terminators\n\n'
-                else:
-                    funcs += f'\n// ---- {ext_cmd.ext_name} extension trampoline/terminators\n\n'
-                cur_extension_name = ext_cmd.ext_name
+            current_block = self.DescribeBlock(command=command, current_block=current_block, out=out, custom_commands_string=' trampoline/terminators\n', indent='')
 
-            if ext_cmd.protect is not None:
-                funcs += f'#if defined({ext_cmd.protect})\n'
+            if command.protect is not None:
+                out.append(f'#if defined({command.protect})\n')
 
-            func_header = ext_cmd.cdecl.replace(";", " {\n")
+            func_header = command.cPrototype.replace(";", " {\n")
             tramp_header = func_header.replace("VKAPI_CALL vk", "VKAPI_CALL ")
             return_prefix = '    '
-            base_name = ext_cmd.name[2:]
+            base_name = command.name[2:]
             has_surface = 0
             update_structure_surface = 0
             update_structure_string = ''
@@ -1102,7 +808,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
             physdev_type_to_replace = ''
             physdev_name_replacement = ''
 
-            for param in ext_cmd.params:
+            for param in command.params:
                 if param.type == 'VkSurfaceKHR':
                     has_surface = 1
                     surface_var_name = param.name
@@ -1130,603 +836,480 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     requires_terminator = 1
                     instance_var_name = param.name
 
-            if ext_cmd.return_type is not None:
+            if command.returnType != 'void':
                 return_prefix += 'return '
                 has_return_type = True
 
-            if (ext_cmd.handle_type == 'VkInstance' or ext_cmd.handle_type == 'VkPhysicalDevice' or
-                'DebugMarkerSetObject' in ext_cmd.name or 'SetDebugUtilsObject' in ext_cmd.name or
-                ext_cmd.name in DEVICE_CMDS_NEED_TERM):
+            if ( command.params[0].type in ['VkInstance', 'VkPhysicalDevice'] or
+                'DebugMarkerSetObject' in command.name or 'SetDebugUtilsObject' in command.name or
+                command.name in DEVICE_CMDS_NEED_TERM):
                 requires_terminator = 1
 
             if requires_terminator == 1:
                 term_header = tramp_header.replace("VKAPI_CALL ", "VKAPI_CALL terminator_")
 
-                funcs += tramp_header
+                out.append(tramp_header)
 
-                if ext_cmd.handle_type == 'VkPhysicalDevice':
-                    funcs += '    const VkLayerInstanceDispatchTable *disp;\n'
-                    funcs += f'    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device({phys_dev_var_name});\n'
-                    funcs += '    if (VK_NULL_HANDLE == unwrapped_phys_dev) {\n'
-                    funcs += '        loader_log(NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n'
-                    funcs += f'                   "{ext_cmd.name}: Invalid {phys_dev_var_name} "\n'
-                    funcs += f'                   "[VUID-{ext_cmd.name}-{phys_dev_var_name}-parameter]");\n'
-                    funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
-                    funcs += '    }\n'
-                    funcs += f'    disp = loader_get_instance_layer_dispatch({phys_dev_var_name});\n'
-                elif ext_cmd.handle_type == 'VkInstance':
-                    funcs += f'    struct loader_instance *inst = loader_get_instance({instance_var_name});\n'
-                    funcs += '    if (NULL == inst) {\n'
-                    funcs += '        loader_log(\n'
-                    funcs += '            NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n'
-                    funcs += f'            "{ext_cmd.name}: Invalid instance [VUID-{ext_cmd.name}-{instance_var_name}-parameter]");\n'
-                    funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
-                    funcs += '    }\n'
-                    funcs += '#error("Not implemented. Likely needs to be manually generated!");\n'
+                if command.params[0].type == 'VkPhysicalDevice':
+                    out.append('    const VkLayerInstanceDispatchTable *disp;\n')
+                    out.append(f'    VkPhysicalDevice unwrapped_phys_dev = loader_unwrap_physical_device({phys_dev_var_name});\n')
+                    out.append('    if (VK_NULL_HANDLE == unwrapped_phys_dev) {\n')
+                    out.append('        loader_log(NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n')
+                    out.append(f'                   "{command.name}: Invalid {phys_dev_var_name} "\n')
+                    out.append(f'                   "[VUID-{command.name}-{phys_dev_var_name}-parameter]");\n')
+                    out.append('        abort(); /* Intentionally fail so user can correct issue. */\n')
+                    out.append('    }\n')
+                    out.append(f'    disp = loader_get_instance_layer_dispatch({phys_dev_var_name});\n')
+                elif command.params[0].type == 'VkInstance':
+                    out.append(f'    struct loader_instance *inst = loader_get_instance({instance_var_name});\n')
+                    out.append('    if (NULL == inst) {\n')
+                    out.append('        loader_log(\n')
+                    out.append('            NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n')
+                    out.append(f'            "{command.name}: Invalid instance [VUID-{command.name}-{instance_var_name}-parameter]");\n')
+                    out.append('        abort(); /* Intentionally fail so user can correct issue. */\n')
+                    out.append('    }\n')
+                    out.append('#error("Not implemented. Likely needs to be manually generated!");\n')
                 else:
-                    funcs += '    const VkLayerDispatchTable *disp = loader_get_dispatch('
-                    funcs += ext_cmd.params[0].name
-                    funcs += ');\n'
-                    funcs += '    if (NULL == disp) {\n'
-                    funcs += '        loader_log(NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n'
-                    funcs += f'                   "{ext_cmd.name}: Invalid {ext_cmd.params[0].name} "\n'
-                    funcs += f'                   "[VUID-{ext_cmd.name}-{ext_cmd.params[0].name}-parameter]");\n'
-                    funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
-                    funcs += '    }\n'
+                    out.append('    const VkLayerDispatchTable *disp = loader_get_dispatch(')
+                    out.append(command.params[0].name)
+                    out.append(');\n')
+                    out.append('    if (NULL == disp) {\n')
+                    out.append('        loader_log(NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n')
+                    out.append(f'                   "{command.name}: Invalid {command.params[0].name} "\n')
+                    out.append(f'                   "[VUID-{command.name}-{command.params[0].name}-parameter]");\n')
+                    out.append('        abort(); /* Intentionally fail so user can correct issue. */\n')
+                    out.append('    }\n')
 
-                if 'DebugMarkerSetObjectName' in ext_cmd.name:
-                    funcs += '    VkDebugMarkerObjectNameInfoEXT local_name_info;\n'
-                    funcs += '    memcpy(&local_name_info, pNameInfo, sizeof(VkDebugMarkerObjectNameInfoEXT));\n'
-                    funcs += '    // If this is a physical device, we have to replace it with the proper one for the next call.\n'
-                    funcs += '    if (pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {\n'
-                    funcs += '        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pNameInfo->object;\n'
-                    funcs += '        local_name_info.object = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n'
-                    funcs += '    }\n'
-                    funcs += '    if (pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {\n'
-                    funcs += '        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pNameInfo->object;\n'
-                    funcs += '        local_name_info.object = (uint64_t)(uintptr_t)instance->instance;\n'
-                    funcs += '    }\n'
-                elif 'DebugMarkerSetObjectTag' in ext_cmd.name:
-                    funcs += '    VkDebugMarkerObjectTagInfoEXT local_tag_info;\n'
-                    funcs += '    memcpy(&local_tag_info, pTagInfo, sizeof(VkDebugMarkerObjectTagInfoEXT));\n'
-                    funcs += '    // If this is a physical device, we have to replace it with the proper one for the next call.\n'
-                    funcs += '    if (pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {\n'
-                    funcs += '        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pTagInfo->object;\n'
-                    funcs += '        local_tag_info.object = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n'
-                    funcs += '    }\n'
-                    funcs += '    if (pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {\n'
-                    funcs += '        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pTagInfo->object;\n'
-                    funcs += '        local_tag_info.object = (uint64_t)(uintptr_t)instance->instance;\n'
-                    funcs += '    }\n'
-                elif 'SetDebugUtilsObjectName' in ext_cmd.name:
-                    funcs += '    VkDebugUtilsObjectNameInfoEXT local_name_info;\n'
-                    funcs += '    memcpy(&local_name_info, pNameInfo, sizeof(VkDebugUtilsObjectNameInfoEXT));\n'
-                    funcs += '    // If this is a physical device, we have to replace it with the proper one for the next call.\n'
-                    funcs += '    if (pNameInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {\n'
-                    funcs += '        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pNameInfo->objectHandle;\n'
-                    funcs += '        local_name_info.objectHandle = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n'
-                    funcs += '    }\n'
-                    funcs += '    if (pNameInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {\n'
-                    funcs += '        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pNameInfo->objectHandle;\n'
-                    funcs += '        local_name_info.objectHandle = (uint64_t)(uintptr_t)instance->instance;\n'
-                    funcs += '    }\n'
-                elif 'SetDebugUtilsObjectTag' in ext_cmd.name:
-                    funcs += '    VkDebugUtilsObjectTagInfoEXT local_tag_info;\n'
-                    funcs += '    memcpy(&local_tag_info, pTagInfo, sizeof(VkDebugUtilsObjectTagInfoEXT));\n'
-                    funcs += '    // If this is a physical device, we have to replace it with the proper one for the next call.\n'
-                    funcs += '    if (pTagInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {\n'
-                    funcs += '        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pTagInfo->objectHandle;\n'
-                    funcs += '        local_tag_info.objectHandle = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n'
-                    funcs += '    }\n'
-                    funcs += '    if (pTagInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {\n'
-                    funcs += '        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pTagInfo->objectHandle;\n'
-                    funcs += '        local_tag_info.objectHandle = (uint64_t)(uintptr_t)instance->instance;\n'
-                    funcs += '    }\n'
+                if 'DebugMarkerSetObjectName' in command.name:
+                    out.append('    VkDebugMarkerObjectNameInfoEXT local_name_info;\n')
+                    out.append('    memcpy(&local_name_info, pNameInfo, sizeof(VkDebugMarkerObjectNameInfoEXT));\n')
+                    out.append('    // If this is a physical device, we have to replace it with the proper one for the next call.\n')
+                    out.append('    if (pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {\n')
+                    out.append('        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pNameInfo->object;\n')
+                    out.append('        local_name_info.object = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n')
+                    out.append('    }\n')
+                    out.append('    if (pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {\n')
+                    out.append('        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pNameInfo->object;\n')
+                    out.append('        local_name_info.object = (uint64_t)(uintptr_t)instance->instance;\n')
+                    out.append('    }\n')
+                elif 'DebugMarkerSetObjectTag' in command.name:
+                    out.append('    VkDebugMarkerObjectTagInfoEXT local_tag_info;\n')
+                    out.append('    memcpy(&local_tag_info, pTagInfo, sizeof(VkDebugMarkerObjectTagInfoEXT));\n')
+                    out.append('    // If this is a physical device, we have to replace it with the proper one for the next call.\n')
+                    out.append('    if (pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {\n')
+                    out.append('        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pTagInfo->object;\n')
+                    out.append('        local_tag_info.object = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n')
+                    out.append('    }\n')
+                    out.append('    if (pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {\n')
+                    out.append('        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pTagInfo->object;\n')
+                    out.append('        local_tag_info.object = (uint64_t)(uintptr_t)instance->instance;\n')
+                    out.append('    }\n')
+                elif 'SetDebugUtilsObjectName' in command.name:
+                    out.append('    VkDebugUtilsObjectNameInfoEXT local_name_info;\n')
+                    out.append('    memcpy(&local_name_info, pNameInfo, sizeof(VkDebugUtilsObjectNameInfoEXT));\n')
+                    out.append('    // If this is a physical device, we have to replace it with the proper one for the next call.\n')
+                    out.append('    if (pNameInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {\n')
+                    out.append('        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pNameInfo->objectHandle;\n')
+                    out.append('        local_name_info.objectHandle = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n')
+                    out.append('    }\n')
+                    out.append('    if (pNameInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {\n')
+                    out.append('        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pNameInfo->objectHandle;\n')
+                    out.append('        local_name_info.objectHandle = (uint64_t)(uintptr_t)instance->instance;\n')
+                    out.append('    }\n')
+                elif 'SetDebugUtilsObjectTag' in command.name:
+                    out.append('    VkDebugUtilsObjectTagInfoEXT local_tag_info;\n')
+                    out.append('    memcpy(&local_tag_info, pTagInfo, sizeof(VkDebugUtilsObjectTagInfoEXT));\n')
+                    out.append('    // If this is a physical device, we have to replace it with the proper one for the next call.\n')
+                    out.append('    if (pTagInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {\n')
+                    out.append('        struct loader_physical_device_tramp *phys_dev_tramp = (struct loader_physical_device_tramp *)(uintptr_t)pTagInfo->objectHandle;\n')
+                    out.append('        local_tag_info.objectHandle = (uint64_t)(uintptr_t)phys_dev_tramp->phys_dev;\n')
+                    out.append('    }\n')
+                    out.append('    if (pTagInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {\n')
+                    out.append('        struct loader_instance* instance = (struct loader_instance *)(uintptr_t)pTagInfo->objectHandle;\n')
+                    out.append('        local_tag_info.objectHandle = (uint64_t)(uintptr_t)instance->instance;\n')
+                    out.append('    }\n')
 
-                if ext_cmd.ext_name in NULL_CHECK_EXT_NAMES:
-                    funcs += '    if (disp->' + base_name + ' != NULL) {\n'
-                    funcs += '    '
-                funcs += return_prefix
-                if ext_cmd.handle_type == 'VkInstance':
-                    funcs += 'inst->'
-                funcs += 'disp->'
-                funcs += base_name
-                funcs += '('
+                if command.extensions[0].name in NULL_CHECK_EXT_NAMES:
+                    out.append('    if (disp->' + base_name + ' != NULL) {\n')
+                    out.append('    ')
+                out.append(return_prefix)
+                if command.params[0].type == 'VkInstance':
+                    out.append('inst->')
+                out.append('disp->')
+                out.append(base_name)
+                out.append('(')
                 count = 0
-                for param in ext_cmd.params:
+                for param in command.params:
                     if count != 0:
-                        funcs += ', '
+                        out.append(', ')
 
                     if param.type == 'VkPhysicalDevice':
-                        funcs += 'unwrapped_phys_dev'
-                    elif ('DebugMarkerSetObject' in ext_cmd.name or 'SetDebugUtilsObject' in ext_cmd.name) and param.name == 'pNameInfo':
-                        funcs += '&local_name_info'
-                    elif ('DebugMarkerSetObject' in ext_cmd.name or 'SetDebugUtilsObject' in ext_cmd.name) and param.name == 'pTagInfo':
-                        funcs += '&local_tag_info'
+                        out.append('unwrapped_phys_dev')
+                    elif ('DebugMarkerSetObject' in command.name or 'SetDebugUtilsObject' in command.name) and param.name == 'pNameInfo':
+                        out.append('&local_name_info')
+                    elif ('DebugMarkerSetObject' in command.name or 'SetDebugUtilsObject' in command.name) and param.name == 'pTagInfo':
+                        out.append('&local_tag_info')
                     else:
-                        funcs += param.name
+                        out.append(param.name)
 
                     count += 1
-                funcs += ');\n'
-                if ext_cmd.ext_name in NULL_CHECK_EXT_NAMES:
-                    if ext_cmd.return_type is not None:
-                        funcs += '    } else {\n'
-                        funcs += '        return VK_SUCCESS;\n'
-                    funcs += '    }\n'
-                funcs += '}\n\n'
+                out.append(');\n')
+                if command.extensions[0].name in NULL_CHECK_EXT_NAMES:
+                    if command.returnType != 'void':
+                        out.append('    } else {\n')
+                        out.append('        return VK_SUCCESS;\n')
+                    out.append('    }\n')
+                out.append('}\n\n')
 
-                funcs += term_header
-                if ext_cmd.handle_type == 'VkPhysicalDevice':
-                    funcs += f'    struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *){phys_dev_var_name};\n'
-                    funcs += '    struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;\n'
-                    funcs += '    if (NULL == icd_term->dispatch.'
-                    funcs += base_name
-                    funcs += ') {\n'
-                    fatal_error_bit = '' if ext_cmd.ext_type =='instance' and has_return_type else 'VULKAN_LOADER_FATAL_ERROR_BIT | '
-                    funcs += f'        loader_log(icd_term->this_instance, {fatal_error_bit}VULKAN_LOADER_ERROR_BIT, 0,\n'
-                    funcs += '                   "ICD associated with VkPhysicalDevice does not support '
-                    funcs += base_name
-                    funcs += '");\n'
+                out.append(term_header)
+                if command.params[0].type == 'VkPhysicalDevice':
+                    out.append(f'    struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *){phys_dev_var_name};\n')
+                    out.append('    struct loader_icd_term *icd_term = phys_dev_term->this_icd_term;\n')
+                    out.append('    if (NULL == icd_term->dispatch.')
+                    out.append(base_name)
+                    out.append(') {\n')
+                    fatal_error_bit = '' if has_return_type and (len(command.extensions) == 0 or command.extensions[0].instance) else 'VULKAN_LOADER_FATAL_ERROR_BIT | '
+                    out.append(f'        loader_log(icd_term->this_instance, {fatal_error_bit}VULKAN_LOADER_ERROR_BIT, 0,\n')
+                    out.append('                   "ICD associated with VkPhysicalDevice does not support ')
+                    out.append(base_name)
+                    out.append('");\n')
 
                     # If this is an instance function taking a physical device (i.e. pre Vulkan 1.1), we need to behave and not crash so return an
                     # error here.
-                    if ext_cmd.ext_type =='instance' and has_return_type:
-                        funcs += '        return VK_ERROR_EXTENSION_NOT_PRESENT;\n'
+                    if has_return_type and (len(command.extensions) == 0 or command.extensions[0].instance):
+                        out.append('        return VK_ERROR_EXTENSION_NOT_PRESENT;\n')
                     else:
-                        funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
-                    funcs += '    }\n'
+                        out.append('        abort(); /* Intentionally fail so user can correct issue. */\n')
+                    out.append('    }\n')
 
                     if has_surface == 1:
-                        funcs += '    VkIcdSurface *icd_surface = NULL;\n'
-                        funcs += f'    if (NULL != {surface_var_name}) {{\n'
-                        funcs += f'        icd_surface = (VkIcdSurface *)(uintptr_t)({surface_var_name});\n'
-                        funcs += '    }\n'
-                        funcs += '    if (NULL != icd_surface && NULL != icd_term->surface_list.list && icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) && icd_term->surface_list[icd_surface->surface_index]) {\n'
+                        out.append('    VkIcdSurface *icd_surface = NULL;\n')
+                        out.append(f'    if (NULL != {surface_var_name}) {{\n')
+                        out.append(f'        icd_surface = (VkIcdSurface *)(uintptr_t)({surface_var_name});\n')
+                        out.append('    }\n')
+                        out.append('    if (NULL != icd_surface && NULL != icd_term->surface_list.list && icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR) && icd_term->surface_list[icd_surface->surface_index]) {\n')
 
                         # If there's a structure with a surface, we need to update its internals with the correct surface for the ICD
                         if update_structure_surface == 1:
-                            funcs += update_structure_string
+                            out.append(update_structure_string)
 
-                        funcs += '    ' + return_prefix + 'icd_term->dispatch.'
-                        funcs += base_name
-                        funcs += '('
+                        out.append('    ' + return_prefix + 'icd_term->dispatch.')
+                        out.append(base_name)
+                        out.append('(')
                         count = 0
-                        for param in ext_cmd.params:
+                        for param in command.params:
                             if count != 0:
-                                funcs += ', '
+                                out.append(', ')
 
                             if not always_use_param_name:
                                 if surface_type_to_replace and surface_type_to_replace == param.type:
-                                    funcs += surface_name_replacement
+                                    out.append(surface_name_replacement)
                                 elif physdev_type_to_replace and physdev_type_to_replace == param.type:
-                                    funcs += physdev_name_replacement
+                                    out.append(physdev_name_replacement)
                                 else:
-                                    funcs += param.name
+                                    out.append(param.name)
                             else:
-                                funcs += param.name
+                                out.append(param.name)
 
                             count += 1
-                        funcs += ');\n'
+                        out.append(');\n')
                         if not has_return_type:
-                            funcs += '        return;\n'
-                        funcs += '    }\n'
+                            out.append('        return;\n')
+                        out.append('    }\n')
 
-                    funcs += return_prefix
-                    funcs += 'icd_term->dispatch.'
-                    funcs += base_name
-                    funcs += '('
+                    out.append(return_prefix)
+                    out.append('icd_term->dispatch.')
+                    out.append(base_name)
+                    out.append('(')
                     count = 0
-                    for param in ext_cmd.params:
+                    for param in command.params:
                         if count != 0:
-                            funcs += ', '
+                            out.append(', ')
 
                         if param.type == 'VkPhysicalDevice':
-                            funcs += 'phys_dev_term->phys_dev'
+                            out.append('phys_dev_term->phys_dev')
                         else:
-                            funcs += param.name
+                            out.append(param.name)
 
                         count += 1
-                    funcs += ');\n'
+                    out.append(');\n')
 
 
-                elif ext_cmd.handle_type == 'VkInstance':
-                    funcs += f'    struct loader_instance *inst = loader_get_instance({instance_var_name});\n'
-                    funcs += '    if (NULL == inst) {\n'
-                    funcs += '        loader_log(\n'
-                    funcs += '            NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n'
-                    funcs += f'            "{ext_cmd.name}: Invalid instance [VUID-{ext_cmd.name}-{instance_var_name}-parameter]");\n'
-                    funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
-                    funcs += '    }\n'
-                    funcs += '#error("Not implemented. Likely needs to be manually generated!");\n'
-                elif ext_cmd.ext_name in ['VK_EXT_debug_utils', 'VK_EXT_debug_marker']:
-                    if ext_cmd.name in ['vkDebugMarkerSetObjectNameEXT', 'vkDebugMarkerSetObjectTagEXT', 'vkSetDebugUtilsObjectNameEXT' , 'vkSetDebugUtilsObjectTagEXT']:
+                elif command.params[0].type == 'VkInstance':
+                    out.append(f'    struct loader_instance *inst = loader_get_instance({instance_var_name});\n')
+                    out.append('    if (NULL == inst) {\n')
+                    out.append('        loader_log(\n')
+                    out.append('            NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n')
+                    out.append(f'            "{command.name}: Invalid instance [VUID-{command.name}-{instance_var_name}-parameter]");\n')
+                    out.append('        abort(); /* Intentionally fail so user can correct issue. */\n')
+                    out.append('    }\n')
+                    out.append('#error("Not implemented. Likely needs to be manually generated!");\n')
+                elif command.extensions[0].name in ['VK_EXT_debug_utils', 'VK_EXT_debug_marker']:
+                    if command.name in ['vkDebugMarkerSetObjectNameEXT', 'vkDebugMarkerSetObjectTagEXT', 'vkSetDebugUtilsObjectNameEXT' , 'vkSetDebugUtilsObjectTagEXT']:
 
-                        is_debug_utils = ext_cmd.ext_name == "VK_EXT_debug_utils"
-                        debug_struct_name = ext_cmd.params[1].name
-                        local_struct = 'local_name_info' if 'ObjectName' in ext_cmd.name else 'local_tag_info'
+                        is_debug_utils = command.extensions[0].name == "VK_EXT_debug_utils"
+                        debug_struct_name = command.params[1].name
+                        local_struct = 'local_name_info' if 'ObjectName' in command.name else 'local_tag_info'
                         member_name = 'objectHandle' if is_debug_utils else 'object'
                         phys_dev_check = 'VK_OBJECT_TYPE_PHYSICAL_DEVICE' if is_debug_utils else 'VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT'
                         surf_check = 'VK_OBJECT_TYPE_SURFACE_KHR' if is_debug_utils else 'VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT'
                         inst_check = 'VK_OBJECT_TYPE_INSTANCE' if is_debug_utils else 'VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT'
-                        funcs += '    struct loader_device *dev;\n'
-                        funcs += f'    struct loader_icd_term *icd_term = loader_get_icd_and_device({ ext_cmd.params[0].name}, &dev);\n'
-                        funcs += '    if (NULL == icd_term || NULL == dev) {\n'
-                        funcs += f'        loader_log(NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0, "{ext_cmd.name[2:]}: Invalid device handle");\n'
-                        funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
-                        funcs += '    }\n'
-                        funcs += f'    { ext_cmd.params[1].type} {local_struct};\n'
-                        funcs += f'    memcpy(&{local_struct}, {debug_struct_name}, sizeof({ ext_cmd.params[1].type}));\n'
-                        funcs += '    // If this is a physical device, we have to replace it with the proper one for the next call.\n'
-                        funcs += f'    if ({debug_struct_name}->objectType == {phys_dev_check}) {{\n'
-                        funcs += f'        struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)(uintptr_t){debug_struct_name}->{member_name};\n'
-                        funcs += f'        {local_struct}.{member_name} = (uint64_t)(uintptr_t)phys_dev_term->phys_dev;\n'
-                        funcs += '    // If this is a KHR_surface, and the ICD has created its own, we have to replace it with the proper one for the next call.\n'
-                        funcs += f'    }} else if ({debug_struct_name}->objectType == {surf_check}) {{\n'
-                        funcs += '        if (NULL != dev && NULL != dev->loader_dispatch.core_dispatch.CreateSwapchainKHR) {\n'
-                        funcs += f'            VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t){debug_struct_name}->{member_name};\n'
-                        funcs += '            if (NULL != icd_term->surface_list.list && icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR)\n'
-                        funcs += '                && icd_term->surface_list.list[icd_surface->surface_index]) {\n'
-                        funcs += f'                {local_struct}.{member_name} = (uint64_t)icd_term->surface_list.list[icd_surface->surface_index];\n'
-                        funcs += '            }\n'
-                        funcs += '        }\n'
-                        funcs += '    // If this is an instance we have to replace it with the proper one for the next call.\n'
-                        funcs += f'    }} else if ({debug_struct_name}->objectType == {inst_check}) {{\n'
-                        funcs += f'        {local_struct}.{member_name} = (uint64_t)(uintptr_t)icd_term->instance;\n'
-                        funcs += '    }\n'
-                        funcs += '    // Exit early if the driver does not support the function - this can happen as a layer or the loader itself supports\n'
-                        funcs += '    // debug utils but the driver does not.\n'
-                        funcs += f'    if (NULL == dev->loader_dispatch.extension_terminator_dispatch.{ext_cmd.name[2:]})\n        return VK_SUCCESS;\n'
+                        out.append('    struct loader_device *dev;\n')
+                        out.append(f'    struct loader_icd_term *icd_term = loader_get_icd_and_device({ command.params[0].name}, &dev);\n')
+                        out.append('    if (NULL == icd_term || NULL == dev) {\n')
+                        out.append(f'        loader_log(NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0, "{command.name[2:]}: Invalid device handle");\n')
+                        out.append('        abort(); /* Intentionally fail so user can correct issue. */\n')
+                        out.append('    }\n')
+                        out.append(f'    { command.params[1].type} {local_struct};\n')
+                        out.append(f'    memcpy(&{local_struct}, {debug_struct_name}, sizeof({ command.params[1].type}));\n')
+                        out.append('    // If this is a physical device, we have to replace it with the proper one for the next call.\n')
+                        out.append(f'    if ({debug_struct_name}->objectType == {phys_dev_check}) {{\n')
+                        out.append(f'        struct loader_physical_device_term *phys_dev_term = (struct loader_physical_device_term *)(uintptr_t){debug_struct_name}->{member_name};\n')
+                        out.append(f'        {local_struct}.{member_name} = (uint64_t)(uintptr_t)phys_dev_term->phys_dev;\n')
+                        out.append('    // If this is a KHR_surface, and the ICD has created its own, we have to replace it with the proper one for the next call.\n')
+                        out.append(f'    }} else if ({debug_struct_name}->objectType == {surf_check}) {{\n')
+                        out.append('        if (NULL != dev && NULL != dev->loader_dispatch.core_dispatch.CreateSwapchainKHR) {\n')
+                        out.append(f'            VkIcdSurface *icd_surface = (VkIcdSurface *)(uintptr_t){debug_struct_name}->{member_name};\n')
+                        out.append('            if (NULL != icd_term->surface_list.list && icd_term->surface_list.capacity > icd_surface->surface_index * sizeof(VkSurfaceKHR)\n')
+                        out.append('                && icd_term->surface_list.list[icd_surface->surface_index]) {\n')
+                        out.append(f'                {local_struct}.{member_name} = (uint64_t)icd_term->surface_list.list[icd_surface->surface_index];\n')
+                        out.append('            }\n')
+                        out.append('        }\n')
+                        out.append('    // If this is an instance we have to replace it with the proper one for the next call.\n')
+                        out.append(f'    }} else if ({debug_struct_name}->objectType == {inst_check}) {{\n')
+                        out.append(f'        {local_struct}.{member_name} = (uint64_t)(uintptr_t)icd_term->instance;\n')
+                        out.append('    }\n')
+                        out.append('    // Exit early if the driver does not support the function - this can happen as a layer or the loader itself supports\n')
+                        out.append('    // debug utils but the driver does not.\n')
+                        out.append(f'    if (NULL == dev->loader_dispatch.extension_terminator_dispatch.{command.name[2:]})\n        return VK_SUCCESS;\n')
                         dispatch = 'dev->loader_dispatch.'
                     else:
-                        funcs += f'    struct loader_dev_dispatch_table *dispatch_table = loader_get_dev_dispatch({ext_cmd.params[0].name});\n'
-                        funcs += '    if (NULL == dispatch_table) {\n'
-                        funcs += f'        loader_log(NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0, "{ext_cmd.ext_name}: Invalid device handle");\n'
-                        funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
-                        funcs += '    }\n'
-                        funcs += '    // Only call down if the device supports the function\n'
-                        funcs += f'    if (NULL != dispatch_table->extension_terminator_dispatch.{base_name})\n    '
+                        out.append(f'    struct loader_dev_dispatch_table *dispatch_table = loader_get_dev_dispatch({command.params[0].name});\n')
+                        out.append('    if (NULL == dispatch_table) {\n')
+                        out.append(f'        loader_log(NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0, "{command.extensions[0].name}: Invalid device handle");\n')
+                        out.append('        abort(); /* Intentionally fail so user can correct issue. */\n')
+                        out.append('    }\n')
+                        out.append('    // Only call down if the device supports the function\n')
+                        out.append(f'    if (NULL != dispatch_table->extension_terminator_dispatch.{base_name})\n    ')
                         dispatch = 'dispatch_table->'
-                    funcs += '    '
+                    out.append('    ')
                     if has_return_type:
-                        funcs += 'return '
-                    funcs += f'{dispatch}extension_terminator_dispatch.{base_name}('
+                        out.append('return ')
+                    out.append(f'{dispatch}extension_terminator_dispatch.{base_name}(')
                     count = 0
-                    for param in ext_cmd.params:
+                    for param in command.params:
                         if count != 0:
-                            funcs += ', '
+                            out.append(', ')
 
                         if param.type == 'VkPhysicalDevice':
-                            funcs += 'phys_dev_term->phys_dev'
+                            out.append('phys_dev_term->phys_dev')
                         elif param.type == 'VkSurfaceKHR':
-                            funcs += 'icd_term->surface_list[icd_surface->surface_index]'
-                        elif ('DebugMarkerSetObject' in ext_cmd.name or 'SetDebugUtilsObject' in ext_cmd.name) and param.name == 'pNameInfo':
-                            funcs += '&local_name_info'
-                        elif ('DebugMarkerSetObject' in ext_cmd.name or 'SetDebugUtilsObject' in ext_cmd.name) and param.name == 'pTagInfo':
-                            funcs += '&local_tag_info'
+                            out.append('icd_term->surface_list[icd_surface->surface_index]')
+                        elif ('DebugMarkerSetObject' in command.name or 'SetDebugUtilsObject' in command.name) and param.name == 'pNameInfo':
+                            out.append('&local_name_info')
+                        elif ('DebugMarkerSetObject' in command.name or 'SetDebugUtilsObject' in command.name) and param.name == 'pTagInfo':
+                            out.append('&local_tag_info')
                         else:
-                            funcs += param.name
+                            out.append(param.name)
                         count += 1
 
-                    funcs += ');\n'
+                    out.append(');\n')
 
                 else:
-                    funcs += '#error("Unknown error path!");\n'
+                    out.append('#error("Unknown error path!");\n')
 
-                funcs += '}\n\n'
+                out.append('}\n\n')
             else:
-                funcs += tramp_header
+                out.append(tramp_header)
 
-                funcs += '    const VkLayerDispatchTable *disp = loader_get_dispatch('
-                funcs += ext_cmd.params[0].name
-                funcs += ');\n'
-                funcs += '    if (NULL == disp) {\n'
-                funcs += '        loader_log(NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n'
-                funcs += f'                   "{ext_cmd.name}: Invalid {ext_cmd.params[0].name} "\n'
-                funcs += f'                   "[VUID-{ext_cmd.name}-{ext_cmd.params[0].name}-parameter]");\n'
-                funcs += '        abort(); /* Intentionally fail so user can correct issue. */\n'
-                funcs += '    }\n'
+                out.append('    const VkLayerDispatchTable *disp = loader_get_dispatch(')
+                out.append(command.params[0].name)
+                out.append(');\n')
+                out.append('    if (NULL == disp) {\n')
+                out.append('        loader_log(NULL, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_VALIDATION_BIT, 0,\n')
+                out.append(f'                   "{command.name}: Invalid {command.params[0].name} "\n')
+                out.append(f'                   "[VUID-{command.name}-{command.params[0].name}-parameter]");\n')
+                out.append('        abort(); /* Intentionally fail so user can correct issue. */\n')
+                out.append('    }\n')
 
-                if ext_cmd.ext_name in NULL_CHECK_EXT_NAMES:
-                    funcs += '    if (disp->' + base_name + ' != NULL) {\n'
-                    funcs += '    '
-                funcs += return_prefix
-                funcs += 'disp->'
-                funcs += base_name
-                funcs += '('
+                if command.extensions[0].name in NULL_CHECK_EXT_NAMES:
+                    out.append('    if (disp->' + base_name + ' != NULL) {\n')
+                    out.append('    ')
+                out.append(return_prefix)
+                out.append('disp->')
+                out.append(base_name)
+                out.append('(')
                 count = 0
-                for param in ext_cmd.params:
+                for param in command.params:
                     if count != 0:
-                        funcs += ', '
-                    funcs += param.name
+                        out.append(', ')
+                    out.append(param.name)
                     count += 1
-                funcs += ');\n'
-                if ext_cmd.ext_name in NULL_CHECK_EXT_NAMES:
-                    if ext_cmd.return_type is not None:
-                        funcs += '    } else {\n'
-                        funcs += '        return VK_SUCCESS;\n'
-                    funcs += '    }\n'
-                funcs += '}\n\n'
+                out.append(');\n')
+                if command.extensions[0].name in NULL_CHECK_EXT_NAMES:
+                    if command.returnType != 'void':
+                        out.append('    } else {\n')
+                        out.append('        return VK_SUCCESS;\n')
+                    out.append('    }\n')
+                out.append('}\n\n')
 
-            if ext_cmd.protect is not None:
-                funcs += f'#endif // {ext_cmd.protect}\n'
+            if command.protect is not None:
+                out.append(f'#endif // {command.protect}\n')
 
-        return funcs
 
 
     #
     # Create a function for the extension GPA call
-    def InstExtensionGPA(self):
-        gpa_func = ''
+    def InstExtensionGPA(self, out):
         cur_extension_name = ''
 
-        gpa_func += '// GPA helpers for extensions\n'
-        gpa_func += 'bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *name, void **addr) {\n'
-        gpa_func += '    *addr = NULL;\n\n'
+        out.append( '// GPA helpers for extensions\n')
+        out.append( 'bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *name, void **addr) {\n')
+        out.append( '    *addr = NULL;\n\n')
 
-        for cur_cmd in self.ext_commands:
-            if (self.getAPIVersion(cur_cmd.ext_name) or
-                cur_cmd.ext_name in WSI_EXT_NAMES or
-                cur_cmd.ext_name in AVOID_EXT_NAMES or
-                cur_cmd.name in AVOID_CMD_NAMES ):
+        for command in [x for x in self.vk.commands.values() if x.extensions]:
+            if (command.version or
+                command.extensions[0].name in WSI_EXT_NAMES or
+                command.extensions[0].name in AVOID_EXT_NAMES or
+                command.name in AVOID_CMD_NAMES ):
                 continue
 
-            if cur_cmd.ext_name != cur_extension_name:
-                gpa_func += f'\n    // ---- {cur_cmd.ext_name} extension commands\n'
-                cur_extension_name = cur_cmd.ext_name
+            if command.extensions[0].name != cur_extension_name:
+                out.append( f'\n    // ---- {command.extensions[0].name} extension commands\n')
+                cur_extension_name = command.extensions[0].name
 
-            if cur_cmd.protect is not None:
-                gpa_func += f'#if defined({cur_cmd.protect})\n'
+            if command.protect is not None:
+                out.append( f'#if defined({command.protect})\n')
 
-            #base_name = cur_cmd.name[2:]
-            base_name = SHARED_ALIASES[cur_cmd.name] if cur_cmd.name in SHARED_ALIASES else cur_cmd.name[2:]
+            #base_name = command.name[2:]
+            base_name = SHARED_ALIASES[command.name] if command.name in SHARED_ALIASES else command.name[2:]
 
-            if cur_cmd.ext_type == 'instance':
-                gpa_func += f'    if (!strcmp("{cur_cmd.name}", name)) {{\n'
-                gpa_func += '        *addr = (ptr_instance->enabled_known_extensions.'
-                gpa_func += cur_cmd.ext_name[3:].lower()
-                gpa_func += ' == 1)\n'
-                gpa_func += f'                     ? (void *){base_name}\n'
-                gpa_func += '                     : NULL;\n'
-                gpa_func += '        return true;\n'
-                gpa_func += '    }\n'
+            if len(command.extensions) > 0 and command.extensions[0].instance:
+                out.append( f'    if (!strcmp("{command.name}", name)) {{\n')
+                out.append( '        *addr = (ptr_instance->enabled_known_extensions.')
+                out.append( command.extensions[0].name[3:].lower())
+                out.append( ' == 1)\n')
+                out.append( f'                     ? (void *){base_name}\n')
+                out.append( '                     : NULL;\n')
+                out.append( '        return true;\n')
+                out.append( '    }\n')
             else:
-                gpa_func += f'    if (!strcmp("{cur_cmd.name}", name)) {{\n'
-                gpa_func += f'        *addr = (void *){base_name};\n'
-                gpa_func += '        return true;\n'
-                gpa_func += '    }\n'
+                out.append( f'    if (!strcmp("{command.name}", name)) {{\n')
+                out.append( f'        *addr = (void *){base_name};\n')
+                out.append( '        return true;\n')
+                out.append( '    }\n')
 
-            if cur_cmd.protect is not None:
-                gpa_func += f'#endif // {cur_cmd.protect}\n'
+            if command.protect is not None:
+                out.append( f'#endif // {command.protect}\n')
 
-        gpa_func += '    return false;\n'
-        gpa_func += '}\n\n'
+        out.append( '    return false;\n')
+        out.append( '}\n\n')
 
-        return gpa_func
+
 
     #
     # Create the extension name init function
-    def InstantExtensionCreate(self):
-        entries = []
-        entries = self.instanceExtensions
-        count = 0
-        cur_extension_name = ''
+    def InstantExtensionCreate(self, out):
 
-        create_func = ''
-        create_func += '// A function that can be used to query enabled extensions during a vkCreateInstance call\n'
-        create_func += 'void extensions_create_instance(struct loader_instance *ptr_instance, const VkInstanceCreateInfo *pCreateInfo) {\n'
-        create_func += '    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {\n'
-        for ext in entries:
-            if (self.getAPIVersion(ext.name) or ext.name in WSI_EXT_NAMES or
-                ext.name in AVOID_EXT_NAMES or ext.name in AVOID_CMD_NAMES or
-                ext.type == 'device' or ext.num_commands == 0):
+        out.append( '// A function that can be used to query enabled extensions during a vkCreateInstance call\n')
+        out.append( 'void extensions_create_instance(struct loader_instance *ptr_instance, const VkInstanceCreateInfo *pCreateInfo) {\n')
+        out.append( '    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {\n')
+        e = ''
+        cur_extension_name = ''
+        for extension in [x for x in self.vk.extensions.values() if x.instance and len(x.commands) > 0]:
+            if extension.name in WSI_EXT_NAMES or extension.name in AVOID_EXT_NAMES or extension.name in AVOID_CMD_NAMES:
                 continue
 
-            if ext.name != cur_extension_name:
-                create_func += f'\n    // ---- {ext.name} extension commands\n'
-                cur_extension_name = ext.name
+            if extension.name != cur_extension_name:
+                out.append( f'\n    // ---- {extension.name} extension commands\n')
+                cur_extension_name = extension.name
 
-            if ext.protect is not None:
-                create_func += f'#if defined({ext.protect})\n'
-            if count == 0:
-                create_func += '        if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], '
-            else:
-                create_func += '        } else if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], '
+            if extension.protect is not None:
+                out.append( f'#if defined({extension.protect})\n')
 
-            create_func += ext.define + ')) {\n'
-            create_func += '            ptr_instance->enabled_known_extensions.'
-            create_func += ext.name[3:].lower()
-            create_func += ' = 1;\n'
+            out.append(f'        {e}if (0 == strcmp(pCreateInfo->ppEnabledExtensionNames[i], ')
+            e = '} else '
 
-            if ext.protect is not None:
-                create_func += f'#endif // {ext.protect}\n'
-            count += 1
+            out.append( extension.nameString + ')) {\n')
+            out.append( '            ptr_instance->enabled_known_extensions.')
+            out.append( extension.name[3:].lower())
+            out.append( ' = 1;\n')
 
-        create_func += '        }\n'
-        create_func += '    }\n'
-        create_func += '}\n\n'
-        return create_func
+            if extension.protect is not None:
+                out.append( f'#endif // {extension.protect}\n')
+
+        out.append( '        }\n')
+        out.append( '    }\n')
+        out.append( '}\n\n')
+
 
     #
-    # Create code to initialize a dispatch table from the appropriate list of
-    # extension entrypoints and return it as a string
-    def DeviceExtensionGetTerminator(self):
-        term_func = ''
-
-        term_func += '// Some device commands still need a terminator because the loader needs to unwrap something about them.\n'
-        term_func += '// In many cases, the item needing unwrapping is a VkPhysicalDevice or VkSurfaceKHR object.  But there may be other items\n'
-        term_func += '// in the future.\n'
-        term_func += 'PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *dev, const char *name, bool* found_name) {\n'
-        term_func += '''    *found_name = false;
+    # Create code to initialize a dispatch table from the appropriate list of extension entrypoints
+    def DeviceExtensionGetTerminator(self, out):
+        out.append('// Some device commands still need a terminator because the loader needs to unwrap something about them.\n')
+        out.append('// In many cases, the item needing unwrapping is a VkPhysicalDevice or VkSurfaceKHR object.  But there may be other items\n')
+        out.append('// in the future.\n')
+        out.append('PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *dev, const char *name, bool* found_name) {\n')
+        out.append('''    *found_name = false;
     if (!name || name[0] != 'v' || name[1] != 'k') {
         return NULL;
     }
     name += 2;
-'''
+''')
         last_protect = None
         last_ext = None
-        for ext_cmd in self.ext_commands:
-            version = self.getAPIVersion(ext_cmd.ext_name)
-            if ext_cmd.name in DEVICE_CMDS_NEED_TERM:
+        for command in [x for x in self.vk.commands.values() if x.extensions]:
+            version = command.version
+            if command.name in DEVICE_CMDS_NEED_TERM:
                 if version:
-                    term_func += f'    // ---- Core {version.name} commands\n'
+                    out.append(f'    // ---- Core {version.name} commands\n')
                 else:
-                    last_protect = ext_cmd.protect
-                    if ext_cmd.protect is not None:
-                        term_func += f'#if defined({ext_cmd.protect})\n'
-                    if last_ext != ext_cmd.ext_name:
-                        term_func += f'    // ---- {ext_cmd.ext_name} extension commands\n'
-                        last_ext = ext_cmd.ext_name
+                    last_protect = command.protect
+                    if command.protect is not None:
+                        out.append(f'#if defined({command.protect})\n')
+                    if last_ext != command.extensions[0].name:
+                        out.append(f'    // ---- {command.extensions[0].name} extension commands\n')
+                        last_ext = command.extensions[0].name
 
-                term_func += f'    if (!strcmp(name, "{ext_cmd.name[2:]}")) {{\n'
-                term_func += '        *found_name = true;\n'
-                if ext_cmd.require:
-                    dep_expr = self.ConvertDependencyExpression(ext_cmd.require, lambda ext_name: f'dev->driver_extensions.{ext_name[3:].lower()}_enabled')
-                    term_func += f'        return (dev->driver_extensions.{ext_cmd.ext_name[3:].lower()}_enabled && ({dep_expr})) ?\n'
+                out.append(f'    if (!strcmp(name, "{command.name[2:]}")) {{\n')
+                out.append('        *found_name = true;\n')
+                if command.name == 'vkGetDeviceGroupSurfacePresentModes2EXT': # command.extensions[0].depends in [x for x in self.vk.commands.values() if x.device]:
+                    # Hardcode the dependency expression as vulkan_object.py doesn't expose this information
+                    dep_expr = self.ConvertDependencyExpression('VK_KHR_device_group,VK_VERSION_1_1', lambda ext_name: f'dev->driver_extensions.{ext_name[3:].lower()}_enabled')
+                    out.append(f'        return (dev->driver_extensions.{command.extensions[0].name[3:].lower()}_enabled && ({dep_expr})) ?\n')
                 else:
-                    term_func += f'        return dev->driver_extensions.{ext_cmd.ext_name[3:].lower()}_enabled ?\n'
-                term_func += f'            (PFN_vkVoidFunction)terminator_{(ext_cmd.name[2:])} : NULL;\n'
-                term_func += '    }\n'
+                    out.append(f'        return dev->driver_extensions.{command.extensions[0].name[3:].lower()}_enabled ?\n')
+                out.append(f'            (PFN_vkVoidFunction)terminator_{(command.name[2:])} : NULL;\n')
+                out.append('    }\n')
 
         if last_protect is not None:
-            term_func += f'#endif // {last_protect}\n'
+            out.append(f'#endif // {last_protect}\n')
 
-        term_func += '    return NULL;\n'
-        term_func += '}\n\n'
+        out.append('    return NULL;\n')
+        out.append('}\n\n')
 
-        return term_func
+
 
     #
-    # Create a dispatch table solely for device functions which have custom terminators
-    def OutputDeviceFunctionTerminatorDispatchTable(self):
-        term_func = ''
-        term_func += '// Functions that required a terminator need to have a separate dispatch table which contains their corresponding\n'
-        term_func += '// device function. This is used in the terminators themselves.\n'
-        term_func += 'struct loader_device_terminator_dispatch {\n'
-
-        last_protect = None
-        last_ext = None
-        for ext_cmd in self.ext_commands:
-            version = self.getAPIVersion(ext_cmd.ext_name)
-            if ext_cmd.name in DEVICE_CMDS_NEED_TERM:
-                if version:
-                    term_func += f'    // ---- Core {version.name} commands\n'
-                else:
-                    last_protect = ext_cmd.protect
-                    if ext_cmd.protect is not None:
-                        term_func += f'#if defined({ext_cmd.protect})\n'
-                    if last_ext != ext_cmd.ext_name:
-                        term_func += f'    // ---- {ext_cmd.ext_name} extension commands\n'
-                        last_ext = ext_cmd.ext_name
-
-                term_func += f'    PFN_{ext_cmd.name} {ext_cmd.name[2:]};\n'
-
-        if last_protect is not None:
-            term_func += f'#endif // {last_protect}\n'
-
-        term_func += '};\n\n'
-
-        return term_func
-
-    def OutputDeviceFunctionTrampolinePrototypes(self):
-        tramp_protos = ''
-        tramp_protos += '// These are prototypes for functions that need their trampoline called in all circumstances.\n'
-        tramp_protos += '// They are used in loader_lookup_device_dispatch_table but are defined afterwards.\n'
-        last_protect = None
-        last_ext = None
-        for ext_cmd in self.ext_commands:
-            version = self.getAPIVersion(ext_cmd.ext_name)
-            if ext_cmd.name in DEVICE_CMDS_MUST_USE_TRAMP:
-                if version:
-                    tramp_protos += f'    // ---- Core {version.name} commands\n'
-                else:
-                    last_protect = ext_cmd.protect
-                    if ext_cmd.protect is not None:
-                        tramp_protos += f'#if defined({ext_cmd.protect})\n'
-                    if last_ext != ext_cmd.ext_name:
-                        tramp_protos += f'    // ---- {ext_cmd.ext_name} extension commands\n'
-                        last_ext = ext_cmd.ext_name
-
-                tramp_protos += f'{ext_cmd.cdecl.replace("VKAPI_CALL vk", "VKAPI_CALL ")}\n'
-
-        if last_protect is not None:
-            tramp_protos += f'#endif // {last_protect}\n'
-        tramp_protos += '\n'
-        return tramp_protos
-
-    #
-    # Create code to initialize a dispatch table from the appropriate list of
-    # extension entrypoints and return it as a string
-    def InitDeviceFunctionTerminatorDispatchTable(self):
-        term_func = ''
-
-        term_func += '// Functions that required a terminator need to have a separate dispatch table which contains their corresponding\n'
-        term_func += '// device function. This is used in the terminators themselves.\n'
-        term_func += 'void init_extension_device_proc_terminator_dispatch(struct loader_device *dev) {\n'
-        term_func += '    struct loader_device_terminator_dispatch* dispatch = &dev->loader_dispatch.extension_terminator_dispatch;\n'
-        term_func += '    PFN_vkGetDeviceProcAddr gpda = (PFN_vkGetDeviceProcAddr)dev->phys_dev_term->this_icd_term->dispatch.GetDeviceProcAddr;\n'
-        last_protect = None
-        last_ext = None
-        for ext_cmd in self.ext_commands:
-            version = self.getAPIVersion(ext_cmd.ext_name)
-            if ext_cmd.name in DEVICE_CMDS_NEED_TERM:
-                if version:
-                    term_func += f'    // ---- Core {version.name} commands\n'
-                else:
-                    last_protect = ext_cmd.protect
-                    if ext_cmd.protect is not None:
-                        term_func += f'#if defined({ext_cmd.protect})\n'
-                    if last_ext != ext_cmd.ext_name:
-                        term_func += f'    // ---- {ext_cmd.ext_name} extension commands\n'
-                        last_ext = ext_cmd.ext_name
-
-
-                if ext_cmd.require:
-                    dep_expr = self.ConvertDependencyExpression(ext_cmd.require, lambda ext_name: f'dev->driver_extensions.{ext_name[3:].lower()}_enabled')
-                    term_func += f'    if (dev->driver_extensions.{ext_cmd.ext_name[3:].lower()}_enabled && ({dep_expr}))\n'
-                    term_func += f'       dispatch->{ext_cmd.name[2:]} = (PFN_{(ext_cmd.name)})gpda(dev->icd_device, "{(ext_cmd.name)}");\n'
-                else:
-                    term_func += f'    if (dev->driver_extensions.{ext_cmd.ext_name[3:].lower()}_enabled)\n'
-                    term_func += f'       dispatch->{ext_cmd.name[2:]} = (PFN_{(ext_cmd.name)})gpda(dev->icd_device, "{(ext_cmd.name)}");\n'
-
-        if last_protect is not None:
-            term_func += f'#endif // {last_protect}\n'
-
-        term_func += '}\n\n'
-
-        return term_func
-
-    #
-    # Create code to initialize a dispatch table from the appropriate list of
-    # core and extension entrypoints and return it as a string
-    def InitInstLoaderExtensionDispatchTable(self):
+    # Create code to initialize a dispatch table from the appropriate list of core and extension entrypoints
+    def InitInstLoaderExtensionDispatchTable(self, out):
         commands = []
-        table = ''
-        cur_extension_name = ''
 
-        table += '// This table contains the loader\'s instance dispatch table, which contains\n'
-        table += '// default functions if no instance layers are activated.  This contains\n'
-        table += '// pointers to "terminator functions".\n'
-        table += 'const VkLayerInstanceDispatchTable instance_disp = {\n'
+        out.append( '// This table contains the loader\'s instance dispatch table, which contains\n')
+        out.append( '// default functions if no instance layers are activated.  This contains\n')
+        out.append( '// pointers to "terminator functions".\n')
+        out.append( 'const VkLayerInstanceDispatchTable instance_disp = {\n')
 
-        for x in range(0, 2):
-            if x == 0:
-                commands = self.core_commands
-            else:
-                commands = self.ext_commands
+        for command_list in [self.core_commands, self.extension_commands]:
+            commands = command_list
 
-            for cur_cmd in commands:
-                version = self.getAPIVersion(cur_cmd.ext_name)
-                if cur_cmd.handle_type == 'VkInstance' or cur_cmd.handle_type == 'VkPhysicalDevice':
-                    if cur_cmd.ext_name != cur_extension_name:
-                        if version:
-                            table += f'\n    // ---- Core {version.name} commands\n'
-                        else:
-                            table += f'\n    // ---- {cur_cmd.ext_name} extension commands\n'
-                        cur_extension_name = cur_cmd.ext_name
-
+            current_block = ''
+            for command in commands:
+                if command.params[0].type in ['VkInstance', 'VkPhysicalDevice']:
+                    current_block = self.DescribeBlock(command, current_block, out)
                     # Remove 'vk' from proto name
-                    base_name = cur_cmd.name[2:]
-                    aliased_name = SHARED_ALIASES[cur_cmd.name][2:] if cur_cmd.name in SHARED_ALIASES else base_name
+                    base_name = command.name[2:]
+                    aliased_name = SHARED_ALIASES[command.name][2:] if command.name in SHARED_ALIASES else base_name
 
                     if (base_name == 'CreateInstance' or base_name == 'CreateDevice' or
                         base_name == 'EnumerateInstanceExtensionProperties' or
@@ -1734,41 +1317,36 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                         base_name == 'EnumerateInstanceVersion'):
                         continue
 
-                    if cur_cmd.protect is not None:
-                        table += f'#if defined({cur_cmd.protect})\n'
+                    if command.protect is not None:
+                        out.append( f'#if defined({command.protect})\n')
 
                     if base_name == 'GetInstanceProcAddr':
-                        table += f'    .{base_name} = {cur_cmd.name},\n'
+                        out.append( f'    .{base_name} = {command.name},\n')
                     else:
-                        table += f'    .{base_name} = terminator_{aliased_name},\n'
+                        out.append( f'    .{base_name} = terminator_{aliased_name},\n')
 
-                    if cur_cmd.protect is not None:
-                        table += f'#endif // {cur_cmd.protect}\n'
-        table += '};\n\n'
+                    if command.protect is not None:
+                        out.append( f'#endif // {command.protect}\n')
+        out.append( '};\n\n')
 
-        return table
+
 
     #
     # Create the extension name whitelist array
-    def OutputInstantExtensionWhitelistArray(self):
-        extensions = self.instanceExtensions
+    def OutputInstantExtensionWhitelistArray(self, out):
+        out.append( '// A null-terminated list of all of the instance extensions supported by the loader.\n')
+        out.append( '// If an instance extension name is not in this list, but it is exported by one or more of the\n')
+        out.append( '// ICDs detected by the loader, then the extension name not in the list will be filtered out\n')
+        out.append( '// before passing the list of extensions to the application.\n')
+        out.append( 'const char *const LOADER_INSTANCE_EXTENSIONS[] = {\n')
+        for extension in self.instance_extensions:
 
-        table = ''
-        table += '// A null-terminated list of all of the instance extensions supported by the loader.\n'
-        table += '// If an instance extension name is not in this list, but it is exported by one or more of the\n'
-        table += '// ICDs detected by the loader, then the extension name not in the list will be filtered out\n'
-        table += '// before passing the list of extensions to the application.\n'
-        table += 'const char *const LOADER_INSTANCE_EXTENSIONS[] = {\n'
-        for ext in extensions:
-            if ext.type == 'device' or self.getAPIVersion(ext.name):
-                continue
+            if extension.protect is not None:
+                out.append( f'#if defined({extension.protect})\n')
+            out.append( '                                                  ')
+            out.append( extension.nameString + ',\n')
 
-            if ext.protect is not None:
-                table += f'#if defined({ext.protect})\n'
-            table += '                                                  '
-            table += ext.define + ',\n'
+            if extension.protect is not None:
+                out.append( f'#endif // {extension.protect}\n')
+        out.append( '                                                  NULL };\n')
 
-            if ext.protect is not None:
-                table += f'#endif // {ext.protect}\n'
-        table += '                                                  NULL };\n'
-        return table

--- a/tests/framework/layer/vk_dispatch_table_helper.h
+++ b/tests/framework/layer/vk_dispatch_table_helper.h
@@ -1,11 +1,11 @@
 #pragma once
 // *** THIS FILE IS GENERATED - DO NOT EDIT ***
-// See dispatch_helper_generator.py for modifications
+// See dispatch_table_helper_generator.py for modifications
 
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
  * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
  * Author: Jon Ashburn <jon@lunarg.com>
  * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: Charles Giessen <charles@lunarg.com>
  */
 
 #include <vulkan/vulkan.h>
@@ -51,8 +52,7 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->BindImageMemory = (PFN_vkBindImageMemory)gpa(device, "vkBindImageMemory");
     table->GetBufferMemoryRequirements = (PFN_vkGetBufferMemoryRequirements)gpa(device, "vkGetBufferMemoryRequirements");
     table->GetImageMemoryRequirements = (PFN_vkGetImageMemoryRequirements)gpa(device, "vkGetImageMemoryRequirements");
-    table->GetImageSparseMemoryRequirements =
-        (PFN_vkGetImageSparseMemoryRequirements)gpa(device, "vkGetImageSparseMemoryRequirements");
+    table->GetImageSparseMemoryRequirements = (PFN_vkGetImageSparseMemoryRequirements)gpa(device, "vkGetImageSparseMemoryRequirements");
     table->QueueBindSparse = (PFN_vkQueueBindSparse)gpa(device, "vkQueueBindSparse");
     table->CreateFence = (PFN_vkCreateFence)gpa(device, "vkCreateFence");
     table->DestroyFence = (PFN_vkDestroyFence)gpa(device, "vkDestroyFence");
@@ -158,23 +158,19 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->CmdExecuteCommands = (PFN_vkCmdExecuteCommands)gpa(device, "vkCmdExecuteCommands");
     table->BindBufferMemory2 = (PFN_vkBindBufferMemory2)gpa(device, "vkBindBufferMemory2");
     table->BindImageMemory2 = (PFN_vkBindImageMemory2)gpa(device, "vkBindImageMemory2");
-    table->GetDeviceGroupPeerMemoryFeatures =
-        (PFN_vkGetDeviceGroupPeerMemoryFeatures)gpa(device, "vkGetDeviceGroupPeerMemoryFeatures");
+    table->GetDeviceGroupPeerMemoryFeatures = (PFN_vkGetDeviceGroupPeerMemoryFeatures)gpa(device, "vkGetDeviceGroupPeerMemoryFeatures");
     table->CmdSetDeviceMask = (PFN_vkCmdSetDeviceMask)gpa(device, "vkCmdSetDeviceMask");
     table->CmdDispatchBase = (PFN_vkCmdDispatchBase)gpa(device, "vkCmdDispatchBase");
     table->GetImageMemoryRequirements2 = (PFN_vkGetImageMemoryRequirements2)gpa(device, "vkGetImageMemoryRequirements2");
     table->GetBufferMemoryRequirements2 = (PFN_vkGetBufferMemoryRequirements2)gpa(device, "vkGetBufferMemoryRequirements2");
-    table->GetImageSparseMemoryRequirements2 =
-        (PFN_vkGetImageSparseMemoryRequirements2)gpa(device, "vkGetImageSparseMemoryRequirements2");
+    table->GetImageSparseMemoryRequirements2 = (PFN_vkGetImageSparseMemoryRequirements2)gpa(device, "vkGetImageSparseMemoryRequirements2");
     table->TrimCommandPool = (PFN_vkTrimCommandPool)gpa(device, "vkTrimCommandPool");
     table->GetDeviceQueue2 = (PFN_vkGetDeviceQueue2)gpa(device, "vkGetDeviceQueue2");
     table->CreateSamplerYcbcrConversion = (PFN_vkCreateSamplerYcbcrConversion)gpa(device, "vkCreateSamplerYcbcrConversion");
     table->DestroySamplerYcbcrConversion = (PFN_vkDestroySamplerYcbcrConversion)gpa(device, "vkDestroySamplerYcbcrConversion");
     table->CreateDescriptorUpdateTemplate = (PFN_vkCreateDescriptorUpdateTemplate)gpa(device, "vkCreateDescriptorUpdateTemplate");
-    table->DestroyDescriptorUpdateTemplate =
-        (PFN_vkDestroyDescriptorUpdateTemplate)gpa(device, "vkDestroyDescriptorUpdateTemplate");
-    table->UpdateDescriptorSetWithTemplate =
-        (PFN_vkUpdateDescriptorSetWithTemplate)gpa(device, "vkUpdateDescriptorSetWithTemplate");
+    table->DestroyDescriptorUpdateTemplate = (PFN_vkDestroyDescriptorUpdateTemplate)gpa(device, "vkDestroyDescriptorUpdateTemplate");
+    table->UpdateDescriptorSetWithTemplate = (PFN_vkUpdateDescriptorSetWithTemplate)gpa(device, "vkUpdateDescriptorSetWithTemplate");
     table->GetDescriptorSetLayoutSupport = (PFN_vkGetDescriptorSetLayoutSupport)gpa(device, "vkGetDescriptorSetLayoutSupport");
     table->CmdDrawIndirectCount = (PFN_vkCmdDrawIndirectCount)gpa(device, "vkCmdDrawIndirectCount");
     table->CmdDrawIndexedIndirectCount = (PFN_vkCmdDrawIndexedIndirectCount)gpa(device, "vkCmdDrawIndexedIndirectCount");
@@ -188,8 +184,7 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->SignalSemaphore = (PFN_vkSignalSemaphore)gpa(device, "vkSignalSemaphore");
     table->GetBufferDeviceAddress = (PFN_vkGetBufferDeviceAddress)gpa(device, "vkGetBufferDeviceAddress");
     table->GetBufferOpaqueCaptureAddress = (PFN_vkGetBufferOpaqueCaptureAddress)gpa(device, "vkGetBufferOpaqueCaptureAddress");
-    table->GetDeviceMemoryOpaqueCaptureAddress =
-        (PFN_vkGetDeviceMemoryOpaqueCaptureAddress)gpa(device, "vkGetDeviceMemoryOpaqueCaptureAddress");
+    table->GetDeviceMemoryOpaqueCaptureAddress = (PFN_vkGetDeviceMemoryOpaqueCaptureAddress)gpa(device, "vkGetDeviceMemoryOpaqueCaptureAddress");
     table->CreatePrivateDataSlot = (PFN_vkCreatePrivateDataSlot)gpa(device, "vkCreatePrivateDataSlot");
     table->DestroyPrivateDataSlot = (PFN_vkDestroyPrivateDataSlot)gpa(device, "vkDestroyPrivateDataSlot");
     table->SetPrivateData = (PFN_vkSetPrivateData)gpa(device, "vkSetPrivateData");
@@ -223,42 +218,51 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->CmdSetRasterizerDiscardEnable = (PFN_vkCmdSetRasterizerDiscardEnable)gpa(device, "vkCmdSetRasterizerDiscardEnable");
     table->CmdSetDepthBiasEnable = (PFN_vkCmdSetDepthBiasEnable)gpa(device, "vkCmdSetDepthBiasEnable");
     table->CmdSetPrimitiveRestartEnable = (PFN_vkCmdSetPrimitiveRestartEnable)gpa(device, "vkCmdSetPrimitiveRestartEnable");
-    table->GetDeviceBufferMemoryRequirements =
-        (PFN_vkGetDeviceBufferMemoryRequirements)gpa(device, "vkGetDeviceBufferMemoryRequirements");
-    table->GetDeviceImageMemoryRequirements =
-        (PFN_vkGetDeviceImageMemoryRequirements)gpa(device, "vkGetDeviceImageMemoryRequirements");
-    table->GetDeviceImageSparseMemoryRequirements =
-        (PFN_vkGetDeviceImageSparseMemoryRequirements)gpa(device, "vkGetDeviceImageSparseMemoryRequirements");
+    table->GetDeviceBufferMemoryRequirements = (PFN_vkGetDeviceBufferMemoryRequirements)gpa(device, "vkGetDeviceBufferMemoryRequirements");
+    table->GetDeviceImageMemoryRequirements = (PFN_vkGetDeviceImageMemoryRequirements)gpa(device, "vkGetDeviceImageMemoryRequirements");
+    table->GetDeviceImageSparseMemoryRequirements = (PFN_vkGetDeviceImageSparseMemoryRequirements)gpa(device, "vkGetDeviceImageSparseMemoryRequirements");
+    table->CmdSetLineStipple = (PFN_vkCmdSetLineStipple)gpa(device, "vkCmdSetLineStipple");
+    table->MapMemory2 = (PFN_vkMapMemory2)gpa(device, "vkMapMemory2");
+    table->UnmapMemory2 = (PFN_vkUnmapMemory2)gpa(device, "vkUnmapMemory2");
+    table->CmdBindIndexBuffer2 = (PFN_vkCmdBindIndexBuffer2)gpa(device, "vkCmdBindIndexBuffer2");
+    table->GetRenderingAreaGranularity = (PFN_vkGetRenderingAreaGranularity)gpa(device, "vkGetRenderingAreaGranularity");
+    table->GetDeviceImageSubresourceLayout = (PFN_vkGetDeviceImageSubresourceLayout)gpa(device, "vkGetDeviceImageSubresourceLayout");
+    table->GetImageSubresourceLayout2 = (PFN_vkGetImageSubresourceLayout2)gpa(device, "vkGetImageSubresourceLayout2");
+    table->CmdPushDescriptorSet = (PFN_vkCmdPushDescriptorSet)gpa(device, "vkCmdPushDescriptorSet");
+    table->CmdPushDescriptorSetWithTemplate = (PFN_vkCmdPushDescriptorSetWithTemplate)gpa(device, "vkCmdPushDescriptorSetWithTemplate");
+    table->CmdSetRenderingAttachmentLocations = (PFN_vkCmdSetRenderingAttachmentLocations)gpa(device, "vkCmdSetRenderingAttachmentLocations");
+    table->CmdSetRenderingInputAttachmentIndices = (PFN_vkCmdSetRenderingInputAttachmentIndices)gpa(device, "vkCmdSetRenderingInputAttachmentIndices");
+    table->CmdBindDescriptorSets2 = (PFN_vkCmdBindDescriptorSets2)gpa(device, "vkCmdBindDescriptorSets2");
+    table->CmdPushConstants2 = (PFN_vkCmdPushConstants2)gpa(device, "vkCmdPushConstants2");
+    table->CmdPushDescriptorSet2 = (PFN_vkCmdPushDescriptorSet2)gpa(device, "vkCmdPushDescriptorSet2");
+    table->CmdPushDescriptorSetWithTemplate2 = (PFN_vkCmdPushDescriptorSetWithTemplate2)gpa(device, "vkCmdPushDescriptorSetWithTemplate2");
+    table->CopyMemoryToImage = (PFN_vkCopyMemoryToImage)gpa(device, "vkCopyMemoryToImage");
+    table->CopyImageToMemory = (PFN_vkCopyImageToMemory)gpa(device, "vkCopyImageToMemory");
+    table->CopyImageToImage = (PFN_vkCopyImageToImage)gpa(device, "vkCopyImageToImage");
+    table->TransitionImageLayout = (PFN_vkTransitionImageLayout)gpa(device, "vkTransitionImageLayout");
     table->CreateSwapchainKHR = (PFN_vkCreateSwapchainKHR)gpa(device, "vkCreateSwapchainKHR");
     table->DestroySwapchainKHR = (PFN_vkDestroySwapchainKHR)gpa(device, "vkDestroySwapchainKHR");
     table->GetSwapchainImagesKHR = (PFN_vkGetSwapchainImagesKHR)gpa(device, "vkGetSwapchainImagesKHR");
     table->AcquireNextImageKHR = (PFN_vkAcquireNextImageKHR)gpa(device, "vkAcquireNextImageKHR");
     table->QueuePresentKHR = (PFN_vkQueuePresentKHR)gpa(device, "vkQueuePresentKHR");
-    table->GetDeviceGroupPresentCapabilitiesKHR =
-        (PFN_vkGetDeviceGroupPresentCapabilitiesKHR)gpa(device, "vkGetDeviceGroupPresentCapabilitiesKHR");
-    table->GetDeviceGroupSurfacePresentModesKHR =
-        (PFN_vkGetDeviceGroupSurfacePresentModesKHR)gpa(device, "vkGetDeviceGroupSurfacePresentModesKHR");
+    table->GetDeviceGroupPresentCapabilitiesKHR = (PFN_vkGetDeviceGroupPresentCapabilitiesKHR)gpa(device, "vkGetDeviceGroupPresentCapabilitiesKHR");
+    table->GetDeviceGroupSurfacePresentModesKHR = (PFN_vkGetDeviceGroupSurfacePresentModesKHR)gpa(device, "vkGetDeviceGroupSurfacePresentModesKHR");
     table->AcquireNextImage2KHR = (PFN_vkAcquireNextImage2KHR)gpa(device, "vkAcquireNextImage2KHR");
     table->CreateSharedSwapchainsKHR = (PFN_vkCreateSharedSwapchainsKHR)gpa(device, "vkCreateSharedSwapchainsKHR");
     table->CreateVideoSessionKHR = (PFN_vkCreateVideoSessionKHR)gpa(device, "vkCreateVideoSessionKHR");
     table->DestroyVideoSessionKHR = (PFN_vkDestroyVideoSessionKHR)gpa(device, "vkDestroyVideoSessionKHR");
-    table->GetVideoSessionMemoryRequirementsKHR =
-        (PFN_vkGetVideoSessionMemoryRequirementsKHR)gpa(device, "vkGetVideoSessionMemoryRequirementsKHR");
+    table->GetVideoSessionMemoryRequirementsKHR = (PFN_vkGetVideoSessionMemoryRequirementsKHR)gpa(device, "vkGetVideoSessionMemoryRequirementsKHR");
     table->BindVideoSessionMemoryKHR = (PFN_vkBindVideoSessionMemoryKHR)gpa(device, "vkBindVideoSessionMemoryKHR");
-    table->CreateVideoSessionParametersKHR =
-        (PFN_vkCreateVideoSessionParametersKHR)gpa(device, "vkCreateVideoSessionParametersKHR");
-    table->UpdateVideoSessionParametersKHR =
-        (PFN_vkUpdateVideoSessionParametersKHR)gpa(device, "vkUpdateVideoSessionParametersKHR");
-    table->DestroyVideoSessionParametersKHR =
-        (PFN_vkDestroyVideoSessionParametersKHR)gpa(device, "vkDestroyVideoSessionParametersKHR");
+    table->CreateVideoSessionParametersKHR = (PFN_vkCreateVideoSessionParametersKHR)gpa(device, "vkCreateVideoSessionParametersKHR");
+    table->UpdateVideoSessionParametersKHR = (PFN_vkUpdateVideoSessionParametersKHR)gpa(device, "vkUpdateVideoSessionParametersKHR");
+    table->DestroyVideoSessionParametersKHR = (PFN_vkDestroyVideoSessionParametersKHR)gpa(device, "vkDestroyVideoSessionParametersKHR");
     table->CmdBeginVideoCodingKHR = (PFN_vkCmdBeginVideoCodingKHR)gpa(device, "vkCmdBeginVideoCodingKHR");
     table->CmdEndVideoCodingKHR = (PFN_vkCmdEndVideoCodingKHR)gpa(device, "vkCmdEndVideoCodingKHR");
     table->CmdControlVideoCodingKHR = (PFN_vkCmdControlVideoCodingKHR)gpa(device, "vkCmdControlVideoCodingKHR");
     table->CmdDecodeVideoKHR = (PFN_vkCmdDecodeVideoKHR)gpa(device, "vkCmdDecodeVideoKHR");
     table->CmdBeginRenderingKHR = (PFN_vkCmdBeginRenderingKHR)gpa(device, "vkCmdBeginRenderingKHR");
     table->CmdEndRenderingKHR = (PFN_vkCmdEndRenderingKHR)gpa(device, "vkCmdEndRenderingKHR");
-    table->GetDeviceGroupPeerMemoryFeaturesKHR =
-        (PFN_vkGetDeviceGroupPeerMemoryFeaturesKHR)gpa(device, "vkGetDeviceGroupPeerMemoryFeaturesKHR");
+    table->GetDeviceGroupPeerMemoryFeaturesKHR = (PFN_vkGetDeviceGroupPeerMemoryFeaturesKHR)gpa(device, "vkGetDeviceGroupPeerMemoryFeaturesKHR");
     table->CmdSetDeviceMaskKHR = (PFN_vkCmdSetDeviceMaskKHR)gpa(device, "vkCmdSetDeviceMaskKHR");
     table->CmdDispatchBaseKHR = (PFN_vkCmdDispatchBaseKHR)gpa(device, "vkCmdDispatchBaseKHR");
     table->TrimCommandPoolKHR = (PFN_vkTrimCommandPoolKHR)gpa(device, "vkTrimCommandPoolKHR");
@@ -266,8 +270,7 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->GetMemoryWin32HandleKHR = (PFN_vkGetMemoryWin32HandleKHR)gpa(device, "vkGetMemoryWin32HandleKHR");
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-    table->GetMemoryWin32HandlePropertiesKHR =
-        (PFN_vkGetMemoryWin32HandlePropertiesKHR)gpa(device, "vkGetMemoryWin32HandlePropertiesKHR");
+    table->GetMemoryWin32HandlePropertiesKHR = (PFN_vkGetMemoryWin32HandlePropertiesKHR)gpa(device, "vkGetMemoryWin32HandlePropertiesKHR");
 #endif  // VK_USE_PLATFORM_WIN32_KHR
     table->GetMemoryFdKHR = (PFN_vkGetMemoryFdKHR)gpa(device, "vkGetMemoryFdKHR");
     table->GetMemoryFdPropertiesKHR = (PFN_vkGetMemoryFdPropertiesKHR)gpa(device, "vkGetMemoryFdPropertiesKHR");
@@ -280,14 +283,10 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->ImportSemaphoreFdKHR = (PFN_vkImportSemaphoreFdKHR)gpa(device, "vkImportSemaphoreFdKHR");
     table->GetSemaphoreFdKHR = (PFN_vkGetSemaphoreFdKHR)gpa(device, "vkGetSemaphoreFdKHR");
     table->CmdPushDescriptorSetKHR = (PFN_vkCmdPushDescriptorSetKHR)gpa(device, "vkCmdPushDescriptorSetKHR");
-    table->CmdPushDescriptorSetWithTemplateKHR =
-        (PFN_vkCmdPushDescriptorSetWithTemplateKHR)gpa(device, "vkCmdPushDescriptorSetWithTemplateKHR");
-    table->CreateDescriptorUpdateTemplateKHR =
-        (PFN_vkCreateDescriptorUpdateTemplateKHR)gpa(device, "vkCreateDescriptorUpdateTemplateKHR");
-    table->DestroyDescriptorUpdateTemplateKHR =
-        (PFN_vkDestroyDescriptorUpdateTemplateKHR)gpa(device, "vkDestroyDescriptorUpdateTemplateKHR");
-    table->UpdateDescriptorSetWithTemplateKHR =
-        (PFN_vkUpdateDescriptorSetWithTemplateKHR)gpa(device, "vkUpdateDescriptorSetWithTemplateKHR");
+    table->CmdPushDescriptorSetWithTemplateKHR = (PFN_vkCmdPushDescriptorSetWithTemplateKHR)gpa(device, "vkCmdPushDescriptorSetWithTemplateKHR");
+    table->CreateDescriptorUpdateTemplateKHR = (PFN_vkCreateDescriptorUpdateTemplateKHR)gpa(device, "vkCreateDescriptorUpdateTemplateKHR");
+    table->DestroyDescriptorUpdateTemplateKHR = (PFN_vkDestroyDescriptorUpdateTemplateKHR)gpa(device, "vkDestroyDescriptorUpdateTemplateKHR");
+    table->UpdateDescriptorSetWithTemplateKHR = (PFN_vkUpdateDescriptorSetWithTemplateKHR)gpa(device, "vkUpdateDescriptorSetWithTemplateKHR");
     table->CreateRenderPass2KHR = (PFN_vkCreateRenderPass2KHR)gpa(device, "vkCreateRenderPass2KHR");
     table->CmdBeginRenderPass2KHR = (PFN_vkCmdBeginRenderPass2KHR)gpa(device, "vkCmdBeginRenderPass2KHR");
     table->CmdNextSubpass2KHR = (PFN_vkCmdNextSubpass2KHR)gpa(device, "vkCmdNextSubpass2KHR");
@@ -304,59 +303,43 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->AcquireProfilingLockKHR = (PFN_vkAcquireProfilingLockKHR)gpa(device, "vkAcquireProfilingLockKHR");
     table->ReleaseProfilingLockKHR = (PFN_vkReleaseProfilingLockKHR)gpa(device, "vkReleaseProfilingLockKHR");
     table->GetImageMemoryRequirements2KHR = (PFN_vkGetImageMemoryRequirements2KHR)gpa(device, "vkGetImageMemoryRequirements2KHR");
-    table->GetBufferMemoryRequirements2KHR =
-        (PFN_vkGetBufferMemoryRequirements2KHR)gpa(device, "vkGetBufferMemoryRequirements2KHR");
-    table->GetImageSparseMemoryRequirements2KHR =
-        (PFN_vkGetImageSparseMemoryRequirements2KHR)gpa(device, "vkGetImageSparseMemoryRequirements2KHR");
-    table->CreateSamplerYcbcrConversionKHR =
-        (PFN_vkCreateSamplerYcbcrConversionKHR)gpa(device, "vkCreateSamplerYcbcrConversionKHR");
-    table->DestroySamplerYcbcrConversionKHR =
-        (PFN_vkDestroySamplerYcbcrConversionKHR)gpa(device, "vkDestroySamplerYcbcrConversionKHR");
+    table->GetBufferMemoryRequirements2KHR = (PFN_vkGetBufferMemoryRequirements2KHR)gpa(device, "vkGetBufferMemoryRequirements2KHR");
+    table->GetImageSparseMemoryRequirements2KHR = (PFN_vkGetImageSparseMemoryRequirements2KHR)gpa(device, "vkGetImageSparseMemoryRequirements2KHR");
+    table->CreateSamplerYcbcrConversionKHR = (PFN_vkCreateSamplerYcbcrConversionKHR)gpa(device, "vkCreateSamplerYcbcrConversionKHR");
+    table->DestroySamplerYcbcrConversionKHR = (PFN_vkDestroySamplerYcbcrConversionKHR)gpa(device, "vkDestroySamplerYcbcrConversionKHR");
     table->BindBufferMemory2KHR = (PFN_vkBindBufferMemory2KHR)gpa(device, "vkBindBufferMemory2KHR");
     table->BindImageMemory2KHR = (PFN_vkBindImageMemory2KHR)gpa(device, "vkBindImageMemory2KHR");
-    table->GetDescriptorSetLayoutSupportKHR =
-        (PFN_vkGetDescriptorSetLayoutSupportKHR)gpa(device, "vkGetDescriptorSetLayoutSupportKHR");
+    table->GetDescriptorSetLayoutSupportKHR = (PFN_vkGetDescriptorSetLayoutSupportKHR)gpa(device, "vkGetDescriptorSetLayoutSupportKHR");
     table->CmdDrawIndirectCountKHR = (PFN_vkCmdDrawIndirectCountKHR)gpa(device, "vkCmdDrawIndirectCountKHR");
     table->CmdDrawIndexedIndirectCountKHR = (PFN_vkCmdDrawIndexedIndirectCountKHR)gpa(device, "vkCmdDrawIndexedIndirectCountKHR");
     table->GetSemaphoreCounterValueKHR = (PFN_vkGetSemaphoreCounterValueKHR)gpa(device, "vkGetSemaphoreCounterValueKHR");
     table->WaitSemaphoresKHR = (PFN_vkWaitSemaphoresKHR)gpa(device, "vkWaitSemaphoresKHR");
     table->SignalSemaphoreKHR = (PFN_vkSignalSemaphoreKHR)gpa(device, "vkSignalSemaphoreKHR");
     table->CmdSetFragmentShadingRateKHR = (PFN_vkCmdSetFragmentShadingRateKHR)gpa(device, "vkCmdSetFragmentShadingRateKHR");
+    table->CmdSetRenderingAttachmentLocationsKHR = (PFN_vkCmdSetRenderingAttachmentLocationsKHR)gpa(device, "vkCmdSetRenderingAttachmentLocationsKHR");
+    table->CmdSetRenderingInputAttachmentIndicesKHR = (PFN_vkCmdSetRenderingInputAttachmentIndicesKHR)gpa(device, "vkCmdSetRenderingInputAttachmentIndicesKHR");
     table->WaitForPresentKHR = (PFN_vkWaitForPresentKHR)gpa(device, "vkWaitForPresentKHR");
     table->GetBufferDeviceAddressKHR = (PFN_vkGetBufferDeviceAddressKHR)gpa(device, "vkGetBufferDeviceAddressKHR");
-    table->GetBufferOpaqueCaptureAddressKHR =
-        (PFN_vkGetBufferOpaqueCaptureAddressKHR)gpa(device, "vkGetBufferOpaqueCaptureAddressKHR");
-    table->GetDeviceMemoryOpaqueCaptureAddressKHR =
-        (PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR)gpa(device, "vkGetDeviceMemoryOpaqueCaptureAddressKHR");
+    table->GetBufferOpaqueCaptureAddressKHR = (PFN_vkGetBufferOpaqueCaptureAddressKHR)gpa(device, "vkGetBufferOpaqueCaptureAddressKHR");
+    table->GetDeviceMemoryOpaqueCaptureAddressKHR = (PFN_vkGetDeviceMemoryOpaqueCaptureAddressKHR)gpa(device, "vkGetDeviceMemoryOpaqueCaptureAddressKHR");
     table->CreateDeferredOperationKHR = (PFN_vkCreateDeferredOperationKHR)gpa(device, "vkCreateDeferredOperationKHR");
     table->DestroyDeferredOperationKHR = (PFN_vkDestroyDeferredOperationKHR)gpa(device, "vkDestroyDeferredOperationKHR");
-    table->GetDeferredOperationMaxConcurrencyKHR =
-        (PFN_vkGetDeferredOperationMaxConcurrencyKHR)gpa(device, "vkGetDeferredOperationMaxConcurrencyKHR");
+    table->GetDeferredOperationMaxConcurrencyKHR = (PFN_vkGetDeferredOperationMaxConcurrencyKHR)gpa(device, "vkGetDeferredOperationMaxConcurrencyKHR");
     table->GetDeferredOperationResultKHR = (PFN_vkGetDeferredOperationResultKHR)gpa(device, "vkGetDeferredOperationResultKHR");
     table->DeferredOperationJoinKHR = (PFN_vkDeferredOperationJoinKHR)gpa(device, "vkDeferredOperationJoinKHR");
-    table->GetPipelineExecutablePropertiesKHR =
-        (PFN_vkGetPipelineExecutablePropertiesKHR)gpa(device, "vkGetPipelineExecutablePropertiesKHR");
-    table->GetPipelineExecutableStatisticsKHR =
-        (PFN_vkGetPipelineExecutableStatisticsKHR)gpa(device, "vkGetPipelineExecutableStatisticsKHR");
-    table->GetPipelineExecutableInternalRepresentationsKHR =
-        (PFN_vkGetPipelineExecutableInternalRepresentationsKHR)gpa(device, "vkGetPipelineExecutableInternalRepresentationsKHR");
+    table->GetPipelineExecutablePropertiesKHR = (PFN_vkGetPipelineExecutablePropertiesKHR)gpa(device, "vkGetPipelineExecutablePropertiesKHR");
+    table->GetPipelineExecutableStatisticsKHR = (PFN_vkGetPipelineExecutableStatisticsKHR)gpa(device, "vkGetPipelineExecutableStatisticsKHR");
+    table->GetPipelineExecutableInternalRepresentationsKHR = (PFN_vkGetPipelineExecutableInternalRepresentationsKHR)gpa(device, "vkGetPipelineExecutableInternalRepresentationsKHR");
     table->MapMemory2KHR = (PFN_vkMapMemory2KHR)gpa(device, "vkMapMemory2KHR");
     table->UnmapMemory2KHR = (PFN_vkUnmapMemory2KHR)gpa(device, "vkUnmapMemory2KHR");
-#if defined(VK_ENABLE_BETA_EXTENSIONS)
-    table->GetEncodedVideoSessionParametersKHR =
-        (PFN_vkGetEncodedVideoSessionParametersKHR)gpa(device, "vkGetEncodedVideoSessionParametersKHR");
-#endif  // VK_ENABLE_BETA_EXTENSIONS
-#if defined(VK_ENABLE_BETA_EXTENSIONS)
+    table->GetEncodedVideoSessionParametersKHR = (PFN_vkGetEncodedVideoSessionParametersKHR)gpa(device, "vkGetEncodedVideoSessionParametersKHR");
     table->CmdEncodeVideoKHR = (PFN_vkCmdEncodeVideoKHR)gpa(device, "vkCmdEncodeVideoKHR");
-#endif  // VK_ENABLE_BETA_EXTENSIONS
     table->CmdSetEvent2KHR = (PFN_vkCmdSetEvent2KHR)gpa(device, "vkCmdSetEvent2KHR");
     table->CmdResetEvent2KHR = (PFN_vkCmdResetEvent2KHR)gpa(device, "vkCmdResetEvent2KHR");
     table->CmdWaitEvents2KHR = (PFN_vkCmdWaitEvents2KHR)gpa(device, "vkCmdWaitEvents2KHR");
     table->CmdPipelineBarrier2KHR = (PFN_vkCmdPipelineBarrier2KHR)gpa(device, "vkCmdPipelineBarrier2KHR");
     table->CmdWriteTimestamp2KHR = (PFN_vkCmdWriteTimestamp2KHR)gpa(device, "vkCmdWriteTimestamp2KHR");
     table->QueueSubmit2KHR = (PFN_vkQueueSubmit2KHR)gpa(device, "vkQueueSubmit2KHR");
-    table->CmdWriteBufferMarker2AMD = (PFN_vkCmdWriteBufferMarker2AMD)gpa(device, "vkCmdWriteBufferMarker2AMD");
-    table->GetQueueCheckpointData2NV = (PFN_vkGetQueueCheckpointData2NV)gpa(device, "vkGetQueueCheckpointData2NV");
     table->CmdCopyBuffer2KHR = (PFN_vkCmdCopyBuffer2KHR)gpa(device, "vkCmdCopyBuffer2KHR");
     table->CmdCopyImage2KHR = (PFN_vkCmdCopyImage2KHR)gpa(device, "vkCmdCopyImage2KHR");
     table->CmdCopyBufferToImage2KHR = (PFN_vkCmdCopyBufferToImage2KHR)gpa(device, "vkCmdCopyBufferToImage2KHR");
@@ -364,19 +347,32 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->CmdBlitImage2KHR = (PFN_vkCmdBlitImage2KHR)gpa(device, "vkCmdBlitImage2KHR");
     table->CmdResolveImage2KHR = (PFN_vkCmdResolveImage2KHR)gpa(device, "vkCmdResolveImage2KHR");
     table->CmdTraceRaysIndirect2KHR = (PFN_vkCmdTraceRaysIndirect2KHR)gpa(device, "vkCmdTraceRaysIndirect2KHR");
-    table->GetDeviceBufferMemoryRequirementsKHR =
-        (PFN_vkGetDeviceBufferMemoryRequirementsKHR)gpa(device, "vkGetDeviceBufferMemoryRequirementsKHR");
-    table->GetDeviceImageMemoryRequirementsKHR =
-        (PFN_vkGetDeviceImageMemoryRequirementsKHR)gpa(device, "vkGetDeviceImageMemoryRequirementsKHR");
-    table->GetDeviceImageSparseMemoryRequirementsKHR =
-        (PFN_vkGetDeviceImageSparseMemoryRequirementsKHR)gpa(device, "vkGetDeviceImageSparseMemoryRequirementsKHR");
+    table->GetDeviceBufferMemoryRequirementsKHR = (PFN_vkGetDeviceBufferMemoryRequirementsKHR)gpa(device, "vkGetDeviceBufferMemoryRequirementsKHR");
+    table->GetDeviceImageMemoryRequirementsKHR = (PFN_vkGetDeviceImageMemoryRequirementsKHR)gpa(device, "vkGetDeviceImageMemoryRequirementsKHR");
+    table->GetDeviceImageSparseMemoryRequirementsKHR = (PFN_vkGetDeviceImageSparseMemoryRequirementsKHR)gpa(device, "vkGetDeviceImageSparseMemoryRequirementsKHR");
+    table->CmdBindIndexBuffer2KHR = (PFN_vkCmdBindIndexBuffer2KHR)gpa(device, "vkCmdBindIndexBuffer2KHR");
+    table->GetRenderingAreaGranularityKHR = (PFN_vkGetRenderingAreaGranularityKHR)gpa(device, "vkGetRenderingAreaGranularityKHR");
+    table->GetDeviceImageSubresourceLayoutKHR = (PFN_vkGetDeviceImageSubresourceLayoutKHR)gpa(device, "vkGetDeviceImageSubresourceLayoutKHR");
+    table->GetImageSubresourceLayout2KHR = (PFN_vkGetImageSubresourceLayout2KHR)gpa(device, "vkGetImageSubresourceLayout2KHR");
+    table->CreatePipelineBinariesKHR = (PFN_vkCreatePipelineBinariesKHR)gpa(device, "vkCreatePipelineBinariesKHR");
+    table->DestroyPipelineBinaryKHR = (PFN_vkDestroyPipelineBinaryKHR)gpa(device, "vkDestroyPipelineBinaryKHR");
+    table->GetPipelineKeyKHR = (PFN_vkGetPipelineKeyKHR)gpa(device, "vkGetPipelineKeyKHR");
+    table->GetPipelineBinaryDataKHR = (PFN_vkGetPipelineBinaryDataKHR)gpa(device, "vkGetPipelineBinaryDataKHR");
+    table->ReleaseCapturedPipelineDataKHR = (PFN_vkReleaseCapturedPipelineDataKHR)gpa(device, "vkReleaseCapturedPipelineDataKHR");
+    table->CmdSetLineStippleKHR = (PFN_vkCmdSetLineStippleKHR)gpa(device, "vkCmdSetLineStippleKHR");
+    table->GetCalibratedTimestampsKHR = (PFN_vkGetCalibratedTimestampsKHR)gpa(device, "vkGetCalibratedTimestampsKHR");
+    table->CmdBindDescriptorSets2KHR = (PFN_vkCmdBindDescriptorSets2KHR)gpa(device, "vkCmdBindDescriptorSets2KHR");
+    table->CmdPushConstants2KHR = (PFN_vkCmdPushConstants2KHR)gpa(device, "vkCmdPushConstants2KHR");
+    table->CmdPushDescriptorSet2KHR = (PFN_vkCmdPushDescriptorSet2KHR)gpa(device, "vkCmdPushDescriptorSet2KHR");
+    table->CmdPushDescriptorSetWithTemplate2KHR = (PFN_vkCmdPushDescriptorSetWithTemplate2KHR)gpa(device, "vkCmdPushDescriptorSetWithTemplate2KHR");
+    table->CmdSetDescriptorBufferOffsets2EXT = (PFN_vkCmdSetDescriptorBufferOffsets2EXT)gpa(device, "vkCmdSetDescriptorBufferOffsets2EXT");
+    table->CmdBindDescriptorBufferEmbeddedSamplers2EXT = (PFN_vkCmdBindDescriptorBufferEmbeddedSamplers2EXT)gpa(device, "vkCmdBindDescriptorBufferEmbeddedSamplers2EXT");
     table->DebugMarkerSetObjectTagEXT = (PFN_vkDebugMarkerSetObjectTagEXT)gpa(device, "vkDebugMarkerSetObjectTagEXT");
     table->DebugMarkerSetObjectNameEXT = (PFN_vkDebugMarkerSetObjectNameEXT)gpa(device, "vkDebugMarkerSetObjectNameEXT");
     table->CmdDebugMarkerBeginEXT = (PFN_vkCmdDebugMarkerBeginEXT)gpa(device, "vkCmdDebugMarkerBeginEXT");
     table->CmdDebugMarkerEndEXT = (PFN_vkCmdDebugMarkerEndEXT)gpa(device, "vkCmdDebugMarkerEndEXT");
     table->CmdDebugMarkerInsertEXT = (PFN_vkCmdDebugMarkerInsertEXT)gpa(device, "vkCmdDebugMarkerInsertEXT");
-    table->CmdBindTransformFeedbackBuffersEXT =
-        (PFN_vkCmdBindTransformFeedbackBuffersEXT)gpa(device, "vkCmdBindTransformFeedbackBuffersEXT");
+    table->CmdBindTransformFeedbackBuffersEXT = (PFN_vkCmdBindTransformFeedbackBuffersEXT)gpa(device, "vkCmdBindTransformFeedbackBuffersEXT");
     table->CmdBeginTransformFeedbackEXT = (PFN_vkCmdBeginTransformFeedbackEXT)gpa(device, "vkCmdBeginTransformFeedbackEXT");
     table->CmdEndTransformFeedbackEXT = (PFN_vkCmdEndTransformFeedbackEXT)gpa(device, "vkCmdEndTransformFeedbackEXT");
     table->CmdBeginQueryIndexedEXT = (PFN_vkCmdBeginQueryIndexedEXT)gpa(device, "vkCmdBeginQueryIndexedEXT");
@@ -388,6 +384,7 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->DestroyCuFunctionNVX = (PFN_vkDestroyCuFunctionNVX)gpa(device, "vkDestroyCuFunctionNVX");
     table->CmdCuLaunchKernelNVX = (PFN_vkCmdCuLaunchKernelNVX)gpa(device, "vkCmdCuLaunchKernelNVX");
     table->GetImageViewHandleNVX = (PFN_vkGetImageViewHandleNVX)gpa(device, "vkGetImageViewHandleNVX");
+    table->GetImageViewHandle64NVX = (PFN_vkGetImageViewHandle64NVX)gpa(device, "vkGetImageViewHandle64NVX");
     table->GetImageViewAddressNVX = (PFN_vkGetImageViewAddressNVX)gpa(device, "vkGetImageViewAddressNVX");
     table->CmdDrawIndirectCountAMD = (PFN_vkCmdDrawIndirectCountAMD)gpa(device, "vkCmdDrawIndirectCountAMD");
     table->CmdDrawIndexedIndirectCountAMD = (PFN_vkCmdDrawIndexedIndirectCountAMD)gpa(device, "vkCmdDrawIndexedIndirectCountAMD");
@@ -395,8 +392,7 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     table->GetMemoryWin32HandleNV = (PFN_vkGetMemoryWin32HandleNV)gpa(device, "vkGetMemoryWin32HandleNV");
 #endif  // VK_USE_PLATFORM_WIN32_KHR
-    table->CmdBeginConditionalRenderingEXT =
-        (PFN_vkCmdBeginConditionalRenderingEXT)gpa(device, "vkCmdBeginConditionalRenderingEXT");
+    table->CmdBeginConditionalRenderingEXT = (PFN_vkCmdBeginConditionalRenderingEXT)gpa(device, "vkCmdBeginConditionalRenderingEXT");
     table->CmdEndConditionalRenderingEXT = (PFN_vkCmdEndConditionalRenderingEXT)gpa(device, "vkCmdEndConditionalRenderingEXT");
     table->CmdSetViewportWScalingNV = (PFN_vkCmdSetViewportWScalingNV)gpa(device, "vkCmdSetViewportWScalingNV");
     table->DisplayPowerControlEXT = (PFN_vkDisplayPowerControlEXT)gpa(device, "vkDisplayPowerControlEXT");
@@ -404,11 +400,9 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->RegisterDisplayEventEXT = (PFN_vkRegisterDisplayEventEXT)gpa(device, "vkRegisterDisplayEventEXT");
     table->GetSwapchainCounterEXT = (PFN_vkGetSwapchainCounterEXT)gpa(device, "vkGetSwapchainCounterEXT");
     table->GetRefreshCycleDurationGOOGLE = (PFN_vkGetRefreshCycleDurationGOOGLE)gpa(device, "vkGetRefreshCycleDurationGOOGLE");
-    table->GetPastPresentationTimingGOOGLE =
-        (PFN_vkGetPastPresentationTimingGOOGLE)gpa(device, "vkGetPastPresentationTimingGOOGLE");
+    table->GetPastPresentationTimingGOOGLE = (PFN_vkGetPastPresentationTimingGOOGLE)gpa(device, "vkGetPastPresentationTimingGOOGLE");
     table->CmdSetDiscardRectangleEXT = (PFN_vkCmdSetDiscardRectangleEXT)gpa(device, "vkCmdSetDiscardRectangleEXT");
-    table->CmdSetDiscardRectangleEnableEXT =
-        (PFN_vkCmdSetDiscardRectangleEnableEXT)gpa(device, "vkCmdSetDiscardRectangleEnableEXT");
+    table->CmdSetDiscardRectangleEnableEXT = (PFN_vkCmdSetDiscardRectangleEnableEXT)gpa(device, "vkCmdSetDiscardRectangleEnableEXT");
     table->CmdSetDiscardRectangleModeEXT = (PFN_vkCmdSetDiscardRectangleModeEXT)gpa(device, "vkCmdSetDiscardRectangleModeEXT");
     table->SetHdrMetadataEXT = (PFN_vkSetHdrMetadataEXT)gpa(device, "vkSetHdrMetadataEXT");
     table->SetDebugUtilsObjectNameEXT = (PFN_vkSetDebugUtilsObjectNameEXT)gpa(device, "vkSetDebugUtilsObjectNameEXT");
@@ -420,83 +414,85 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->CmdEndDebugUtilsLabelEXT = (PFN_vkCmdEndDebugUtilsLabelEXT)gpa(device, "vkCmdEndDebugUtilsLabelEXT");
     table->CmdInsertDebugUtilsLabelEXT = (PFN_vkCmdInsertDebugUtilsLabelEXT)gpa(device, "vkCmdInsertDebugUtilsLabelEXT");
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-    table->GetAndroidHardwareBufferPropertiesANDROID =
-        (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)gpa(device, "vkGetAndroidHardwareBufferPropertiesANDROID");
+    table->GetAndroidHardwareBufferPropertiesANDROID = (PFN_vkGetAndroidHardwareBufferPropertiesANDROID)gpa(device, "vkGetAndroidHardwareBufferPropertiesANDROID");
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-    table->GetMemoryAndroidHardwareBufferANDROID =
-        (PFN_vkGetMemoryAndroidHardwareBufferANDROID)gpa(device, "vkGetMemoryAndroidHardwareBufferANDROID");
+    table->GetMemoryAndroidHardwareBufferANDROID = (PFN_vkGetMemoryAndroidHardwareBufferANDROID)gpa(device, "vkGetMemoryAndroidHardwareBufferANDROID");
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
+#if defined(VK_ENABLE_BETA_EXTENSIONS)
+    table->CreateExecutionGraphPipelinesAMDX = (PFN_vkCreateExecutionGraphPipelinesAMDX)gpa(device, "vkCreateExecutionGraphPipelinesAMDX");
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#if defined(VK_ENABLE_BETA_EXTENSIONS)
+    table->GetExecutionGraphPipelineScratchSizeAMDX = (PFN_vkGetExecutionGraphPipelineScratchSizeAMDX)gpa(device, "vkGetExecutionGraphPipelineScratchSizeAMDX");
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#if defined(VK_ENABLE_BETA_EXTENSIONS)
+    table->GetExecutionGraphPipelineNodeIndexAMDX = (PFN_vkGetExecutionGraphPipelineNodeIndexAMDX)gpa(device, "vkGetExecutionGraphPipelineNodeIndexAMDX");
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#if defined(VK_ENABLE_BETA_EXTENSIONS)
+    table->CmdInitializeGraphScratchMemoryAMDX = (PFN_vkCmdInitializeGraphScratchMemoryAMDX)gpa(device, "vkCmdInitializeGraphScratchMemoryAMDX");
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#if defined(VK_ENABLE_BETA_EXTENSIONS)
+    table->CmdDispatchGraphAMDX = (PFN_vkCmdDispatchGraphAMDX)gpa(device, "vkCmdDispatchGraphAMDX");
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#if defined(VK_ENABLE_BETA_EXTENSIONS)
+    table->CmdDispatchGraphIndirectAMDX = (PFN_vkCmdDispatchGraphIndirectAMDX)gpa(device, "vkCmdDispatchGraphIndirectAMDX");
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#if defined(VK_ENABLE_BETA_EXTENSIONS)
+    table->CmdDispatchGraphIndirectCountAMDX = (PFN_vkCmdDispatchGraphIndirectCountAMDX)gpa(device, "vkCmdDispatchGraphIndirectCountAMDX");
+#endif  // VK_ENABLE_BETA_EXTENSIONS
     table->CmdSetSampleLocationsEXT = (PFN_vkCmdSetSampleLocationsEXT)gpa(device, "vkCmdSetSampleLocationsEXT");
-    table->GetImageDrmFormatModifierPropertiesEXT =
-        (PFN_vkGetImageDrmFormatModifierPropertiesEXT)gpa(device, "vkGetImageDrmFormatModifierPropertiesEXT");
+    table->GetImageDrmFormatModifierPropertiesEXT = (PFN_vkGetImageDrmFormatModifierPropertiesEXT)gpa(device, "vkGetImageDrmFormatModifierPropertiesEXT");
     table->CreateValidationCacheEXT = (PFN_vkCreateValidationCacheEXT)gpa(device, "vkCreateValidationCacheEXT");
     table->DestroyValidationCacheEXT = (PFN_vkDestroyValidationCacheEXT)gpa(device, "vkDestroyValidationCacheEXT");
     table->MergeValidationCachesEXT = (PFN_vkMergeValidationCachesEXT)gpa(device, "vkMergeValidationCachesEXT");
     table->GetValidationCacheDataEXT = (PFN_vkGetValidationCacheDataEXT)gpa(device, "vkGetValidationCacheDataEXT");
     table->CmdBindShadingRateImageNV = (PFN_vkCmdBindShadingRateImageNV)gpa(device, "vkCmdBindShadingRateImageNV");
-    table->CmdSetViewportShadingRatePaletteNV =
-        (PFN_vkCmdSetViewportShadingRatePaletteNV)gpa(device, "vkCmdSetViewportShadingRatePaletteNV");
+    table->CmdSetViewportShadingRatePaletteNV = (PFN_vkCmdSetViewportShadingRatePaletteNV)gpa(device, "vkCmdSetViewportShadingRatePaletteNV");
     table->CmdSetCoarseSampleOrderNV = (PFN_vkCmdSetCoarseSampleOrderNV)gpa(device, "vkCmdSetCoarseSampleOrderNV");
     table->CreateAccelerationStructureNV = (PFN_vkCreateAccelerationStructureNV)gpa(device, "vkCreateAccelerationStructureNV");
     table->DestroyAccelerationStructureNV = (PFN_vkDestroyAccelerationStructureNV)gpa(device, "vkDestroyAccelerationStructureNV");
-    table->GetAccelerationStructureMemoryRequirementsNV =
-        (PFN_vkGetAccelerationStructureMemoryRequirementsNV)gpa(device, "vkGetAccelerationStructureMemoryRequirementsNV");
-    table->BindAccelerationStructureMemoryNV =
-        (PFN_vkBindAccelerationStructureMemoryNV)gpa(device, "vkBindAccelerationStructureMemoryNV");
-    table->CmdBuildAccelerationStructureNV =
-        (PFN_vkCmdBuildAccelerationStructureNV)gpa(device, "vkCmdBuildAccelerationStructureNV");
+    table->GetAccelerationStructureMemoryRequirementsNV = (PFN_vkGetAccelerationStructureMemoryRequirementsNV)gpa(device, "vkGetAccelerationStructureMemoryRequirementsNV");
+    table->BindAccelerationStructureMemoryNV = (PFN_vkBindAccelerationStructureMemoryNV)gpa(device, "vkBindAccelerationStructureMemoryNV");
+    table->CmdBuildAccelerationStructureNV = (PFN_vkCmdBuildAccelerationStructureNV)gpa(device, "vkCmdBuildAccelerationStructureNV");
     table->CmdCopyAccelerationStructureNV = (PFN_vkCmdCopyAccelerationStructureNV)gpa(device, "vkCmdCopyAccelerationStructureNV");
     table->CmdTraceRaysNV = (PFN_vkCmdTraceRaysNV)gpa(device, "vkCmdTraceRaysNV");
     table->CreateRayTracingPipelinesNV = (PFN_vkCreateRayTracingPipelinesNV)gpa(device, "vkCreateRayTracingPipelinesNV");
-    table->GetRayTracingShaderGroupHandlesKHR =
-        (PFN_vkGetRayTracingShaderGroupHandlesKHR)gpa(device, "vkGetRayTracingShaderGroupHandlesKHR");
-    table->GetRayTracingShaderGroupHandlesNV =
-        (PFN_vkGetRayTracingShaderGroupHandlesNV)gpa(device, "vkGetRayTracingShaderGroupHandlesNV");
-    table->GetAccelerationStructureHandleNV =
-        (PFN_vkGetAccelerationStructureHandleNV)gpa(device, "vkGetAccelerationStructureHandleNV");
-    table->CmdWriteAccelerationStructuresPropertiesNV =
-        (PFN_vkCmdWriteAccelerationStructuresPropertiesNV)gpa(device, "vkCmdWriteAccelerationStructuresPropertiesNV");
+    table->GetRayTracingShaderGroupHandlesKHR = (PFN_vkGetRayTracingShaderGroupHandlesKHR)gpa(device, "vkGetRayTracingShaderGroupHandlesKHR");
+    table->GetRayTracingShaderGroupHandlesNV = (PFN_vkGetRayTracingShaderGroupHandlesNV)gpa(device, "vkGetRayTracingShaderGroupHandlesNV");
+    table->GetAccelerationStructureHandleNV = (PFN_vkGetAccelerationStructureHandleNV)gpa(device, "vkGetAccelerationStructureHandleNV");
+    table->CmdWriteAccelerationStructuresPropertiesNV = (PFN_vkCmdWriteAccelerationStructuresPropertiesNV)gpa(device, "vkCmdWriteAccelerationStructuresPropertiesNV");
     table->CompileDeferredNV = (PFN_vkCompileDeferredNV)gpa(device, "vkCompileDeferredNV");
-    table->GetMemoryHostPointerPropertiesEXT =
-        (PFN_vkGetMemoryHostPointerPropertiesEXT)gpa(device, "vkGetMemoryHostPointerPropertiesEXT");
+    table->GetMemoryHostPointerPropertiesEXT = (PFN_vkGetMemoryHostPointerPropertiesEXT)gpa(device, "vkGetMemoryHostPointerPropertiesEXT");
     table->CmdWriteBufferMarkerAMD = (PFN_vkCmdWriteBufferMarkerAMD)gpa(device, "vkCmdWriteBufferMarkerAMD");
+    table->CmdWriteBufferMarker2AMD = (PFN_vkCmdWriteBufferMarker2AMD)gpa(device, "vkCmdWriteBufferMarker2AMD");
     table->GetCalibratedTimestampsEXT = (PFN_vkGetCalibratedTimestampsEXT)gpa(device, "vkGetCalibratedTimestampsEXT");
     table->CmdDrawMeshTasksNV = (PFN_vkCmdDrawMeshTasksNV)gpa(device, "vkCmdDrawMeshTasksNV");
     table->CmdDrawMeshTasksIndirectNV = (PFN_vkCmdDrawMeshTasksIndirectNV)gpa(device, "vkCmdDrawMeshTasksIndirectNV");
-    table->CmdDrawMeshTasksIndirectCountNV =
-        (PFN_vkCmdDrawMeshTasksIndirectCountNV)gpa(device, "vkCmdDrawMeshTasksIndirectCountNV");
+    table->CmdDrawMeshTasksIndirectCountNV = (PFN_vkCmdDrawMeshTasksIndirectCountNV)gpa(device, "vkCmdDrawMeshTasksIndirectCountNV");
     table->CmdSetExclusiveScissorEnableNV = (PFN_vkCmdSetExclusiveScissorEnableNV)gpa(device, "vkCmdSetExclusiveScissorEnableNV");
     table->CmdSetExclusiveScissorNV = (PFN_vkCmdSetExclusiveScissorNV)gpa(device, "vkCmdSetExclusiveScissorNV");
     table->CmdSetCheckpointNV = (PFN_vkCmdSetCheckpointNV)gpa(device, "vkCmdSetCheckpointNV");
     table->GetQueueCheckpointDataNV = (PFN_vkGetQueueCheckpointDataNV)gpa(device, "vkGetQueueCheckpointDataNV");
+    table->GetQueueCheckpointData2NV = (PFN_vkGetQueueCheckpointData2NV)gpa(device, "vkGetQueueCheckpointData2NV");
     table->InitializePerformanceApiINTEL = (PFN_vkInitializePerformanceApiINTEL)gpa(device, "vkInitializePerformanceApiINTEL");
-    table->UninitializePerformanceApiINTEL =
-        (PFN_vkUninitializePerformanceApiINTEL)gpa(device, "vkUninitializePerformanceApiINTEL");
+    table->UninitializePerformanceApiINTEL = (PFN_vkUninitializePerformanceApiINTEL)gpa(device, "vkUninitializePerformanceApiINTEL");
     table->CmdSetPerformanceMarkerINTEL = (PFN_vkCmdSetPerformanceMarkerINTEL)gpa(device, "vkCmdSetPerformanceMarkerINTEL");
-    table->CmdSetPerformanceStreamMarkerINTEL =
-        (PFN_vkCmdSetPerformanceStreamMarkerINTEL)gpa(device, "vkCmdSetPerformanceStreamMarkerINTEL");
+    table->CmdSetPerformanceStreamMarkerINTEL = (PFN_vkCmdSetPerformanceStreamMarkerINTEL)gpa(device, "vkCmdSetPerformanceStreamMarkerINTEL");
     table->CmdSetPerformanceOverrideINTEL = (PFN_vkCmdSetPerformanceOverrideINTEL)gpa(device, "vkCmdSetPerformanceOverrideINTEL");
-    table->AcquirePerformanceConfigurationINTEL =
-        (PFN_vkAcquirePerformanceConfigurationINTEL)gpa(device, "vkAcquirePerformanceConfigurationINTEL");
-    table->ReleasePerformanceConfigurationINTEL =
-        (PFN_vkReleasePerformanceConfigurationINTEL)gpa(device, "vkReleasePerformanceConfigurationINTEL");
-    table->QueueSetPerformanceConfigurationINTEL =
-        (PFN_vkQueueSetPerformanceConfigurationINTEL)gpa(device, "vkQueueSetPerformanceConfigurationINTEL");
+    table->AcquirePerformanceConfigurationINTEL = (PFN_vkAcquirePerformanceConfigurationINTEL)gpa(device, "vkAcquirePerformanceConfigurationINTEL");
+    table->ReleasePerformanceConfigurationINTEL = (PFN_vkReleasePerformanceConfigurationINTEL)gpa(device, "vkReleasePerformanceConfigurationINTEL");
+    table->QueueSetPerformanceConfigurationINTEL = (PFN_vkQueueSetPerformanceConfigurationINTEL)gpa(device, "vkQueueSetPerformanceConfigurationINTEL");
     table->GetPerformanceParameterINTEL = (PFN_vkGetPerformanceParameterINTEL)gpa(device, "vkGetPerformanceParameterINTEL");
     table->SetLocalDimmingAMD = (PFN_vkSetLocalDimmingAMD)gpa(device, "vkSetLocalDimmingAMD");
     table->GetBufferDeviceAddressEXT = (PFN_vkGetBufferDeviceAddressEXT)gpa(device, "vkGetBufferDeviceAddressEXT");
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-    table->AcquireFullScreenExclusiveModeEXT =
-        (PFN_vkAcquireFullScreenExclusiveModeEXT)gpa(device, "vkAcquireFullScreenExclusiveModeEXT");
+    table->AcquireFullScreenExclusiveModeEXT = (PFN_vkAcquireFullScreenExclusiveModeEXT)gpa(device, "vkAcquireFullScreenExclusiveModeEXT");
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-    table->ReleaseFullScreenExclusiveModeEXT =
-        (PFN_vkReleaseFullScreenExclusiveModeEXT)gpa(device, "vkReleaseFullScreenExclusiveModeEXT");
+    table->ReleaseFullScreenExclusiveModeEXT = (PFN_vkReleaseFullScreenExclusiveModeEXT)gpa(device, "vkReleaseFullScreenExclusiveModeEXT");
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-    table->GetDeviceGroupSurfacePresentModes2EXT =
-        (PFN_vkGetDeviceGroupSurfacePresentModes2EXT)gpa(device, "vkGetDeviceGroupSurfacePresentModes2EXT");
+    table->GetDeviceGroupSurfacePresentModes2EXT = (PFN_vkGetDeviceGroupSurfacePresentModes2EXT)gpa(device, "vkGetDeviceGroupSurfacePresentModes2EXT");
 #endif  // VK_USE_PLATFORM_WIN32_KHR
     table->CmdSetLineStippleEXT = (PFN_vkCmdSetLineStippleEXT)gpa(device, "vkCmdSetLineStippleEXT");
     table->ResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)gpa(device, "vkResetQueryPoolEXT");
@@ -512,94 +508,83 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->CmdSetDepthBoundsTestEnableEXT = (PFN_vkCmdSetDepthBoundsTestEnableEXT)gpa(device, "vkCmdSetDepthBoundsTestEnableEXT");
     table->CmdSetStencilTestEnableEXT = (PFN_vkCmdSetStencilTestEnableEXT)gpa(device, "vkCmdSetStencilTestEnableEXT");
     table->CmdSetStencilOpEXT = (PFN_vkCmdSetStencilOpEXT)gpa(device, "vkCmdSetStencilOpEXT");
+    table->CopyMemoryToImageEXT = (PFN_vkCopyMemoryToImageEXT)gpa(device, "vkCopyMemoryToImageEXT");
+    table->CopyImageToMemoryEXT = (PFN_vkCopyImageToMemoryEXT)gpa(device, "vkCopyImageToMemoryEXT");
+    table->CopyImageToImageEXT = (PFN_vkCopyImageToImageEXT)gpa(device, "vkCopyImageToImageEXT");
+    table->TransitionImageLayoutEXT = (PFN_vkTransitionImageLayoutEXT)gpa(device, "vkTransitionImageLayoutEXT");
+    table->GetImageSubresourceLayout2EXT = (PFN_vkGetImageSubresourceLayout2EXT)gpa(device, "vkGetImageSubresourceLayout2EXT");
     table->ReleaseSwapchainImagesEXT = (PFN_vkReleaseSwapchainImagesEXT)gpa(device, "vkReleaseSwapchainImagesEXT");
-    table->GetGeneratedCommandsMemoryRequirementsNV =
-        (PFN_vkGetGeneratedCommandsMemoryRequirementsNV)gpa(device, "vkGetGeneratedCommandsMemoryRequirementsNV");
-    table->CmdPreprocessGeneratedCommandsNV =
-        (PFN_vkCmdPreprocessGeneratedCommandsNV)gpa(device, "vkCmdPreprocessGeneratedCommandsNV");
+    table->GetGeneratedCommandsMemoryRequirementsNV = (PFN_vkGetGeneratedCommandsMemoryRequirementsNV)gpa(device, "vkGetGeneratedCommandsMemoryRequirementsNV");
+    table->CmdPreprocessGeneratedCommandsNV = (PFN_vkCmdPreprocessGeneratedCommandsNV)gpa(device, "vkCmdPreprocessGeneratedCommandsNV");
     table->CmdExecuteGeneratedCommandsNV = (PFN_vkCmdExecuteGeneratedCommandsNV)gpa(device, "vkCmdExecuteGeneratedCommandsNV");
     table->CmdBindPipelineShaderGroupNV = (PFN_vkCmdBindPipelineShaderGroupNV)gpa(device, "vkCmdBindPipelineShaderGroupNV");
     table->CreateIndirectCommandsLayoutNV = (PFN_vkCreateIndirectCommandsLayoutNV)gpa(device, "vkCreateIndirectCommandsLayoutNV");
-    table->DestroyIndirectCommandsLayoutNV =
-        (PFN_vkDestroyIndirectCommandsLayoutNV)gpa(device, "vkDestroyIndirectCommandsLayoutNV");
+    table->DestroyIndirectCommandsLayoutNV = (PFN_vkDestroyIndirectCommandsLayoutNV)gpa(device, "vkDestroyIndirectCommandsLayoutNV");
+    table->CmdSetDepthBias2EXT = (PFN_vkCmdSetDepthBias2EXT)gpa(device, "vkCmdSetDepthBias2EXT");
     table->CreatePrivateDataSlotEXT = (PFN_vkCreatePrivateDataSlotEXT)gpa(device, "vkCreatePrivateDataSlotEXT");
     table->DestroyPrivateDataSlotEXT = (PFN_vkDestroyPrivateDataSlotEXT)gpa(device, "vkDestroyPrivateDataSlotEXT");
     table->SetPrivateDataEXT = (PFN_vkSetPrivateDataEXT)gpa(device, "vkSetPrivateDataEXT");
     table->GetPrivateDataEXT = (PFN_vkGetPrivateDataEXT)gpa(device, "vkGetPrivateDataEXT");
+    table->CreateCudaModuleNV = (PFN_vkCreateCudaModuleNV)gpa(device, "vkCreateCudaModuleNV");
+    table->GetCudaModuleCacheNV = (PFN_vkGetCudaModuleCacheNV)gpa(device, "vkGetCudaModuleCacheNV");
+    table->CreateCudaFunctionNV = (PFN_vkCreateCudaFunctionNV)gpa(device, "vkCreateCudaFunctionNV");
+    table->DestroyCudaModuleNV = (PFN_vkDestroyCudaModuleNV)gpa(device, "vkDestroyCudaModuleNV");
+    table->DestroyCudaFunctionNV = (PFN_vkDestroyCudaFunctionNV)gpa(device, "vkDestroyCudaFunctionNV");
+    table->CmdCudaLaunchKernelNV = (PFN_vkCmdCudaLaunchKernelNV)gpa(device, "vkCmdCudaLaunchKernelNV");
 #if defined(VK_USE_PLATFORM_METAL_EXT)
     table->ExportMetalObjectsEXT = (PFN_vkExportMetalObjectsEXT)gpa(device, "vkExportMetalObjectsEXT");
 #endif  // VK_USE_PLATFORM_METAL_EXT
     table->GetDescriptorSetLayoutSizeEXT = (PFN_vkGetDescriptorSetLayoutSizeEXT)gpa(device, "vkGetDescriptorSetLayoutSizeEXT");
-    table->GetDescriptorSetLayoutBindingOffsetEXT =
-        (PFN_vkGetDescriptorSetLayoutBindingOffsetEXT)gpa(device, "vkGetDescriptorSetLayoutBindingOffsetEXT");
+    table->GetDescriptorSetLayoutBindingOffsetEXT = (PFN_vkGetDescriptorSetLayoutBindingOffsetEXT)gpa(device, "vkGetDescriptorSetLayoutBindingOffsetEXT");
     table->GetDescriptorEXT = (PFN_vkGetDescriptorEXT)gpa(device, "vkGetDescriptorEXT");
     table->CmdBindDescriptorBuffersEXT = (PFN_vkCmdBindDescriptorBuffersEXT)gpa(device, "vkCmdBindDescriptorBuffersEXT");
-    table->CmdSetDescriptorBufferOffsetsEXT =
-        (PFN_vkCmdSetDescriptorBufferOffsetsEXT)gpa(device, "vkCmdSetDescriptorBufferOffsetsEXT");
-    table->CmdBindDescriptorBufferEmbeddedSamplersEXT =
-        (PFN_vkCmdBindDescriptorBufferEmbeddedSamplersEXT)gpa(device, "vkCmdBindDescriptorBufferEmbeddedSamplersEXT");
-    table->GetBufferOpaqueCaptureDescriptorDataEXT =
-        (PFN_vkGetBufferOpaqueCaptureDescriptorDataEXT)gpa(device, "vkGetBufferOpaqueCaptureDescriptorDataEXT");
-    table->GetImageOpaqueCaptureDescriptorDataEXT =
-        (PFN_vkGetImageOpaqueCaptureDescriptorDataEXT)gpa(device, "vkGetImageOpaqueCaptureDescriptorDataEXT");
-    table->GetImageViewOpaqueCaptureDescriptorDataEXT =
-        (PFN_vkGetImageViewOpaqueCaptureDescriptorDataEXT)gpa(device, "vkGetImageViewOpaqueCaptureDescriptorDataEXT");
-    table->GetSamplerOpaqueCaptureDescriptorDataEXT =
-        (PFN_vkGetSamplerOpaqueCaptureDescriptorDataEXT)gpa(device, "vkGetSamplerOpaqueCaptureDescriptorDataEXT");
-    table->GetAccelerationStructureOpaqueCaptureDescriptorDataEXT =
-        (PFN_vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT)gpa(
-            device, "vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT");
-    table->CmdSetFragmentShadingRateEnumNV =
-        (PFN_vkCmdSetFragmentShadingRateEnumNV)gpa(device, "vkCmdSetFragmentShadingRateEnumNV");
-    table->GetImageSubresourceLayout2EXT = (PFN_vkGetImageSubresourceLayout2EXT)gpa(device, "vkGetImageSubresourceLayout2EXT");
+    table->CmdSetDescriptorBufferOffsetsEXT = (PFN_vkCmdSetDescriptorBufferOffsetsEXT)gpa(device, "vkCmdSetDescriptorBufferOffsetsEXT");
+    table->CmdBindDescriptorBufferEmbeddedSamplersEXT = (PFN_vkCmdBindDescriptorBufferEmbeddedSamplersEXT)gpa(device, "vkCmdBindDescriptorBufferEmbeddedSamplersEXT");
+    table->GetBufferOpaqueCaptureDescriptorDataEXT = (PFN_vkGetBufferOpaqueCaptureDescriptorDataEXT)gpa(device, "vkGetBufferOpaqueCaptureDescriptorDataEXT");
+    table->GetImageOpaqueCaptureDescriptorDataEXT = (PFN_vkGetImageOpaqueCaptureDescriptorDataEXT)gpa(device, "vkGetImageOpaqueCaptureDescriptorDataEXT");
+    table->GetImageViewOpaqueCaptureDescriptorDataEXT = (PFN_vkGetImageViewOpaqueCaptureDescriptorDataEXT)gpa(device, "vkGetImageViewOpaqueCaptureDescriptorDataEXT");
+    table->GetSamplerOpaqueCaptureDescriptorDataEXT = (PFN_vkGetSamplerOpaqueCaptureDescriptorDataEXT)gpa(device, "vkGetSamplerOpaqueCaptureDescriptorDataEXT");
+    table->GetAccelerationStructureOpaqueCaptureDescriptorDataEXT = (PFN_vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT)gpa(device, "vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT");
+    table->CmdSetFragmentShadingRateEnumNV = (PFN_vkCmdSetFragmentShadingRateEnumNV)gpa(device, "vkCmdSetFragmentShadingRateEnumNV");
     table->GetDeviceFaultInfoEXT = (PFN_vkGetDeviceFaultInfoEXT)gpa(device, "vkGetDeviceFaultInfoEXT");
     table->CmdSetVertexInputEXT = (PFN_vkCmdSetVertexInputEXT)gpa(device, "vkCmdSetVertexInputEXT");
 #if defined(VK_USE_PLATFORM_FUCHSIA)
     table->GetMemoryZirconHandleFUCHSIA = (PFN_vkGetMemoryZirconHandleFUCHSIA)gpa(device, "vkGetMemoryZirconHandleFUCHSIA");
 #endif  // VK_USE_PLATFORM_FUCHSIA
 #if defined(VK_USE_PLATFORM_FUCHSIA)
-    table->GetMemoryZirconHandlePropertiesFUCHSIA =
-        (PFN_vkGetMemoryZirconHandlePropertiesFUCHSIA)gpa(device, "vkGetMemoryZirconHandlePropertiesFUCHSIA");
+    table->GetMemoryZirconHandlePropertiesFUCHSIA = (PFN_vkGetMemoryZirconHandlePropertiesFUCHSIA)gpa(device, "vkGetMemoryZirconHandlePropertiesFUCHSIA");
 #endif  // VK_USE_PLATFORM_FUCHSIA
 #if defined(VK_USE_PLATFORM_FUCHSIA)
-    table->ImportSemaphoreZirconHandleFUCHSIA =
-        (PFN_vkImportSemaphoreZirconHandleFUCHSIA)gpa(device, "vkImportSemaphoreZirconHandleFUCHSIA");
+    table->ImportSemaphoreZirconHandleFUCHSIA = (PFN_vkImportSemaphoreZirconHandleFUCHSIA)gpa(device, "vkImportSemaphoreZirconHandleFUCHSIA");
 #endif  // VK_USE_PLATFORM_FUCHSIA
 #if defined(VK_USE_PLATFORM_FUCHSIA)
-    table->GetSemaphoreZirconHandleFUCHSIA =
-        (PFN_vkGetSemaphoreZirconHandleFUCHSIA)gpa(device, "vkGetSemaphoreZirconHandleFUCHSIA");
+    table->GetSemaphoreZirconHandleFUCHSIA = (PFN_vkGetSemaphoreZirconHandleFUCHSIA)gpa(device, "vkGetSemaphoreZirconHandleFUCHSIA");
 #endif  // VK_USE_PLATFORM_FUCHSIA
 #if defined(VK_USE_PLATFORM_FUCHSIA)
     table->CreateBufferCollectionFUCHSIA = (PFN_vkCreateBufferCollectionFUCHSIA)gpa(device, "vkCreateBufferCollectionFUCHSIA");
 #endif  // VK_USE_PLATFORM_FUCHSIA
 #if defined(VK_USE_PLATFORM_FUCHSIA)
-    table->SetBufferCollectionImageConstraintsFUCHSIA =
-        (PFN_vkSetBufferCollectionImageConstraintsFUCHSIA)gpa(device, "vkSetBufferCollectionImageConstraintsFUCHSIA");
+    table->SetBufferCollectionImageConstraintsFUCHSIA = (PFN_vkSetBufferCollectionImageConstraintsFUCHSIA)gpa(device, "vkSetBufferCollectionImageConstraintsFUCHSIA");
 #endif  // VK_USE_PLATFORM_FUCHSIA
 #if defined(VK_USE_PLATFORM_FUCHSIA)
-    table->SetBufferCollectionBufferConstraintsFUCHSIA =
-        (PFN_vkSetBufferCollectionBufferConstraintsFUCHSIA)gpa(device, "vkSetBufferCollectionBufferConstraintsFUCHSIA");
+    table->SetBufferCollectionBufferConstraintsFUCHSIA = (PFN_vkSetBufferCollectionBufferConstraintsFUCHSIA)gpa(device, "vkSetBufferCollectionBufferConstraintsFUCHSIA");
 #endif  // VK_USE_PLATFORM_FUCHSIA
 #if defined(VK_USE_PLATFORM_FUCHSIA)
     table->DestroyBufferCollectionFUCHSIA = (PFN_vkDestroyBufferCollectionFUCHSIA)gpa(device, "vkDestroyBufferCollectionFUCHSIA");
 #endif  // VK_USE_PLATFORM_FUCHSIA
 #if defined(VK_USE_PLATFORM_FUCHSIA)
-    table->GetBufferCollectionPropertiesFUCHSIA =
-        (PFN_vkGetBufferCollectionPropertiesFUCHSIA)gpa(device, "vkGetBufferCollectionPropertiesFUCHSIA");
+    table->GetBufferCollectionPropertiesFUCHSIA = (PFN_vkGetBufferCollectionPropertiesFUCHSIA)gpa(device, "vkGetBufferCollectionPropertiesFUCHSIA");
 #endif  // VK_USE_PLATFORM_FUCHSIA
-    table->GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI =
-        (PFN_vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI)gpa(device, "vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI");
+    table->GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI = (PFN_vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI)gpa(device, "vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI");
     table->CmdSubpassShadingHUAWEI = (PFN_vkCmdSubpassShadingHUAWEI)gpa(device, "vkCmdSubpassShadingHUAWEI");
     table->CmdBindInvocationMaskHUAWEI = (PFN_vkCmdBindInvocationMaskHUAWEI)gpa(device, "vkCmdBindInvocationMaskHUAWEI");
     table->GetMemoryRemoteAddressNV = (PFN_vkGetMemoryRemoteAddressNV)gpa(device, "vkGetMemoryRemoteAddressNV");
     table->GetPipelinePropertiesEXT = (PFN_vkGetPipelinePropertiesEXT)gpa(device, "vkGetPipelinePropertiesEXT");
     table->CmdSetPatchControlPointsEXT = (PFN_vkCmdSetPatchControlPointsEXT)gpa(device, "vkCmdSetPatchControlPointsEXT");
-    table->CmdSetRasterizerDiscardEnableEXT =
-        (PFN_vkCmdSetRasterizerDiscardEnableEXT)gpa(device, "vkCmdSetRasterizerDiscardEnableEXT");
+    table->CmdSetRasterizerDiscardEnableEXT = (PFN_vkCmdSetRasterizerDiscardEnableEXT)gpa(device, "vkCmdSetRasterizerDiscardEnableEXT");
     table->CmdSetDepthBiasEnableEXT = (PFN_vkCmdSetDepthBiasEnableEXT)gpa(device, "vkCmdSetDepthBiasEnableEXT");
     table->CmdSetLogicOpEXT = (PFN_vkCmdSetLogicOpEXT)gpa(device, "vkCmdSetLogicOpEXT");
-    table->CmdSetPrimitiveRestartEnableEXT =
-        (PFN_vkCmdSetPrimitiveRestartEnableEXT)gpa(device, "vkCmdSetPrimitiveRestartEnableEXT");
+    table->CmdSetPrimitiveRestartEnableEXT = (PFN_vkCmdSetPrimitiveRestartEnableEXT)gpa(device, "vkCmdSetPrimitiveRestartEnableEXT");
     table->CmdSetColorWriteEnableEXT = (PFN_vkCmdSetColorWriteEnableEXT)gpa(device, "vkCmdSetColorWriteEnableEXT");
     table->CmdDrawMultiEXT = (PFN_vkCmdDrawMultiEXT)gpa(device, "vkCmdDrawMultiEXT");
     table->CmdDrawMultiIndexedEXT = (PFN_vkCmdDrawMultiIndexedEXT)gpa(device, "vkCmdDrawMultiIndexedEXT");
@@ -615,23 +600,20 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->CmdCopyMicromapToMemoryEXT = (PFN_vkCmdCopyMicromapToMemoryEXT)gpa(device, "vkCmdCopyMicromapToMemoryEXT");
     table->CmdCopyMemoryToMicromapEXT = (PFN_vkCmdCopyMemoryToMicromapEXT)gpa(device, "vkCmdCopyMemoryToMicromapEXT");
     table->CmdWriteMicromapsPropertiesEXT = (PFN_vkCmdWriteMicromapsPropertiesEXT)gpa(device, "vkCmdWriteMicromapsPropertiesEXT");
-    table->GetDeviceMicromapCompatibilityEXT =
-        (PFN_vkGetDeviceMicromapCompatibilityEXT)gpa(device, "vkGetDeviceMicromapCompatibilityEXT");
+    table->GetDeviceMicromapCompatibilityEXT = (PFN_vkGetDeviceMicromapCompatibilityEXT)gpa(device, "vkGetDeviceMicromapCompatibilityEXT");
     table->GetMicromapBuildSizesEXT = (PFN_vkGetMicromapBuildSizesEXT)gpa(device, "vkGetMicromapBuildSizesEXT");
     table->CmdDrawClusterHUAWEI = (PFN_vkCmdDrawClusterHUAWEI)gpa(device, "vkCmdDrawClusterHUAWEI");
     table->CmdDrawClusterIndirectHUAWEI = (PFN_vkCmdDrawClusterIndirectHUAWEI)gpa(device, "vkCmdDrawClusterIndirectHUAWEI");
     table->SetDeviceMemoryPriorityEXT = (PFN_vkSetDeviceMemoryPriorityEXT)gpa(device, "vkSetDeviceMemoryPriorityEXT");
-    table->GetDescriptorSetLayoutHostMappingInfoVALVE =
-        (PFN_vkGetDescriptorSetLayoutHostMappingInfoVALVE)gpa(device, "vkGetDescriptorSetLayoutHostMappingInfoVALVE");
-    table->GetDescriptorSetHostMappingVALVE =
-        (PFN_vkGetDescriptorSetHostMappingVALVE)gpa(device, "vkGetDescriptorSetHostMappingVALVE");
+    table->GetDescriptorSetLayoutHostMappingInfoVALVE = (PFN_vkGetDescriptorSetLayoutHostMappingInfoVALVE)gpa(device, "vkGetDescriptorSetLayoutHostMappingInfoVALVE");
+    table->GetDescriptorSetHostMappingVALVE = (PFN_vkGetDescriptorSetHostMappingVALVE)gpa(device, "vkGetDescriptorSetHostMappingVALVE");
     table->CmdCopyMemoryIndirectNV = (PFN_vkCmdCopyMemoryIndirectNV)gpa(device, "vkCmdCopyMemoryIndirectNV");
     table->CmdCopyMemoryToImageIndirectNV = (PFN_vkCmdCopyMemoryToImageIndirectNV)gpa(device, "vkCmdCopyMemoryToImageIndirectNV");
     table->CmdDecompressMemoryNV = (PFN_vkCmdDecompressMemoryNV)gpa(device, "vkCmdDecompressMemoryNV");
-    table->CmdDecompressMemoryIndirectCountNV =
-        (PFN_vkCmdDecompressMemoryIndirectCountNV)gpa(device, "vkCmdDecompressMemoryIndirectCountNV");
-    table->CmdSetTessellationDomainOriginEXT =
-        (PFN_vkCmdSetTessellationDomainOriginEXT)gpa(device, "vkCmdSetTessellationDomainOriginEXT");
+    table->CmdDecompressMemoryIndirectCountNV = (PFN_vkCmdDecompressMemoryIndirectCountNV)gpa(device, "vkCmdDecompressMemoryIndirectCountNV");
+    table->GetPipelineIndirectMemoryRequirementsNV = (PFN_vkGetPipelineIndirectMemoryRequirementsNV)gpa(device, "vkGetPipelineIndirectMemoryRequirementsNV");
+    table->CmdUpdatePipelineIndirectBufferNV = (PFN_vkCmdUpdatePipelineIndirectBufferNV)gpa(device, "vkCmdUpdatePipelineIndirectBufferNV");
+    table->GetPipelineIndirectDeviceAddressNV = (PFN_vkGetPipelineIndirectDeviceAddressNV)gpa(device, "vkGetPipelineIndirectDeviceAddressNV");
     table->CmdSetDepthClampEnableEXT = (PFN_vkCmdSetDepthClampEnableEXT)gpa(device, "vkCmdSetDepthClampEnableEXT");
     table->CmdSetPolygonModeEXT = (PFN_vkCmdSetPolygonModeEXT)gpa(device, "vkCmdSetPolygonModeEXT");
     table->CmdSetRasterizationSamplesEXT = (PFN_vkCmdSetRasterizationSamplesEXT)gpa(device, "vkCmdSetRasterizationSamplesEXT");
@@ -642,155 +624,140 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->CmdSetColorBlendEnableEXT = (PFN_vkCmdSetColorBlendEnableEXT)gpa(device, "vkCmdSetColorBlendEnableEXT");
     table->CmdSetColorBlendEquationEXT = (PFN_vkCmdSetColorBlendEquationEXT)gpa(device, "vkCmdSetColorBlendEquationEXT");
     table->CmdSetColorWriteMaskEXT = (PFN_vkCmdSetColorWriteMaskEXT)gpa(device, "vkCmdSetColorWriteMaskEXT");
+    table->CmdSetTessellationDomainOriginEXT = (PFN_vkCmdSetTessellationDomainOriginEXT)gpa(device, "vkCmdSetTessellationDomainOriginEXT");
     table->CmdSetRasterizationStreamEXT = (PFN_vkCmdSetRasterizationStreamEXT)gpa(device, "vkCmdSetRasterizationStreamEXT");
-    table->CmdSetConservativeRasterizationModeEXT =
-        (PFN_vkCmdSetConservativeRasterizationModeEXT)gpa(device, "vkCmdSetConservativeRasterizationModeEXT");
-    table->CmdSetExtraPrimitiveOverestimationSizeEXT =
-        (PFN_vkCmdSetExtraPrimitiveOverestimationSizeEXT)gpa(device, "vkCmdSetExtraPrimitiveOverestimationSizeEXT");
+    table->CmdSetConservativeRasterizationModeEXT = (PFN_vkCmdSetConservativeRasterizationModeEXT)gpa(device, "vkCmdSetConservativeRasterizationModeEXT");
+    table->CmdSetExtraPrimitiveOverestimationSizeEXT = (PFN_vkCmdSetExtraPrimitiveOverestimationSizeEXT)gpa(device, "vkCmdSetExtraPrimitiveOverestimationSizeEXT");
     table->CmdSetDepthClipEnableEXT = (PFN_vkCmdSetDepthClipEnableEXT)gpa(device, "vkCmdSetDepthClipEnableEXT");
     table->CmdSetSampleLocationsEnableEXT = (PFN_vkCmdSetSampleLocationsEnableEXT)gpa(device, "vkCmdSetSampleLocationsEnableEXT");
     table->CmdSetColorBlendAdvancedEXT = (PFN_vkCmdSetColorBlendAdvancedEXT)gpa(device, "vkCmdSetColorBlendAdvancedEXT");
     table->CmdSetProvokingVertexModeEXT = (PFN_vkCmdSetProvokingVertexModeEXT)gpa(device, "vkCmdSetProvokingVertexModeEXT");
     table->CmdSetLineRasterizationModeEXT = (PFN_vkCmdSetLineRasterizationModeEXT)gpa(device, "vkCmdSetLineRasterizationModeEXT");
     table->CmdSetLineStippleEnableEXT = (PFN_vkCmdSetLineStippleEnableEXT)gpa(device, "vkCmdSetLineStippleEnableEXT");
-    table->CmdSetDepthClipNegativeOneToOneEXT =
-        (PFN_vkCmdSetDepthClipNegativeOneToOneEXT)gpa(device, "vkCmdSetDepthClipNegativeOneToOneEXT");
+    table->CmdSetDepthClipNegativeOneToOneEXT = (PFN_vkCmdSetDepthClipNegativeOneToOneEXT)gpa(device, "vkCmdSetDepthClipNegativeOneToOneEXT");
     table->CmdSetViewportWScalingEnableNV = (PFN_vkCmdSetViewportWScalingEnableNV)gpa(device, "vkCmdSetViewportWScalingEnableNV");
     table->CmdSetViewportSwizzleNV = (PFN_vkCmdSetViewportSwizzleNV)gpa(device, "vkCmdSetViewportSwizzleNV");
     table->CmdSetCoverageToColorEnableNV = (PFN_vkCmdSetCoverageToColorEnableNV)gpa(device, "vkCmdSetCoverageToColorEnableNV");
-    table->CmdSetCoverageToColorLocationNV =
-        (PFN_vkCmdSetCoverageToColorLocationNV)gpa(device, "vkCmdSetCoverageToColorLocationNV");
+    table->CmdSetCoverageToColorLocationNV = (PFN_vkCmdSetCoverageToColorLocationNV)gpa(device, "vkCmdSetCoverageToColorLocationNV");
     table->CmdSetCoverageModulationModeNV = (PFN_vkCmdSetCoverageModulationModeNV)gpa(device, "vkCmdSetCoverageModulationModeNV");
-    table->CmdSetCoverageModulationTableEnableNV =
-        (PFN_vkCmdSetCoverageModulationTableEnableNV)gpa(device, "vkCmdSetCoverageModulationTableEnableNV");
-    table->CmdSetCoverageModulationTableNV =
-        (PFN_vkCmdSetCoverageModulationTableNV)gpa(device, "vkCmdSetCoverageModulationTableNV");
+    table->CmdSetCoverageModulationTableEnableNV = (PFN_vkCmdSetCoverageModulationTableEnableNV)gpa(device, "vkCmdSetCoverageModulationTableEnableNV");
+    table->CmdSetCoverageModulationTableNV = (PFN_vkCmdSetCoverageModulationTableNV)gpa(device, "vkCmdSetCoverageModulationTableNV");
     table->CmdSetShadingRateImageEnableNV = (PFN_vkCmdSetShadingRateImageEnableNV)gpa(device, "vkCmdSetShadingRateImageEnableNV");
-    table->CmdSetRepresentativeFragmentTestEnableNV =
-        (PFN_vkCmdSetRepresentativeFragmentTestEnableNV)gpa(device, "vkCmdSetRepresentativeFragmentTestEnableNV");
+    table->CmdSetRepresentativeFragmentTestEnableNV = (PFN_vkCmdSetRepresentativeFragmentTestEnableNV)gpa(device, "vkCmdSetRepresentativeFragmentTestEnableNV");
     table->CmdSetCoverageReductionModeNV = (PFN_vkCmdSetCoverageReductionModeNV)gpa(device, "vkCmdSetCoverageReductionModeNV");
     table->GetShaderModuleIdentifierEXT = (PFN_vkGetShaderModuleIdentifierEXT)gpa(device, "vkGetShaderModuleIdentifierEXT");
-    table->GetShaderModuleCreateInfoIdentifierEXT =
-        (PFN_vkGetShaderModuleCreateInfoIdentifierEXT)gpa(device, "vkGetShaderModuleCreateInfoIdentifierEXT");
+    table->GetShaderModuleCreateInfoIdentifierEXT = (PFN_vkGetShaderModuleCreateInfoIdentifierEXT)gpa(device, "vkGetShaderModuleCreateInfoIdentifierEXT");
     table->CreateOpticalFlowSessionNV = (PFN_vkCreateOpticalFlowSessionNV)gpa(device, "vkCreateOpticalFlowSessionNV");
     table->DestroyOpticalFlowSessionNV = (PFN_vkDestroyOpticalFlowSessionNV)gpa(device, "vkDestroyOpticalFlowSessionNV");
     table->BindOpticalFlowSessionImageNV = (PFN_vkBindOpticalFlowSessionImageNV)gpa(device, "vkBindOpticalFlowSessionImageNV");
     table->CmdOpticalFlowExecuteNV = (PFN_vkCmdOpticalFlowExecuteNV)gpa(device, "vkCmdOpticalFlowExecuteNV");
+    table->AntiLagUpdateAMD = (PFN_vkAntiLagUpdateAMD)gpa(device, "vkAntiLagUpdateAMD");
     table->CreateShadersEXT = (PFN_vkCreateShadersEXT)gpa(device, "vkCreateShadersEXT");
     table->DestroyShaderEXT = (PFN_vkDestroyShaderEXT)gpa(device, "vkDestroyShaderEXT");
     table->GetShaderBinaryDataEXT = (PFN_vkGetShaderBinaryDataEXT)gpa(device, "vkGetShaderBinaryDataEXT");
     table->CmdBindShadersEXT = (PFN_vkCmdBindShadersEXT)gpa(device, "vkCmdBindShadersEXT");
-    table->GetFramebufferTilePropertiesQCOM =
-        (PFN_vkGetFramebufferTilePropertiesQCOM)gpa(device, "vkGetFramebufferTilePropertiesQCOM");
-    table->GetDynamicRenderingTilePropertiesQCOM =
-        (PFN_vkGetDynamicRenderingTilePropertiesQCOM)gpa(device, "vkGetDynamicRenderingTilePropertiesQCOM");
-    table->CmdSetAttachmentFeedbackLoopEnableEXT =
-        (PFN_vkCmdSetAttachmentFeedbackLoopEnableEXT)gpa(device, "vkCmdSetAttachmentFeedbackLoopEnableEXT");
+    table->CmdSetDepthClampRangeEXT = (PFN_vkCmdSetDepthClampRangeEXT)gpa(device, "vkCmdSetDepthClampRangeEXT");
+    table->GetFramebufferTilePropertiesQCOM = (PFN_vkGetFramebufferTilePropertiesQCOM)gpa(device, "vkGetFramebufferTilePropertiesQCOM");
+    table->GetDynamicRenderingTilePropertiesQCOM = (PFN_vkGetDynamicRenderingTilePropertiesQCOM)gpa(device, "vkGetDynamicRenderingTilePropertiesQCOM");
+    table->ConvertCooperativeVectorMatrixNV = (PFN_vkConvertCooperativeVectorMatrixNV)gpa(device, "vkConvertCooperativeVectorMatrixNV");
+    table->CmdConvertCooperativeVectorMatrixNV = (PFN_vkCmdConvertCooperativeVectorMatrixNV)gpa(device, "vkCmdConvertCooperativeVectorMatrixNV");
+    table->SetLatencySleepModeNV = (PFN_vkSetLatencySleepModeNV)gpa(device, "vkSetLatencySleepModeNV");
+    table->LatencySleepNV = (PFN_vkLatencySleepNV)gpa(device, "vkLatencySleepNV");
+    table->SetLatencyMarkerNV = (PFN_vkSetLatencyMarkerNV)gpa(device, "vkSetLatencyMarkerNV");
+    table->GetLatencyTimingsNV = (PFN_vkGetLatencyTimingsNV)gpa(device, "vkGetLatencyTimingsNV");
+    table->QueueNotifyOutOfBandNV = (PFN_vkQueueNotifyOutOfBandNV)gpa(device, "vkQueueNotifyOutOfBandNV");
+    table->CmdSetAttachmentFeedbackLoopEnableEXT = (PFN_vkCmdSetAttachmentFeedbackLoopEnableEXT)gpa(device, "vkCmdSetAttachmentFeedbackLoopEnableEXT");
+#if defined(VK_USE_PLATFORM_SCREEN_QNX)
+    table->GetScreenBufferPropertiesQNX = (PFN_vkGetScreenBufferPropertiesQNX)gpa(device, "vkGetScreenBufferPropertiesQNX");
+#endif  // VK_USE_PLATFORM_SCREEN_QNX
+    table->GetClusterAccelerationStructureBuildSizesNV = (PFN_vkGetClusterAccelerationStructureBuildSizesNV)gpa(device, "vkGetClusterAccelerationStructureBuildSizesNV");
+    table->CmdBuildClusterAccelerationStructureIndirectNV = (PFN_vkCmdBuildClusterAccelerationStructureIndirectNV)gpa(device, "vkCmdBuildClusterAccelerationStructureIndirectNV");
+    table->GetPartitionedAccelerationStructuresBuildSizesNV = (PFN_vkGetPartitionedAccelerationStructuresBuildSizesNV)gpa(device, "vkGetPartitionedAccelerationStructuresBuildSizesNV");
+    table->CmdBuildPartitionedAccelerationStructuresNV = (PFN_vkCmdBuildPartitionedAccelerationStructuresNV)gpa(device, "vkCmdBuildPartitionedAccelerationStructuresNV");
+    table->GetGeneratedCommandsMemoryRequirementsEXT = (PFN_vkGetGeneratedCommandsMemoryRequirementsEXT)gpa(device, "vkGetGeneratedCommandsMemoryRequirementsEXT");
+    table->CmdPreprocessGeneratedCommandsEXT = (PFN_vkCmdPreprocessGeneratedCommandsEXT)gpa(device, "vkCmdPreprocessGeneratedCommandsEXT");
+    table->CmdExecuteGeneratedCommandsEXT = (PFN_vkCmdExecuteGeneratedCommandsEXT)gpa(device, "vkCmdExecuteGeneratedCommandsEXT");
+    table->CreateIndirectCommandsLayoutEXT = (PFN_vkCreateIndirectCommandsLayoutEXT)gpa(device, "vkCreateIndirectCommandsLayoutEXT");
+    table->DestroyIndirectCommandsLayoutEXT = (PFN_vkDestroyIndirectCommandsLayoutEXT)gpa(device, "vkDestroyIndirectCommandsLayoutEXT");
+    table->CreateIndirectExecutionSetEXT = (PFN_vkCreateIndirectExecutionSetEXT)gpa(device, "vkCreateIndirectExecutionSetEXT");
+    table->DestroyIndirectExecutionSetEXT = (PFN_vkDestroyIndirectExecutionSetEXT)gpa(device, "vkDestroyIndirectExecutionSetEXT");
+    table->UpdateIndirectExecutionSetPipelineEXT = (PFN_vkUpdateIndirectExecutionSetPipelineEXT)gpa(device, "vkUpdateIndirectExecutionSetPipelineEXT");
+    table->UpdateIndirectExecutionSetShaderEXT = (PFN_vkUpdateIndirectExecutionSetShaderEXT)gpa(device, "vkUpdateIndirectExecutionSetShaderEXT");
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+    table->GetMemoryMetalHandleEXT = (PFN_vkGetMemoryMetalHandleEXT)gpa(device, "vkGetMemoryMetalHandleEXT");
+#endif  // VK_USE_PLATFORM_METAL_EXT
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+    table->GetMemoryMetalHandlePropertiesEXT = (PFN_vkGetMemoryMetalHandlePropertiesEXT)gpa(device, "vkGetMemoryMetalHandlePropertiesEXT");
+#endif  // VK_USE_PLATFORM_METAL_EXT
     table->CreateAccelerationStructureKHR = (PFN_vkCreateAccelerationStructureKHR)gpa(device, "vkCreateAccelerationStructureKHR");
-    table->DestroyAccelerationStructureKHR =
-        (PFN_vkDestroyAccelerationStructureKHR)gpa(device, "vkDestroyAccelerationStructureKHR");
-    table->CmdBuildAccelerationStructuresKHR =
-        (PFN_vkCmdBuildAccelerationStructuresKHR)gpa(device, "vkCmdBuildAccelerationStructuresKHR");
-    table->CmdBuildAccelerationStructuresIndirectKHR =
-        (PFN_vkCmdBuildAccelerationStructuresIndirectKHR)gpa(device, "vkCmdBuildAccelerationStructuresIndirectKHR");
+    table->DestroyAccelerationStructureKHR = (PFN_vkDestroyAccelerationStructureKHR)gpa(device, "vkDestroyAccelerationStructureKHR");
+    table->CmdBuildAccelerationStructuresKHR = (PFN_vkCmdBuildAccelerationStructuresKHR)gpa(device, "vkCmdBuildAccelerationStructuresKHR");
+    table->CmdBuildAccelerationStructuresIndirectKHR = (PFN_vkCmdBuildAccelerationStructuresIndirectKHR)gpa(device, "vkCmdBuildAccelerationStructuresIndirectKHR");
     table->BuildAccelerationStructuresKHR = (PFN_vkBuildAccelerationStructuresKHR)gpa(device, "vkBuildAccelerationStructuresKHR");
     table->CopyAccelerationStructureKHR = (PFN_vkCopyAccelerationStructureKHR)gpa(device, "vkCopyAccelerationStructureKHR");
-    table->CopyAccelerationStructureToMemoryKHR =
-        (PFN_vkCopyAccelerationStructureToMemoryKHR)gpa(device, "vkCopyAccelerationStructureToMemoryKHR");
-    table->CopyMemoryToAccelerationStructureKHR =
-        (PFN_vkCopyMemoryToAccelerationStructureKHR)gpa(device, "vkCopyMemoryToAccelerationStructureKHR");
-    table->WriteAccelerationStructuresPropertiesKHR =
-        (PFN_vkWriteAccelerationStructuresPropertiesKHR)gpa(device, "vkWriteAccelerationStructuresPropertiesKHR");
-    table->CmdCopyAccelerationStructureKHR =
-        (PFN_vkCmdCopyAccelerationStructureKHR)gpa(device, "vkCmdCopyAccelerationStructureKHR");
-    table->CmdCopyAccelerationStructureToMemoryKHR =
-        (PFN_vkCmdCopyAccelerationStructureToMemoryKHR)gpa(device, "vkCmdCopyAccelerationStructureToMemoryKHR");
-    table->CmdCopyMemoryToAccelerationStructureKHR =
-        (PFN_vkCmdCopyMemoryToAccelerationStructureKHR)gpa(device, "vkCmdCopyMemoryToAccelerationStructureKHR");
-    table->GetAccelerationStructureDeviceAddressKHR =
-        (PFN_vkGetAccelerationStructureDeviceAddressKHR)gpa(device, "vkGetAccelerationStructureDeviceAddressKHR");
-    table->CmdWriteAccelerationStructuresPropertiesKHR =
-        (PFN_vkCmdWriteAccelerationStructuresPropertiesKHR)gpa(device, "vkCmdWriteAccelerationStructuresPropertiesKHR");
-    table->GetDeviceAccelerationStructureCompatibilityKHR =
-        (PFN_vkGetDeviceAccelerationStructureCompatibilityKHR)gpa(device, "vkGetDeviceAccelerationStructureCompatibilityKHR");
-    table->GetAccelerationStructureBuildSizesKHR =
-        (PFN_vkGetAccelerationStructureBuildSizesKHR)gpa(device, "vkGetAccelerationStructureBuildSizesKHR");
+    table->CopyAccelerationStructureToMemoryKHR = (PFN_vkCopyAccelerationStructureToMemoryKHR)gpa(device, "vkCopyAccelerationStructureToMemoryKHR");
+    table->CopyMemoryToAccelerationStructureKHR = (PFN_vkCopyMemoryToAccelerationStructureKHR)gpa(device, "vkCopyMemoryToAccelerationStructureKHR");
+    table->WriteAccelerationStructuresPropertiesKHR = (PFN_vkWriteAccelerationStructuresPropertiesKHR)gpa(device, "vkWriteAccelerationStructuresPropertiesKHR");
+    table->CmdCopyAccelerationStructureKHR = (PFN_vkCmdCopyAccelerationStructureKHR)gpa(device, "vkCmdCopyAccelerationStructureKHR");
+    table->CmdCopyAccelerationStructureToMemoryKHR = (PFN_vkCmdCopyAccelerationStructureToMemoryKHR)gpa(device, "vkCmdCopyAccelerationStructureToMemoryKHR");
+    table->CmdCopyMemoryToAccelerationStructureKHR = (PFN_vkCmdCopyMemoryToAccelerationStructureKHR)gpa(device, "vkCmdCopyMemoryToAccelerationStructureKHR");
+    table->GetAccelerationStructureDeviceAddressKHR = (PFN_vkGetAccelerationStructureDeviceAddressKHR)gpa(device, "vkGetAccelerationStructureDeviceAddressKHR");
+    table->CmdWriteAccelerationStructuresPropertiesKHR = (PFN_vkCmdWriteAccelerationStructuresPropertiesKHR)gpa(device, "vkCmdWriteAccelerationStructuresPropertiesKHR");
+    table->GetDeviceAccelerationStructureCompatibilityKHR = (PFN_vkGetDeviceAccelerationStructureCompatibilityKHR)gpa(device, "vkGetDeviceAccelerationStructureCompatibilityKHR");
+    table->GetAccelerationStructureBuildSizesKHR = (PFN_vkGetAccelerationStructureBuildSizesKHR)gpa(device, "vkGetAccelerationStructureBuildSizesKHR");
     table->CmdTraceRaysKHR = (PFN_vkCmdTraceRaysKHR)gpa(device, "vkCmdTraceRaysKHR");
     table->CreateRayTracingPipelinesKHR = (PFN_vkCreateRayTracingPipelinesKHR)gpa(device, "vkCreateRayTracingPipelinesKHR");
-    table->GetRayTracingCaptureReplayShaderGroupHandlesKHR =
-        (PFN_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR)gpa(device, "vkGetRayTracingCaptureReplayShaderGroupHandlesKHR");
+    table->GetRayTracingCaptureReplayShaderGroupHandlesKHR = (PFN_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR)gpa(device, "vkGetRayTracingCaptureReplayShaderGroupHandlesKHR");
     table->CmdTraceRaysIndirectKHR = (PFN_vkCmdTraceRaysIndirectKHR)gpa(device, "vkCmdTraceRaysIndirectKHR");
-    table->GetRayTracingShaderGroupStackSizeKHR =
-        (PFN_vkGetRayTracingShaderGroupStackSizeKHR)gpa(device, "vkGetRayTracingShaderGroupStackSizeKHR");
-    table->CmdSetRayTracingPipelineStackSizeKHR =
-        (PFN_vkCmdSetRayTracingPipelineStackSizeKHR)gpa(device, "vkCmdSetRayTracingPipelineStackSizeKHR");
+    table->GetRayTracingShaderGroupStackSizeKHR = (PFN_vkGetRayTracingShaderGroupStackSizeKHR)gpa(device, "vkGetRayTracingShaderGroupStackSizeKHR");
+    table->CmdSetRayTracingPipelineStackSizeKHR = (PFN_vkCmdSetRayTracingPipelineStackSizeKHR)gpa(device, "vkCmdSetRayTracingPipelineStackSizeKHR");
     table->CmdDrawMeshTasksEXT = (PFN_vkCmdDrawMeshTasksEXT)gpa(device, "vkCmdDrawMeshTasksEXT");
     table->CmdDrawMeshTasksIndirectEXT = (PFN_vkCmdDrawMeshTasksIndirectEXT)gpa(device, "vkCmdDrawMeshTasksIndirectEXT");
-    table->CmdDrawMeshTasksIndirectCountEXT =
-        (PFN_vkCmdDrawMeshTasksIndirectCountEXT)gpa(device, "vkCmdDrawMeshTasksIndirectCountEXT");
+    table->CmdDrawMeshTasksIndirectCountEXT = (PFN_vkCmdDrawMeshTasksIndirectCountEXT)gpa(device, "vkCmdDrawMeshTasksIndirectCountEXT");
 }
 
-static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLayerInstanceDispatchTable *table,
-                                                      PFN_vkGetInstanceProcAddr gpa) {
+static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa) {
     memset(table, 0, sizeof(*table));
 
     // Instance function pointers
+    table->CreateInstance = (PFN_vkCreateInstance)gpa(instance, "vkCreateInstance");
     table->DestroyInstance = (PFN_vkDestroyInstance)gpa(instance, "vkDestroyInstance");
     table->EnumeratePhysicalDevices = (PFN_vkEnumeratePhysicalDevices)gpa(instance, "vkEnumeratePhysicalDevices");
     table->GetPhysicalDeviceFeatures = (PFN_vkGetPhysicalDeviceFeatures)gpa(instance, "vkGetPhysicalDeviceFeatures");
-    table->GetPhysicalDeviceFormatProperties =
-        (PFN_vkGetPhysicalDeviceFormatProperties)gpa(instance, "vkGetPhysicalDeviceFormatProperties");
-    table->GetPhysicalDeviceImageFormatProperties =
-        (PFN_vkGetPhysicalDeviceImageFormatProperties)gpa(instance, "vkGetPhysicalDeviceImageFormatProperties");
+    table->GetPhysicalDeviceFormatProperties = (PFN_vkGetPhysicalDeviceFormatProperties)gpa(instance, "vkGetPhysicalDeviceFormatProperties");
+    table->GetPhysicalDeviceImageFormatProperties = (PFN_vkGetPhysicalDeviceImageFormatProperties)gpa(instance, "vkGetPhysicalDeviceImageFormatProperties");
     table->GetPhysicalDeviceProperties = (PFN_vkGetPhysicalDeviceProperties)gpa(instance, "vkGetPhysicalDeviceProperties");
-    table->GetPhysicalDeviceQueueFamilyProperties =
-        (PFN_vkGetPhysicalDeviceQueueFamilyProperties)gpa(instance, "vkGetPhysicalDeviceQueueFamilyProperties");
-    table->GetPhysicalDeviceMemoryProperties =
-        (PFN_vkGetPhysicalDeviceMemoryProperties)gpa(instance, "vkGetPhysicalDeviceMemoryProperties");
+    table->GetPhysicalDeviceQueueFamilyProperties = (PFN_vkGetPhysicalDeviceQueueFamilyProperties)gpa(instance, "vkGetPhysicalDeviceQueueFamilyProperties");
+    table->GetPhysicalDeviceMemoryProperties = (PFN_vkGetPhysicalDeviceMemoryProperties)gpa(instance, "vkGetPhysicalDeviceMemoryProperties");
     table->GetInstanceProcAddr = gpa;
-    table->EnumerateDeviceExtensionProperties =
-        (PFN_vkEnumerateDeviceExtensionProperties)gpa(instance, "vkEnumerateDeviceExtensionProperties");
+    table->CreateDevice = (PFN_vkCreateDevice)gpa(instance, "vkCreateDevice");
+    table->EnumerateInstanceExtensionProperties = (PFN_vkEnumerateInstanceExtensionProperties)gpa(instance, "vkEnumerateInstanceExtensionProperties");
+    table->EnumerateDeviceExtensionProperties = (PFN_vkEnumerateDeviceExtensionProperties)gpa(instance, "vkEnumerateDeviceExtensionProperties");
+    table->EnumerateInstanceLayerProperties = (PFN_vkEnumerateInstanceLayerProperties)gpa(instance, "vkEnumerateInstanceLayerProperties");
     table->EnumerateDeviceLayerProperties = (PFN_vkEnumerateDeviceLayerProperties)gpa(instance, "vkEnumerateDeviceLayerProperties");
-    table->GetPhysicalDeviceSparseImageFormatProperties =
-        (PFN_vkGetPhysicalDeviceSparseImageFormatProperties)gpa(instance, "vkGetPhysicalDeviceSparseImageFormatProperties");
+    table->GetPhysicalDeviceSparseImageFormatProperties = (PFN_vkGetPhysicalDeviceSparseImageFormatProperties)gpa(instance, "vkGetPhysicalDeviceSparseImageFormatProperties");
+    table->EnumerateInstanceVersion = (PFN_vkEnumerateInstanceVersion)gpa(instance, "vkEnumerateInstanceVersion");
     table->EnumeratePhysicalDeviceGroups = (PFN_vkEnumeratePhysicalDeviceGroups)gpa(instance, "vkEnumeratePhysicalDeviceGroups");
     table->GetPhysicalDeviceFeatures2 = (PFN_vkGetPhysicalDeviceFeatures2)gpa(instance, "vkGetPhysicalDeviceFeatures2");
     table->GetPhysicalDeviceProperties2 = (PFN_vkGetPhysicalDeviceProperties2)gpa(instance, "vkGetPhysicalDeviceProperties2");
-    table->GetPhysicalDeviceFormatProperties2 =
-        (PFN_vkGetPhysicalDeviceFormatProperties2)gpa(instance, "vkGetPhysicalDeviceFormatProperties2");
-    table->GetPhysicalDeviceImageFormatProperties2 =
-        (PFN_vkGetPhysicalDeviceImageFormatProperties2)gpa(instance, "vkGetPhysicalDeviceImageFormatProperties2");
-    table->GetPhysicalDeviceQueueFamilyProperties2 =
-        (PFN_vkGetPhysicalDeviceQueueFamilyProperties2)gpa(instance, "vkGetPhysicalDeviceQueueFamilyProperties2");
-    table->GetPhysicalDeviceMemoryProperties2 =
-        (PFN_vkGetPhysicalDeviceMemoryProperties2)gpa(instance, "vkGetPhysicalDeviceMemoryProperties2");
-    table->GetPhysicalDeviceSparseImageFormatProperties2 =
-        (PFN_vkGetPhysicalDeviceSparseImageFormatProperties2)gpa(instance, "vkGetPhysicalDeviceSparseImageFormatProperties2");
-    table->GetPhysicalDeviceExternalBufferProperties =
-        (PFN_vkGetPhysicalDeviceExternalBufferProperties)gpa(instance, "vkGetPhysicalDeviceExternalBufferProperties");
-    table->GetPhysicalDeviceExternalFenceProperties =
-        (PFN_vkGetPhysicalDeviceExternalFenceProperties)gpa(instance, "vkGetPhysicalDeviceExternalFenceProperties");
-    table->GetPhysicalDeviceExternalSemaphoreProperties =
-        (PFN_vkGetPhysicalDeviceExternalSemaphoreProperties)gpa(instance, "vkGetPhysicalDeviceExternalSemaphoreProperties");
-    table->GetPhysicalDeviceToolProperties =
-        (PFN_vkGetPhysicalDeviceToolProperties)gpa(instance, "vkGetPhysicalDeviceToolProperties");
+    table->GetPhysicalDeviceFormatProperties2 = (PFN_vkGetPhysicalDeviceFormatProperties2)gpa(instance, "vkGetPhysicalDeviceFormatProperties2");
+    table->GetPhysicalDeviceImageFormatProperties2 = (PFN_vkGetPhysicalDeviceImageFormatProperties2)gpa(instance, "vkGetPhysicalDeviceImageFormatProperties2");
+    table->GetPhysicalDeviceQueueFamilyProperties2 = (PFN_vkGetPhysicalDeviceQueueFamilyProperties2)gpa(instance, "vkGetPhysicalDeviceQueueFamilyProperties2");
+    table->GetPhysicalDeviceMemoryProperties2 = (PFN_vkGetPhysicalDeviceMemoryProperties2)gpa(instance, "vkGetPhysicalDeviceMemoryProperties2");
+    table->GetPhysicalDeviceSparseImageFormatProperties2 = (PFN_vkGetPhysicalDeviceSparseImageFormatProperties2)gpa(instance, "vkGetPhysicalDeviceSparseImageFormatProperties2");
+    table->GetPhysicalDeviceExternalBufferProperties = (PFN_vkGetPhysicalDeviceExternalBufferProperties)gpa(instance, "vkGetPhysicalDeviceExternalBufferProperties");
+    table->GetPhysicalDeviceExternalFenceProperties = (PFN_vkGetPhysicalDeviceExternalFenceProperties)gpa(instance, "vkGetPhysicalDeviceExternalFenceProperties");
+    table->GetPhysicalDeviceExternalSemaphoreProperties = (PFN_vkGetPhysicalDeviceExternalSemaphoreProperties)gpa(instance, "vkGetPhysicalDeviceExternalSemaphoreProperties");
+    table->GetPhysicalDeviceToolProperties = (PFN_vkGetPhysicalDeviceToolProperties)gpa(instance, "vkGetPhysicalDeviceToolProperties");
     table->DestroySurfaceKHR = (PFN_vkDestroySurfaceKHR)gpa(instance, "vkDestroySurfaceKHR");
-    table->GetPhysicalDeviceSurfaceSupportKHR =
-        (PFN_vkGetPhysicalDeviceSurfaceSupportKHR)gpa(instance, "vkGetPhysicalDeviceSurfaceSupportKHR");
-    table->GetPhysicalDeviceSurfaceCapabilitiesKHR =
-        (PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR)gpa(instance, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
-    table->GetPhysicalDeviceSurfaceFormatsKHR =
-        (PFN_vkGetPhysicalDeviceSurfaceFormatsKHR)gpa(instance, "vkGetPhysicalDeviceSurfaceFormatsKHR");
-    table->GetPhysicalDeviceSurfacePresentModesKHR =
-        (PFN_vkGetPhysicalDeviceSurfacePresentModesKHR)gpa(instance, "vkGetPhysicalDeviceSurfacePresentModesKHR");
-    table->GetPhysicalDevicePresentRectanglesKHR =
-        (PFN_vkGetPhysicalDevicePresentRectanglesKHR)gpa(instance, "vkGetPhysicalDevicePresentRectanglesKHR");
-    table->GetPhysicalDeviceDisplayPropertiesKHR =
-        (PFN_vkGetPhysicalDeviceDisplayPropertiesKHR)gpa(instance, "vkGetPhysicalDeviceDisplayPropertiesKHR");
-    table->GetPhysicalDeviceDisplayPlanePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR)gpa(instance, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR");
-    table->GetDisplayPlaneSupportedDisplaysKHR =
-        (PFN_vkGetDisplayPlaneSupportedDisplaysKHR)gpa(instance, "vkGetDisplayPlaneSupportedDisplaysKHR");
+    table->GetPhysicalDeviceSurfaceSupportKHR = (PFN_vkGetPhysicalDeviceSurfaceSupportKHR)gpa(instance, "vkGetPhysicalDeviceSurfaceSupportKHR");
+    table->GetPhysicalDeviceSurfaceCapabilitiesKHR = (PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR)gpa(instance, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
+    table->GetPhysicalDeviceSurfaceFormatsKHR = (PFN_vkGetPhysicalDeviceSurfaceFormatsKHR)gpa(instance, "vkGetPhysicalDeviceSurfaceFormatsKHR");
+    table->GetPhysicalDeviceSurfacePresentModesKHR = (PFN_vkGetPhysicalDeviceSurfacePresentModesKHR)gpa(instance, "vkGetPhysicalDeviceSurfacePresentModesKHR");
+    table->GetPhysicalDevicePresentRectanglesKHR = (PFN_vkGetPhysicalDevicePresentRectanglesKHR)gpa(instance, "vkGetPhysicalDevicePresentRectanglesKHR");
+    table->GetPhysicalDeviceDisplayPropertiesKHR = (PFN_vkGetPhysicalDeviceDisplayPropertiesKHR)gpa(instance, "vkGetPhysicalDeviceDisplayPropertiesKHR");
+    table->GetPhysicalDeviceDisplayPlanePropertiesKHR = (PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR)gpa(instance, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR");
+    table->GetDisplayPlaneSupportedDisplaysKHR = (PFN_vkGetDisplayPlaneSupportedDisplaysKHR)gpa(instance, "vkGetDisplayPlaneSupportedDisplaysKHR");
     table->GetDisplayModePropertiesKHR = (PFN_vkGetDisplayModePropertiesKHR)gpa(instance, "vkGetDisplayModePropertiesKHR");
     table->CreateDisplayModeKHR = (PFN_vkCreateDisplayModeKHR)gpa(instance, "vkCreateDisplayModeKHR");
     table->GetDisplayPlaneCapabilitiesKHR = (PFN_vkGetDisplayPlaneCapabilitiesKHR)gpa(instance, "vkGetDisplayPlaneCapabilitiesKHR");
@@ -799,22 +766,19 @@ static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLay
     table->CreateXlibSurfaceKHR = (PFN_vkCreateXlibSurfaceKHR)gpa(instance, "vkCreateXlibSurfaceKHR");
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
-    table->GetPhysicalDeviceXlibPresentationSupportKHR =
-        (PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR)gpa(instance, "vkGetPhysicalDeviceXlibPresentationSupportKHR");
+    table->GetPhysicalDeviceXlibPresentationSupportKHR = (PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR)gpa(instance, "vkGetPhysicalDeviceXlibPresentationSupportKHR");
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     table->CreateXcbSurfaceKHR = (PFN_vkCreateXcbSurfaceKHR)gpa(instance, "vkCreateXcbSurfaceKHR");
 #endif  // VK_USE_PLATFORM_XCB_KHR
 #if defined(VK_USE_PLATFORM_XCB_KHR)
-    table->GetPhysicalDeviceXcbPresentationSupportKHR =
-        (PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR)gpa(instance, "vkGetPhysicalDeviceXcbPresentationSupportKHR");
+    table->GetPhysicalDeviceXcbPresentationSupportKHR = (PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR)gpa(instance, "vkGetPhysicalDeviceXcbPresentationSupportKHR");
 #endif  // VK_USE_PLATFORM_XCB_KHR
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
     table->CreateWaylandSurfaceKHR = (PFN_vkCreateWaylandSurfaceKHR)gpa(instance, "vkCreateWaylandSurfaceKHR");
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-    table->GetPhysicalDeviceWaylandPresentationSupportKHR =
-        (PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR)gpa(instance, "vkGetPhysicalDeviceWaylandPresentationSupportKHR");
+    table->GetPhysicalDeviceWaylandPresentationSupportKHR = (PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR)gpa(instance, "vkGetPhysicalDeviceWaylandPresentationSupportKHR");
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     table->CreateAndroidSurfaceKHR = (PFN_vkCreateAndroidSurfaceKHR)gpa(instance, "vkCreateAndroidSurfaceKHR");
@@ -823,65 +787,40 @@ static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLay
     table->CreateWin32SurfaceKHR = (PFN_vkCreateWin32SurfaceKHR)gpa(instance, "vkCreateWin32SurfaceKHR");
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-    table->GetPhysicalDeviceWin32PresentationSupportKHR =
-        (PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR)gpa(instance, "vkGetPhysicalDeviceWin32PresentationSupportKHR");
+    table->GetPhysicalDeviceWin32PresentationSupportKHR = (PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR)gpa(instance, "vkGetPhysicalDeviceWin32PresentationSupportKHR");
 #endif  // VK_USE_PLATFORM_WIN32_KHR
-    table->GetPhysicalDeviceVideoCapabilitiesKHR =
-        (PFN_vkGetPhysicalDeviceVideoCapabilitiesKHR)gpa(instance, "vkGetPhysicalDeviceVideoCapabilitiesKHR");
-    table->GetPhysicalDeviceVideoFormatPropertiesKHR =
-        (PFN_vkGetPhysicalDeviceVideoFormatPropertiesKHR)gpa(instance, "vkGetPhysicalDeviceVideoFormatPropertiesKHR");
+    table->GetPhysicalDeviceVideoCapabilitiesKHR = (PFN_vkGetPhysicalDeviceVideoCapabilitiesKHR)gpa(instance, "vkGetPhysicalDeviceVideoCapabilitiesKHR");
+    table->GetPhysicalDeviceVideoFormatPropertiesKHR = (PFN_vkGetPhysicalDeviceVideoFormatPropertiesKHR)gpa(instance, "vkGetPhysicalDeviceVideoFormatPropertiesKHR");
     table->GetPhysicalDeviceFeatures2KHR = (PFN_vkGetPhysicalDeviceFeatures2KHR)gpa(instance, "vkGetPhysicalDeviceFeatures2KHR");
-    table->GetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)gpa(instance, "vkGetPhysicalDeviceProperties2KHR");
-    table->GetPhysicalDeviceFormatProperties2KHR =
-        (PFN_vkGetPhysicalDeviceFormatProperties2KHR)gpa(instance, "vkGetPhysicalDeviceFormatProperties2KHR");
-    table->GetPhysicalDeviceImageFormatProperties2KHR =
-        (PFN_vkGetPhysicalDeviceImageFormatProperties2KHR)gpa(instance, "vkGetPhysicalDeviceImageFormatProperties2KHR");
-    table->GetPhysicalDeviceQueueFamilyProperties2KHR =
-        (PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR)gpa(instance, "vkGetPhysicalDeviceQueueFamilyProperties2KHR");
-    table->GetPhysicalDeviceMemoryProperties2KHR =
-        (PFN_vkGetPhysicalDeviceMemoryProperties2KHR)gpa(instance, "vkGetPhysicalDeviceMemoryProperties2KHR");
-    table->GetPhysicalDeviceSparseImageFormatProperties2KHR =
-        (PFN_vkGetPhysicalDeviceSparseImageFormatProperties2KHR)gpa(instance, "vkGetPhysicalDeviceSparseImageFormatProperties2KHR");
-    table->EnumeratePhysicalDeviceGroupsKHR =
-        (PFN_vkEnumeratePhysicalDeviceGroupsKHR)gpa(instance, "vkEnumeratePhysicalDeviceGroupsKHR");
-    table->GetPhysicalDeviceExternalBufferPropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR)gpa(instance, "vkGetPhysicalDeviceExternalBufferPropertiesKHR");
-    table->GetPhysicalDeviceExternalSemaphorePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)gpa(instance, "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
-    table->GetPhysicalDeviceExternalFencePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR)gpa(instance, "vkGetPhysicalDeviceExternalFencePropertiesKHR");
-    table->EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-        (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)gpa(
-            instance, "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
-    table->GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR = (PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR)gpa(
-        instance, "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR");
-    table->GetPhysicalDeviceSurfaceCapabilities2KHR =
-        (PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR)gpa(instance, "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
-    table->GetPhysicalDeviceSurfaceFormats2KHR =
-        (PFN_vkGetPhysicalDeviceSurfaceFormats2KHR)gpa(instance, "vkGetPhysicalDeviceSurfaceFormats2KHR");
-    table->GetPhysicalDeviceDisplayProperties2KHR =
-        (PFN_vkGetPhysicalDeviceDisplayProperties2KHR)gpa(instance, "vkGetPhysicalDeviceDisplayProperties2KHR");
-    table->GetPhysicalDeviceDisplayPlaneProperties2KHR =
-        (PFN_vkGetPhysicalDeviceDisplayPlaneProperties2KHR)gpa(instance, "vkGetPhysicalDeviceDisplayPlaneProperties2KHR");
+    table->GetPhysicalDeviceProperties2KHR = (PFN_vkGetPhysicalDeviceProperties2KHR)gpa(instance, "vkGetPhysicalDeviceProperties2KHR");
+    table->GetPhysicalDeviceFormatProperties2KHR = (PFN_vkGetPhysicalDeviceFormatProperties2KHR)gpa(instance, "vkGetPhysicalDeviceFormatProperties2KHR");
+    table->GetPhysicalDeviceImageFormatProperties2KHR = (PFN_vkGetPhysicalDeviceImageFormatProperties2KHR)gpa(instance, "vkGetPhysicalDeviceImageFormatProperties2KHR");
+    table->GetPhysicalDeviceQueueFamilyProperties2KHR = (PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR)gpa(instance, "vkGetPhysicalDeviceQueueFamilyProperties2KHR");
+    table->GetPhysicalDeviceMemoryProperties2KHR = (PFN_vkGetPhysicalDeviceMemoryProperties2KHR)gpa(instance, "vkGetPhysicalDeviceMemoryProperties2KHR");
+    table->GetPhysicalDeviceSparseImageFormatProperties2KHR = (PFN_vkGetPhysicalDeviceSparseImageFormatProperties2KHR)gpa(instance, "vkGetPhysicalDeviceSparseImageFormatProperties2KHR");
+    table->EnumeratePhysicalDeviceGroupsKHR = (PFN_vkEnumeratePhysicalDeviceGroupsKHR)gpa(instance, "vkEnumeratePhysicalDeviceGroupsKHR");
+    table->GetPhysicalDeviceExternalBufferPropertiesKHR = (PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR)gpa(instance, "vkGetPhysicalDeviceExternalBufferPropertiesKHR");
+    table->GetPhysicalDeviceExternalSemaphorePropertiesKHR = (PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)gpa(instance, "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
+    table->GetPhysicalDeviceExternalFencePropertiesKHR = (PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR)gpa(instance, "vkGetPhysicalDeviceExternalFencePropertiesKHR");
+    table->EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR = (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)gpa(instance, "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
+    table->GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR = (PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR)gpa(instance, "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR");
+    table->GetPhysicalDeviceSurfaceCapabilities2KHR = (PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR)gpa(instance, "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
+    table->GetPhysicalDeviceSurfaceFormats2KHR = (PFN_vkGetPhysicalDeviceSurfaceFormats2KHR)gpa(instance, "vkGetPhysicalDeviceSurfaceFormats2KHR");
+    table->GetPhysicalDeviceDisplayProperties2KHR = (PFN_vkGetPhysicalDeviceDisplayProperties2KHR)gpa(instance, "vkGetPhysicalDeviceDisplayProperties2KHR");
+    table->GetPhysicalDeviceDisplayPlaneProperties2KHR = (PFN_vkGetPhysicalDeviceDisplayPlaneProperties2KHR)gpa(instance, "vkGetPhysicalDeviceDisplayPlaneProperties2KHR");
     table->GetDisplayModeProperties2KHR = (PFN_vkGetDisplayModeProperties2KHR)gpa(instance, "vkGetDisplayModeProperties2KHR");
-    table->GetDisplayPlaneCapabilities2KHR =
-        (PFN_vkGetDisplayPlaneCapabilities2KHR)gpa(instance, "vkGetDisplayPlaneCapabilities2KHR");
-    table->GetPhysicalDeviceFragmentShadingRatesKHR =
-        (PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR)gpa(instance, "vkGetPhysicalDeviceFragmentShadingRatesKHR");
-#if defined(VK_ENABLE_BETA_EXTENSIONS)
-    table->GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR = (PFN_vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR)gpa(
-        instance, "vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR");
-#endif  // VK_ENABLE_BETA_EXTENSIONS
+    table->GetDisplayPlaneCapabilities2KHR = (PFN_vkGetDisplayPlaneCapabilities2KHR)gpa(instance, "vkGetDisplayPlaneCapabilities2KHR");
+    table->GetPhysicalDeviceFragmentShadingRatesKHR = (PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR)gpa(instance, "vkGetPhysicalDeviceFragmentShadingRatesKHR");
+    table->GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR = (PFN_vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR)gpa(instance, "vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR");
+    table->GetPhysicalDeviceCooperativeMatrixPropertiesKHR = (PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR)gpa(instance, "vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR");
+    table->GetPhysicalDeviceCalibrateableTimeDomainsKHR = (PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsKHR)gpa(instance, "vkGetPhysicalDeviceCalibrateableTimeDomainsKHR");
     table->CreateDebugReportCallbackEXT = (PFN_vkCreateDebugReportCallbackEXT)gpa(instance, "vkCreateDebugReportCallbackEXT");
     table->DestroyDebugReportCallbackEXT = (PFN_vkDestroyDebugReportCallbackEXT)gpa(instance, "vkDestroyDebugReportCallbackEXT");
     table->DebugReportMessageEXT = (PFN_vkDebugReportMessageEXT)gpa(instance, "vkDebugReportMessageEXT");
 #if defined(VK_USE_PLATFORM_GGP)
-    table->CreateStreamDescriptorSurfaceGGP =
-        (PFN_vkCreateStreamDescriptorSurfaceGGP)gpa(instance, "vkCreateStreamDescriptorSurfaceGGP");
+    table->CreateStreamDescriptorSurfaceGGP = (PFN_vkCreateStreamDescriptorSurfaceGGP)gpa(instance, "vkCreateStreamDescriptorSurfaceGGP");
 #endif  // VK_USE_PLATFORM_GGP
-    table->GetPhysicalDeviceExternalImageFormatPropertiesNV =
-        (PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV)gpa(instance, "vkGetPhysicalDeviceExternalImageFormatPropertiesNV");
+    table->GetPhysicalDeviceExternalImageFormatPropertiesNV = (PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV)gpa(instance, "vkGetPhysicalDeviceExternalImageFormatPropertiesNV");
 #if defined(VK_USE_PLATFORM_VI_NN)
     table->CreateViSurfaceNN = (PFN_vkCreateViSurfaceNN)gpa(instance, "vkCreateViSurfaceNN");
 #endif  // VK_USE_PLATFORM_VI_NN
@@ -892,8 +831,7 @@ static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLay
 #if defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
     table->GetRandROutputDisplayEXT = (PFN_vkGetRandROutputDisplayEXT)gpa(instance, "vkGetRandROutputDisplayEXT");
 #endif  // VK_USE_PLATFORM_XLIB_XRANDR_EXT
-    table->GetPhysicalDeviceSurfaceCapabilities2EXT =
-        (PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT)gpa(instance, "vkGetPhysicalDeviceSurfaceCapabilities2EXT");
+    table->GetPhysicalDeviceSurfaceCapabilities2EXT = (PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT)gpa(instance, "vkGetPhysicalDeviceSurfaceCapabilities2EXT");
 #if defined(VK_USE_PLATFORM_IOS_MVK)
     table->CreateIOSSurfaceMVK = (PFN_vkCreateIOSSurfaceMVK)gpa(instance, "vkCreateIOSSurfaceMVK");
 #endif  // VK_USE_PLATFORM_IOS_MVK
@@ -903,26 +841,19 @@ static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLay
     table->CreateDebugUtilsMessengerEXT = (PFN_vkCreateDebugUtilsMessengerEXT)gpa(instance, "vkCreateDebugUtilsMessengerEXT");
     table->DestroyDebugUtilsMessengerEXT = (PFN_vkDestroyDebugUtilsMessengerEXT)gpa(instance, "vkDestroyDebugUtilsMessengerEXT");
     table->SubmitDebugUtilsMessageEXT = (PFN_vkSubmitDebugUtilsMessageEXT)gpa(instance, "vkSubmitDebugUtilsMessageEXT");
-    table->GetPhysicalDeviceMultisamplePropertiesEXT =
-        (PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT)gpa(instance, "vkGetPhysicalDeviceMultisamplePropertiesEXT");
-    table->GetPhysicalDeviceCalibrateableTimeDomainsEXT =
-        (PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT)gpa(instance, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT");
+    table->GetPhysicalDeviceMultisamplePropertiesEXT = (PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT)gpa(instance, "vkGetPhysicalDeviceMultisamplePropertiesEXT");
+    table->GetPhysicalDeviceCalibrateableTimeDomainsEXT = (PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT)gpa(instance, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT");
 #if defined(VK_USE_PLATFORM_FUCHSIA)
     table->CreateImagePipeSurfaceFUCHSIA = (PFN_vkCreateImagePipeSurfaceFUCHSIA)gpa(instance, "vkCreateImagePipeSurfaceFUCHSIA");
 #endif  // VK_USE_PLATFORM_FUCHSIA
 #if defined(VK_USE_PLATFORM_METAL_EXT)
     table->CreateMetalSurfaceEXT = (PFN_vkCreateMetalSurfaceEXT)gpa(instance, "vkCreateMetalSurfaceEXT");
 #endif  // VK_USE_PLATFORM_METAL_EXT
-    table->GetPhysicalDeviceToolPropertiesEXT =
-        (PFN_vkGetPhysicalDeviceToolPropertiesEXT)gpa(instance, "vkGetPhysicalDeviceToolPropertiesEXT");
-    table->GetPhysicalDeviceCooperativeMatrixPropertiesNV =
-        (PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV)gpa(instance, "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV");
-    table->GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV =
-        (PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV)gpa(
-            instance, "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV");
+    table->GetPhysicalDeviceToolPropertiesEXT = (PFN_vkGetPhysicalDeviceToolPropertiesEXT)gpa(instance, "vkGetPhysicalDeviceToolPropertiesEXT");
+    table->GetPhysicalDeviceCooperativeMatrixPropertiesNV = (PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV)gpa(instance, "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV");
+    table->GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = (PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV)gpa(instance, "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV");
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-    table->GetPhysicalDeviceSurfacePresentModes2EXT =
-        (PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT)gpa(instance, "vkGetPhysicalDeviceSurfacePresentModes2EXT");
+    table->GetPhysicalDeviceSurfacePresentModes2EXT = (PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT)gpa(instance, "vkGetPhysicalDeviceSurfacePresentModes2EXT");
 #endif  // VK_USE_PLATFORM_WIN32_KHR
     table->CreateHeadlessSurfaceEXT = (PFN_vkCreateHeadlessSurfaceEXT)gpa(instance, "vkCreateHeadlessSurfaceEXT");
     table->AcquireDrmDisplayEXT = (PFN_vkAcquireDrmDisplayEXT)gpa(instance, "vkAcquireDrmDisplayEXT");
@@ -937,16 +868,15 @@ static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLay
     table->CreateDirectFBSurfaceEXT = (PFN_vkCreateDirectFBSurfaceEXT)gpa(instance, "vkCreateDirectFBSurfaceEXT");
 #endif  // VK_USE_PLATFORM_DIRECTFB_EXT
 #if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
-    table->GetPhysicalDeviceDirectFBPresentationSupportEXT =
-        (PFN_vkGetPhysicalDeviceDirectFBPresentationSupportEXT)gpa(instance, "vkGetPhysicalDeviceDirectFBPresentationSupportEXT");
+    table->GetPhysicalDeviceDirectFBPresentationSupportEXT = (PFN_vkGetPhysicalDeviceDirectFBPresentationSupportEXT)gpa(instance, "vkGetPhysicalDeviceDirectFBPresentationSupportEXT");
 #endif  // VK_USE_PLATFORM_DIRECTFB_EXT
 #if defined(VK_USE_PLATFORM_SCREEN_QNX)
     table->CreateScreenSurfaceQNX = (PFN_vkCreateScreenSurfaceQNX)gpa(instance, "vkCreateScreenSurfaceQNX");
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
 #if defined(VK_USE_PLATFORM_SCREEN_QNX)
-    table->GetPhysicalDeviceScreenPresentationSupportQNX =
-        (PFN_vkGetPhysicalDeviceScreenPresentationSupportQNX)gpa(instance, "vkGetPhysicalDeviceScreenPresentationSupportQNX");
+    table->GetPhysicalDeviceScreenPresentationSupportQNX = (PFN_vkGetPhysicalDeviceScreenPresentationSupportQNX)gpa(instance, "vkGetPhysicalDeviceScreenPresentationSupportQNX");
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
-    table->GetPhysicalDeviceOpticalFlowImageFormatsNV =
-        (PFN_vkGetPhysicalDeviceOpticalFlowImageFormatsNV)gpa(instance, "vkGetPhysicalDeviceOpticalFlowImageFormatsNV");
+    table->GetPhysicalDeviceOpticalFlowImageFormatsNV = (PFN_vkGetPhysicalDeviceOpticalFlowImageFormatsNV)gpa(instance, "vkGetPhysicalDeviceOpticalFlowImageFormatsNV");
+    table->GetPhysicalDeviceCooperativeVectorPropertiesNV = (PFN_vkGetPhysicalDeviceCooperativeVectorPropertiesNV)gpa(instance, "vkGetPhysicalDeviceCooperativeVectorPropertiesNV");
+    table->GetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV = (PFN_vkGetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV)gpa(instance, "vkGetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV");
 }


### PR DESCRIPTION
Requires hardcoding a few things to make it work, most notably:
* Missing Extension Requires Depends information
* Missing aliases for handles

On the whole, the codegen outputs *almost* identical files from before, making the refactor not able to introduce issues into the output. The changes that do occur to remove duplicated if statements from aliased handles or for comments and whitespace.