### PR TITLE
ci: Use PKG_CONFIG_PATH instead of 32 bit pkg-config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
             - run: |
                 sudo apt install --yes --no-install-recommends \
                 gcc-multilib g++-multilib libc6:i386 libc6-dev-i386 libgcc-s1:i386 \
-                libwayland-dev:i386 libxrandr-dev:i386 pkg-config:i386
+                libwayland-dev:i386 libxrandr-dev:i386
             - run: |
                 cmake -S. -B build \
                 -D CMAKE_BUILD_TYPE=${{matrix.config}} \
@@ -130,17 +130,15 @@ jobs:
                 -D UPDATE_DEPS=ON \
                 -D BUILD_WERROR=ON \
                 -D SYSCONFDIR=/etc/not_vulkan \
-                -D PKG_CONFIG_EXECUTABLE=/usr/bin/i686-linux-gnu-pkg-config \
+                -D CMAKE_CXX_FLAGS=-m32 \
+                -D CMAKE_C_FLAGS=-m32 \
                 -G Ninja
               env:
-                CFLAGS: -m32
-                CXXFLAGS: -m32
-                LDFLAGS: -m32
-                ASFLAGS: --32
+                # https://gitlab.kitware.com/cmake/cmake/-/issues/25317
+                PKG_CONFIG_PATH: /usr/lib/i386-linux-gnu/pkgconfig
             - run: cmake --build build
             - run: cmake --install build --prefix /tmp
-            - run: ctest --output-on-failure
-              working-directory: build/
+            - run: ctest --output-on-failure --test-dir build/
 
     linux-32-no-asm:
         needs: codegen
@@ -159,7 +157,7 @@ jobs:
             - run: |
                 sudo apt install --yes --no-install-recommends \
                 gcc-multilib g++-multilib libc6:i386 libc6-dev-i386 libgcc-s1:i386 \
-                libwayland-dev:i386 libxrandr-dev:i386 pkg-config:i386
+                libwayland-dev:i386 libxrandr-dev:i386
             - run: |
                 cmake -S. -B build \
                 -D CMAKE_BUILD_TYPE=Release \
@@ -167,16 +165,14 @@ jobs:
                 -D UPDATE_DEPS=ON \
                 -D BUILD_WERROR=ON \
                 -D USE_GAS=OFF \
-                -D PKG_CONFIG_EXECUTABLE=/usr/bin/i686-linux-gnu-pkg-config \
+                -D CMAKE_CXX_FLAGS=-m32 \
+                -D CMAKE_C_FLAGS=-m32 \
                 -G Ninja
               env:
-                CFLAGS: -m32
-                CXXFLAGS: -m32
-                LDFLAGS: -m32
-                ASFLAGS: --32
+                # https://gitlab.kitware.com/cmake/cmake/-/issues/25317
+                PKG_CONFIG_PATH: /usr/lib/i386-linux-gnu/pkgconfig
             - run: cmake --build build
-            - run: ctest --output-on-failure -E UnknownFunction
-              working-directory: build/
+            - run: ctest --output-on-failure -E UnknownFunction --test-dir build/
 
     windows_vs:
         # windows is 2x expensive to run on GitHub machines, so only run if we know something else simple passed as well

--- a/BUILD.md
+++ b/BUILD.md
@@ -522,22 +522,22 @@ If not already installed, install the following 32-bit development libraries:
 
 `gcc-multilib gcc-multilib g++-multilib libc6:i386 libc6-dev-i386 libgcc-s1:i386 libwayland-dev:i386 libxrandr-dev:i386`
 
-This list may vary depending on your distribution and which windowing systems
-you are building for.
+This list may vary depending on your distribution and which windowing systems you are building for.
 
-Set up your environment for building 32-bit targets:
+Set up your environment for building 32-bit targets when configuring your build:
 
-    export CFLAGS=-m32
-    export CXXFLAGS=-m32
-    export LDFLAGS=-m32
-    export ASFLAGS=--32
+      cmake ... -D CMAKE_CXX_FLAGS=-m32 -D CMAKE_C_FLAGS=-m32
+
+However, you may find that pkg-config picks incorrect libraries. This is due to a CMake implementation issue:
+https://gitlab.kitware.com/cmake/cmake/-/issues/25317
 
 Your PKG_CONFIG configuration may be different, depending on your distribution.
 
+You can the `PKG_CONFIG_PATH` environment variable to address this issue.
+
 Finally, build the repository normally as explained above.
 
-These notes are taken from the Github Actions workflow `linux-32` which is run
-regularly as a part of CI.
+These notes are taken from the Github Actions workflow `linux-32` which is run regularly as a part of CI.
 
 ## Building on MacOS
 


### PR DESCRIPTION
ci shouldn't have to use the 32 bit version of pkg-config.

I tracked it down the problem is in CMake. Specifically FindPkgConfig.cmake

I listed the issue in the yml and docs for reference to make it clear that it is a CMake bug.