### PR TITLE
Vulkan SC downstream fixes

### DIFF
--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -60,7 +60,7 @@ class DispatchTableHelperGenerator(BaseGenerator):
 #include <vulkan/vulkan.h>
 #include <vulkan/vk_layer.h>
 #include <string.h>
-#include "loader/generated/vk_layer_dispatch_table.h"
+#include "vk_layer_dispatch_table.h"
 
 ''')
 

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -72,30 +72,34 @@ def RunGenerators(api: str, registry: str, directory: str, styleFile: str, targe
     from base_generator import (SetTargetApiName, SetMergedApiNames)
     SetTargetApiName(api)
 
+    # Generated directory and dispatch table helper file name may be API specific (e.g. Vulkan SC)
+    generated_directory = 'loader/generated'
+    dispatch_table_helper_filename = 'vk_dispatch_table_helper.h'
+
     generators.update({
         'vk_layer_dispatch_table.h': {
             'generator' : LoaderExtensionGenerator,
-            'genCombined': True,
-            'directory' : 'loader/generated',
+            'genCombined': False,
+            'directory' : generated_directory,
         },
         'vk_loader_extensions.c': {
             'generator' : LoaderExtensionGenerator,
-            'genCombined': True,
-            'directory' : 'loader/generated',
+            'genCombined': False,
+            'directory' : generated_directory,
         },
         'vk_loader_extensions.h': {
             'generator' : LoaderExtensionGenerator,
-            'genCombined': True,
-            'directory' : 'loader/generated',
+            'genCombined': False,
+            'directory' : generated_directory,
         },
         'vk_object_types.h': {
             'generator' : HelperFileGenerator,
             'genCombined': True,
-            'directory' : 'loader/generated',
+            'directory' : generated_directory,
         },
-        'vk_dispatch_table_helper.h': {
+        f'{dispatch_table_helper_filename}': {
             'generator' : DispatchTableHelperGenerator,
-            'genCombined': True,
+            'genCombined': False,
             'directory' : 'tests/framework/layer',
         }
     })

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -26,7 +26,7 @@ if(UNIX)
     target_compile_options(testing_framework_util PUBLIC -fPIC)
 endif()
 # Gives access to all headers in the framework folder, in the framework binary, and in the whole project (mainly for loader/generated)
-target_include_directories(testing_framework_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR})
+target_include_directories(testing_framework_util PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/loader/generated")
 
 if (UNIX)
     if (LOADER_ENABLE_ADDRESS_SANITIZER)

--- a/tests/framework/layer/vk_dispatch_table_helper.h
+++ b/tests/framework/layer/vk_dispatch_table_helper.h
@@ -28,7 +28,7 @@
 #include <vulkan/vulkan.h>
 #include <vulkan/vk_layer.h>
 #include <string.h>
-#include "loader/generated/vk_layer_dispatch_table.h"
+#include "vk_layer_dispatch_table.h"
 
 static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDispatchTable *table, PFN_vkGetDeviceProcAddr gpa) {
     memset(table, 0, sizeof(*table));


### PR DESCRIPTION
During the downstreaming of Vulkan-Loader 1.4.310 into Vulkan SC, we've found that:

- some of the refactoring doesn't work as intended
- some parts are easier to maintain downstream if handled slightly differently
- some parts appreciate minor fixing

To be precise:

- Hardcoded references to the name of `generated/` folders irrespective of api type always require downstream workarounds. It's far cleaner to handle them when it's not part of a huge literal, but a variable we can override in a snippet.
- `genCombined: True` is a safe default, but in these cases some need modification to not be permanent conflicts downstream.
- `tests/framework/CMakeLists.txt` has no quotes around `CMAKE_SOURCE_DIR` et al. but this variable really wanted to be PROJECT_SOURCE_DIR. Current script works only as long as Vulkan-Loader is the top-level project when these two variables coincide.