### PR TITLE
Cleanup BUILDER_VALUE macros in tests

### DIFF
--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -79,39 +79,39 @@ struct PhysicalDevice {
     PhysicalDevice(const char* name) : deviceName(name) {}
 
     DispatchableHandle<VkPhysicalDevice> vk_physical_device;
-    BUILDER_VALUE(PhysicalDevice, std::string, deviceName, "")
-    BUILDER_VALUE(PhysicalDevice, VkPhysicalDeviceProperties, properties, {})
-    BUILDER_VALUE(PhysicalDevice, VkPhysicalDeviceFeatures, features, {})
-    BUILDER_VALUE(PhysicalDevice, VkPhysicalDeviceMemoryProperties, memory_properties, {})
-    BUILDER_VALUE(PhysicalDevice, VkImageFormatProperties, image_format_properties, {})
-    BUILDER_VALUE(PhysicalDevice, VkExternalMemoryProperties, external_memory_properties, {})
-    BUILDER_VALUE(PhysicalDevice, VkExternalSemaphoreProperties, external_semaphore_properties, {})
-    BUILDER_VALUE(PhysicalDevice, VkExternalFenceProperties, external_fence_properties, {})
-    BUILDER_VALUE(PhysicalDevice, uint32_t, pci_bus, {})
+    BUILDER_VALUE(std::string, deviceName)
+    BUILDER_VALUE(VkPhysicalDeviceProperties, properties)
+    BUILDER_VALUE(VkPhysicalDeviceFeatures, features)
+    BUILDER_VALUE(VkPhysicalDeviceMemoryProperties, memory_properties)
+    BUILDER_VALUE(VkImageFormatProperties, image_format_properties)
+    BUILDER_VALUE(VkExternalMemoryProperties, external_memory_properties)
+    BUILDER_VALUE(VkExternalSemaphoreProperties, external_semaphore_properties)
+    BUILDER_VALUE(VkExternalFenceProperties, external_fence_properties)
+    BUILDER_VALUE(uint32_t, pci_bus)
 
-    BUILDER_VECTOR(PhysicalDevice, MockQueueFamilyProperties, queue_family_properties, queue_family_properties)
-    BUILDER_VECTOR(PhysicalDevice, VkFormatProperties, format_properties, format_properties)
-    BUILDER_VECTOR(PhysicalDevice, VkSparseImageFormatProperties, sparse_image_format_properties, sparse_image_format_properties)
+    BUILDER_VECTOR(MockQueueFamilyProperties, queue_family_properties, queue_family_properties)
+    BUILDER_VECTOR(VkFormatProperties, format_properties, format_properties)
+    BUILDER_VECTOR(VkSparseImageFormatProperties, sparse_image_format_properties, sparse_image_format_properties)
 
-    BUILDER_VECTOR(PhysicalDevice, Extension, extensions, extension)
+    BUILDER_VECTOR(Extension, extensions, extension)
 
-    BUILDER_VALUE(PhysicalDevice, VkSurfaceCapabilitiesKHR, surface_capabilities, {})
-    BUILDER_VECTOR(PhysicalDevice, VkSurfaceFormatKHR, surface_formats, surface_format)
-    BUILDER_VECTOR(PhysicalDevice, VkPresentModeKHR, surface_present_modes, surface_present_mode)
-    BUILDER_VALUE(PhysicalDevice, VkSurfacePresentScalingCapabilitiesEXT, surface_present_scaling_capabilities, {})
+    BUILDER_VALUE(VkSurfaceCapabilitiesKHR, surface_capabilities)
+    BUILDER_VECTOR(VkSurfaceFormatKHR, surface_formats, surface_format)
+    BUILDER_VECTOR(VkPresentModeKHR, surface_present_modes, surface_present_mode)
+    BUILDER_VALUE(VkSurfacePresentScalingCapabilitiesEXT, surface_present_scaling_capabilities)
     // No good way to make this a builder value. Each std::vector<VkPresentModeKHR> corresponds to each surface_present_modes
     // element
     std::vector<std::vector<VkPresentModeKHR>> surface_present_mode_compatibility{};
 
-    BUILDER_VECTOR(PhysicalDevice, VkDisplayPropertiesKHR, display_properties, display_properties)
-    BUILDER_VECTOR(PhysicalDevice, VkDisplayPlanePropertiesKHR, display_plane_properties, display_plane_properties)
-    BUILDER_VECTOR(PhysicalDevice, VkDisplayKHR, displays, displays)
-    BUILDER_VECTOR(PhysicalDevice, VkDisplayModePropertiesKHR, display_mode_properties, display_mode_properties)
-    BUILDER_VALUE(PhysicalDevice, VkDisplayModeKHR, display_mode, {})
-    BUILDER_VALUE(PhysicalDevice, VkDisplayPlaneCapabilitiesKHR, display_plane_capabilities, {})
+    BUILDER_VECTOR(VkDisplayPropertiesKHR, display_properties, display_properties)
+    BUILDER_VECTOR(VkDisplayPlanePropertiesKHR, display_plane_properties, display_plane_properties)
+    BUILDER_VECTOR(VkDisplayKHR, displays, displays)
+    BUILDER_VECTOR(VkDisplayModePropertiesKHR, display_mode_properties, display_mode_properties)
+    BUILDER_VALUE(VkDisplayModeKHR, display_mode)
+    BUILDER_VALUE(VkDisplayPlaneCapabilitiesKHR, display_plane_capabilities)
 
-    BUILDER_VALUE(PhysicalDevice, VkLayeredDriverUnderlyingApiMSFT, layered_driver_underlying_api,
-                  VK_LAYERED_DRIVER_UNDERLYING_API_NONE_MSFT)
+    BUILDER_VALUE_WITH_DEFAULT(VkLayeredDriverUnderlyingApiMSFT, layered_driver_underlying_api,
+                               VK_LAYERED_DRIVER_UNDERLYING_API_NONE_MSFT)
 
     PhysicalDevice& set_api_version(uint32_t version) {
         properties.apiVersion = version;
@@ -128,12 +128,12 @@ struct PhysicalDevice {
     // Unknown physical device functions. Add a `VulkanFunction` to this list which will be searched in
     // vkGetInstanceProcAddr for custom_instance_functions and vk_icdGetPhysicalDeviceProcAddr for custom_physical_device_functions.
     // To add unknown device functions, add it to the PhysicalDevice directly (in the known_device_functions member)
-    BUILDER_VECTOR(PhysicalDevice, VulkanFunction, custom_physical_device_functions, custom_physical_device_function)
+    BUILDER_VECTOR(VulkanFunction, custom_physical_device_functions, custom_physical_device_function)
 
     // List of function names which are 'known' to the physical device but have test defined implementations
     // The purpose of this list is so that vkGetDeviceProcAddr returns 'a real function pointer' in tests
     // without actually implementing any of the logic inside of it.
-    BUILDER_VECTOR(PhysicalDevice, VulkanFunction, known_device_functions, device_function)
+    BUILDER_VECTOR(VulkanFunction, known_device_functions, device_function)
 };
 
 struct PhysicalDeviceGroup {
@@ -154,25 +154,25 @@ struct PhysicalDeviceGroup {
 struct TestICD {
     std::filesystem::path manifest_file_path;
 
-    BUILDER_VALUE(TestICD, bool, exposes_vk_icdNegotiateLoaderICDInterfaceVersion, true)
-    BUILDER_VALUE(TestICD, bool, exposes_vkEnumerateInstanceExtensionProperties, true)
-    BUILDER_VALUE(TestICD, bool, exposes_vkCreateInstance, true)
-    BUILDER_VALUE(TestICD, bool, exposes_vk_icdGetPhysicalDeviceProcAddr, true)
+    BUILDER_VALUE_WITH_DEFAULT(bool, exposes_vk_icdNegotiateLoaderICDInterfaceVersion, true)
+    BUILDER_VALUE_WITH_DEFAULT(bool, exposes_vkEnumerateInstanceExtensionProperties, true)
+    BUILDER_VALUE_WITH_DEFAULT(bool, exposes_vkCreateInstance, true)
+    BUILDER_VALUE_WITH_DEFAULT(bool, exposes_vk_icdGetPhysicalDeviceProcAddr, true)
 #if defined(WIN32)
-    BUILDER_VALUE(TestICD, bool, exposes_vk_icdEnumerateAdapterPhysicalDevices, true)
+    BUILDER_VALUE_WITH_DEFAULT(bool, exposes_vk_icdEnumerateAdapterPhysicalDevices, true)
 #endif
 
     CalledICDGIPA called_vk_icd_gipa = CalledICDGIPA::not_called;
     CalledNegotiateInterface called_negotiate_interface = CalledNegotiateInterface::not_called;
 
     InterfaceVersionCheck interface_version_check = InterfaceVersionCheck::not_called;
-    BUILDER_VALUE(TestICD, uint32_t, min_icd_interface_version, 0)
-    BUILDER_VALUE(TestICD, uint32_t, max_icd_interface_version, 7)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, min_icd_interface_version, 0)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, max_icd_interface_version, 7)
     uint32_t icd_interface_version_received = 0;
 
     bool called_enumerate_adapter_physical_devices = false;
 
-    BUILDER_VALUE(TestICD, bool, enable_icd_wsi, false);
+    BUILDER_VALUE(bool, enable_icd_wsi);
     bool is_using_icd_wsi = false;
 
     TestICD& setup_WSI(const char* api_selection = nullptr) {
@@ -182,14 +182,14 @@ struct TestICD {
         return *this;
     }
 
-    BUILDER_VALUE(TestICD, uint32_t, icd_api_version, VK_API_VERSION_1_0)
-    BUILDER_VECTOR(TestICD, LayerDefinition, instance_layers, instance_layer)
-    BUILDER_VECTOR(TestICD, Extension, instance_extensions, instance_extension)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, icd_api_version, VK_API_VERSION_1_0)
+    BUILDER_VECTOR(LayerDefinition, instance_layers, instance_layer)
+    BUILDER_VECTOR(Extension, instance_extensions, instance_extension)
     std::vector<Extension> enabled_instance_extensions;
 
-    BUILDER_VECTOR_MOVE_ONLY(TestICD, PhysicalDevice, physical_devices, physical_device);
+    BUILDER_VECTOR_MOVE_ONLY(PhysicalDevice, physical_devices, physical_device);
 
-    BUILDER_VECTOR(TestICD, PhysicalDeviceGroup, physical_device_groups, physical_device_group);
+    BUILDER_VECTOR(PhysicalDeviceGroup, physical_device_groups, physical_device_group);
 
     DispatchableHandle<VkInstance> instance_handle;
     std::vector<DispatchableHandle<VkDevice>> device_handles;
@@ -198,27 +198,27 @@ struct TestICD {
     std::vector<uint64_t> callback_handles;
     std::vector<uint64_t> swapchain_handles;
 
-    BUILDER_VALUE(TestICD, bool, can_query_vkEnumerateInstanceVersion, true);
-    BUILDER_VALUE(TestICD, bool, can_query_GetPhysicalDeviceFuncs, true);
+    BUILDER_VALUE_WITH_DEFAULT(bool, can_query_vkEnumerateInstanceVersion, true);
+    BUILDER_VALUE_WITH_DEFAULT(bool, can_query_GetPhysicalDeviceFuncs, true);
 
     // Unknown instance functions Add a `VulkanFunction` to this list which will be searched in
     // vkGetInstanceProcAddr for custom_instance_functions and vk_icdGetPhysicalDeviceProcAddr for
     // custom_physical_device_functions. To add unknown device functions, add it to the PhysicalDevice directly (in the
     // known_device_functions member)
-    BUILDER_VECTOR(TestICD, VulkanFunction, custom_instance_functions, custom_instance_function)
+    BUILDER_VECTOR(VulkanFunction, custom_instance_functions, custom_instance_function)
 
     // Must explicitely state support for the tooling info extension, that way we can control if vkGetInstanceProcAddr returns a
     // function pointer for vkGetPhysicalDeviceToolPropertiesEXT or vkGetPhysicalDeviceToolProperties (core version)
-    BUILDER_VALUE(TestICD, bool, supports_tooling_info_ext, false);
-    BUILDER_VALUE(TestICD, bool, supports_tooling_info_core, false);
+    BUILDER_VALUE(bool, supports_tooling_info_ext);
+    BUILDER_VALUE(bool, supports_tooling_info_core);
     // List of tooling properties that this driver 'supports'
-    BUILDER_VECTOR(TestICD, VkPhysicalDeviceToolPropertiesEXT, tooling_properties, tooling_property)
+    BUILDER_VECTOR(VkPhysicalDeviceToolPropertiesEXT, tooling_properties, tooling_property)
     std::vector<DispatchableHandle<VkCommandBuffer>> allocated_command_buffers;
 
     VkInstanceCreateFlags passed_in_instance_create_flags{};
 
-    BUILDER_VALUE(TestICD, VkResult, enum_physical_devices_return_code, VK_SUCCESS);
-    BUILDER_VALUE(TestICD, VkResult, enum_adapter_physical_devices_return_code, VK_SUCCESS);
+    BUILDER_VALUE_WITH_DEFAULT(VkResult, enum_physical_devices_return_code, VK_SUCCESS);
+    BUILDER_VALUE_WITH_DEFAULT(VkResult, enum_adapter_physical_devices_return_code, VK_SUCCESS);
 
     PhysicalDevice& GetPhysDevice(VkPhysicalDevice physicalDevice) {
         for (auto& phys_dev : physical_devices) {
@@ -258,7 +258,7 @@ struct TestICD {
     }
 
 #if defined(WIN32)
-    BUILDER_VALUE(TestICD, LUID, adapterLUID, {})
+    BUILDER_VALUE(LUID, adapterLUID)
 #endif  // defined(WIN32)
 };
 

--- a/tests/framework/layer/layer_util.h
+++ b/tests/framework/layer/layer_util.h
@@ -30,11 +30,11 @@
 #include "test_util.h"
 
 struct LayerDefinition {
-    BUILDER_VALUE(LayerDefinition, std::string, layerName, {})
-    BUILDER_VALUE(LayerDefinition, uint32_t, specVersion, VK_API_VERSION_1_0)
-    BUILDER_VALUE(LayerDefinition, uint32_t, implementationVersion, VK_API_VERSION_1_0)
-    BUILDER_VALUE(LayerDefinition, std::string, description, {})
-    BUILDER_VECTOR(LayerDefinition, Extension, extensions, extension)
+    BUILDER_VALUE(std::string, layerName)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, specVersion, VK_API_VERSION_1_0)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, implementationVersion, VK_API_VERSION_1_0)
+    BUILDER_VALUE(std::string, description)
+    BUILDER_VECTOR(Extension, extensions, extension)
 
     VkLayerProperties get() const noexcept {
         VkLayerProperties props{};

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -94,58 +94,57 @@ struct TestLayer {
     std::filesystem::path manifest_file_path;
     uint32_t manifest_version = VK_MAKE_API_VERSION(0, 1, 1, 2);
 
-    BUILDER_VALUE(TestLayer, bool, is_meta_layer, false)
+    BUILDER_VALUE(bool, is_meta_layer)
 
-    BUILDER_VALUE(TestLayer, uint32_t, api_version, VK_API_VERSION_1_0)
-    BUILDER_VALUE(TestLayer, uint32_t, reported_layer_props, 1)
-    BUILDER_VALUE(TestLayer, uint32_t, reported_extension_props, 0)
-    BUILDER_VALUE(TestLayer, uint32_t, reported_instance_version, VK_API_VERSION_1_0)
-    BUILDER_VALUE(TestLayer, uint32_t, implementation_version, 2)
-    BUILDER_VALUE(TestLayer, uint32_t, min_implementation_version, 0)
-    BUILDER_VALUE(TestLayer, std::string, description, {})
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, api_version, VK_API_VERSION_1_0)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, reported_layer_props, 1)
+    BUILDER_VALUE(uint32_t, reported_extension_props)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, reported_instance_version, VK_API_VERSION_1_0)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, implementation_version, 2)
+    BUILDER_VALUE(uint32_t, min_implementation_version)
+    BUILDER_VALUE(std::string, description)
 
     // Some layers may try to change the API version during instance creation - we should allow testing of such behavior
-    BUILDER_VALUE(TestLayer, uint32_t, alter_api_version, VK_API_VERSION_1_0)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, alter_api_version, VK_API_VERSION_1_0)
 
-    BUILDER_VECTOR(TestLayer, std::string, alternative_function_names, alternative_function_name)
+    BUILDER_VECTOR(std::string, alternative_function_names, alternative_function_name)
 
-    BUILDER_VECTOR(TestLayer, Extension, instance_extensions, instance_extension)
+    BUILDER_VECTOR(Extension, instance_extensions, instance_extension)
     std::vector<Extension> enabled_instance_extensions;
 
-    BUILDER_VECTOR(TestLayer, Extension, device_extensions, device_extension)
+    BUILDER_VECTOR(Extension, device_extensions, device_extension)
 
-    BUILDER_VALUE(TestLayer, std::string, enable_environment, {});
-    BUILDER_VALUE(TestLayer, std::string, disable_environment, {});
+    BUILDER_VALUE(std::string, enable_environment);
+    BUILDER_VALUE(std::string, disable_environment);
 
     // Modifies the extension list returned by vkEnumerateInstanceExtensionProperties to include what is in this vector
-    BUILDER_VECTOR(TestLayer, Extension, injected_instance_extensions, injected_instance_extension)
+    BUILDER_VECTOR(Extension, injected_instance_extensions, injected_instance_extension)
     // Modifies the extension list returned by  vkEnumerateDeviceExtensionProperties to include what is in this vector
-    BUILDER_VECTOR(TestLayer, Extension, injected_device_extensions, injected_device_extension)
+    BUILDER_VECTOR(Extension, injected_device_extensions, injected_device_extension)
 
-    BUILDER_VECTOR(TestLayer, LayerDefinition, meta_component_layers, meta_component_layer);
+    BUILDER_VECTOR(LayerDefinition, meta_component_layers, meta_component_layer);
 
-    BUILDER_VALUE(TestLayer, bool, intercept_vkEnumerateInstanceExtensionProperties, false)
-    BUILDER_VALUE(TestLayer, bool, intercept_vkEnumerateInstanceLayerProperties, false)
+    BUILDER_VALUE(bool, intercept_vkEnumerateInstanceExtensionProperties)
+    BUILDER_VALUE(bool, intercept_vkEnumerateInstanceLayerProperties)
     // Called in vkCreateInstance after calling down the chain & returning
-    BUILDER_VALUE(TestLayer, std::function<VkResult(TestLayer& layer)>, create_instance_callback, {})
+    BUILDER_VALUE(std::function<VkResult(TestLayer& layer)>, create_instance_callback)
     // Called in vkCreateDevice after calling down the chain & returning
-    BUILDER_VALUE(TestLayer, std::function<VkResult(TestLayer& layer)>, create_device_callback, {})
+    BUILDER_VALUE(std::function<VkResult(TestLayer& layer)>, create_device_callback)
 
     // Physical device modifier test flags and members.  This data is primarily used to test adding, removing and
     // re-ordering physical device data in a layer.
-    BUILDER_VALUE(TestLayer, bool, add_phys_devs, false)
-    BUILDER_VALUE(TestLayer, bool, remove_phys_devs, false)
-    BUILDER_VALUE(TestLayer, bool, reorder_phys_devs, false)
-    BUILDER_VECTOR(TestLayer, VkPhysicalDevice, complete_physical_devices, complete_physical_device)
-    BUILDER_VECTOR(TestLayer, VkPhysicalDevice, removed_physical_devices, removed_physical_device)
-    BUILDER_VECTOR(TestLayer, VkPhysicalDevice, added_physical_devices, added_physical_device)
-    BUILDER_VECTOR(TestLayer, VkPhysicalDeviceGroupProperties, complete_physical_device_groups, complete_physical_device_group)
-    BUILDER_VECTOR(TestLayer, VkPhysicalDeviceGroupProperties, removed_physical_device_groups, removed_physical_device_group)
-    BUILDER_VECTOR(TestLayer, VkPhysicalDeviceGroupProperties, added_physical_device_groups, added_physical_device_group)
+    BUILDER_VALUE(bool, add_phys_devs)
+    BUILDER_VALUE(bool, remove_phys_devs)
+    BUILDER_VALUE(bool, reorder_phys_devs)
+    BUILDER_VECTOR(VkPhysicalDevice, complete_physical_devices, complete_physical_device)
+    BUILDER_VECTOR(VkPhysicalDevice, removed_physical_devices, removed_physical_device)
+    BUILDER_VECTOR(VkPhysicalDevice, added_physical_devices, added_physical_device)
+    BUILDER_VECTOR(VkPhysicalDeviceGroupProperties, complete_physical_device_groups, complete_physical_device_group)
+    BUILDER_VECTOR(VkPhysicalDeviceGroupProperties, removed_physical_device_groups, removed_physical_device_group)
+    BUILDER_VECTOR(VkPhysicalDeviceGroupProperties, added_physical_device_groups, added_physical_device_group)
 
-    BUILDER_VECTOR(TestLayer, VulkanFunction, custom_physical_device_implementation_functions,
-                   custom_physical_device_implementation_function)
-    BUILDER_VECTOR(TestLayer, VulkanFunction, custom_device_implementation_functions, custom_device_implementation_function)
+    BUILDER_VECTOR(VulkanFunction, custom_physical_device_implementation_functions, custom_physical_device_implementation_function)
+    BUILDER_VECTOR(VulkanFunction, custom_device_implementation_functions, custom_device_implementation_function)
 
     // Only need a single map for all 'custom' function - assumes that all function names are distinct, IE there cannot be a
     // physical device and device level function with the same name
@@ -170,10 +169,10 @@ struct TestLayer {
     }
 
     // Allows distinguishing different layers (that use the same binary)
-    BUILDER_VALUE(TestLayer, std::string, make_spurious_log_in_create_instance, "")
-    BUILDER_VALUE(TestLayer, bool, do_spurious_allocations_in_create_instance, false)
+    BUILDER_VALUE(std::string, make_spurious_log_in_create_instance)
+    BUILDER_VALUE(bool, do_spurious_allocations_in_create_instance)
     void* spurious_instance_memory_allocation = nullptr;
-    BUILDER_VALUE(TestLayer, bool, do_spurious_allocations_in_create_device, false)
+    BUILDER_VALUE(bool, do_spurious_allocations_in_create_device)
     struct DeviceMemAlloc {
         void* allocation;
         VkDevice device;
@@ -181,25 +180,25 @@ struct TestLayer {
     std::vector<DeviceMemAlloc> spurious_device_memory_allocations;
 
     // By default query GPDPA from GIPA, don't use value given from pNext
-    BUILDER_VALUE(TestLayer, bool, use_gipa_GetPhysicalDeviceProcAddr, true)
+    BUILDER_VALUE_WITH_DEFAULT(bool, use_gipa_GetPhysicalDeviceProcAddr, true)
 
     // Have a layer query for vkCreateDevice with a NULL instance handle
-    BUILDER_VALUE(TestLayer, bool, buggy_query_of_vkCreateDevice, false)
+    BUILDER_VALUE(bool, buggy_query_of_vkCreateDevice)
 
     // Makes the layer try to create a device using the loader provided function in the layer chain
-    BUILDER_VALUE(TestLayer, bool, call_create_device_while_create_device_is_called, false)
-    BUILDER_VALUE(TestLayer, uint32_t, physical_device_index_to_use_during_create_device, 0)
+    BUILDER_VALUE(bool, call_create_device_while_create_device_is_called)
+    BUILDER_VALUE(uint32_t, physical_device_index_to_use_during_create_device)
 
-    BUILDER_VALUE(TestLayer, bool, check_if_EnumDevExtProps_is_same_as_queried_function, false)
+    BUILDER_VALUE(bool, check_if_EnumDevExtProps_is_same_as_queried_function)
 
     // Clober the data pointed to by pInstance to overwrite the magic value
-    BUILDER_VALUE(TestLayer, bool, clobber_pInstance, false)
+    BUILDER_VALUE(bool, clobber_pInstance)
     // Clober the data pointed to by pDevice to overwrite the magic value
-    BUILDER_VALUE(TestLayer, bool, clobber_pDevice, false)
+    BUILDER_VALUE(bool, clobber_pDevice)
 
-    BUILDER_VALUE(TestLayer, bool, query_vkEnumerateInstanceLayerProperties, false)
-    BUILDER_VALUE(TestLayer, bool, query_vkEnumerateInstanceExtensionProperties, false)
-    BUILDER_VALUE(TestLayer, bool, query_vkEnumerateInstanceVersion, false)
+    BUILDER_VALUE(bool, query_vkEnumerateInstanceLayerProperties)
+    BUILDER_VALUE(bool, query_vkEnumerateInstanceExtensionProperties)
+    BUILDER_VALUE(bool, query_vkEnumerateInstanceVersion)
 
     PFN_vkGetInstanceProcAddr next_vkGetInstanceProcAddr = VK_NULL_HANDLE;
     PFN_GetPhysicalDeviceProcAddr next_GetPhysicalDeviceProcAddr = VK_NULL_HANDLE;

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -478,10 +478,10 @@ void FillDebugUtilsCreateDetails(InstanceCreateInfo& create_info, DebugUtilsLogg
 void FillDebugUtilsCreateDetails(InstanceCreateInfo& create_info, DebugUtilsWrapper& wrapper);
 
 struct LoaderSettingsLayerConfiguration {
-    BUILDER_VALUE(LoaderSettingsLayerConfiguration, std::string, name, {})
-    BUILDER_VALUE(LoaderSettingsLayerConfiguration, std::filesystem::path, path, {})
-    BUILDER_VALUE(LoaderSettingsLayerConfiguration, std::string, control, {})
-    BUILDER_VALUE(LoaderSettingsLayerConfiguration, bool, treat_as_implicit_manifest, false)
+    BUILDER_VALUE(std::string, name)
+    BUILDER_VALUE(std::filesystem::path, path)
+    BUILDER_VALUE(std::string, control)
+    BUILDER_VALUE(bool, treat_as_implicit_manifest)
 };
 inline bool operator==(LoaderSettingsLayerConfiguration const& a, LoaderSettingsLayerConfiguration const& b) {
     return a.name == b.name && a.path == b.path && a.control == b.control &&
@@ -497,19 +497,19 @@ inline bool operator>=(LoaderSettingsLayerConfiguration const& a, LoaderSettings
 
 // Log files and their associated filter
 struct LoaderLogConfiguration {
-    BUILDER_VECTOR(LoaderLogConfiguration, std::string, destinations, destination)
-    BUILDER_VECTOR(LoaderLogConfiguration, std::string, filters, filter)
+    BUILDER_VECTOR(std::string, destinations, destination)
+    BUILDER_VECTOR(std::string, filters, filter)
 };
 struct AppSpecificSettings {
-    BUILDER_VECTOR(AppSpecificSettings, std::string, app_keys, app_key)
-    BUILDER_VECTOR(AppSpecificSettings, LoaderSettingsLayerConfiguration, layer_configurations, layer_configuration)
-    BUILDER_VECTOR(AppSpecificSettings, std::string, stderr_log, stderr_log_filter)
-    BUILDER_VECTOR(AppSpecificSettings, LoaderLogConfiguration, log_configurations, log_configuration)
+    BUILDER_VECTOR(std::string, app_keys, app_key)
+    BUILDER_VECTOR(LoaderSettingsLayerConfiguration, layer_configurations, layer_configuration)
+    BUILDER_VECTOR(std::string, stderr_log, stderr_log_filter)
+    BUILDER_VECTOR(LoaderLogConfiguration, log_configurations, log_configuration)
 };
 
 struct LoaderSettings {
-    BUILDER_VALUE(LoaderSettings, ManifestVersion, file_format_version, {})
-    BUILDER_VECTOR(LoaderSettings, AppSpecificSettings, app_specific_settings, app_specific_setting);
+    BUILDER_VALUE(ManifestVersion, file_format_version)
+    BUILDER_VECTOR(AppSpecificSettings, app_specific_settings, app_specific_setting);
 };
 
 struct FrameworkEnvironment;  // forward declaration
@@ -589,27 +589,27 @@ struct TestICDDetails {
     TestICDDetails(std::filesystem::path icd_binary_path, uint32_t api_version = VK_API_VERSION_1_0) noexcept {
         icd_manifest.set_lib_path(icd_binary_path).set_api_version(api_version);
     }
-    BUILDER_VALUE(TestICDDetails, ManifestICD, icd_manifest, {});
-    BUILDER_VALUE(TestICDDetails, std::filesystem::path, json_name, "test_icd");
+    BUILDER_VALUE(ManifestICD, icd_manifest);
+    BUILDER_VALUE_WITH_DEFAULT(std::filesystem::path, json_name, "test_icd");
     // Uses the json_name without modification - default is to append _1 in the json file to distinguish drivers
-    BUILDER_VALUE(TestICDDetails, bool, disable_icd_inc, false);
-    BUILDER_VALUE(TestICDDetails, ManifestDiscoveryType, discovery_type, ManifestDiscoveryType::generic);
-    BUILDER_VALUE(TestICDDetails, bool, is_fake, false);
+    BUILDER_VALUE(bool, disable_icd_inc);
+    BUILDER_VALUE_WITH_DEFAULT(ManifestDiscoveryType, discovery_type, ManifestDiscoveryType::generic);
+    BUILDER_VALUE(bool, is_fake);
     // If discovery type is env-var, is_dir controls whether to use the path to the file or folder the manifest is in
-    BUILDER_VALUE(TestICDDetails, bool, is_dir, false);
-    BUILDER_VALUE(TestICDDetails, LibraryPathType, library_path_type, LibraryPathType::absolute);
+    BUILDER_VALUE(bool, is_dir);
+    BUILDER_VALUE_WITH_DEFAULT(LibraryPathType, library_path_type, LibraryPathType::absolute);
 };
 
 struct TestLayerDetails {
     TestLayerDetails(ManifestLayer layer_manifest, const std::string& json_name) noexcept
         : layer_manifest(layer_manifest), json_name(json_name) {}
-    BUILDER_VALUE(TestLayerDetails, ManifestLayer, layer_manifest, {});
-    BUILDER_VALUE(TestLayerDetails, std::string, json_name, "test_layer");
-    BUILDER_VALUE(TestLayerDetails, ManifestDiscoveryType, discovery_type, ManifestDiscoveryType::generic);
-    BUILDER_VALUE(TestLayerDetails, bool, is_fake, false);
+    BUILDER_VALUE(ManifestLayer, layer_manifest);
+    BUILDER_VALUE_WITH_DEFAULT(std::string, json_name, "test_layer");
+    BUILDER_VALUE_WITH_DEFAULT(ManifestDiscoveryType, discovery_type, ManifestDiscoveryType::generic);
+    BUILDER_VALUE(bool, is_fake);
     // If discovery type is env-var, is_dir controls whether to use the path to the file or folder the manifest is in
-    BUILDER_VALUE(TestLayerDetails, bool, is_dir, true);
-    BUILDER_VALUE(TestLayerDetails, LibraryPathType, library_path_type, LibraryPathType::absolute);
+    BUILDER_VALUE_WITH_DEFAULT(bool, is_dir, true);
+    BUILDER_VALUE_WITH_DEFAULT(LibraryPathType, library_path_type, LibraryPathType::absolute);
 };
 
 // Locations manifests can go in the test framework
@@ -632,10 +632,10 @@ enum class ManifestLocation {
 };
 
 struct FrameworkSettings {
-    BUILDER_VALUE(FrameworkSettings, const char*, log_filter, "all");
-    BUILDER_VALUE(FrameworkSettings, bool, enable_default_search_paths, true);
-    BUILDER_VALUE(FrameworkSettings, LoaderSettings, loader_settings, {});
-    BUILDER_VALUE(FrameworkSettings, bool, secure_loader_settings, false);
+    BUILDER_VALUE_WITH_DEFAULT(const char*, log_filter, "all");
+    BUILDER_VALUE_WITH_DEFAULT(bool, enable_default_search_paths, true);
+    BUILDER_VALUE(LoaderSettings, loader_settings);
+    BUILDER_VALUE(bool, secure_loader_settings);
 };
 
 struct FrameworkEnvironment {

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -504,44 +504,44 @@ inline std::string version_to_string(uint32_t version) {
 }
 
 // Macro to ease the definition of variables with builder member functions
-// class_name = class the member variable is apart of
 // type = type of the variable
 // name = name of the variable
 // default_value = value to default initialize, use {} if nothing else makes sense
-#define BUILDER_VALUE(class_name, type, name, default_value) \
-    type name = default_value;                               \
-    class_name& set_##name(type const& name) {               \
-        this->name = name;                                   \
-        return *this;                                        \
+#define BUILDER_VALUE_WITH_DEFAULT(type, name, default_value) \
+    type name = default_value;                                \
+    auto set_##name(type const& name)->decltype(*this) {      \
+        this->name = name;                                    \
+        return *this;                                         \
     }
 
+#define BUILDER_VALUE(type, name) BUILDER_VALUE_WITH_DEFAULT(type, name, {})
+
 // Macro to ease the definition of vectors with builder member functions
-// class_name = class the member variable is apart of
 // type = type of the variable
 // name = name of the variable
 // singular_name = used for the `add_singular_name` member function
-#define BUILDER_VECTOR(class_name, type, name, singular_name)                    \
-    std::vector<type> name;                                                      \
-    class_name& add_##singular_name(type const& singular_name) {                 \
-        this->name.push_back(singular_name);                                     \
-        return *this;                                                            \
-    }                                                                            \
-    class_name& add_##singular_name##s(std::vector<type> const& singular_name) { \
-        for (auto& elem : singular_name) this->name.push_back(elem);             \
-        return *this;                                                            \
+#define BUILDER_VECTOR(type, name, singular_name)                                          \
+    std::vector<type> name;                                                                \
+    auto add_##singular_name(type const& singular_name)->decltype(*this) {                 \
+        this->name.push_back(singular_name);                                               \
+        return *this;                                                                      \
+    }                                                                                      \
+    auto add_##singular_name##s(std::vector<type> const& singular_name)->decltype(*this) { \
+        for (auto& elem : singular_name) this->name.push_back(elem);                       \
+        return *this;                                                                      \
     }
 // Like BUILDER_VECTOR but for move only types - where passing in means giving up ownership
-#define BUILDER_VECTOR_MOVE_ONLY(class_name, type, name, singular_name) \
-    std::vector<type> name;                                             \
-    class_name& add_##singular_name(type&& singular_name) {             \
-        this->name.push_back(std::move(singular_name));                 \
-        return *this;                                                   \
+#define BUILDER_VECTOR_MOVE_ONLY(type, name, singular_name)           \
+    std::vector<type> name;                                           \
+    auto add_##singular_name(type&& singular_name)->decltype(*this) { \
+        this->name.push_back(std::move(singular_name));               \
+        return *this;                                                 \
     }
 
 struct ManifestVersion {
-    BUILDER_VALUE(ManifestVersion, uint32_t, major, 1)
-    BUILDER_VALUE(ManifestVersion, uint32_t, minor, 0)
-    BUILDER_VALUE(ManifestVersion, uint32_t, patch, 0)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, major, 1)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, minor, 0)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, patch, 0)
 
     std::string get_version_str() const noexcept {
         return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
@@ -550,11 +550,11 @@ struct ManifestVersion {
 
 // ManifestICD builder
 struct ManifestICD {
-    BUILDER_VALUE(ManifestICD, ManifestVersion, file_format_version, {})
-    BUILDER_VALUE(ManifestICD, uint32_t, api_version, 0)
-    BUILDER_VALUE(ManifestICD, std::filesystem::path, lib_path, {})
-    BUILDER_VALUE(ManifestICD, bool, is_portability_driver, false)
-    BUILDER_VALUE(ManifestICD, std::string, library_arch, "")
+    BUILDER_VALUE(ManifestVersion, file_format_version)
+    BUILDER_VALUE(uint32_t, api_version)
+    BUILDER_VALUE(std::filesystem::path, lib_path)
+    BUILDER_VALUE(bool, is_portability_driver)
+    BUILDER_VALUE(std::string, library_arch)
     std::string get_manifest_str() const;
 };
 
@@ -571,8 +571,8 @@ struct ManifestLayer {
                 return "INSTANCE";
         }
         struct FunctionOverride {
-            BUILDER_VALUE(FunctionOverride, std::string, vk_func, {})
-            BUILDER_VALUE(FunctionOverride, std::string, override_name, {})
+            BUILDER_VALUE(std::string, vk_func)
+            BUILDER_VALUE(std::string, override_name)
 
             void get_manifest_str(JsonWriter& writer) const { writer.AddKeyedString(vk_func, override_name); }
         };
@@ -585,36 +585,36 @@ struct ManifestLayer {
             std::vector<std::string> entrypoints;
             void get_manifest_str(JsonWriter& writer) const;
         };
-        BUILDER_VALUE(LayerDescription, std::string, name, {})
-        BUILDER_VALUE(LayerDescription, Type, type, Type::INSTANCE)
-        BUILDER_VALUE(LayerDescription, std::filesystem::path, lib_path, {})
-        BUILDER_VALUE(LayerDescription, uint32_t, api_version, VK_API_VERSION_1_0)
-        BUILDER_VALUE(LayerDescription, uint32_t, implementation_version, 0)
-        BUILDER_VALUE(LayerDescription, std::string, description, {})
-        BUILDER_VECTOR(LayerDescription, FunctionOverride, functions, function)
-        BUILDER_VECTOR(LayerDescription, Extension, instance_extensions, instance_extension)
-        BUILDER_VECTOR(LayerDescription, Extension, device_extensions, device_extension)
-        BUILDER_VALUE(LayerDescription, std::string, enable_environment, {})
-        BUILDER_VALUE(LayerDescription, std::string, disable_environment, {})
-        BUILDER_VECTOR(LayerDescription, std::string, component_layers, component_layer)
-        BUILDER_VECTOR(LayerDescription, std::string, blacklisted_layers, blacklisted_layer)
-        BUILDER_VECTOR(LayerDescription, std::filesystem::path, override_paths, override_path)
-        BUILDER_VECTOR(LayerDescription, FunctionOverride, pre_instance_functions, pre_instance_function)
-        BUILDER_VECTOR(LayerDescription, std::string, app_keys, app_key)
-        BUILDER_VALUE(LayerDescription, std::string, library_arch, "")
+        BUILDER_VALUE(std::string, name)
+        BUILDER_VALUE_WITH_DEFAULT(Type, type, Type::INSTANCE)
+        BUILDER_VALUE(std::filesystem::path, lib_path)
+        BUILDER_VALUE_WITH_DEFAULT(uint32_t, api_version, VK_API_VERSION_1_0)
+        BUILDER_VALUE(uint32_t, implementation_version)
+        BUILDER_VALUE(std::string, description)
+        BUILDER_VECTOR(FunctionOverride, functions, function)
+        BUILDER_VECTOR(Extension, instance_extensions, instance_extension)
+        BUILDER_VECTOR(Extension, device_extensions, device_extension)
+        BUILDER_VALUE(std::string, enable_environment)
+        BUILDER_VALUE(std::string, disable_environment)
+        BUILDER_VECTOR(std::string, component_layers, component_layer)
+        BUILDER_VECTOR(std::string, blacklisted_layers, blacklisted_layer)
+        BUILDER_VECTOR(std::filesystem::path, override_paths, override_path)
+        BUILDER_VECTOR(FunctionOverride, pre_instance_functions, pre_instance_function)
+        BUILDER_VECTOR(std::string, app_keys, app_key)
+        BUILDER_VALUE(std::string, library_arch)
 
         void get_manifest_str(JsonWriter& writer) const;
         VkLayerProperties get_layer_properties() const;
     };
-    BUILDER_VALUE(ManifestLayer, ManifestVersion, file_format_version, {})
-    BUILDER_VECTOR(ManifestLayer, LayerDescription, layers, layer)
+    BUILDER_VALUE(ManifestVersion, file_format_version)
+    BUILDER_VECTOR(LayerDescription, layers, layer)
 
     std::string get_manifest_str() const;
 };
 
 struct Extension {
-    BUILDER_VALUE(Extension, std::string, extensionName, {})
-    BUILDER_VALUE(Extension, uint32_t, specVersion, VK_API_VERSION_1_0)
+    BUILDER_VALUE(std::string, extensionName)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, specVersion, VK_API_VERSION_1_0)
 
     Extension(const char* name, uint32_t specVersion = VK_API_VERSION_1_0) noexcept
         : extensionName(name), specVersion(specVersion) {}
@@ -630,25 +630,25 @@ struct Extension {
 };
 
 struct MockQueueFamilyProperties {
-    BUILDER_VALUE(MockQueueFamilyProperties, VkQueueFamilyProperties, properties, {})
-    BUILDER_VALUE(MockQueueFamilyProperties, bool, support_present, false)
+    BUILDER_VALUE(VkQueueFamilyProperties, properties)
+    BUILDER_VALUE(bool, support_present)
 
     VkQueueFamilyProperties get() const noexcept { return properties; }
 };
 
 struct InstanceCreateInfo {
-    BUILDER_VALUE(InstanceCreateInfo, VkInstanceCreateInfo, instance_info, {})
-    BUILDER_VALUE(InstanceCreateInfo, VkApplicationInfo, application_info, {})
-    BUILDER_VALUE(InstanceCreateInfo, std::string, app_name, {})
-    BUILDER_VALUE(InstanceCreateInfo, std::string, engine_name, {})
-    BUILDER_VALUE(InstanceCreateInfo, uint32_t, flags, 0)
-    BUILDER_VALUE(InstanceCreateInfo, uint32_t, app_version, 0)
-    BUILDER_VALUE(InstanceCreateInfo, uint32_t, engine_version, 0)
-    BUILDER_VALUE(InstanceCreateInfo, uint32_t, api_version, VK_API_VERSION_1_0)
-    BUILDER_VECTOR(InstanceCreateInfo, const char*, enabled_layers, layer)
-    BUILDER_VECTOR(InstanceCreateInfo, const char*, enabled_extensions, extension)
+    BUILDER_VALUE(VkInstanceCreateInfo, instance_info)
+    BUILDER_VALUE(VkApplicationInfo, application_info)
+    BUILDER_VALUE(std::string, app_name)
+    BUILDER_VALUE(std::string, engine_name)
+    BUILDER_VALUE(uint32_t, flags)
+    BUILDER_VALUE(uint32_t, app_version)
+    BUILDER_VALUE(uint32_t, engine_version)
+    BUILDER_VALUE_WITH_DEFAULT(uint32_t, api_version, VK_API_VERSION_1_0)
+    BUILDER_VECTOR(const char*, enabled_layers, layer)
+    BUILDER_VECTOR(const char*, enabled_extensions, extension)
     // tell the get() function to not provide `application_info`
-    BUILDER_VALUE(InstanceCreateInfo, bool, fill_in_application_info, true)
+    BUILDER_VALUE_WITH_DEFAULT(bool, fill_in_application_info, true)
 
     InstanceCreateInfo();
 
@@ -663,8 +663,8 @@ struct DeviceQueueCreateInfo {
     DeviceQueueCreateInfo();
     DeviceQueueCreateInfo(const VkDeviceQueueCreateInfo* create_info);
 
-    BUILDER_VALUE(DeviceQueueCreateInfo, VkDeviceQueueCreateInfo, queue_create_info, {})
-    BUILDER_VECTOR(DeviceQueueCreateInfo, float, priorities, priority)
+    BUILDER_VALUE(VkDeviceQueueCreateInfo, queue_create_info)
+    BUILDER_VECTOR(float, priorities, priority)
 
     VkDeviceQueueCreateInfo get() noexcept;
 };
@@ -673,10 +673,10 @@ struct DeviceCreateInfo {
     DeviceCreateInfo() = default;
     DeviceCreateInfo(const VkDeviceCreateInfo* create_info);
 
-    BUILDER_VALUE(DeviceCreateInfo, VkDeviceCreateInfo, dev, {})
-    BUILDER_VECTOR(DeviceCreateInfo, const char*, enabled_extensions, extension)
-    BUILDER_VECTOR(DeviceCreateInfo, const char*, enabled_layers, layer)
-    BUILDER_VECTOR(DeviceCreateInfo, DeviceQueueCreateInfo, queue_info_details, device_queue)
+    BUILDER_VALUE(VkDeviceCreateInfo, dev)
+    BUILDER_VECTOR(const char*, enabled_extensions, extension)
+    BUILDER_VECTOR(const char*, enabled_layers, layer)
+    BUILDER_VECTOR(DeviceQueueCreateInfo, queue_info_details, device_queue)
 
     VkDeviceCreateInfo* get() noexcept;
 


### PR DESCRIPTION
Changes BUILDER_VALUE & BUILDER_VECTOR to deduce the return type, so the class name doesn't need to be given.

Changes BUILDER_VALUE to default everything with {}, and adds BUILDER_VALUE_WITH_DEFAULT for the places that want a specific default value instead.