### PR TITLE
Add drivers field to settings file

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3818,6 +3818,12 @@ VkResult loader_icd_scan(const struct loader_instance *inst, struct loader_icd_t
         goto out;
     }
 
+    // Add any drivers provided by the loader settings file
+    res = loader_settings_get_additional_driver_files(inst, &manifest_files);
+    if (VK_SUCCESS != res) {
+        goto out;
+    }
+
     icd_details = loader_stack_alloc(sizeof(struct ICDManifestInfo) * manifest_files.count);
     if (NULL == icd_details) {
         res = VK_ERROR_OUT_OF_HOST_MEMORY;

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -110,14 +110,23 @@ VkResult loader_copy_to_new_str(const struct loader_instance *inst, const char *
 // Allocate a loader_string_list with enough space for allocated_count strings inside of it
 VkResult create_string_list(const struct loader_instance *inst, uint32_t allocated_count, struct loader_string_list *string_list);
 // Resize if there isn't enough space, then add the string str to the end of the loader_string_list
-// This function takes ownership of the str passed in - but only when it succeeds
+// This function takes ownership of the str passed in
 VkResult append_str_to_string_list(const struct loader_instance *inst, struct loader_string_list *string_list, char *str);
-// Resize if there isn't enough space, then copy the string str to a new string the end of the loader_string_list
+// Resize if there isn't enough space, then add the string str to the start of the loader_string_list
+// This function takes ownership of the str passed in
+VkResult prepend_str_to_string_list(const struct loader_instance *inst, struct loader_string_list *string_list, char *str);
+// Copy the string str to a new string and append it to string_list, resizing string_list if there isn't enough space.
 // This function does not take ownership of the string, it merely copies it.
-// This function appends a null terminator to the string automatically
+// This function automatically appends a null terminator to the string being copied
 // The str_len parameter does not include the null terminator
 VkResult copy_str_to_string_list(const struct loader_instance *inst, struct loader_string_list *string_list, const char *str,
                                  size_t str_len);
+// Copy the string str to a new string and prepend it to string_list, resizing string_list if there isn't enough space.
+// This function does not take ownership of the string, it merely copies it.
+// This function automatically appends a null terminator to the string being copied
+// The str_len parameter does not include the null terminator
+VkResult copy_str_to_start_of_string_list(const struct loader_instance *inst, struct loader_string_list *string_list,
+                                          const char *str, size_t str_len);
 
 // Free any string inside of loader_string_list and then free the list itself
 void free_string_list(const struct loader_instance *inst, struct loader_string_list *string_list);
@@ -214,6 +223,8 @@ void unload_drivers_without_physical_devices(struct loader_instance *inst);
 
 VkStringErrorFlags vk_string_validate(const int max_length, const char *char_array);
 char *loader_get_next_path(char *path);
+VkResult add_if_manifest_file(const struct loader_instance *inst, const char *file_name, struct loader_string_list *out_files);
+VkResult prepend_if_manifest_file(const struct loader_instance *inst, const char *file_name, struct loader_string_list *out_files);
 VkResult add_data_files(const struct loader_instance *inst, char *search_path, struct loader_string_list *out_files,
                         bool use_first_found_manifest);
 

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -44,6 +44,11 @@ void free_layer_configuration(const struct loader_instance* inst, loader_setting
     memset(layer_configuration, 0, sizeof(loader_settings_layer_configuration));
 }
 
+void free_driver_configuration(const struct loader_instance* inst, loader_settings_driver_configuration* driver_configuration) {
+    loader_instance_heap_free(inst, driver_configuration->path);
+    memset(driver_configuration, 0, sizeof(loader_settings_driver_configuration));
+}
+
 void free_loader_settings(const struct loader_instance* inst, loader_settings* settings) {
     if (NULL != settings->layer_configurations) {
         for (uint32_t i = 0; i < settings->layer_configuration_count; i++) {
@@ -207,6 +212,74 @@ out:
     return res;
 }
 
+VkResult parse_additional_driver(const struct loader_instance* inst, cJSON* additional_driver_json,
+                                 loader_settings_driver_configuration* additional_driver) {
+    VkResult res = VK_SUCCESS;
+    res = loader_parse_json_string(additional_driver_json, "path", &(additional_driver->path));
+    if (res != VK_SUCCESS) {
+        goto out;
+    }
+out:
+    if (res != VK_SUCCESS) {
+        free_driver_configuration(inst, additional_driver);
+    }
+    return res;
+}
+
+VkResult parse_additional_drivers(const struct loader_instance* inst, cJSON* settings_object, loader_settings* loader_settings) {
+    VkResult res = VK_SUCCESS;
+
+    cJSON* use_additional_drivers_exclusively_json =
+        loader_cJSON_GetObjectItem(settings_object, "use_additional_drivers_exclusively");
+    if (use_additional_drivers_exclusively_json && use_additional_drivers_exclusively_json->type == cJSON_True) {
+        loader_settings->use_additional_drivers_exclusively = true;
+    }
+
+    cJSON* additional_drivers_json = loader_cJSON_GetObjectItem(settings_object, "additional_drivers");
+    if (NULL == additional_drivers_json) {
+        return VK_SUCCESS;
+    }
+
+    uint32_t additional_driver_count = loader_cJSON_GetArraySize(additional_drivers_json);
+    if (additional_driver_count == 0) {
+        return VK_SUCCESS;
+    }
+
+    loader_settings->additional_driver_count = additional_driver_count;
+
+    loader_settings->additional_drivers = loader_instance_heap_calloc(
+        inst, sizeof(loader_settings_layer_configuration) * additional_driver_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+    if (NULL == loader_settings->additional_drivers) {
+        res = VK_ERROR_OUT_OF_HOST_MEMORY;
+        goto out;
+    }
+
+    cJSON* driver = NULL;
+    size_t i = 0;
+    cJSON_ArrayForEach(driver, additional_drivers_json) {
+        if (driver->type != cJSON_Object) {
+            res = VK_ERROR_INITIALIZATION_FAILED;
+            goto out;
+        }
+        res = parse_additional_driver(inst, driver, &(loader_settings->additional_drivers[i++]));
+        if (VK_SUCCESS != res) {
+            goto out;
+        }
+    }
+out:
+    if (res != VK_SUCCESS) {
+        if (loader_settings->additional_drivers) {
+            for (size_t index = 0; index < loader_settings->additional_driver_count; index++) {
+                free_driver_configuration(inst, &(loader_settings->additional_drivers[index]));
+            }
+            loader_settings->additional_driver_count = 0;
+            loader_instance_heap_free(inst, loader_settings->additional_drivers);
+            loader_settings->additional_drivers = NULL;
+        }
+    }
+    return res;
+}
+
 VkResult check_if_settings_path_exists(const struct loader_instance* inst, const char* base, const char* suffix,
                                        char** settings_file_path) {
     if (NULL == base || NULL == suffix) {
@@ -248,6 +321,23 @@ VkResult get_unix_settings_path(const struct loader_instance* inst, char** setti
                                          settings_file_path);
 }
 
+bool check_if_layer_configurations_are_equal(loader_settings_layer_configuration* a, loader_settings_layer_configuration* b) {
+    if (!a->name || !b->name || 0 != strcmp(a->name, b->name)) {
+        return false;
+    }
+    if (!a->path || !b->path || 0 != strcmp(a->path, b->path)) {
+        return false;
+    }
+    return a->control == b->control;
+}
+
+bool check_if_driver_configurations_are_equal(loader_settings_driver_configuration* a, loader_settings_driver_configuration* b) {
+    if (!a->path || !b->path || 0 != strcmp(a->path, b->path)) {
+        return false;
+    }
+    return true;
+}
+
 bool check_if_settings_are_equal(loader_settings* a, loader_settings* b) {
     // If either pointer is null, return true
     if (NULL == a || NULL == b) return false;
@@ -256,19 +346,13 @@ bool check_if_settings_are_equal(loader_settings* a, loader_settings* b) {
     are_equal &= a->has_unordered_layer_location == b->has_unordered_layer_location;
     are_equal &= a->debug_level == b->debug_level;
     are_equal &= a->layer_configuration_count == b->layer_configuration_count;
+    are_equal &= a->additional_driver_count == b->additional_driver_count;
     if (!are_equal) return false;
     for (uint32_t i = 0; i < a->layer_configuration_count && i < b->layer_configuration_count; i++) {
-        if (a->layer_configurations[i].name && b->layer_configurations[i].name) {
-            are_equal &= 0 == strcmp(a->layer_configurations[i].name, b->layer_configurations[i].name);
-        } else {
-            are_equal = false;
-        }
-        if (a->layer_configurations[i].path && b->layer_configurations[i].path) {
-            are_equal &= 0 == strcmp(a->layer_configurations[i].path, b->layer_configurations[i].path);
-        } else {
-            are_equal = false;
-        }
-        are_equal &= a->layer_configurations[i].control == b->layer_configurations[i].control;
+        are_equal &= check_if_layer_configurations_are_equal(&a->layer_configurations[i], &b->layer_configurations[i]);
+    }
+    for (uint32_t i = 0; i < a->additional_driver_count && i < b->additional_driver_count; i++) {
+        are_equal &= check_if_driver_configurations_are_equal(&a->additional_drivers[i], &b->additional_drivers[i]);
     }
     return are_equal;
 }
@@ -301,6 +385,17 @@ void log_settings(const struct loader_instance* inst, loader_settings* settings)
         }
         loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Control: %s",
                    loader_settings_layer_control_to_string(settings->layer_configurations[i].control));
+    }
+    if (settings->additional_driver_count > 0) {
+        loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "----");
+        loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Use Additional Drivers Exclusively = %s",
+                   settings->use_additional_drivers_exclusively ? "true" : "false");
+        loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Additional Driver Configurations count = %d",
+                   settings->additional_driver_count);
+        for (uint32_t i = 0; i < settings->additional_driver_count; i++) {
+            loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "---- Driver Configuration [%d] ----", i);
+            loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "Path: %s", settings->additional_drivers[i].path);
+        }
     }
     loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "---------------------------------");
 }
@@ -469,6 +564,11 @@ VkResult get_loader_settings(const struct loader_instance* inst, loader_settings
             loader_settings->has_unordered_layer_location = true;
             break;
         }
+    }
+
+    res = parse_additional_drivers(inst, settings_to_use, loader_settings);
+    if (res != VK_SUCCESS) {
+        goto out;
     }
 
     loader_settings->settings_file_path = settings_file_path;
@@ -863,6 +963,27 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
             }
         }
     }
+out:
+    return res;
+}
+
+VkResult loader_settings_get_additional_driver_files(const struct loader_instance* inst, struct loader_string_list* out_files) {
+    VkResult res = VK_SUCCESS;
+
+    const loader_settings* settings = get_current_settings_and_lock(inst);
+
+    if (NULL == settings || !settings->settings_active) {
+        goto out;
+    }
+
+    if (settings->use_additional_drivers_exclusively) {
+        free_string_list(inst, out_files);
+    }
+
+    for (uint32_t i = 0; i < settings->additional_driver_count; i++) {
+        res = prepend_if_manifest_file(inst, settings->additional_drivers[i].path, out_files);
+    }
+
 out:
     return res;
 }

--- a/loader/settings.h
+++ b/loader/settings.h
@@ -34,6 +34,7 @@
 
 struct loader_instance;
 struct loader_layer_list;
+struct loader_string_list;
 struct loader_pointer_layer_list;
 struct loader_envvar_all_filters;
 typedef struct log_configuration log_configuration;
@@ -61,6 +62,10 @@ typedef struct loader_settings_layer_configuration {
 
 } loader_settings_layer_configuration;
 
+typedef struct loader_settings_driver_configuration {
+    char* path;
+} loader_settings_driver_configuration;
+
 typedef struct loader_settings {
     bool settings_active;
     bool has_unordered_layer_location;
@@ -68,6 +73,10 @@ typedef struct loader_settings {
 
     uint32_t layer_configuration_count;
     loader_settings_layer_configuration* layer_configurations;
+
+    bool use_additional_drivers_exclusively;
+    uint32_t additional_driver_count;
+    loader_settings_driver_configuration* additional_drivers;
 
     char* settings_file_path;
 } loader_settings;
@@ -112,3 +121,7 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
                                              const struct loader_layer_list* instance_layers,
                                              struct loader_pointer_layer_list* target_layer_list,
                                              struct loader_pointer_layer_list* activated_layer_list);
+
+// Add any drivers that the loader settings file contains to the out_files list. If the use_additional_drivers_exclusively field is
+// true, clear the out_files list before adding any additional drivers
+VkResult loader_settings_get_additional_driver_files(const struct loader_instance* inst, struct loader_string_list* out_files);

--- a/tests/framework/test_environment.cpp
+++ b/tests/framework/test_environment.cpp
@@ -687,11 +687,11 @@ TestICD& FrameworkEnvironment::add_icd(TestICDDetails icd_details) noexcept {
             case (ManifestDiscoveryType::unsecured_generic):
                 platform_shim->add_unsecured_manifest(ManifestCategory::icd, icds.back().manifest_path);
                 break;
-            case (ManifestDiscoveryType::null_dir):
-            case (ManifestDiscoveryType::none):
-                break;
             case (ManifestDiscoveryType::windows_app_package):
                 platform_shim->set_app_package_path(folder.location());
+                break;
+            case (ManifestDiscoveryType::null_dir):
+            case (ManifestDiscoveryType::none):
                 break;
         }
     }
@@ -903,6 +903,16 @@ std::string get_loader_settings_file_contents(const LoaderSettings& loader_setti
                     writer.AddString(filter);
                 }
                 writer.EndArray();
+                writer.EndObject();
+            }
+            writer.EndArray();
+        }
+        if (!setting.driver_configurations.empty()) {
+            writer.AddKeyedBool("use_additional_drivers_exclusively", setting.use_additional_drivers_exclusively);
+            writer.StartKeyedArray("additional_drivers");
+            for (const auto& driver : setting.driver_configurations) {
+                writer.StartObject();
+                writer.AddKeyedString("path", driver.path);
                 writer.EndObject();
             }
             writer.EndArray();

--- a/tests/framework/test_environment.h
+++ b/tests/framework/test_environment.h
@@ -513,6 +513,7 @@ struct LoaderSettingsLayerConfiguration {
     BUILDER_VALUE(std::string, control)
     BUILDER_VALUE(bool, treat_as_implicit_manifest)
 };
+// Needed for next_permutation
 inline bool operator==(LoaderSettingsLayerConfiguration const& a, LoaderSettingsLayerConfiguration const& b) {
     return a.name == b.name && a.path == b.path && a.control == b.control &&
            a.treat_as_implicit_manifest == b.treat_as_implicit_manifest;
@@ -525,6 +526,10 @@ inline bool operator>(LoaderSettingsLayerConfiguration const& a, LoaderSettingsL
 inline bool operator<=(LoaderSettingsLayerConfiguration const& a, LoaderSettingsLayerConfiguration const& b) { return !(b < a); }
 inline bool operator>=(LoaderSettingsLayerConfiguration const& a, LoaderSettingsLayerConfiguration const& b) { return !(a < b); }
 
+struct LoaderSettingsDriverConfiguration {
+    BUILDER_VALUE(std::string, path)
+};
+
 // Log files and their associated filter
 struct LoaderLogConfiguration {
     BUILDER_VECTOR(std::string, destinations, destination)
@@ -533,6 +538,8 @@ struct LoaderLogConfiguration {
 struct AppSpecificSettings {
     BUILDER_VECTOR(std::string, app_keys, app_key)
     BUILDER_VECTOR(LoaderSettingsLayerConfiguration, layer_configurations, layer_configuration)
+    BUILDER_VECTOR(LoaderSettingsDriverConfiguration, driver_configurations, driver_configuration)
+    BUILDER_VALUE(bool, use_additional_drivers_exclusively)
     BUILDER_VECTOR(std::string, stderr_log, stderr_log_filter)
     BUILDER_VECTOR(LoaderLogConfiguration, log_configurations, log_configuration)
 };

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -3018,3 +3018,112 @@ TEST(SettingsFile, EnvVarsWorkTogether) {
         EXPECT_TRUE(env.platform_shim->find_in_log("Insert instance layer \"VK_LAYER_add_env_var_implicit_layer\""));
     }
 }
+
+// additional drivers being provided by settings file
+TEST(SettingsFile, AdditionalDrivers) {
+    FrameworkEnvironment env{};
+    const char* regular_driver_name = "regular";
+    const char* settings_driver_name = "settings";
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+        .add_physical_device(PhysicalDevice{}.set_deviceName(regular_driver_name).finish());
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2).set_discovery_type(ManifestDiscoveryType::override_folder))
+        .add_physical_device(PhysicalDevice{}.set_deviceName(settings_driver_name).finish());
+
+    env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(
+        AppSpecificSettings{}.add_driver_configuration(LoaderSettingsDriverConfiguration{}.set_path(env.get_icd_manifest_path(1))));
+    env.update_loader_settings(env.loader_settings);
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.CheckCreate();
+    auto pds = inst.GetPhysDevs();
+    ASSERT_EQ(pds.size(), 2U);
+    VkPhysicalDeviceProperties props1{}, props2{};
+    inst.functions->vkGetPhysicalDeviceProperties(pds.at(0), &props1);
+    inst.functions->vkGetPhysicalDeviceProperties(pds.at(1), &props2);
+    ASSERT_TRUE(string_eq(props1.deviceName, regular_driver_name));
+    ASSERT_TRUE(string_eq(props2.deviceName, settings_driver_name));
+}
+// settings file provided drivers replacing system found drivers
+TEST(SettingsFile, ExclusiveAdditionalDrivers) {
+    FrameworkEnvironment env{};
+    const char* regular_driver_name = "regular";
+    const char* settings_driver_name = "settings";
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+        .add_physical_device(PhysicalDevice{}.set_deviceName(regular_driver_name).finish());
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2).set_discovery_type(ManifestDiscoveryType::override_folder))
+        .add_physical_device(PhysicalDevice{}.set_deviceName(settings_driver_name).finish());
+
+    env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(
+        AppSpecificSettings{}.set_use_additional_drivers_exclusively(true).add_driver_configuration(
+            LoaderSettingsDriverConfiguration{}.set_path(env.get_icd_manifest_path(1))));
+    env.update_loader_settings(env.loader_settings);
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.CheckCreate();
+    auto pds = inst.GetPhysDevs();
+    ASSERT_EQ(pds.size(), 1U);
+    VkPhysicalDeviceProperties props1{};
+    inst.functions->vkGetPhysicalDeviceProperties(pds.at(0), &props1);
+    ASSERT_TRUE(string_eq(props1.deviceName, settings_driver_name));
+}
+// settings file provided drivers + VK_LOADER_DRIVERS_SELECT
+TEST(SettingsFile, AdditionalDriversReplacesVK_LOADER_DRIVERS_SELECT) {
+    FrameworkEnvironment env{};
+    const char* regular_driver_name = "regular";
+    const char* settings_driver_name = "settings";
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+        .add_physical_device(PhysicalDevice{}.set_deviceName(regular_driver_name).finish());
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2).set_discovery_type(ManifestDiscoveryType::override_folder))
+        .add_physical_device(PhysicalDevice{}.set_deviceName(settings_driver_name).finish());
+
+    env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(
+        AppSpecificSettings{}.add_driver_configuration(LoaderSettingsDriverConfiguration{}.set_path(env.get_icd_manifest_path(1))));
+    env.update_loader_settings(env.loader_settings);
+
+    {
+        EnvVarWrapper VK_LOADER_DRIVERS_SELECT{"VK_LOADER_DRIVERS_SELECT",
+                                               std::string("*") + env.get_icd_manifest_path(0).stem().string() + std::string("*")};
+        InstWrapper inst{env.vulkan_functions};
+        inst.CheckCreate();
+        auto pds = inst.GetPhysDevs();
+        ASSERT_EQ(pds.size(), 1U);
+        VkPhysicalDeviceProperties props1{};
+        inst.functions->vkGetPhysicalDeviceProperties(pds.at(0), &props1);
+        ASSERT_TRUE(string_eq(props1.deviceName, regular_driver_name));
+    }
+    {
+        EnvVarWrapper VK_LOADER_DRIVERS_SELECT{"VK_LOADER_DRIVERS_SELECT",
+                                               std::string("*") + env.get_icd_manifest_path(1).stem().string() + std::string("*")};
+        InstWrapper inst{env.vulkan_functions};
+        inst.CheckCreate();
+        auto pds = inst.GetPhysDevs();
+        ASSERT_EQ(pds.size(), 1U);
+        VkPhysicalDeviceProperties props1{};
+        inst.functions->vkGetPhysicalDeviceProperties(pds.at(0), &props1);
+        ASSERT_TRUE(string_eq(props1.deviceName, settings_driver_name));
+    }
+    env.loader_settings.app_specific_settings.at(0).set_use_additional_drivers_exclusively(true);
+    env.update_loader_settings(env.loader_settings);
+    {
+        EnvVarWrapper VK_LOADER_DRIVERS_SELECT{"VK_LOADER_DRIVERS_SELECT",
+                                               std::string("*") + env.get_icd_manifest_path(0).stem().string() + std::string("*")};
+        InstWrapper inst{env.vulkan_functions};
+        inst.CheckCreate(VK_ERROR_INCOMPATIBLE_DRIVER);
+    }
+    {
+        EnvVarWrapper VK_LOADER_DRIVERS_SELECT{"VK_LOADER_DRIVERS_SELECT",
+                                               std::string("*") + env.get_icd_manifest_path(1).stem().string() + std::string("*")};
+        InstWrapper inst{env.vulkan_functions};
+        inst.CheckCreate();
+        auto pds = inst.GetPhysDevs();
+        ASSERT_EQ(pds.size(), 1U);
+        VkPhysicalDeviceProperties props1{};
+        inst.functions->vkGetPhysicalDeviceProperties(pds.at(0), &props1);
+        ASSERT_TRUE(string_eq(props1.deviceName, settings_driver_name));
+    }
+}
+// settings file provided drivers + VK_LOADER_DRIVERS_DISABLE
+
+TEST(SettingsFile, AdditionalDriversReplacesVK_LOADER_DRIVERS_DISABLE) {
+    // TODO
+}


### PR DESCRIPTION
Allows the settings file to contain 'additional drivers' which are just paths to ICD manifest files.

Adds the `use_additional_drivers_exclusively` boolean field and `additional_drivers` list to settings array on a per-application basis (AKA in the same object as the `layers` list. 

TODO: 
Finish writing tests. Make sure environment variables work properly or at least don't make things more complicated.
Document changes to manifest file.