### PR TITLE
Disable mingw CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -344,6 +344,7 @@ jobs:
 
     mingw:
       # windows is 2x expensive to run on GitHub machines, so only run if we know something else simple passed as well
+      if: false # Disabled due to issues with msys2 making CMake unable to find a working compiler
       needs: linux-no-asm
       runs-on: windows-2022
       defaults:


### PR DESCRIPTION
Currently, this job fails due to:

-- Check for working C compiler: C:/msys64/mingw64/bin/cc.exe - broken CMake Error at C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeTestCCompiler.cmake:67 (message):
  The C compiler  "C:/msys64/mingw64/bin/cc.exe"   is not able to compile a simple test program.

  The root cause is still unknown so it was decided to disable the CI check in the meantime.