### PR TITLE
Fix vkGetPhysicalDeviceSurfaceSupportKHR returning an error code

### DIFF
--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -382,7 +382,9 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceSupportKHR(VkP
 
     VkResult res = wsi_unwrap_icd_surface(icd_term, &surface);
     if (res != VK_SUCCESS) {
-        return res;
+        // set pSupported to false as this driver doesn't support WSI functionality
+        *pSupported = false;
+        return VK_SUCCESS;
     }
 
     return icd_term->dispatch.GetPhysicalDeviceSurfaceSupportKHR(phys_dev_term->phys_dev, queueFamilyIndex, surface, pSupported);

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -102,6 +102,51 @@ bool IsPhysicalDeviceExtensionAvailable(const char* extension_name) {
     return false;
 }
 
+PhysicalDevice& GetPhysDevice(VkPhysicalDevice physicalDevice) {
+    for (auto& phys_dev : icd.physical_devices) {
+        if (phys_dev.vk_physical_device.handle == physicalDevice) return phys_dev;
+    }
+    assert(false && "vkPhysicalDevice not found!");
+    return icd.physical_devices[0];
+}
+
+std::vector<PhysicalDevice>::iterator find_physical_device(VkPhysicalDevice physicalDevice) {
+    auto found = std::find_if(icd.physical_devices.begin(), icd.physical_devices.end(), [physicalDevice](PhysicalDevice& phys_dev) {
+        return phys_dev.vk_physical_device.handle == physicalDevice;
+    });
+    return found;
+}
+
+bool is_physical_device_found(std::vector<PhysicalDevice>::iterator found) { return found != icd.physical_devices.end(); }
+
+bool is_valid_surface(VkSurfaceKHR surface_to_check) {
+    uint64_t surf_handle = (uint64_t)(surface_to_check);
+    auto found = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), surf_handle);
+    return found != icd.surface_handles.end();
+}
+
+struct FindDevice {
+    bool found = false;
+    uint32_t phys_dev_index = 0;
+    uint32_t dev_index = 0;
+};
+
+FindDevice lookup_device(VkDevice device) {
+    FindDevice fd{};
+    for (uint32_t p = 0; p < icd.physical_devices.size(); p++) {
+        auto const& phys_dev = icd.physical_devices.at(p);
+        for (uint32_t d = 0; d < phys_dev.device_handles.size(); d++) {
+            if (phys_dev.device_handles.at(d) == device) {
+                fd.found = true;
+                fd.phys_dev_index = p;
+                fd.dev_index = d;
+                return fd;
+            }
+        }
+    }
+    return fd;
+}
+
 // typename T must have '.get()' function that returns a type U
 template <typename T, typename U>
 VkResult FillCountPtr(std::vector<T> const& data_vec, uint32_t* pCount, U* pData) {
@@ -427,8 +472,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroyDebugReportCallbackEXT([[maybe_unused]]
 VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectTagEXT(VkDevice dev, const VkDebugMarkerObjectTagInfoEXT* pTagInfo) {
     if (pTagInfo && pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pTagInfo->object);
-        if (pd != icd.physical_devices.at(icd.lookup_device(dev).phys_dev_index).vk_physical_device.handle)
-            return VK_ERROR_DEVICE_LOST;
+        if (pd != icd.physical_devices.at(lookup_device(dev).phys_dev_index).vk_physical_device.handle) return VK_ERROR_DEVICE_LOST;
     }
     if (pTagInfo && pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT) {
         if (pTagInfo->object != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
@@ -441,8 +485,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectTagEXT(VkDevice dev, c
 VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectNameEXT(VkDevice dev, const VkDebugMarkerObjectNameInfoEXT* pNameInfo) {
     if (pNameInfo && pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pNameInfo->object);
-        if (pd != icd.physical_devices.at(icd.lookup_device(dev).phys_dev_index).vk_physical_device.handle)
-            return VK_ERROR_DEVICE_LOST;
+        if (pd != icd.physical_devices.at(lookup_device(dev).phys_dev_index).vk_physical_device.handle) return VK_ERROR_DEVICE_LOST;
     }
     if (pNameInfo && pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT) {
         if (pNameInfo->object != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
@@ -459,8 +502,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerInsertEXT(VkCommandBuffer, const
 VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectNameEXT(VkDevice dev, const VkDebugUtilsObjectNameInfoEXT* pNameInfo) {
     if (pNameInfo && pNameInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pNameInfo->objectHandle);
-        if (pd != icd.physical_devices.at(icd.lookup_device(dev).phys_dev_index).vk_physical_device.handle)
-            return VK_ERROR_DEVICE_LOST;
+        if (pd != icd.physical_devices.at(lookup_device(dev).phys_dev_index).vk_physical_device.handle) return VK_ERROR_DEVICE_LOST;
     }
     if (pNameInfo && pNameInfo->objectType == VK_OBJECT_TYPE_SURFACE_KHR) {
         if (pNameInfo->objectHandle != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
@@ -473,8 +515,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectNameEXT(VkDevice dev, c
 VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectTagEXT(VkDevice dev, const VkDebugUtilsObjectTagInfoEXT* pTagInfo) {
     if (pTagInfo && pTagInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pTagInfo->objectHandle);
-        if (pd != icd.physical_devices.at(icd.lookup_device(dev).phys_dev_index).vk_physical_device.handle)
-            return VK_ERROR_DEVICE_LOST;
+        if (pd != icd.physical_devices.at(lookup_device(dev).phys_dev_index).vk_physical_device.handle) return VK_ERROR_DEVICE_LOST;
     }
     if (pTagInfo && pTagInfo->objectType == VK_OBJECT_TYPE_SURFACE_KHR) {
         if (pTagInfo->objectHandle != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
@@ -503,7 +544,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateDeviceLayerProperties(VkPhysicalD
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char* pLayerName,
                                                                          uint32_t* pPropertyCount,
                                                                          VkExtensionProperties* pProperties) {
-    auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+    auto& phys_dev = GetPhysDevice(physicalDevice);
     if (pLayerName != nullptr) {
         assert(false && "Drivers don't contain layers???");
         return VK_SUCCESS;
@@ -515,18 +556,17 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateDeviceExtensionProperties(VkPhysi
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice,
                                                                          uint32_t* pQueueFamilyPropertyCount,
                                                                          VkQueueFamilyProperties* pQueueFamilyProperties) {
-    auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+    auto& phys_dev = GetPhysDevice(physicalDevice);
     FillCountPtr(phys_dev.queue_family_properties, pQueueFamilyPropertyCount, pQueueFamilyProperties);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
     check_allocator_handle(pAllocator);
-    // VK_SUCCESS
-    auto found = std::find_if(icd.physical_devices.begin(), icd.physical_devices.end(), [physicalDevice](PhysicalDevice& phys_dev) {
-        return phys_dev.vk_physical_device.handle == physicalDevice;
-    });
-    if (found == icd.physical_devices.end()) return VK_ERROR_INITIALIZATION_FAILED;
+    auto found = find_physical_device(physicalDevice);
+    if (!is_physical_device_found(found)) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
     auto device_handle = DispatchableHandle<VkDevice>();
     *pDevice = device_handle.handle;
     found->device_handles.push_back(device_handle.handle);
@@ -543,7 +583,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroyDevice(VkDevice device, const VkAllocat
     check_allocator_handle(pAllocator);
     auto found = std::find(icd.device_handles.begin(), icd.device_handles.end(), device);
     if (found != icd.device_handles.end()) icd.device_handles.erase(found);
-    auto fd = icd.lookup_device(device);
+    auto fd = lookup_device(device);
     if (!fd.found) return;
     auto& phys_dev = icd.physical_devices.at(fd.phys_dev_index);
     phys_dev.device_handles.erase(phys_dev.device_handles.begin() + fd.dev_index);
@@ -623,7 +663,9 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWin32SurfaceKHR([[maybe_unused]] VkI
                                                             [[maybe_unused]] const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
                                                             const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    if (IsInstanceExtensionSupported(VK_KHR_WIN32_SURFACE_EXTENSION_NAME)) {
+        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    }
     return VK_SUCCESS;
 }
 
@@ -635,7 +677,9 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWaylandSurfaceKHR([[maybe_unused]] V
                                                               [[maybe_unused]] const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
                                                               const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    if (IsInstanceExtensionSupported(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME)) {
+        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    }
     return VK_SUCCESS;
 }
 
@@ -649,7 +693,9 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXcbSurfaceKHR([[maybe_unused]] VkIns
                                                           [[maybe_unused]] const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    if (IsInstanceExtensionSupported(VK_KHR_XCB_SURFACE_EXTENSION_NAME)) {
+        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    }
     return VK_SUCCESS;
 }
 
@@ -664,7 +710,9 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXlibSurfaceKHR([[maybe_unused]] VkIn
                                                            [[maybe_unused]] const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
                                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    if (IsInstanceExtensionSupported(VK_KHR_XCB_SURFACE_EXTENSION_NAME)) {
+        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    }
     return VK_SUCCESS;
 }
 
@@ -747,15 +795,17 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateHeadlessSurfaceEXT([[maybe_unused]] 
                                                                [[maybe_unused]] const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
                                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    if (IsInstanceExtensionSupported(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME)) {
+        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    }
     return VK_SUCCESS;
 }
 
 VKAPI_ATTR void VKAPI_CALL test_vkDestroySurfaceKHR([[maybe_unused]] VkInstance instance, VkSurfaceKHR surface,
                                                     const VkAllocationCallbacks* pAllocator) {
     if (surface != VK_NULL_HANDLE) {
-        uint64_t fake_surf_handle = from_nondispatch_handle(surface);
-        auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), fake_surf_handle);
+        uint64_t surf_handle = from_nondispatch_handle(surface);
+        auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), surf_handle);
         if (found_iter != icd.surface_handles.end()) {
             // Remove it from the list
             icd.surface_handles.erase(found_iter);
@@ -814,30 +864,32 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDeviceGroupSurfacePresentModesKHR([[may
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
                                                                          VkSurfaceKHR surface, VkBool32* pSupported) {
     if (surface != VK_NULL_HANDLE) {
-        uint64_t fake_surf_handle = (uint64_t)(surface);
-        auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), fake_surf_handle);
-        if (found_iter == icd.surface_handles.end()) {
-            assert(false && "Surface not found during GetPhysicalDeviceSurfaceSupportKHR query!");
-            return VK_ERROR_UNKNOWN;
+        if (!is_valid_surface(surface)) {
+            *pSupported = VK_FALSE;
+            return VK_SUCCESS;
         }
     }
     if (nullptr != pSupported) {
-        *pSupported = icd.GetPhysDevice(physicalDevice).queue_family_properties.at(queueFamilyIndex).support_present;
+        auto found = find_physical_device(physicalDevice);
+        if (is_physical_device_found(found)) {
+            *pSupported = found->queue_family_properties.at(queueFamilyIndex).support_present;
+        } else {
+            *pSupported = VK_FALSE;
+            return VK_SUCCESS;
+        }
     }
     return VK_SUCCESS;
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                               VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
     if (surface != VK_NULL_HANDLE) {
-        uint64_t fake_surf_handle = (uint64_t)(surface);
-        auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), fake_surf_handle);
-        if (found_iter == icd.surface_handles.end()) {
+        if (!is_valid_surface(surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfaceCapabilitiesKHR query!");
             return VK_ERROR_UNKNOWN;
         }
     }
     if (nullptr != pSurfaceCapabilities) {
-        *pSurfaceCapabilities = icd.GetPhysDevice(physicalDevice).surface_capabilities;
+        *pSurfaceCapabilities = GetPhysDevice(physicalDevice).surface_capabilities;
     }
     return VK_SUCCESS;
 }
@@ -845,9 +897,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceFormatsKHR(VkPhysi
                                                                          uint32_t* pSurfaceFormatCount,
                                                                          VkSurfaceFormatKHR* pSurfaceFormats) {
     if (surface != VK_NULL_HANDLE) {
-        uint64_t fake_surf_handle = (uint64_t)(surface);
-        auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), fake_surf_handle);
-        if (found_iter == icd.surface_handles.end()) {
+        if (!is_valid_surface(surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfaceFormatsKHR query!");
             return VK_ERROR_UNKNOWN;
         }
@@ -857,16 +907,14 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceFormatsKHR(VkPhysi
             return VK_ERROR_UNKNOWN;
         }
     }
-    FillCountPtr(icd.GetPhysDevice(physicalDevice).surface_formats, pSurfaceFormatCount, pSurfaceFormats);
+    FillCountPtr(GetPhysDevice(physicalDevice).surface_formats, pSurfaceFormatCount, pSurfaceFormats);
     return VK_SUCCESS;
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfacePresentModesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                               uint32_t* pPresentModeCount,
                                                                               VkPresentModeKHR* pPresentModes) {
     if (surface != VK_NULL_HANDLE) {
-        uint64_t fake_surf_handle = (uint64_t)(surface);
-        auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), fake_surf_handle);
-        if (found_iter == icd.surface_handles.end()) {
+        if (!is_valid_surface(surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfacePresentModesKHR query!");
             return VK_ERROR_UNKNOWN;
         }
@@ -876,7 +924,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfacePresentModesKHR(Vk
             return VK_ERROR_UNKNOWN;
         }
     }
-    FillCountPtr(icd.GetPhysDevice(physicalDevice).surface_present_modes, pPresentModeCount, pPresentModes);
+    FillCountPtr(GetPhysDevice(physicalDevice).surface_present_modes, pPresentModeCount, pPresentModes);
     return VK_SUCCESS;
 }
 
@@ -886,9 +934,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfacePresentModes2EXT(V
                                                                                uint32_t* pPresentModeCount,
                                                                                VkPresentModeKHR* pPresentModes) {
     if (pSurfaceInfo->surface != VK_NULL_HANDLE) {
-        uint64_t fake_surf_handle = (uint64_t)(pSurfaceInfo->surface);
-        auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), fake_surf_handle);
-        if (found_iter == icd.surface_handles.end()) {
+        if (!is_valid_surface(surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfacePresentModesKHR query!");
             return VK_ERROR_UNKNOWN;
         }
@@ -898,7 +944,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfacePresentModes2EXT(V
             return VK_ERROR_UNKNOWN;
         }
     }
-    FillCountPtr(icd.GetPhysDevice(physicalDevice).surface_present_modes, pPresentModeCount, pPresentModes);
+    FillCountPtr(GetPhysDevice(physicalDevice).surface_present_modes, pPresentModeCount, pPresentModes);
     return VK_SUCCESS;
 }
 #endif
@@ -907,25 +953,25 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfacePresentModes2EXT(V
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDevice physicalDevice,
                                                                             uint32_t* pPropertyCount,
                                                                             VkDisplayPropertiesKHR* pProperties) {
-    FillCountPtr(icd.GetPhysDevice(physicalDevice).display_properties, pPropertyCount, pProperties);
+    FillCountPtr(GetPhysDevice(physicalDevice).display_properties, pPropertyCount, pProperties);
     return VK_SUCCESS;
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(VkPhysicalDevice physicalDevice,
                                                                                  uint32_t* pPropertyCount,
                                                                                  VkDisplayPlanePropertiesKHR* pProperties) {
-    FillCountPtr(icd.GetPhysDevice(physicalDevice).display_plane_properties, pPropertyCount, pProperties);
+    FillCountPtr(GetPhysDevice(physicalDevice).display_plane_properties, pPropertyCount, pProperties);
     return VK_SUCCESS;
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice,
                                                                           [[maybe_unused]] uint32_t planeIndex,
                                                                           uint32_t* pDisplayCount, VkDisplayKHR* pDisplays) {
-    FillCountPtr(icd.GetPhysDevice(physicalDevice).displays, pDisplayCount, pDisplays);
+    FillCountPtr(GetPhysDevice(physicalDevice).displays, pDisplayCount, pDisplays);
     return VK_SUCCESS;
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice,
                                                                   [[maybe_unused]] VkDisplayKHR display, uint32_t* pPropertyCount,
                                                                   VkDisplayModePropertiesKHR* pProperties) {
-    FillCountPtr(icd.GetPhysDevice(physicalDevice).display_mode_properties, pPropertyCount, pProperties);
+    FillCountPtr(GetPhysDevice(physicalDevice).display_mode_properties, pPropertyCount, pProperties);
     return VK_SUCCESS;
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDisplayModeKHR(VkPhysicalDevice physicalDevice, [[maybe_unused]] VkDisplayKHR display,
@@ -933,7 +979,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDisplayModeKHR(VkPhysicalDevice phys
                                                            const VkAllocationCallbacks* pAllocator, VkDisplayModeKHR* pMode) {
     check_allocator_handle(pAllocator);
     if (nullptr != pMode) {
-        *pMode = icd.GetPhysDevice(physicalDevice).display_mode;
+        *pMode = GetPhysDevice(physicalDevice).display_mode;
     }
     return VK_SUCCESS;
 }
@@ -942,7 +988,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDisplayPlaneCapabilitiesKHR(VkPhysicalD
                                                                      [[maybe_unused]] uint32_t planeIndex,
                                                                      VkDisplayPlaneCapabilitiesKHR* pCapabilities) {
     if (nullptr != pCapabilities) {
-        *pCapabilities = icd.GetPhysDevice(physicalDevice).display_plane_capabilities;
+        *pCapabilities = GetPhysDevice(physicalDevice).display_plane_capabilities;
     }
     return VK_SUCCESS;
 }
@@ -950,7 +996,9 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDisplayPlaneSurfaceKHR(
     [[maybe_unused]] VkInstance instance, [[maybe_unused]] const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
     const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    if (IsInstanceExtensionSupported(VK_KHR_DISPLAY_EXTENSION_NAME)) {
+        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    }
     return VK_SUCCESS;
 }
 
@@ -961,7 +1009,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceCapabilities2KHR(V
     if (nullptr != pSurfaceInfo && nullptr != pSurfaceCapabilities) {
         if (IsInstanceExtensionSupported("VK_EXT_surface_maintenance1") &&
             IsInstanceExtensionEnabled("VK_EXT_surface_maintenance1")) {
-            auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+            auto& phys_dev = GetPhysDevice(physicalDevice);
             void* pNext = pSurfaceCapabilities->pNext;
             while (pNext) {
                 VkBaseOutStructure pNext_base_structure{};
@@ -1027,7 +1075,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhys
     if (nullptr != pSurfaceFormatCount) {
         test_vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, pSurfaceInfo->surface, pSurfaceFormatCount, nullptr);
         if (nullptr != pSurfaceFormats) {
-            auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+            auto& phys_dev = GetPhysDevice(physicalDevice);
             // Since the structures are different, we have to copy each item over seperately.  Since we have multiple, we
             // have to manually copy the data here instead of calling the next function
             for (uint32_t cnt = 0; cnt < *pSurfaceFormatCount; ++cnt) {
@@ -1082,7 +1130,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkAllocateCommandBuffers([[maybe_unused]] Vk
 
 VKAPI_ATTR void VKAPI_CALL test_vkGetDeviceQueue([[maybe_unused]] VkDevice device, [[maybe_unused]] uint32_t queueFamilyIndex,
                                                  uint32_t queueIndex, VkQueue* pQueue) {
-    auto fd = icd.lookup_device(device);
+    auto fd = lookup_device(device);
     if (fd.found) {
         *pQueue = icd.physical_devices.at(fd.phys_dev_index).queue_handles[queueIndex].handle;
     }
@@ -1093,8 +1141,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkAcquireDrmDisplayEXT(VkPhysicalDevice, int
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDrmDisplayEXT(VkPhysicalDevice physicalDevice, [[maybe_unused]] int32_t drmFd,
                                                        [[maybe_unused]] uint32_t connectorId, VkDisplayKHR* display) {
-    if (nullptr != display && icd.GetPhysDevice(physicalDevice).displays.size() > 0) {
-        *display = icd.GetPhysDevice(physicalDevice).displays[0];
+    if (nullptr != display && GetPhysDevice(physicalDevice).displays.size() > 0) {
+        *display = GetPhysDevice(physicalDevice).displays[0];
     }
     return VK_SUCCESS;
 }
@@ -1103,13 +1151,13 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDrmDisplayEXT(VkPhysicalDevice physical
 // 1.0
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures* pFeatures) {
     if (nullptr != pFeatures) {
-        memcpy(pFeatures, &icd.GetPhysDevice(physicalDevice).features, sizeof(VkPhysicalDeviceFeatures));
+        memcpy(pFeatures, &GetPhysDevice(physicalDevice).features, sizeof(VkPhysicalDeviceFeatures));
     }
 }
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
                                                               VkPhysicalDeviceProperties* pProperties) {
     if (nullptr != pProperties) {
-        auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+        auto& phys_dev = GetPhysDevice(physicalDevice);
         memcpy(pProperties, &phys_dev.properties, sizeof(VkPhysicalDeviceProperties));
         size_t max_len = (phys_dev.deviceName.length() > VK_MAX_PHYSICAL_DEVICE_NAME_SIZE) ? VK_MAX_PHYSICAL_DEVICE_NAME_SIZE
                                                                                            : phys_dev.deviceName.length();
@@ -1120,19 +1168,19 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceProperties(VkPhysicalDevice p
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceMemoryProperties(VkPhysicalDevice physicalDevice,
                                                                     VkPhysicalDeviceMemoryProperties* pMemoryProperties) {
     if (nullptr != pMemoryProperties) {
-        memcpy(pMemoryProperties, &icd.GetPhysDevice(physicalDevice).memory_properties, sizeof(VkPhysicalDeviceMemoryProperties));
+        memcpy(pMemoryProperties, &GetPhysDevice(physicalDevice).memory_properties, sizeof(VkPhysicalDeviceMemoryProperties));
     }
 }
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceSparseImageFormatProperties(
     VkPhysicalDevice physicalDevice, [[maybe_unused]] VkFormat format, [[maybe_unused]] VkImageType type,
     [[maybe_unused]] VkSampleCountFlagBits samples, [[maybe_unused]] VkImageUsageFlags usage, [[maybe_unused]] VkImageTiling tiling,
     uint32_t* pPropertyCount, VkSparseImageFormatProperties* pProperties) {
-    FillCountPtr(icd.GetPhysDevice(physicalDevice).sparse_image_format_properties, pPropertyCount, pProperties);
+    FillCountPtr(GetPhysDevice(physicalDevice).sparse_image_format_properties, pPropertyCount, pProperties);
 }
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                     VkFormatProperties* pFormatProperties) {
     if (nullptr != pFormatProperties) {
-        memcpy(pFormatProperties, &icd.GetPhysDevice(physicalDevice).format_properties[static_cast<uint32_t>(format)],
+        memcpy(pFormatProperties, &GetPhysDevice(physicalDevice).format_properties[static_cast<uint32_t>(format)],
                sizeof(VkFormatProperties));
     }
 }
@@ -1141,7 +1189,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceImageFormatProperties(
     [[maybe_unused]] VkImageTiling tiling, [[maybe_unused]] VkImageUsageFlags usage, [[maybe_unused]] VkImageCreateFlags flags,
     VkImageFormatProperties* pImageFormatProperties) {
     if (nullptr != pImageFormatProperties) {
-        memcpy(pImageFormatProperties, &icd.GetPhysDevice(physicalDevice).image_format_properties, sizeof(VkImageFormatProperties));
+        memcpy(pImageFormatProperties, &GetPhysDevice(physicalDevice).image_format_properties, sizeof(VkImageFormatProperties));
     }
     return VK_SUCCESS;
 }
@@ -1156,7 +1204,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceFeatures2(VkPhysicalDevice ph
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice,
                                                                VkPhysicalDeviceProperties2* pProperties) {
     if (nullptr != pProperties) {
-        auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+        auto& phys_dev = GetPhysDevice(physicalDevice);
         test_vkGetPhysicalDeviceProperties(physicalDevice, &pProperties->properties);
         VkBaseInStructure* pNext = reinterpret_cast<VkBaseInStructure*>(pProperties->pNext);
         while (pNext) {
@@ -1184,7 +1232,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceQueueFamilyProperties2(VkPhys
     if (nullptr != pQueueFamilyPropertyCount) {
         test_vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, nullptr);
         if (nullptr != pQueueFamilyProperties) {
-            auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+            auto& phys_dev = GetPhysDevice(physicalDevice);
             // Since the structures are different, we have to copy each item over seperately.  Since we have multiple, we
             // have to manually copy the data here instead of calling the next function
             for (uint32_t queue = 0; queue < *pQueueFamilyPropertyCount; ++queue) {
@@ -1202,7 +1250,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceSparseImageFormatProperties2(
                                                             pFormatInfo->samples, pFormatInfo->usage, pFormatInfo->tiling,
                                                             pPropertyCount, nullptr);
         if (nullptr != pProperties) {
-            auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+            auto& phys_dev = GetPhysDevice(physicalDevice);
             // Since the structures are different, we have to copy each item over seperately.  Since we have multiple, we
             // have to manually copy the data here instead of calling the next function
             for (uint32_t cnt = 0; cnt < *pPropertyCount; ++cnt) {
@@ -1236,7 +1284,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceExternalBufferProperties(
     VkPhysicalDevice physicalDevice, [[maybe_unused]] const VkPhysicalDeviceExternalBufferInfo* pExternalBufferInfo,
     VkExternalBufferProperties* pExternalBufferProperties) {
     if (nullptr != pExternalBufferProperties) {
-        auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+        auto& phys_dev = GetPhysDevice(physicalDevice);
         memcpy(&pExternalBufferProperties->externalMemoryProperties, &phys_dev.external_memory_properties,
                sizeof(VkExternalMemoryProperties));
     }
@@ -1245,7 +1293,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceExternalSemaphoreProperties(
     VkPhysicalDevice physicalDevice, [[maybe_unused]] const VkPhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo,
     VkExternalSemaphoreProperties* pExternalSemaphoreProperties) {
     if (nullptr != pExternalSemaphoreProperties) {
-        auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+        auto& phys_dev = GetPhysDevice(physicalDevice);
         memcpy(pExternalSemaphoreProperties, &phys_dev.external_semaphore_properties, sizeof(VkExternalSemaphoreProperties));
     }
 }
@@ -1253,7 +1301,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceExternalFenceProperties(
     VkPhysicalDevice physicalDevice, [[maybe_unused]] const VkPhysicalDeviceExternalFenceInfo* pExternalFenceInfo,
     VkExternalFenceProperties* pExternalFenceProperties) {
     if (nullptr != pExternalFenceProperties) {
-        auto& phys_dev = icd.GetPhysDevice(physicalDevice);
+        auto& phys_dev = GetPhysDevice(physicalDevice);
         memcpy(pExternalFenceProperties, &phys_dev.external_fence_properties, sizeof(VkExternalFenceProperties));
     }
 }
@@ -1655,10 +1703,9 @@ bool should_check(std::vector<const char*> const& exts, VkDevice device, const c
 }
 
 PFN_vkVoidFunction get_device_func(VkDevice device, const char* pName) {
-    TestICD::FindDevice fd{};
     DeviceCreateInfo create_info{};
     if (device != nullptr) {
-        fd = icd.lookup_device(device);
+        auto fd = lookup_device(device);
         if (!fd.found) return NULL;
         create_info = icd.physical_devices.at(fd.phys_dev_index).device_create_infos.at(fd.dev_index);
     }

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -934,7 +934,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfacePresentModes2EXT(V
                                                                                uint32_t* pPresentModeCount,
                                                                                VkPresentModeKHR* pPresentModes) {
     if (pSurfaceInfo->surface != VK_NULL_HANDLE) {
-        if (!is_valid_surface(surface)) {
+        if (!is_valid_surface(pSurfaceInfo->surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfacePresentModesKHR query!");
             return VK_ERROR_UNKNOWN;
         }

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -220,41 +220,11 @@ struct TestICD {
     BUILDER_VALUE_WITH_DEFAULT(VkResult, enum_physical_devices_return_code, VK_SUCCESS);
     BUILDER_VALUE_WITH_DEFAULT(VkResult, enum_adapter_physical_devices_return_code, VK_SUCCESS);
 
-    PhysicalDevice& GetPhysDevice(VkPhysicalDevice physicalDevice) {
-        for (auto& phys_dev : physical_devices) {
-            if (phys_dev.vk_physical_device.handle == physicalDevice) return phys_dev;
-        }
-        assert(false && "vkPhysicalDevice not found!");
-        return physical_devices[0];
-    }
-
     InstanceCreateInfo GetVkInstanceCreateInfo() {
         InstanceCreateInfo info;
         for (auto& layer : instance_layers) info.enabled_layers.push_back(layer.layerName.data());
         for (auto& ext : instance_extensions) info.enabled_extensions.push_back(ext.extensionName.data());
         return info;
-    }
-
-    struct FindDevice {
-        bool found = false;
-        uint32_t phys_dev_index = 0;
-        uint32_t dev_index = 0;
-    };
-
-    FindDevice lookup_device(VkDevice device) {
-        FindDevice fd{};
-        for (uint32_t p = 0; p < physical_devices.size(); p++) {
-            auto const& phys_dev = physical_devices.at(p);
-            for (uint32_t d = 0; d < phys_dev.device_handles.size(); d++) {
-                if (phys_dev.device_handles.at(d) == device) {
-                    fd.found = true;
-                    fd.phys_dev_index = p;
-                    fd.dev_index = d;
-                    return fd;
-                }
-            }
-        }
-        return fd;
     }
 
 #if defined(WIN32)


### PR DESCRIPTION
wsi_unwrap_icd_surface() returns VK_ERROR_EXTENSION_NOT_PRESENT when the
surface extension isn't supported by an ICD. Which is a problem for
vkGetPhysicalDeviceSurfaceSupportKHR because its suppose to set the out
parameter to false, not return an error code. The fix is to not propagate VK_ERROR_EXTENSION_NOT_PRESENT
up from vkGetPhysicalDeviceSurfaceSupportKHR, simply set pSupported to false and return VK_SUCCESS.

Also makes improvements to test_icd.cpp and adds a test for this case (only valid on linux, where multiple surface extensions are easily used at the same time).

@aqnuep Not looking for a heavy review, more making sure you agree that vkGetPhysicalDeviceSurfaceSupportKHR had a bug and this is the fix for it.