### PR TITLE
Cleanup command extension checking of device functions

### DIFF
--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -1627,7 +1627,7 @@ void init_extension_device_proc_terminator_dispatch(struct loader_device *dev) {
     // ---- VK_KHR_swapchain extension commands
     if (dev->driver_extensions.khr_swapchain_enabled)
        dispatch->CreateSwapchainKHR = (PFN_vkCreateSwapchainKHR)gpda(dev->icd_device, "vkCreateSwapchainKHR");
-    if (dev->driver_extensions.khr_swapchain_enabled)
+    if (dev->driver_extensions.khr_swapchain_enabled || dev->driver_extensions.khr_device_group_enabled)
        dispatch->GetDeviceGroupSurfacePresentModesKHR = (PFN_vkGetDeviceGroupSurfacePresentModesKHR)gpda(dev->icd_device, "vkGetDeviceGroupSurfacePresentModesKHR");
 
     // ---- VK_KHR_display_swapchain extension commands
@@ -1660,7 +1660,7 @@ void init_extension_device_proc_terminator_dispatch(struct loader_device *dev) {
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 
     // ---- VK_EXT_full_screen_exclusive extension commands
-    if (dev->driver_extensions.ext_full_screen_exclusive_enabled && (dev->driver_extensions.khr_device_group_enabled || dev->driver_extensions.version_1_1_enabled))
+    if (dev->driver_extensions.ext_full_screen_exclusive_enabled)
        dispatch->GetDeviceGroupSurfacePresentModes2EXT = (PFN_vkGetDeviceGroupSurfacePresentModes2EXT)gpda(dev->icd_device, "vkGetDeviceGroupSurfacePresentModes2EXT");
 #endif // VK_USE_PLATFORM_WIN32_KHR
 }
@@ -13648,7 +13648,7 @@ PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *de
     }
     if (!strcmp(name, "GetDeviceGroupSurfacePresentModesKHR")) {
         *found_name = true;
-        return dev->driver_extensions.khr_swapchain_enabled ?
+        return dev->driver_extensions.khr_swapchain_enabled || dev->driver_extensions.khr_device_group_enabled ?
             (PFN_vkVoidFunction)terminator_GetDeviceGroupSurfacePresentModesKHR : NULL;
     }
     // ---- VK_KHR_display_swapchain extension commands
@@ -13713,7 +13713,7 @@ PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *de
     // ---- VK_EXT_full_screen_exclusive extension commands
     if (!strcmp(name, "GetDeviceGroupSurfacePresentModes2EXT")) {
         *found_name = true;
-        return (dev->driver_extensions.ext_full_screen_exclusive_enabled && (dev->driver_extensions.khr_device_group_enabled || dev->driver_extensions.version_1_1_enabled)) ?
+        return dev->driver_extensions.ext_full_screen_exclusive_enabled ?
             (PFN_vkVoidFunction)terminator_GetDeviceGroupSurfacePresentModes2EXT : NULL;
     }
 #endif // VK_USE_PLATFORM_WIN32_KHR


### PR DESCRIPTION
Remove some TODO's about needing the detailed dependency info of a command. Commands from extensions are available if any of the extensions they come from are enabled. The extensions themselves have complex requirements for enabling, but because the loader tries to do basic validation, it should only check that the primary extensions are available. This is so that the loader doesn't replicate all of the complicated dependency checking logic that already present in the Validation Layer.