### PR TITLE
Fix pAllocator in lazily allocated ICD surfaces

### DIFF
--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -82,6 +82,7 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
 
     VkResult result = VK_SUCCESS;
     if (icd_term->scanned_icd->interface_version >= ICD_VER_SUPPORTS_ICD_SURFACE_KHR) {
+        VkAllocationCallbacks *pAllocator = icd_surface->callbacks_valid ? &icd_surface->callbacks : NULL;
         if (VK_NULL_HANDLE == icd_term->surface_list.list[icd_surface->surface_index]) {
             // If the surface does not exist yet for the target ICD, then create it lazily
             switch (icd_surface->base.platform) {
@@ -89,8 +90,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_WAYLAND:
                     if (NULL != icd_term->dispatch.CreateWaylandSurfaceKHR) {
                         result = icd_term->dispatch.CreateWaylandSurfaceKHR(
-                            icd_term->instance, (const VkWaylandSurfaceCreateInfoKHR *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkWaylandSurfaceCreateInfoKHR *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -101,8 +102,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_WIN32:
                     if (NULL != icd_term->dispatch.CreateWin32SurfaceKHR) {
                         result = icd_term->dispatch.CreateWin32SurfaceKHR(
-                            icd_term->instance, (const VkWin32SurfaceCreateInfoKHR *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkWin32SurfaceCreateInfoKHR *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -113,8 +114,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_XCB:
                     if (NULL != icd_term->dispatch.CreateXcbSurfaceKHR) {
                         result = icd_term->dispatch.CreateXcbSurfaceKHR(
-                            icd_term->instance, (const VkXcbSurfaceCreateInfoKHR *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkXcbSurfaceCreateInfoKHR *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -125,8 +126,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_XLIB:
                     if (NULL != icd_term->dispatch.CreateXlibSurfaceKHR) {
                         result = icd_term->dispatch.CreateXlibSurfaceKHR(
-                            icd_term->instance, (const VkXlibSurfaceCreateInfoKHR *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkXlibSurfaceCreateInfoKHR *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -137,8 +138,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_MACOS:
                     if (NULL != icd_term->dispatch.CreateMacOSSurfaceMVK) {
                         result = icd_term->dispatch.CreateMacOSSurfaceMVK(
-                            icd_term->instance, (const VkMacOSSurfaceCreateInfoMVK *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkMacOSSurfaceCreateInfoMVK *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -148,8 +149,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_DISPLAY:
                     if (NULL != icd_term->dispatch.CreateDisplayPlaneSurfaceKHR) {
                         result = icd_term->dispatch.CreateDisplayPlaneSurfaceKHR(
-                            icd_term->instance, (const VkDisplaySurfaceCreateInfoKHR *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkDisplaySurfaceCreateInfoKHR *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -158,8 +159,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_HEADLESS:
                     if (NULL != icd_term->dispatch.CreateHeadlessSurfaceEXT) {
                         result = icd_term->dispatch.CreateHeadlessSurfaceEXT(
-                            icd_term->instance, (const VkHeadlessSurfaceCreateInfoEXT *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkHeadlessSurfaceCreateInfoEXT *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -169,8 +170,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_METAL:
                     if (NULL != icd_term->dispatch.CreateMetalSurfaceEXT) {
                         result = icd_term->dispatch.CreateMetalSurfaceEXT(
-                            icd_term->instance, (const VkMetalSurfaceCreateInfoEXT *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkMetalSurfaceCreateInfoEXT *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -181,8 +182,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_DIRECTFB:
                     if (NULL != icd_term->dispatch.CreateDirectFBSurfaceEXT) {
                         result = icd_term->dispatch.CreateDirectFBSurfaceEXT(
-                            icd_term->instance, (const VkDirectFBSurfaceCreateInfoEXT *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkDirectFBSurfaceCreateInfoEXT *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -193,8 +194,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_VI:
                     if (NULL != icd_term->dispatch.CreateViSurfaceNN) {
                         result = icd_term->dispatch.CreateViSurfaceNN(
-                            icd_term->instance, (const VkViSurfaceCreateInfoNN *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkViSurfaceCreateInfoNN *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -206,7 +207,7 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                     if (NULL != icd_term->dispatch.CreateStreamDescriptorSurfaceGGP) {
                         result = icd_term->dispatch.CreateStreamDescriptorSurfaceGGP(
                             icd_term->instance, (const VkStreamDescriptorSurfaceCreateInfoGGP *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            pAllocator, &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -217,8 +218,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_SCREEN:
                     if (NULL != icd_term->dispatch.CreateScreenSurfaceQNX) {
                         result = icd_term->dispatch.CreateScreenSurfaceQNX(
-                            icd_term->instance, (const VkScreenSurfaceCreateInfoQNX *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkScreenSurfaceCreateInfoQNX *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -229,8 +230,8 @@ VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *
                 case VK_ICD_WSI_PLATFORM_FUCHSIA:
                     if (NULL != icd_term->dispatch.CreateImagePipeSurfaceFUCHSIA) {
                         result = icd_term->dispatch.CreateImagePipeSurfaceFUCHSIA(
-                            icd_term->instance, (const VkImagePipeSurfaceCreateInfoFUCHSIA *)icd_surface->create_info,
-                            &icd_term->this_instance->alloc_callbacks, &icd_term->surface_list.list[icd_surface->surface_index]);
+                            icd_term->instance, (const VkImagePipeSurfaceCreateInfoFUCHSIA *)icd_surface->create_info, pAllocator,
+                            &icd_term->surface_list.list[icd_surface->surface_index]);
                     } else {
                         result = VK_ERROR_EXTENSION_NOT_PRESENT;
                     }
@@ -754,7 +755,7 @@ VkResult allocate_icd_surface_struct(struct loader_instance *instance, size_t ba
     }
 
     // Next, if so, proceed with the implementation of this function:
-    icd_surface = loader_instance_heap_alloc(instance, sizeof(VkIcdSurface), VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
+    icd_surface = loader_instance_heap_calloc(instance, sizeof(VkIcdSurface), VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
     if (icd_surface == NULL) {
         res = VK_ERROR_OUT_OF_HOST_MEMORY;
         goto out;
@@ -796,7 +797,7 @@ out:
 
 VkResult copy_surface_create_info(struct loader_instance *loader_inst, VkIcdSurface *icd_surface, const void *create_info,
                                   size_t struct_type_info_count, const struct loader_struct_type_info *struct_type_info,
-                                  const char *base_struct_name) {
+                                  const char *base_struct_name, const VkAllocationCallbacks *pAllocator) {
     size_t create_info_total_size = 0;
     const void *pnext = create_info;
     while (NULL != pnext) {
@@ -841,6 +842,10 @@ VkResult copy_surface_create_info(struct loader_instance *loader_inst, VkIcdSurf
                 break;
             }
         }
+    }
+    if (pAllocator) {
+        icd_surface->callbacks_valid = true;
+        icd_surface->callbacks = *pAllocator;
     }
 
     return VK_SUCCESS;
@@ -922,7 +927,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateWin32SurfaceKHR(VkInstance insta
         {VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR, sizeof(VkWin32SurfaceCreateInfoKHR)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkWin32SurfaceCreateInfoKHR");
+                             "VkWin32SurfaceCreateInfoKHR", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -1021,7 +1026,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateWaylandSurfaceKHR(VkInstance ins
         {VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR, sizeof(VkWaylandSurfaceCreateInfoKHR)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkWaylandSurfaceCreateInfoKHR");
+                             "VkWaylandSurfaceCreateInfoKHR", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -1124,7 +1129,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateXcbSurfaceKHR(VkInstance instanc
         {VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR, sizeof(VkXcbSurfaceCreateInfoKHR)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkXcbSurfaceCreateInfoKHR");
+                             "VkXcbSurfaceCreateInfoKHR", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -1230,7 +1235,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateXlibSurfaceKHR(VkInstance instan
         {VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR, sizeof(VkXlibSurfaceCreateInfoKHR)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkXlibSurfaceCreateInfoKHR");
+                             "VkXlibSurfaceCreateInfoKHR", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -1335,7 +1340,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDirectFBSurfaceEXT(VkInstance in
         {VK_STRUCTURE_TYPE_DIRECTFB_SURFACE_CREATE_INFO_EXT, sizeof(VkDirectFBSurfaceCreateInfoEXT)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkDirectFBSurfaceCreateInfoEXT");
+                             "VkDirectFBSurfaceCreateInfoEXT", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -1483,7 +1488,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateHeadlessSurfaceEXT(VkInstance in
         {VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT, sizeof(VkHeadlessSurfaceCreateInfoEXT)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkHeadlessSurfaceCreateInfoEXT");
+                             "VkHeadlessSurfaceCreateInfoEXT", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -1569,7 +1574,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateMacOSSurfaceMVK(VkInstance insta
         {VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK, sizeof(VkMacOSSurfaceCreateInfoMVK)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkMacOSSurfaceCreateInfoMVK");
+                             "VkMacOSSurfaceCreateInfoMVK", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -1680,7 +1685,7 @@ terminator_CreateStreamDescriptorSurfaceGGP(VkInstance instance, const VkStreamD
         {VK_STRUCTURE_TYPE_STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP, sizeof(VkStreamDescriptorSurfaceCreateInfoGGP)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkStreamDescriptorSurfaceCreateInfoGGP");
+                             "VkStreamDescriptorSurfaceCreateInfoGGP", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -1735,7 +1740,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateMetalSurfaceEXT(VkInstance insta
         {VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT, sizeof(VkMetalSurfaceCreateInfoEXT)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkMetalSurfaceCreateInfoEXT");
+                             "VkMetalSurfaceCreateInfoEXT", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -1796,7 +1801,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateScreenSurfaceQNX(VkInstance inst
         {VK_STRUCTURE_TYPE_SCREEN_SURFACE_CREATE_INFO_QNX, sizeof(VkScreenSurfaceCreateInfoQNX)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkScreenSurfaceCreateInfoQNX");
+                             "VkScreenSurfaceCreateInfoQNX", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -1896,7 +1901,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateViSurfaceNN(VkInstance instance,
         {VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN, sizeof(VkViSurfaceCreateInfoNN)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkViSurfaceCreateInfoNN");
+                             "VkViSurfaceCreateInfoNN", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -2210,7 +2215,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDisplayPlaneSurfaceKHR(VkInstanc
         {VK_STRUCTURE_TYPE_DISPLAY_SURFACE_STEREO_CREATE_INFO_NV, sizeof(VkDisplaySurfaceStereoCreateInfoNV)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkDisplaySurfaceCreateInfoKHR");
+                             "VkDisplaySurfaceCreateInfoKHR", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 
@@ -2639,7 +2644,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateImagePipeSurfaceFUCHSIA(VkInstan
         {VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA, sizeof(VkImagePipeSurfaceCreateInfoFUCHSIA)},
     };
     copy_surface_create_info(loader_inst, icd_surface, pCreateInfo, sizeof(ci_types) / sizeof(ci_types[0]), ci_types,
-                             "VkImagePipeSurfaceCreateInfoFUCHSIA");
+                             "VkImagePipeSurfaceCreateInfoFUCHSIA", pAllocator);
 
     *pSurface = (VkSurfaceKHR)(uintptr_t)icd_surface;
 

--- a/loader/wsi.h
+++ b/loader/wsi.h
@@ -75,6 +75,9 @@ typedef struct {
     uint32_t entire_size;          // Size of entire VkIcdSurface
     uint32_t surface_index;        // This surface's index into each drivers list of created surfaces
 
+    bool callbacks_valid;             // Need to store if a VkAllocationCallbacks pointer was used.
+    VkAllocationCallbacks callbacks;  // Storage for the callbacks
+
     // The create info parameters captured by the union in VkIcdSurface are insufficient, as they do not
     // capture every single parameter from the create info (e.g. flags that did not have any flags defined
     // at the time) and they also cannot capture extension structures, so we are including a separate
@@ -83,6 +86,7 @@ typedef struct {
     // structures is rather limited (there is only a single display surface creation structure extension
     // at the time of writing).
     uint8_t *create_info;
+
 } VkIcdSurface;
 
 VkResult wsi_unwrap_icd_surface(struct loader_icd_term *icd_term, VkSurfaceKHR *surface);

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -155,6 +155,15 @@ VkResult FillCountPtr(std::vector<T> const& data_vec, uint32_t* pCount, T* pData
     return VK_SUCCESS;
 }
 
+void check_allocator_handle(const VkAllocationCallbacks* pAllocator) {
+    if (pAllocator) {
+        if (nullptr == pAllocator->pfnAllocation || nullptr == pAllocator->pfnFree || nullptr == pAllocator->pfnReallocation) {
+            std::cout << "pAllocator functions are NULL!\n";
+            abort();
+        }
+    }
+}
+
 //// Instance Functions ////
 
 // VK_SUCCESS,VK_INCOMPLETE
@@ -182,11 +191,11 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceVersion(uint32_t* pApiVer
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
-                                                     [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                     VkInstance* pInstance) {
+                                                     const VkAllocationCallbacks* pAllocator, VkInstance* pInstance) {
     if (pCreateInfo == nullptr) {
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
+    check_allocator_handle(pAllocator);
 
     uint32_t default_api_version = VK_API_VERSION_1_0;
     uint32_t api_version =
@@ -214,9 +223,9 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo*
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR void VKAPI_CALL test_vkDestroyInstance([[maybe_unused]] VkInstance instance,
-                                                  [[maybe_unused]] const VkAllocationCallbacks* pAllocator) {
+VKAPI_ATTR void VKAPI_CALL test_vkDestroyInstance([[maybe_unused]] VkInstance instance, const VkAllocationCallbacks* pAllocator) {
     icd.enabled_instance_extensions.clear();
+    check_allocator_handle(pAllocator);
 }
 
 // VK_SUCCESS,VK_INCOMPLETE
@@ -511,7 +520,8 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceQueueFamilyProperties(VkPhysi
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
-                                                   [[maybe_unused]] const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
+                                                   const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
+    check_allocator_handle(pAllocator);
     // VK_SUCCESS
     auto found = std::find_if(icd.physical_devices.begin(), icd.physical_devices.end(), [physicalDevice](PhysicalDevice& phys_dev) {
         return phys_dev.vk_physical_device.handle == physicalDevice;
@@ -529,7 +539,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevi
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR void VKAPI_CALL test_vkDestroyDevice(VkDevice device, [[maybe_unused]] const VkAllocationCallbacks* pAllocator) {
+VKAPI_ATTR void VKAPI_CALL test_vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
+    check_allocator_handle(pAllocator);
     auto found = std::find(icd.device_handles.begin(), icd.device_handles.end(), device);
     if (found != icd.device_handles.end()) icd.device_handles.erase(found);
     auto fd = icd.lookup_device(device);
@@ -610,8 +621,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateAndroidSurfaceKHR(VkInstance instanc
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWin32SurfaceKHR([[maybe_unused]] VkInstance instance,
                                                             [[maybe_unused]] const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
-                                                            [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                            VkSurfaceKHR* pSurface) {
+                                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
@@ -622,8 +633,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceWin32PresentationSupportK
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWaylandSurfaceKHR([[maybe_unused]] VkInstance instance,
                                                               [[maybe_unused]] const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
-                                                              [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                              VkSurfaceKHR* pSurface) {
+                                                              const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
@@ -636,8 +647,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceWaylandPresentationSuppor
 #if defined(VK_USE_PLATFORM_XCB_KHR)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXcbSurfaceKHR([[maybe_unused]] VkInstance instance,
                                                           [[maybe_unused]] const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
-                                                          [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                          VkSurfaceKHR* pSurface) {
+                                                          const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
@@ -651,8 +662,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceXcbPresentationSupportKHR
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXlibSurfaceKHR([[maybe_unused]] VkInstance instance,
                                                            [[maybe_unused]] const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
-                                                           [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                           VkSurfaceKHR* pSurface) {
+                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
@@ -665,8 +676,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceXlibPresentationSupportKH
 #if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDirectFBSurfaceEXT([[maybe_unused]] VkInstance instance,
                                                                [[maybe_unused]] const VkDirectFBSurfaceCreateInfoEXT* pCreateInfo,
-                                                               [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                               VkSurfaceKHR* pSurface) {
+                                                               const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
@@ -680,8 +691,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceDirectFBPresentationSuppo
 #if defined(VK_USE_PLATFORM_MACOS_MVK)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMacOSSurfaceMVK([[maybe_unused]] VkInstance instance,
                                                             [[maybe_unused]] const VkMacOSSurfaceCreateInfoMVK* pCreateInfo,
-                                                            [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                            VkSurfaceKHR* pSurface) {
+                                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
@@ -690,8 +701,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMacOSSurfaceMVK([[maybe_unused]] VkI
 #if defined(VK_USE_PLATFORM_IOS_MVK)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateIOSSurfaceMVK([[maybe_unused]] VkInstance instance,
                                                           [[maybe_unused]] const VkIOSSurfaceCreateInfoMVK* pCreateInfo,
-                                                          [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                          VkSurfaceKHR* pSurface) {
+                                                          const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
@@ -700,7 +711,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateIOSSurfaceMVK([[maybe_unused]] VkIns
 #if defined(VK_USE_PLATFORM_GGP)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateStreamDescriptorSurfaceGGP(
     [[maybe_unused]] VkInstance instance, [[maybe_unused]] const VkStreamDescriptorSurfaceCreateInfoGGP* pCreateInfo,
-    [[maybe_unused]] const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
@@ -709,8 +721,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateStreamDescriptorSurfaceGGP(
 #if defined(VK_USE_PLATFORM_METAL_EXT)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMetalSurfaceEXT([[maybe_unused]] VkInstance instance,
                                                             [[maybe_unused]] const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
-                                                            [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                            VkSurfaceKHR* pSurface) {
+                                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
@@ -719,8 +731,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMetalSurfaceEXT([[maybe_unused]] VkI
 #if defined(VK_USE_PLATFORM_SCREEN_QNX)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateScreenSurfaceQNX([[maybe_unused]] VkInstance instance,
                                                              [[maybe_unused]] const VkScreenSurfaceCreateInfoQNX* pCreateInfo,
-                                                             [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                             VkSurfaceKHR* pSurface) {
+                                                             const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
@@ -733,14 +745,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceScreenPresentationSupport
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateHeadlessSurfaceEXT([[maybe_unused]] VkInstance instance,
                                                                [[maybe_unused]] const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
-                                                               [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                               VkSurfaceKHR* pSurface) {
+                                                               const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
 
 VKAPI_ATTR void VKAPI_CALL test_vkDestroySurfaceKHR([[maybe_unused]] VkInstance instance, VkSurfaceKHR surface,
-                                                    [[maybe_unused]] const VkAllocationCallbacks* pAllocator) {
+                                                    const VkAllocationCallbacks* pAllocator) {
     if (surface != VK_NULL_HANDLE) {
         uint64_t fake_surf_handle = from_nondispatch_handle(surface);
         auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), fake_surf_handle);
@@ -755,8 +767,8 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroySurfaceKHR([[maybe_unused]] VkInstance 
 // VK_KHR_swapchain
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSwapchainKHR([[maybe_unused]] VkDevice device,
                                                          [[maybe_unused]] const VkSwapchainCreateInfoKHR* pCreateInfo,
-                                                         [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                         VkSwapchainKHR* pSwapchain) {
+                                                         const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.swapchain_handles, pSwapchain);
     return VK_SUCCESS;
 }
@@ -777,7 +789,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetSwapchainImagesKHR([[maybe_unused]] VkD
 }
 
 VKAPI_ATTR void VKAPI_CALL test_vkDestroySwapchainKHR([[maybe_unused]] VkDevice device, VkSwapchainKHR swapchain,
-                                                      [[maybe_unused]] const VkAllocationCallbacks* pAllocator) {
+                                                      const VkAllocationCallbacks* pAllocator) {
+    check_allocator_handle(pAllocator);
     if (swapchain != VK_NULL_HANDLE) {
         uint64_t fake_swapchain_handle = from_nondispatch_handle(swapchain);
         auto found_iter = icd.swapchain_handles.erase(
@@ -917,8 +930,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDisplayModePropertiesKHR(VkPhysicalDevi
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDisplayModeKHR(VkPhysicalDevice physicalDevice, [[maybe_unused]] VkDisplayKHR display,
                                                            [[maybe_unused]] const VkDisplayModeCreateInfoKHR* pCreateInfo,
-                                                           [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                           VkDisplayModeKHR* pMode) {
+                                                           const VkAllocationCallbacks* pAllocator, VkDisplayModeKHR* pMode) {
+    check_allocator_handle(pAllocator);
     if (nullptr != pMode) {
         *pMode = icd.GetPhysDevice(physicalDevice).display_mode;
     }
@@ -935,7 +948,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDisplayPlaneCapabilitiesKHR(VkPhysicalD
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDisplayPlaneSurfaceKHR(
     [[maybe_unused]] VkInstance instance, [[maybe_unused]] const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
-    [[maybe_unused]] const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    check_allocator_handle(pAllocator);
     common_nondispatch_handle_creation(icd.surface_handles, pSurface);
     return VK_SUCCESS;
 }
@@ -1026,8 +1040,9 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhys
 // VK_KHR_display_swapchain
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSharedSwapchainsKHR([[maybe_unused]] VkDevice device, uint32_t swapchainCount,
                                                                 const VkSwapchainCreateInfoKHR* pCreateInfos,
-                                                                [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
+                                                                const VkAllocationCallbacks* pAllocator,
                                                                 VkSwapchainKHR* pSwapchains) {
+    check_allocator_handle(pAllocator);
     for (uint32_t i = 0; i < swapchainCount; i++) {
         uint64_t surface_integer_value = from_nondispatch_handle(pCreateInfos[i].surface);
         auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), surface_integer_value);
@@ -1042,8 +1057,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSharedSwapchainsKHR([[maybe_unused]]
 //// misc
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateCommandPool([[maybe_unused]] VkDevice device,
                                                         [[maybe_unused]] const VkCommandPoolCreateInfo* pCreateInfo,
-                                                        [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
-                                                        VkCommandPool* pCommandPool) {
+                                                        const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool) {
+    check_allocator_handle(pAllocator);
     if (pCommandPool != nullptr) {
         pCommandPool = reinterpret_cast<VkCommandPool*>(0xdeadbeefdeadbeef);
     }


### PR DESCRIPTION
The pAllocator passed into each surface creation function would be a
pointer to the instance's pAllocator callbacks, regardless of whether
they were valid.

This commit saves the VkAllocationCallbacks passed into the surface
create function so that it can be used when the surface handle is
actually created in the driver.