### PR TITLE
Speedup tests by putting physical devices in a map

### DIFF
--- a/tests/loader_alloc_callback_tests.cpp
+++ b/tests/loader_alloc_callback_tests.cpp
@@ -714,8 +714,7 @@ TEST(Allocation, CreateInstanceDeviceIntentionalAllocFail) {
                         .set_library_arch(sizeof(void*) == 8 ? "64" : "32"))
             .set_icd_api_version(VK_API_VERSION_1_1)
             .add_instance_extension("VK_KHR_get_physical_device_properties2")
-            .add_physical_device("physical_device_0")
-            .physical_devices.at(0)
+            .add_and_get_physical_device("physical_device_0")
             .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false})
             .add_extensions({"VK_EXT_one", "VK_EXT_two", "VK_EXT_three", "VK_EXT_four", "VK_EXT_five"});
     }
@@ -880,7 +879,7 @@ TEST(Allocation, EnumeratePhysicalDevicesIntentionalAllocFail) {
         auto& driver = env.reset_icd();
 
         for (uint32_t i = 0; i < physical_dev_count; i++) {
-            driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i))
+            driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i))
                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false});
         }
         MemoryTracker tracker{{false, 0, true, fail_index}};
@@ -902,7 +901,7 @@ TEST(Allocation, EnumeratePhysicalDevicesIntentionalAllocFail) {
         ASSERT_EQ(physical_dev_count, returned_physical_count);
 
         for (uint32_t i = 0; i < 2; i++) {
-            driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(physical_dev_count))
+            driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(physical_dev_count))
                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false});
             physical_dev_count += 1;
         }
@@ -976,7 +975,7 @@ TEST(Allocation, CreateInstanceDeviceWithDXGIDriverIntentionalAllocFail) {
 
     for (uint32_t i = 0; i < 2; i++) {
         auto& driver = env.get_test_icd(i);
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i))
+        driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i))
             .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false});
     }
 

--- a/tests/loader_debug_ext_tests.cpp
+++ b/tests/loader_debug_ext_tests.cpp
@@ -53,8 +53,8 @@ class DebugReportTest : public ::testing::Test {
         env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
         for (uint32_t icd = 0; icd < 3; ++icd) {
             env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_0));
-            env->get_test_icd(icd).physical_devices.push_back({});
-            env->get_test_icd(icd).physical_devices.push_back({});
+            env->get_test_icd(icd).add_physical_device({});
+            env->get_test_icd(icd).add_physical_device({});
         }
         // Initialize the expected output
         allow_any_message = false;
@@ -387,8 +387,8 @@ class DebugUtilTest : public ::testing::Test {
         env = std::unique_ptr<FrameworkEnvironment>(new FrameworkEnvironment());
         for (uint32_t icd = 0; icd < 3; ++icd) {
             env->add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_0));
-            env->get_test_icd(icd).physical_devices.push_back({});
-            env->get_test_icd(icd).physical_devices.push_back({});
+            env->get_test_icd(icd).add_physical_device({});
+            env->get_test_icd(icd).add_physical_device({});
         }
         // Initialize the expected output
         allow_any_message = false;
@@ -1041,9 +1041,8 @@ void CheckDeviceFunctions(FrameworkEnvironment& env, bool use_GIPA, bool enable_
 
 TEST(GetProcAddr, DebugFuncsWithTerminator) {
     FrameworkEnvironment env{};
-    auto& driver =
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).setup_WSI().add_physical_device("physical_device_0");
-    driver.physical_devices.at(0).add_extensions({"VK_KHR_swapchain"});
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).setup_WSI();
+    auto& phys_dev = driver.add_and_get_physical_device("physical_device_0").add_extensions({"VK_KHR_swapchain"});
     // Hardware doesn't support the debug extensions
 
     // Use getDeviceProcAddr & vary enabling the debug extensions
@@ -1056,7 +1055,7 @@ TEST(GetProcAddr, DebugFuncsWithTerminator) {
 
     // Now set the hardware to support the extensions and run the situations again
     driver.add_instance_extensions({"VK_EXT_debug_utils", "VK_EXT_debug_report"});
-    driver.physical_devices.at(0).add_extensions({"VK_EXT_debug_marker"});
+    phys_dev.add_extensions({"VK_EXT_debug_marker"});
 
     // Use getDeviceProcAddr & vary enabling the debug extensions
     ASSERT_NO_FATAL_FAILURE(CheckDeviceFunctions(env, false, false, true));
@@ -1069,9 +1068,10 @@ TEST(GetProcAddr, DebugFuncsWithTerminator) {
 
 TEST(GetProcAddr, DebugFuncsWithTrampoline) {
     FrameworkEnvironment env{};
-    auto& driver =
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).setup_WSI().add_physical_device("physical_device_0");
-    driver.physical_devices.at(0).add_extensions({"VK_KHR_swapchain"});
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA))
+                       .setup_WSI()
+                       .add_and_get_physical_device("physical_device_0")
+                       .add_extensions({"VK_KHR_swapchain"});
     // Hardware doesn't support the debug extensions
 
     // Use getDeviceProcAddr & vary enabling the debug extensions
@@ -1103,9 +1103,10 @@ TEST(GetProcAddr, DebugFuncsWithTrampoline) {
 
 TEST(GetProcAddr, DebugFuncsWithDebugExtsForceAdded) {
     FrameworkEnvironment env{};
-    auto& driver =
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).setup_WSI().add_physical_device("physical_device_0");
-    driver.physical_devices.at(0).add_extensions({"VK_KHR_swapchain"});
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA))
+                       .setup_WSI()
+                       .add_and_get_physical_device("physical_device_0")
+                       .add_extensions({"VK_KHR_swapchain"});
     // Hardware doesn't support the debug extensions
 
     // Use getDeviceProcAddr & vary enabling the debug extensions

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -256,7 +256,7 @@ TEST(EnvVarICDOverrideSetup, XDGContainsJsonFile) {
 TEST(EnvVarICDOverrideSetup, TestOnlyAddDriverEnvVar) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_EXPORT_NONE).set_discovery_type(ManifestDiscoveryType::add_env_var));
-    env.get_test_icd(0).physical_devices.emplace_back("pd0");
+    env.get_test_icd(0).add_and_get_physical_device("pd0");
 
     InstWrapper inst{env.vulkan_functions};
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
@@ -272,7 +272,7 @@ TEST(EnvVarICDOverrideSetup, TestOnlyAddDriverEnvVar) {
 TEST(EnvVarICDOverrideSetup, TestOnlyAddDriverEnvVarRunningWithElevatedPrivileges) {
     FrameworkEnvironment env{FrameworkSettings{}.set_run_as_if_with_elevated_privleges(true)};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_EXPORT_NONE).set_discovery_type(ManifestDiscoveryType::add_env_var));
-    env.get_test_icd(0).physical_devices.emplace_back("pd0");
+    env.get_test_icd(0).add_and_get_physical_device("pd0");
 
     InstWrapper inst{env.vulkan_functions};
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);

--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -202,8 +202,9 @@ TEST(GetProcAddr, Verify10FunctionsLoadWithMultipleDrivers) {
 // and return VK_SUCCESS to maintain previous behavior.
 TEST(GetDeviceProcAddr, SwapchainFuncsWithTerminator) {
     FrameworkEnvironment env{};
-    auto& driver =
-        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).setup_WSI().add_physical_device("physical_device_0");
+    auto& test_physical_device = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA))
+                                     .setup_WSI()
+                                     .add_and_get_physical_device("physical_device_0");
 
     InstWrapper inst(env.vulkan_functions);
     inst.create_info.add_extension("VK_EXT_debug_utils");
@@ -250,7 +251,7 @@ TEST(GetDeviceProcAddr, SwapchainFuncsWithTerminator) {
         log.logger.clear();
         ASSERT_FALSE(dev_funcs.vkDestroySwapchainKHR);
     }
-    driver.physical_devices.at(0).add_extensions({"VK_KHR_swapchain", "VK_KHR_display_swapchain", "VK_EXT_debug_marker"});
+    test_physical_device.add_extensions({"VK_KHR_swapchain", "VK_KHR_display_swapchain", "VK_EXT_debug_marker"});
     {
         DeviceWrapper dev{inst};
         dev.create_info.add_extensions({"VK_KHR_swapchain", "VK_KHR_display_swapchain", "VK_EXT_debug_marker"});
@@ -328,15 +329,15 @@ TEST(GetProcAddr, PreserveLayerGettingVkCreateDeviceWithNullInstance) {
 
 TEST(GetDeviceProcAddr, AppQueries11FunctionsWhileOnlyEnabling10) {
     FrameworkEnvironment env{};
-    auto& driver =
+    auto& test_physical_device =
         env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1))
             .set_icd_api_version(VK_API_VERSION_1_1)
-            .add_physical_device(
+            .add_and_get_physical_device(
                 PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).add_extension(VK_KHR_MAINTENANCE_5_EXTENSION_NAME).finish());
 
     std::vector<const char*> functions = {"vkGetDeviceQueue2", "vkCmdDispatchBase", "vkCreateDescriptorUpdateTemplate"};
     for (const auto& f : functions) {
-        driver.physical_devices.back().add_device_function(VulkanFunction{f, [] {}});
+        test_physical_device.add_device_function(VulkanFunction{f, [] {}});
     }
     {  // doesn't enable the feature or extension
         InstWrapper inst{env.vulkan_functions};
@@ -382,15 +383,15 @@ TEST(GetDeviceProcAddr, AppQueries11FunctionsWhileOnlyEnabling10) {
 
 TEST(GetDeviceProcAddr, AppQueries12FunctionsWhileOnlyEnabling11) {
     FrameworkEnvironment env{};
-    auto& driver =
+    auto& test_physical_device =
         env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_2))
             .set_icd_api_version(VK_API_VERSION_1_2)
-            .add_physical_device(
+            .add_and_get_physical_device(
                 PhysicalDevice{}.set_api_version(VK_API_VERSION_1_2).add_extension(VK_KHR_MAINTENANCE_5_EXTENSION_NAME).finish());
     std::vector<const char*> functions = {"vkCmdDrawIndirectCount", "vkCmdNextSubpass2", "vkGetBufferDeviceAddress",
                                           "vkGetDeviceMemoryOpaqueCaptureAddress"};
     for (const auto& f : functions) {
-        driver.physical_devices.back().add_device_function(VulkanFunction{f, [] {}});
+        test_physical_device.add_device_function(VulkanFunction{f, [] {}});
     }
     {  // doesn't enable the feature or extension
         InstWrapper inst{env.vulkan_functions};
@@ -439,16 +440,16 @@ TEST(GetDeviceProcAddr, AppQueries12FunctionsWhileOnlyEnabling11) {
 
 TEST(GetDeviceProcAddr, AppQueries13FunctionsWhileOnlyEnabling12) {
     FrameworkEnvironment env{};
-    auto& driver =
+    auto& test_physical_device =
         env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_3))
             .set_icd_api_version(VK_API_VERSION_1_3)
-            .add_physical_device(
+            .add_and_get_physical_device(
                 PhysicalDevice{}.set_api_version(VK_API_VERSION_1_3).add_extension(VK_KHR_MAINTENANCE_5_EXTENSION_NAME).finish());
     std::vector<const char*> functions = {"vkCreatePrivateDataSlot", "vkGetDeviceBufferMemoryRequirements", "vkCmdWaitEvents2",
                                           "vkGetDeviceImageSparseMemoryRequirements"};
 
     for (const auto& f : functions) {
-        driver.physical_devices.back().add_device_function(VulkanFunction{f, [] {}});
+        test_physical_device.add_device_function(VulkanFunction{f, [] {}});
     }
     {  // doesn't enable the feature or extension
         InstWrapper inst{env.vulkan_functions};

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -4803,6 +4803,7 @@ TEST(LayerPhysDeviceMod, AddPhysicalDevices) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
+        std::array<PhysicalDevice*, 3> added_phys_devs;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
@@ -4812,12 +4813,11 @@ TEST(LayerPhysDeviceMod, AddPhysicalDevices) {
 #else
             strncpy(properties.deviceName, dev_name.c_str(), VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 #endif
-            cur_icd.add_physical_device({});
-            cur_icd.physical_devices.back().set_properties(properties);
+            added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[0]);
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(cur_icd.physical_devices[2]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
+        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
     }
     const uint32_t icd_devices = 6;
 
@@ -4880,6 +4880,7 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDevices) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
+        std::array<PhysicalDevice*, 3> added_phys_devs;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
@@ -4889,12 +4890,11 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDevices) {
 #else
             strncpy(properties.deviceName, dev_name.c_str(), VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 #endif
-            cur_icd.add_physical_device({});
-            cur_icd.physical_devices.back().set_properties(properties);
+            added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[0]);
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(cur_icd.physical_devices[2]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
+        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
     }
     const uint32_t icd_devices = 6;
 
@@ -4930,6 +4930,7 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDevices) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
+        std::array<PhysicalDevice*, 3> added_phys_devs;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
@@ -4939,12 +4940,11 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDevices) {
 #else
             strncpy(properties.deviceName, dev_name.c_str(), VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 #endif
-            cur_icd.add_physical_device({});
-            cur_icd.physical_devices.back().set_properties(properties);
+            added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[0]);
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(cur_icd.physical_devices[2]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
+        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
     }
     const uint32_t icd_devices = 6;
 
@@ -4980,6 +4980,7 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
+        std::array<PhysicalDevice*, 3> added_phys_devs;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
@@ -4989,12 +4990,11 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
 #else
             strncpy(properties.deviceName, dev_name.c_str(), VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 #endif
-            cur_icd.add_physical_device({});
-            cur_icd.physical_devices.back().set_properties(properties);
+            added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[0]);
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(cur_icd.physical_devices[2]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
+        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
     }
     const uint32_t icd_devices = 6;
 
@@ -5056,6 +5056,7 @@ TEST(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
+        std::array<PhysicalDevice*, 3> added_phys_devs;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
@@ -5065,12 +5066,11 @@ TEST(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
 #else
             strncpy(properties.deviceName, dev_name.c_str(), VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 #endif
-            cur_icd.add_physical_device({});
-            cur_icd.physical_devices.back().set_properties(properties);
+            added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[0]);
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(cur_icd.physical_devices[2]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
+        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
     }
     const uint32_t icd_groups = 4;
 
@@ -5143,6 +5143,7 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
+        std::array<PhysicalDevice*, 3> added_phys_devs;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
@@ -5152,12 +5153,11 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
 #else
             strncpy(properties.deviceName, dev_name.c_str(), VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 #endif
-            cur_icd.add_physical_device({});
-            cur_icd.physical_devices.back().set_properties(properties);
+            added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[0]);
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(cur_icd.physical_devices[2]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
+        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
     }
     const uint32_t icd_groups = 3;
 
@@ -5195,6 +5195,7 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
+        std::array<PhysicalDevice*, 3> added_phys_devs;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
@@ -5204,12 +5205,11 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
 #else
             strncpy(properties.deviceName, dev_name.c_str(), VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 #endif
-            cur_icd.add_physical_device({});
-            cur_icd.physical_devices.back().set_properties(properties);
+            added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[0]);
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(cur_icd.physical_devices[2]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
+        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
     }
     const uint32_t icd_groups = 4;
 
@@ -5247,6 +5247,7 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
         VkPhysicalDeviceProperties properties{};
         properties.apiVersion = VK_API_VERSION_1_2;
         properties.vendorID = 0x11000000 + (icd << 6);
+        std::array<PhysicalDevice*, 3> added_phys_devs;
         for (uint32_t dev = 0; dev < 3; ++dev) {
             properties.deviceID = properties.vendorID + dev;
             properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
@@ -5256,12 +5257,11 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
 #else
             strncpy(properties.deviceName, dev_name.c_str(), VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 #endif
-            cur_icd.add_physical_device({});
-            cur_icd.physical_devices.back().set_properties(properties);
+            added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[0]);
-        cur_icd.physical_device_groups.back().use_physical_device(cur_icd.physical_devices[1]);
-        cur_icd.physical_device_groups.emplace_back(cur_icd.physical_devices[2]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
+        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[1]);
+        cur_icd.physical_device_groups.emplace_back(added_phys_devs[2]);
     }
     const uint32_t icd_groups = 4;
 

--- a/tests/loader_phys_dev_inst_ext_tests.cpp
+++ b/tests/loader_phys_dev_inst_ext_tests.cpp
@@ -60,7 +60,7 @@ void FillInRandomDeviceProps(VkPhysicalDeviceProperties& props, uint32_t api_ver
 TEST(LoaderInstPhysDevExts, PhysDevProps2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -73,7 +73,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevProps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -87,9 +87,9 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2KHRNoICDSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_API_VERSION_1_0, 5, 123);
+    FillInRandomDeviceProps(test_physical_device.properties, VK_API_VERSION_1_0, 5, 123);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -125,9 +125,9 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2Simple) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_1));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_API_VERSION_1_1, 5, 123);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device.properties, VK_API_VERSION_1_1, 5, 123);
     {
         InstWrapper instance(env.vulkan_functions);
         instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -227,9 +227,9 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_0));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_API_VERSION_1_0, 5, 123);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device.properties, VK_API_VERSION_1_0, 5, 123);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -312,8 +312,7 @@ TEST(LoaderInstPhysDevExts, PhysDevProps2Mixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -415,7 +414,7 @@ void FillInRandomFeatures(VkPhysicalDeviceFeatures& feats) {
 TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -428,7 +427,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevFeatsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -443,8 +442,8 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomFeatures(env.get_test_icd(0).physical_devices.back().features);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomFeatures(test_physical_device.features);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -473,10 +472,10 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2Simple) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_1));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    env.get_test_icd(0).physical_devices.back().set_api_version(VK_API_VERSION_1_1);
-    FillInRandomFeatures(env.get_test_icd(0).physical_devices.back().features);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    test_physical_device.set_api_version(VK_API_VERSION_1_1);
+    FillInRandomFeatures(test_physical_device.features);
     {
         InstWrapper instance(env.vulkan_functions);
         instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -556,9 +555,9 @@ TEST(LoaderInstPhysDevExts, PhysDevFeats2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_0));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    FillInRandomFeatures(env.get_test_icd(0).physical_devices.back().features);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    FillInRandomFeatures(test_physical_device.features);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -628,8 +627,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFeatsMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -678,7 +676,7 @@ void FillInRandomFormatProperties(std::vector<VkFormatProperties>& props) {
 TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -692,7 +690,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevFormatPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -708,8 +706,8 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomFormatProperties(env.get_test_icd(0).physical_devices.back().format_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomFormatProperties(test_physical_device.format_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extensions(
@@ -745,10 +743,10 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatProps2Simple) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_1));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    env.get_test_icd(0).physical_devices.back().set_api_version(VK_API_VERSION_1_1);
-    FillInRandomFormatProperties(env.get_test_icd(0).physical_devices.back().format_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    test_physical_device.set_api_version(VK_API_VERSION_1_1);
+    FillInRandomFormatProperties(test_physical_device.format_properties);
     {
         InstWrapper instance(env.vulkan_functions);
         instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -834,9 +832,9 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatProps2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    FillInRandomFormatProperties(env.get_test_icd(0).physical_devices.back().format_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    FillInRandomFormatProperties(test_physical_device.format_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -912,8 +910,7 @@ TEST(LoaderInstPhysDevExts, PhysDevFormatPropsMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -966,7 +963,7 @@ void FillInRandomImageFormatData(VkImageFormatProperties& props) {
 TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -980,7 +977,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevImageFormatPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -996,8 +993,8 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomImageFormatData(env.get_test_icd(0).physical_devices.back().image_format_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomImageFormatData(test_physical_device.image_format_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1046,9 +1043,9 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2Simple) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    FillInRandomImageFormatData(env.get_test_icd(0).physical_devices.back().image_format_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    FillInRandomImageFormatData(test_physical_device.image_format_properties);
     {
         InstWrapper instance(env.vulkan_functions);
         instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -1189,9 +1186,9 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatProps2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    FillInRandomImageFormatData(env.get_test_icd(0).physical_devices.back().image_format_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    FillInRandomImageFormatData(test_physical_device.image_format_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -1289,8 +1286,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatPropsMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -1349,7 +1345,7 @@ TEST(LoaderInstPhysDevExts, PhysDevImageFormatPropsMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -1363,7 +1359,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevMemoryPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1393,8 +1389,8 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomMemoryData(env.get_test_icd(0).physical_devices.back().memory_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomMemoryData(test_physical_device.memory_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1425,9 +1421,9 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2Simple) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    FillInRandomMemoryData(env.get_test_icd(0).physical_devices.back().memory_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    FillInRandomMemoryData(test_physical_device.memory_properties);
     {
         InstWrapper instance(env.vulkan_functions);
         instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -1508,9 +1504,9 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryProps2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    FillInRandomMemoryData(env.get_test_icd(0).physical_devices.back().memory_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    FillInRandomMemoryData(test_physical_device.memory_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -1580,8 +1576,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryPropsMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -1621,7 +1616,7 @@ TEST(LoaderInstPhysDevExts, PhysDevMemoryPropsMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -1635,7 +1630,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1666,8 +1661,8 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    uint32_t num_fam = FillInRandomQueueFamilyData(env.get_test_icd(0).physical_devices.back().queue_family_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    uint32_t num_fam = FillInRandomQueueFamilyData(test_physical_device.queue_family_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1707,9 +1702,9 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2Simple) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    uint32_t num_fam = FillInRandomQueueFamilyData(env.get_test_icd(0).physical_devices.back().queue_family_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    uint32_t num_fam = FillInRandomQueueFamilyData(test_physical_device.queue_family_properties);
     {
         InstWrapper instance(env.vulkan_functions);
         instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -1820,9 +1815,9 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyProps2KHRInstanceSupports11) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    uint32_t num_fam = FillInRandomQueueFamilyData(env.get_test_icd(0).physical_devices.back().queue_family_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    uint32_t num_fam = FillInRandomQueueFamilyData(test_physical_device.queue_family_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -1907,8 +1902,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyPropsMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -1956,7 +1950,7 @@ TEST(LoaderInstPhysDevExts, PhysDevQueueFamilyPropsMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -1970,7 +1964,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1997,8 +1991,8 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRInstanceAndICDSuppo
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomSparseImageFormatData(env.get_test_icd(0).physical_devices.back().sparse_image_format_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomSparseImageFormatData(test_physical_device.sparse_image_format_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -2052,9 +2046,9 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2Simple) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    FillInRandomSparseImageFormatData(env.get_test_icd(0).physical_devices.back().sparse_image_format_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    FillInRandomSparseImageFormatData(test_physical_device.sparse_image_format_properties);
     {
         InstWrapper instance(env.vulkan_functions);
         instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -2207,9 +2201,9 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatProps2KHRInstanceSupports11)
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
-    FillInRandomSparseImageFormatData(env.get_test_icd(0).physical_devices.back().sparse_image_format_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, 0});
+    FillInRandomSparseImageFormatData(test_physical_device.sparse_image_format_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -2309,8 +2303,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatPropsMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -2378,7 +2371,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSparseImageFormatPropsMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsKHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -2392,7 +2385,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsKHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
@@ -2415,8 +2408,8 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomExtMemoryData(env.get_test_icd(0).physical_devices.back().external_memory_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomExtMemoryData(test_physical_device.external_memory_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
@@ -2434,7 +2427,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2KHRInstanceAndICDSupport) {
     VkPhysicalDeviceExternalBufferInfoKHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO_KHR};
     VkExternalBufferPropertiesKHR props{VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR};
     GetPhysicalDeviceExternalBufferPropertiesKHR(physical_device, &info, &props);
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_memory_properties, props.externalMemoryProperties);
+    ASSERT_EQ(test_physical_device.external_memory_properties, props.externalMemoryProperties);
 }
 
 // Test vkGetPhysicalDeviceExternalBufferProperties where instance supports, an ICD, and a device under that ICD
@@ -2445,9 +2438,9 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2Simple) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME, 0});
-    FillInRandomExtMemoryData(env.get_test_icd(0).physical_devices.back().external_memory_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME, 0});
+    FillInRandomExtMemoryData(test_physical_device.external_memory_properties);
     {
         InstWrapper instance(env.vulkan_functions);
         instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -2465,7 +2458,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2Simple) {
         VkPhysicalDeviceExternalBufferInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO};
         VkExternalBufferProperties props{VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES};
         GetPhysicalDeviceExternalBufferProperties(physical_device, &info, &props);
-        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_memory_properties, props.externalMemoryProperties);
+        ASSERT_EQ(test_physical_device.external_memory_properties, props.externalMemoryProperties);
     }
     {  // Now do the same logic but the application didn't enable 1.0 or the extension so they get the emulated call
         InstWrapper instance(env.vulkan_functions);
@@ -2515,7 +2508,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufProps2Simple) {
         VkPhysicalDeviceExternalBufferInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO};
         VkExternalBufferProperties props{VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES};
         GetPhysicalDeviceExternalBufferProperties(physical_device, &info, &props);
-        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_memory_properties, props.externalMemoryProperties);
+        ASSERT_EQ(test_physical_device.external_memory_properties, props.externalMemoryProperties);
         ASSERT_FALSE(log.find("Emulating call in ICD"));
     }
 }
@@ -2555,8 +2548,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -2590,8 +2582,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (uint32_t pd = 0; pd < dev_counts[icd]; ++pd) {
-                auto& cur_dev = cur_icd.physical_devices[pd];
+            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -2627,7 +2618,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsKHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -2641,7 +2632,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsKHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
@@ -2666,8 +2657,8 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomExtSemData(env.get_test_icd(0).physical_devices.back().external_semaphore_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomExtSemData(test_physical_device.external_semaphore_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
@@ -2685,7 +2676,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2KHRInstanceAndICDSupport) {
     VkPhysicalDeviceExternalSemaphoreInfoKHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO_KHR};
     VkExternalSemaphorePropertiesKHR props{VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES_KHR};
     GetPhysicalDeviceExternalSemaphorePropertiesKHR(physical_device, &info, &props);
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_semaphore_properties, props);
+    ASSERT_EQ(test_physical_device.external_semaphore_properties, props);
 }
 
 // Test vkGetPhysicalDeviceExternalSemaphoreProperties where instance supports, an ICD, and a device under that ICD
@@ -2696,9 +2687,9 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2Simple) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME, 0});
-    FillInRandomExtSemData(env.get_test_icd(0).physical_devices.back().external_semaphore_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME, 0});
+    FillInRandomExtSemData(test_physical_device.external_semaphore_properties);
     {
         InstWrapper instance(env.vulkan_functions);
         instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -2716,7 +2707,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2Simple) {
         VkPhysicalDeviceExternalSemaphoreInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO};
         VkExternalSemaphoreProperties props{VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES};
         GetPhysicalDeviceExternalSemaphoreProperties(physical_device, &info, &props);
-        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_semaphore_properties, props);
+        ASSERT_EQ(test_physical_device.external_semaphore_properties, props);
     }
     {  // Now do the same logic but the application didn't enable 1.0 or the extension so they get the emulated call
         InstWrapper instance(env.vulkan_functions);
@@ -2764,7 +2755,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemProps2Simple) {
         VkPhysicalDeviceExternalSemaphoreInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO};
         VkExternalSemaphoreProperties props{VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES};
         GetPhysicalDeviceExternalSemaphoreProperties(physical_device, &info, &props);
-        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_semaphore_properties, props);
+        ASSERT_EQ(test_physical_device.external_semaphore_properties, props);
         ASSERT_FALSE(log.find("Emulating call in ICD"));
     }
 }
@@ -2804,8 +2795,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -2839,8 +2829,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (uint32_t pd = 0; pd < dev_counts[icd]; ++pd) {
-                auto& cur_dev = cur_icd.physical_devices[pd];
+            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -2875,7 +2864,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsKHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -2889,7 +2878,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsKHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME);
@@ -2914,8 +2903,8 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2KHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomExtFenceData(env.get_test_icd(0).physical_devices.back().external_fence_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomExtFenceData(test_physical_device.external_fence_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME);
@@ -2933,7 +2922,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2KHRInstanceAndICDSupport) {
     VkPhysicalDeviceExternalFenceInfoKHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO_KHR};
     VkExternalFencePropertiesKHR props{VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES_KHR};
     GetPhysicalDeviceExternalFencePropertiesKHR(physical_device, &info, &props);
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_fence_properties, props);
+    ASSERT_EQ(test_physical_device.external_fence_properties, props);
 }
 
 // Test vkGetPhysicalDeviceExternalFenceProperties where instance supports, an ICD, and a device under that ICD
@@ -2944,9 +2933,9 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2Simple) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).icd_api_version = VK_API_VERSION_1_1;
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME, 0});
-    FillInRandomExtFenceData(env.get_test_icd(0).physical_devices.back().external_fence_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.extensions.push_back({VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME, 0});
+    FillInRandomExtFenceData(test_physical_device.external_fence_properties);
     {
         InstWrapper instance(env.vulkan_functions);
         instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -2964,7 +2953,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2Simple) {
         VkPhysicalDeviceExternalFenceInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO};
         VkExternalFenceProperties props{VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES};
         GetPhysicalDeviceExternalFenceProperties(physical_device, &info, &props);
-        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_fence_properties, props);
+        ASSERT_EQ(test_physical_device.external_fence_properties, props);
     }
     {  // Now do the same logic but the application didn't enable 1.0 or the extension so they get the emulated call
         InstWrapper instance(env.vulkan_functions);
@@ -3013,7 +3002,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFenceProps2Simple) {
         VkPhysicalDeviceExternalFenceInfo info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO};
         VkExternalFenceProperties props{VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES};
         GetPhysicalDeviceExternalFenceProperties(physical_device, &info, &props);
-        ASSERT_EQ(env.get_test_icd(0).physical_devices.back().external_fence_properties, props);
+        ASSERT_EQ(test_physical_device.external_fence_properties, props);
         ASSERT_FALSE(log.find("Emulating call in ICD"));
     }
 }
@@ -3052,8 +3041,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -3087,8 +3075,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (uint32_t pd = 0; pd < dev_counts[icd]; ++pd) {
-                auto& cur_dev = cur_icd.physical_devices[pd];
+            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -3123,7 +3110,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -3137,7 +3124,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
@@ -3174,10 +3161,10 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRInstanceAndICDSupport) {
     Extension third_ext{VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME};
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.add_instance_extensions({first_ext, second_ext, third_ext});
-    cur_icd.physical_devices.push_back({});
+    auto& test_physical_device = cur_icd.add_and_get_physical_device({});
     cur_icd.min_icd_interface_version = 3;
     cur_icd.enable_icd_wsi = true;
-    FillInRandomSurfaceCapsData(env.get_test_icd(0).physical_devices.back().surface_capabilities);
+    FillInRandomSurfaceCapsData(test_physical_device.surface_capabilities);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extensions(
@@ -3257,8 +3244,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
             cur_dev.extensions.push_back({VK_KHR_SURFACE_EXTENSION_NAME, 0});
             cur_dev.extensions.push_back({VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME, 0});
 
@@ -3316,7 +3302,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceCaps2KHRMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -3330,7 +3316,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
@@ -3359,10 +3345,10 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRInstanceAndICDSupport) {
     Extension third_ext{VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME};
     auto& cur_icd = env.get_test_icd(0);
     cur_icd.add_instance_extensions({first_ext, second_ext, third_ext});
-    cur_icd.physical_devices.push_back({});
+    auto& test_physical_device = cur_icd.add_and_get_physical_device({});
     cur_icd.min_icd_interface_version = 3;
     cur_icd.enable_icd_wsi = true;
-    FillInRandomSurfaceFormatsData(env.get_test_icd(0).physical_devices.back().surface_formats);
+    FillInRandomSurfaceFormatsData(test_physical_device.surface_formats);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extensions(
@@ -3392,10 +3378,10 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRInstanceAndICDSupport) {
     std::vector<VkSurfaceFormatKHR> formats{};
     uint32_t count_1 = 0;
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface, &count_1, nullptr));
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().surface_formats.size(), count_1);
+    ASSERT_EQ(test_physical_device.surface_formats.size(), count_1);
     formats.resize(count_1);
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface, &count_1, formats.data()));
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().surface_formats.size(), count_1);
+    ASSERT_EQ(test_physical_device.surface_formats.size(), count_1);
 
     VkPhysicalDeviceSurfaceInfo2KHR info{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, nullptr, surface};
     std::vector<VkSurfaceFormat2KHR> formats2{};
@@ -3450,8 +3436,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
             cur_dev.extensions.push_back({VK_KHR_SURFACE_EXTENSION_NAME, 0});
             cur_dev.extensions.push_back({VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME, 0});
 
@@ -3523,7 +3508,7 @@ TEST(LoaderInstPhysDevExts, PhysDevSurfaceFormats2KHRMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -3537,7 +3522,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_DISPLAY_EXTENSION_NAME);
@@ -3574,8 +3559,8 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomDisplayPropData(env.get_test_icd(0).physical_devices.back().display_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomDisplayPropData(test_physical_device.display_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -3593,12 +3578,12 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRInstanceAndICDSupport) {
     std::vector<VkDisplayPropertiesKHR> props{};
     uint32_t prop_count = 0;
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPropertiesKHR(physical_device, &prop_count, nullptr));
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().display_properties.size(), prop_count);
+    ASSERT_EQ(test_physical_device.display_properties.size(), prop_count);
     props.resize(prop_count);
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPropertiesKHR(physical_device, &prop_count, props.data()));
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().display_properties.size(), prop_count);
+    ASSERT_EQ(test_physical_device.display_properties.size(), prop_count);
 
-    ASSERT_EQ(props, env.get_test_icd(0).physical_devices.back().display_properties);
+    ASSERT_EQ(props, test_physical_device.display_properties);
 }
 
 // Test vkGetPhysicalDeviceDisplayPropertiesKHR where instance supports it with some ICDs that both support
@@ -3637,8 +3622,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -3672,8 +3656,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (uint32_t pd = 0; pd < dev_counts[icd]; ++pd) {
-                auto& cur_dev = cur_icd.physical_devices[pd];
+            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -3711,7 +3694,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -3725,7 +3708,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_DISPLAY_EXTENSION_NAME);
@@ -3750,8 +3733,8 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomDisplayPlanePropData(env.get_test_icd(0).physical_devices.back().display_plane_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomDisplayPlanePropData(test_physical_device.display_plane_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -3769,12 +3752,12 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRInstanceAndICDSupport) {
     std::vector<VkDisplayPlanePropertiesKHR> props{};
     uint32_t prop_count = 0;
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPlanePropertiesKHR(physical_device, &prop_count, nullptr));
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().display_plane_properties.size(), prop_count);
+    ASSERT_EQ(test_physical_device.display_plane_properties.size(), prop_count);
     props.resize(prop_count);
     ASSERT_EQ(VK_SUCCESS, GetPhysicalDeviceDisplayPlanePropertiesKHR(physical_device, &prop_count, props.data()));
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().display_plane_properties.size(), prop_count);
+    ASSERT_EQ(test_physical_device.display_plane_properties.size(), prop_count);
 
-    ASSERT_EQ(props, env.get_test_icd(0).physical_devices.back().display_plane_properties);
+    ASSERT_EQ(props, test_physical_device.display_plane_properties);
 }
 
 // Test vkGetPhysicalDeviceDisplayPlanePropertiesKHR where instance supports it with some ICDs that both support
@@ -3813,8 +3796,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -3848,8 +3830,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (uint32_t pd = 0; pd < dev_counts[icd]; ++pd) {
-                auto& cur_dev = cur_icd.physical_devices[pd];
+            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -3887,7 +3868,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRMixed) {
 TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -3901,7 +3882,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRNoSupport) {
 TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_DISPLAY_EXTENSION_NAME);
@@ -3925,8 +3906,8 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    GenerateRandomDisplays(env.get_test_icd(0).physical_devices.back().displays);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    GenerateRandomDisplays(test_physical_device.displays);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -3944,12 +3925,12 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRInstanceAndICDSupport) {
     std::vector<VkDisplayKHR> disps{};
     uint32_t disp_count = 0;
     ASSERT_EQ(VK_SUCCESS, GetDisplayPlaneSupportedDisplaysKHR(physical_device, 0, &disp_count, nullptr));
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().displays.size(), disp_count);
+    ASSERT_EQ(test_physical_device.displays.size(), disp_count);
     disps.resize(disp_count);
     ASSERT_EQ(VK_SUCCESS, GetDisplayPlaneSupportedDisplaysKHR(physical_device, 0, &disp_count, disps.data()));
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().displays.size(), disp_count);
+    ASSERT_EQ(test_physical_device.displays.size(), disp_count);
 
-    ASSERT_EQ(disps, env.get_test_icd(0).physical_devices.back().displays);
+    ASSERT_EQ(disps, test_physical_device.displays);
 }
 
 // Test vkGetDisplayPlaneSupportedDisplaysKHR where instance supports it with some ICDs that both support
@@ -3988,8 +3969,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -4023,8 +4003,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (uint32_t pd = 0; pd < dev_counts[icd]; ++pd) {
-                auto& cur_dev = cur_icd.physical_devices[pd];
+            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -4062,7 +4041,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRMixed) {
 TEST(LoaderInstPhysDevExts, GetDispModePropsKHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -4075,7 +4054,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRNoSupport) {
 TEST(LoaderInstPhysDevExts, GetDispModePropsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_DISPLAY_EXTENSION_NAME);
@@ -4101,8 +4080,8 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    GenerateRandomDisplayModeProps(env.get_test_icd(0).physical_devices.back().display_mode_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    GenerateRandomDisplayModeProps(test_physical_device.display_mode_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -4119,12 +4098,12 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRInstanceAndICDSupport) {
     std::vector<VkDisplayModePropertiesKHR> props{};
     uint32_t props_count = 0;
     ASSERT_EQ(VK_SUCCESS, GetDisplayModePropertiesKHR(physical_device, VK_NULL_HANDLE, &props_count, nullptr));
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().display_mode_properties.size(), props_count);
+    ASSERT_EQ(test_physical_device.display_mode_properties.size(), props_count);
     props.resize(props_count);
     ASSERT_EQ(VK_SUCCESS, GetDisplayModePropertiesKHR(physical_device, VK_NULL_HANDLE, &props_count, props.data()));
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.back().display_mode_properties.size(), props_count);
+    ASSERT_EQ(test_physical_device.display_mode_properties.size(), props_count);
 
-    ASSERT_EQ(props, env.get_test_icd(0).physical_devices.back().display_mode_properties);
+    ASSERT_EQ(props, test_physical_device.display_mode_properties);
 }
 
 // Test vkGetDisplayModePropertiesKHR where instance supports it with some ICDs that both support
@@ -4163,8 +4142,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -4197,8 +4175,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (uint32_t pd = 0; pd < dev_counts[icd]; ++pd) {
-                auto& cur_dev = cur_icd.physical_devices[pd];
+            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -4237,7 +4214,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRMixed) {
 TEST(LoaderInstPhysDevExts, GetDispModesKHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -4250,7 +4227,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRNoSupport) {
 TEST(LoaderInstPhysDevExts, GetDispModesKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_DISPLAY_EXTENSION_NAME);
@@ -4265,8 +4242,8 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.back().display_mode = CreateRandomDisplayMode();
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device.display_mode = CreateRandomDisplayMode();
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -4283,7 +4260,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRInstanceAndICDSupport) {
     VkDisplayModeKHR mode{};
     VkDisplayModeCreateInfoKHR create_info{VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR};
     ASSERT_EQ(VK_SUCCESS, CreateDisplayModeKHR(physical_device, VK_NULL_HANDLE, &create_info, nullptr, &mode));
-    ASSERT_EQ(mode, env.get_test_icd(0).physical_devices.back().display_mode);
+    ASSERT_EQ(mode, test_physical_device.display_mode);
 }
 
 // Test vkCreateDisplayModeKHR where instance supports it with some ICDs that both support
@@ -4322,8 +4299,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -4356,8 +4332,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (uint32_t pd = 0; pd < dev_counts[icd]; ++pd) {
-                auto& cur_dev = cur_icd.physical_devices[pd];
+            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -4390,7 +4365,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRMixed) {
 TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -4403,7 +4378,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRNoSupport) {
 TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_DISPLAY_EXTENSION_NAME);
@@ -4439,8 +4414,8 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRInstanceAndICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
     env.get_test_icd(0).add_instance_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({});
-    GenerateRandomDisplayPlaneCaps(env.get_test_icd(0).physical_devices.back().display_plane_capabilities);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    GenerateRandomDisplayPlaneCaps(test_physical_device.display_plane_capabilities);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension({VK_KHR_DISPLAY_EXTENSION_NAME});
@@ -4456,7 +4431,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRInstanceAndICDSupport) {
 
     VkDisplayPlaneCapabilitiesKHR caps{};
     ASSERT_EQ(VK_SUCCESS, GetDisplayPlaneCapabilitiesKHR(physical_device, 0, 0, &caps));
-    ASSERT_EQ(caps, env.get_test_icd(0).physical_devices.back().display_plane_capabilities);
+    ASSERT_EQ(caps, test_physical_device.display_plane_capabilities);
 }
 
 // Test vkGetDisplayPlaneCapabilitiesKHR where instance supports it with some ICDs that both support
@@ -4495,8 +4470,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
             if ((icd == 0 && dev == 1) || icd == 3) {
@@ -4529,8 +4503,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (uint32_t pd = 0; pd < dev_counts[icd]; ++pd) {
-                auto& cur_dev = cur_icd.physical_devices[pd];
+            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -4563,7 +4536,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -4577,7 +4550,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME);
@@ -4595,8 +4568,8 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRInstanceAndICDSupport) {
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomDisplayPropData(env.get_test_icd(0).physical_devices.back().display_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomDisplayPropData(test_physical_device.display_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extensions({VK_KHR_DISPLAY_EXTENSION_NAME, VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME});
@@ -4668,8 +4641,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
             cur_dev.extensions.push_back({VK_KHR_DISPLAY_EXTENSION_NAME, 0});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
@@ -4723,7 +4695,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispProps2KHRMixed) {
 TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -4737,7 +4709,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME);
@@ -4755,8 +4727,8 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRInstanceAndICDSupport) {
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomDisplayPlanePropData(env.get_test_icd(0).physical_devices.back().display_plane_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomDisplayPlanePropData(test_physical_device.display_plane_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extensions({VK_KHR_DISPLAY_EXTENSION_NAME, VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME});
@@ -4827,8 +4799,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
             cur_dev.extensions.push_back({VK_KHR_DISPLAY_EXTENSION_NAME, 0});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
@@ -4881,7 +4852,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlaneProps2KHRMixed) {
 TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -4894,7 +4865,7 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME);
@@ -4911,8 +4882,8 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRInstanceAndICDSupport) {
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
-    env.get_test_icd(0).physical_devices.push_back({});
-    GenerateRandomDisplayModeProps(env.get_test_icd(0).physical_devices.back().display_mode_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    GenerateRandomDisplayModeProps(test_physical_device.display_mode_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extensions({VK_KHR_DISPLAY_EXTENSION_NAME, VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME});
@@ -4981,8 +4952,7 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
             cur_dev.extensions.push_back({VK_KHR_DISPLAY_EXTENSION_NAME, 0});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
@@ -5033,7 +5003,7 @@ TEST(LoaderInstPhysDevExts, GetDispModeProps2KHRMixed) {
 TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -5046,7 +5016,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRNoSupport) {
 TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME);
@@ -5063,8 +5033,8 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRInstanceAndICDSupport) {
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
-    env.get_test_icd(0).physical_devices.push_back({});
-    FillInRandomDisplayPropData(env.get_test_icd(0).physical_devices.back().display_properties);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    FillInRandomDisplayPropData(test_physical_device.display_properties);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extensions({VK_KHR_DISPLAY_EXTENSION_NAME, VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME});
@@ -5125,8 +5095,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
             cur_dev.extensions.push_back({VK_KHR_DISPLAY_EXTENSION_NAME, 0});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
@@ -5173,7 +5142,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCaps2KHRMixed) {
 TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -5186,7 +5155,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTNoSupport) {
 TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME);
@@ -5203,8 +5172,8 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTInstanceAndICDSupport) {
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
-    env.get_test_icd(0).physical_devices.push_back({});
-    GenerateRandomDisplays(env.get_test_icd(0).physical_devices.back().displays);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    GenerateRandomDisplays(test_physical_device.displays);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extensions({VK_KHR_DISPLAY_EXTENSION_NAME, VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME});
@@ -5259,8 +5228,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
             cur_dev.extensions.push_back({VK_KHR_DISPLAY_EXTENSION_NAME, 0});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
@@ -5294,8 +5262,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (uint32_t pd = 0; pd < dev_counts[icd]; ++pd) {
-                auto& cur_dev = cur_icd.physical_devices[pd];
+            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -5325,7 +5292,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTMixed) {
 TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTNoSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -5338,7 +5305,7 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTNoSupport) {
 TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTNoICDSupport) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(0).physical_devices.push_back({});
+    env.get_test_icd(0).add_physical_device({});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME);
@@ -5355,8 +5322,8 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTInstanceAndICDSupport) {
     Extension first_ext{VK_KHR_DISPLAY_EXTENSION_NAME};
     Extension second_ext{VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME};
     env.get_test_icd(0).add_instance_extensions({first_ext, second_ext});
-    env.get_test_icd(0).physical_devices.push_back({});
-    GenerateRandomDisplays(env.get_test_icd(0).physical_devices.back().displays);
+    auto& test_physical_device = env.get_test_icd(0).add_and_get_physical_device({});
+    GenerateRandomDisplays(test_physical_device.displays);
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extensions({VK_KHR_DISPLAY_EXTENSION_NAME, VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME});
@@ -5372,7 +5339,7 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTInstanceAndICDSupport) {
 
     VkDisplayKHR display = VK_NULL_HANDLE;
     ASSERT_EQ(VK_SUCCESS, GetDrmDisplayEXT(physical_device, 0, 0, &display));
-    ASSERT_EQ(display, env.get_test_icd(0).physical_devices.back().displays[0]);
+    ASSERT_EQ(display, test_physical_device.displays[0]);
 }
 
 // Test vkGetDrmDisplayEXT where instance supports it with some ICDs that both support
@@ -5412,8 +5379,7 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTMixed) {
 
         for (uint32_t dev = 0; dev < dev_counts[icd]; ++dev) {
             uint32_t device_version = VK_API_VERSION_1_0;
-            cur_icd.physical_devices.push_back({});
-            auto& cur_dev = cur_icd.physical_devices.back();
+            auto& cur_dev = cur_icd.add_and_get_physical_device({});
             cur_dev.extensions.push_back({VK_KHR_DISPLAY_EXTENSION_NAME, 0});
 
             // 2nd device in ICD 0 and the one device in ICD 3 support the extension and 1.1
@@ -5447,8 +5413,7 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (uint32_t pd = 0; pd < dev_counts[icd]; ++pd) {
-                auto& cur_dev = cur_icd.physical_devices[pd];
+            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -5481,18 +5446,18 @@ TEST(LoaderInstPhysDevExts, DifferentInstanceExtensions) {
     // Add 3 drivers each of which supports a different instance extension
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
     env.get_test_icd(0).add_instance_extension({VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({"pd0"});
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME, 0});
+    env.get_test_icd(0).add_and_get_physical_device({"pd0"}).extensions.push_back(
+        {VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
     env.get_test_icd(1).add_instance_extension({VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME});
-    env.get_test_icd(1).physical_devices.push_back({"pd1"});
-    env.get_test_icd(1).physical_devices.back().extensions.push_back({VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME, 0});
+    env.get_test_icd(1).add_and_get_physical_device({"pd1"}).extensions.push_back(
+        {VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
     env.get_test_icd(2).add_instance_extension({VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME});
-    env.get_test_icd(2).physical_devices.push_back({"pd2"});
-    env.get_test_icd(2).physical_devices.back().extensions.push_back({VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME, 0});
+    env.get_test_icd(2).add_and_get_physical_device({"pd2"}).extensions.push_back(
+        {VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME, 0});
 
     DebugUtilsLogger log{VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT};
     InstWrapper inst{env.vulkan_functions};
@@ -5535,16 +5500,13 @@ TEST(LoaderInstPhysDevExts, DifferentPhysicalDeviceExtensions) {
 
     // Add 3 drivers each of which supports a different physical device extension
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
-    env.get_test_icd(0).physical_devices.push_back("pd0");
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME, 0});
+    env.get_test_icd(0).add_and_get_physical_device("pd0").extensions.push_back({VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
-    env.get_test_icd(1).physical_devices.push_back("pd1");
-    env.get_test_icd(1).physical_devices.back().extensions.push_back({VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME, 0});
+    env.get_test_icd(1).add_and_get_physical_device("pd1").extensions.push_back({VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
-    env.get_test_icd(2).physical_devices.push_back("pd2");
-    env.get_test_icd(2).physical_devices.back().extensions.push_back({VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME, 0});
+    env.get_test_icd(2).add_and_get_physical_device("pd2").extensions.push_back({VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME, 0});
 
     DebugUtilsLogger log{VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT};
     InstWrapper inst{env.vulkan_functions};

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -335,11 +335,12 @@ TEST(EnumerateDeviceLayerProperties, LayersMatch) {
 
 TEST(EnumerateDeviceExtensionProperties, DeviceExtensionEnumerated) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device("physical_device_0");
+    auto& test_physical_device =
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_and_get_physical_device("physical_device_0");
 
     std::array<Extension, 2> device_extensions = {Extension{"MyExtension0", 4}, Extension{"MyExtension1", 7}};
     for (auto& ext : device_extensions) {
-        driver.physical_devices.front().extensions.push_back(ext);
+        test_physical_device.extensions.push_back(ext);
     }
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
@@ -362,11 +363,12 @@ TEST(EnumerateDeviceExtensionProperties, DeviceExtensionEnumerated) {
 
 TEST(EnumerateDeviceExtensionProperties, PropertyCountLessThanAvailable) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device("physical_device_0");
+    auto& test_physical_device =
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_and_get_physical_device("physical_device_0");
 
     std::array<Extension, 2> device_extensions = {Extension{"MyExtension0", 4}, Extension{"MyExtension1", 7}};
     for (auto& ext : device_extensions) {
-        driver.physical_devices.front().extensions.push_back(ext);
+        test_physical_device.extensions.push_back(ext);
     }
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
@@ -482,10 +484,7 @@ TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentNoExtensions) {
     std::vector<Extension> exts = {Extension{"MyDriverExtension0", 4}, Extension{"MyDriverExtension1", 7},
                                    Extension{"MyDriverExtension2", 6}, Extension{"MyDriverExtension3", 10}};
 
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
-        .add_physical_device("physical_device_0")
-        .physical_devices.at(0)
-        .add_extensions(exts);
+    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_and_get_physical_device("physical_device_0").add_extensions(exts);
 
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("implicit_layer_name")
@@ -501,7 +500,7 @@ TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentNoExtensions) {
 
 TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentWithExtensions) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device({});
+    auto& test_physical_device = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_and_get_physical_device({});
 
     std::vector<Extension> exts;
     std::vector<ManifestLayer::LayerDescription::Extension> layer_exts;
@@ -518,10 +517,10 @@ TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentWithExtensions) {
     auto& layer = env.get_test_layer();
     layer.device_extensions = exts;
 
-    driver.physical_devices.front().extensions.emplace_back("MyDriverExtension0", 4);
-    driver.physical_devices.front().extensions.emplace_back("MyDriverExtension1", 7);
+    test_physical_device.extensions.emplace_back("MyDriverExtension0", 4);
+    test_physical_device.extensions.emplace_back("MyDriverExtension1", 7);
 
-    exts.insert(exts.begin(), driver.physical_devices.front().extensions.begin(), driver.physical_devices.front().extensions.end());
+    exts.insert(exts.begin(), test_physical_device.extensions.begin(), test_physical_device.extensions.end());
 
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
@@ -532,7 +531,7 @@ TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentWithExtensions) {
 
 TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentWithLotsOfExtensions) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device({});
+    auto& test_physical_device = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_and_get_physical_device({});
 
     std::vector<Extension> exts;
     std::vector<ManifestLayer::LayerDescription::Extension> layer_exts;
@@ -549,12 +548,12 @@ TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentWithLotsOfExtension
     auto& layer = env.get_test_layer();
     layer.device_extensions = exts;
 
-    driver.physical_devices.front().extensions.emplace_back("MyDriverExtension0", 4);
-    driver.physical_devices.front().extensions.emplace_back("MyDriverExtension1", 7);
-    driver.physical_devices.front().extensions.emplace_back("MyDriverExtension2", 6);
-    driver.physical_devices.front().extensions.emplace_back("MyDriverExtension3", 9);
+    test_physical_device.extensions.emplace_back("MyDriverExtension0", 4);
+    test_physical_device.extensions.emplace_back("MyDriverExtension1", 7);
+    test_physical_device.extensions.emplace_back("MyDriverExtension2", 6);
+    test_physical_device.extensions.emplace_back("MyDriverExtension3", 9);
 
-    exts.insert(exts.begin(), driver.physical_devices.front().extensions.begin(), driver.physical_devices.front().extensions.end());
+    exts.insert(exts.begin(), test_physical_device.extensions.begin(), test_physical_device.extensions.end());
 
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
@@ -617,7 +616,7 @@ TEST(EnumerateDeviceExtensionProperties, NoDriverExtensionsImplicitLayerPresentW
 
 TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentWithDuplicateExtensions) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device({});
+    auto& test_physical_device = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_and_get_physical_device({});
 
     std::vector<Extension> exts;
     std::vector<ManifestLayer::LayerDescription::Extension> layer_exts;
@@ -634,14 +633,14 @@ TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentWithDuplicateExtens
     auto& layer = env.get_test_layer();
     layer.device_extensions = exts;
 
-    driver.physical_devices.front().extensions.emplace_back("MyDriverExtension0", 4);
-    driver.physical_devices.front().extensions.emplace_back("MyDriverExtension1", 7);
+    test_physical_device.extensions.emplace_back("MyDriverExtension0", 4);
+    test_physical_device.extensions.emplace_back("MyDriverExtension1", 7);
 
-    driver.physical_devices.front().extensions.insert(driver.physical_devices.front().extensions.end(), exts.begin(), exts.end());
+    test_physical_device.extensions.insert(test_physical_device.extensions.end(), exts.begin(), exts.end());
     exts.emplace_back("MyDriverExtension0", 4);
     exts.emplace_back("MyDriverExtension1", 7);
 
-    driver.physical_devices.front().extensions = exts;
+    test_physical_device.extensions = exts;
 
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
@@ -652,7 +651,7 @@ TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentWithDuplicateExtens
 
 TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentWithOnlyDuplicateExtensions) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_physical_device({});
+    auto& test_physical_device = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).add_and_get_physical_device({});
 
     std::vector<Extension> exts;
     std::vector<ManifestLayer::LayerDescription::Extension> layer_exts;
@@ -669,7 +668,7 @@ TEST(EnumerateDeviceExtensionProperties, ImplicitLayerPresentWithOnlyDuplicateEx
     auto& layer = env.get_test_layer();
     layer.device_extensions = exts;
 
-    driver.physical_devices.front().extensions = exts;
+    test_physical_device.extensions = exts;
 
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
@@ -705,8 +704,8 @@ TEST(EnumeratePhysicalDevices, TwoCall) {
 
     const uint32_t real_device_count = 2;
     for (uint32_t i = 0; i < real_device_count; i++) {
-        driver.add_physical_device(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+        driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i))
+            .extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
     }
 
     InstWrapper inst{env.vulkan_functions};
@@ -731,8 +730,8 @@ TEST(EnumeratePhysicalDevices, MatchOneAndTwoCallNumbers) {
 
     const uint32_t real_device_count = 3;
     for (uint32_t i = 0; i < real_device_count; i++) {
-        driver.add_physical_device(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+        driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i))
+            .extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
     }
 
     InstWrapper inst1{env.vulkan_functions};
@@ -767,8 +766,8 @@ TEST(EnumeratePhysicalDevices, TwoCallIncomplete) {
 
     const uint32_t real_device_count = 2;
     for (uint32_t i = 0; i < real_device_count; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+        driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i))
+            .extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
     }
 
     InstWrapper inst{env.vulkan_functions};
@@ -844,7 +843,7 @@ TEST(EnumeratePhysicalDevices, CallTwiceNormal) {
     auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_min_icd_interface_version(5);
 
     for (size_t i = 0; i < 4; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
+        driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
     }
 
     InstWrapper inst{env.vulkan_functions};
@@ -870,7 +869,7 @@ TEST(EnumeratePhysicalDevices, CallTwiceIncompleteOnceNormal) {
     auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_min_icd_interface_version(5);
 
     for (size_t i = 0; i < 8; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
+        driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
     }
 
     InstWrapper inst{env.vulkan_functions};
@@ -906,7 +905,7 @@ TEST(EnumeratePhysicalDevices, CallThriceSuccessReduce) {
     auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_min_icd_interface_version(5);
 
     for (size_t i = 0; i < 8; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
+        driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
     }
 
     InstWrapper inst{env.vulkan_functions};
@@ -941,8 +940,8 @@ TEST(EnumeratePhysicalDevices, CallThriceAddInBetween) {
     FrameworkEnvironment env{};
     auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_min_icd_interface_version(5);
 
-    driver.physical_devices.emplace_back("physical_device_0");
-    driver.physical_devices.emplace_back("physical_device_1");
+    driver.add_physical_device("physical_device_0");
+    driver.add_physical_device("physical_device_1");
 
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
@@ -953,8 +952,8 @@ TEST(EnumeratePhysicalDevices, CallThriceAddInBetween) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &returned_physical_count, physical_device_handles_1.data()));
     ASSERT_EQ(physical_count, returned_physical_count);
 
-    driver.physical_devices.emplace_back("physical_device_2");
-    driver.physical_devices.emplace_back("physical_device_3");
+    driver.add_physical_device("physical_device_2");
+    driver.add_physical_device("physical_device_3");
 
     std::vector<VkPhysicalDevice> physical_device_handles_2 = std::vector<VkPhysicalDevice>(returned_physical_count);
     ASSERT_EQ(VK_INCOMPLETE, inst->vkEnumeratePhysicalDevices(inst, &returned_physical_count, physical_device_handles_2.data()));
@@ -981,7 +980,7 @@ TEST(EnumeratePhysicalDevices, CallThriceRemoveInBetween) {
     auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_min_icd_interface_version(5);
 
     for (size_t i = 0; i < 4; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
+        driver.add_physical_device(std::string("physical_device_") + std::to_string(i));
     }
 
     InstWrapper inst{env.vulkan_functions};
@@ -1035,10 +1034,11 @@ TEST(EnumeratePhysicalDevices, CallThriceRemoveInBetween) {
 TEST(EnumeratePhysicalDevices, MultipleAddRemoves) {
     FrameworkEnvironment env{};
     auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2)).set_min_icd_interface_version(5);
+    auto phys_dev_handle_0 = driver.add_and_get_physical_device("physical_device_0").vk_physical_device.handle;
+    auto phys_dev_handle_1 = driver.add_and_get_physical_device("physical_device_1").vk_physical_device.handle;
+    auto phys_dev_handle_2 = driver.add_and_get_physical_device("physical_device_2").vk_physical_device.handle;
+    auto phys_dev_handle_3 = driver.add_and_get_physical_device("physical_device_3").vk_physical_device.handle;
 
-    for (size_t i = 0; i < 4; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-    }
     std::array<std::vector<VkPhysicalDevice>, 8> physical_dev_handles;
 
     InstWrapper inst{env.vulkan_functions};
@@ -1051,7 +1051,7 @@ TEST(EnumeratePhysicalDevices, MultipleAddRemoves) {
     ASSERT_EQ(physical_count, returned_physical_count);
 
     // Delete the 2nd physical device (0, 2, 3)
-    driver.physical_devices.erase(std::next(driver.physical_devices.begin()));
+    driver.physical_devices.erase(phys_dev_handle_1);
 
     // Query using old number from last call (4), but it should only return 3
     physical_count = static_cast<uint32_t>(driver.physical_devices.size());
@@ -1061,8 +1061,8 @@ TEST(EnumeratePhysicalDevices, MultipleAddRemoves) {
     physical_dev_handles[1].resize(returned_physical_count);
 
     // Add two new physical devices to the front (A, B, 0, 2, 3)
-    driver.physical_devices.emplace(driver.physical_devices.begin(), "physical_device_B");
-    driver.physical_devices.emplace(driver.physical_devices.begin(), "physical_device_A");
+    auto phys_dev_handle_a = driver.add_physical_device_at_index(0, "physical_device_B").vk_physical_device.handle;
+    auto phys_dev_handle_b = driver.add_physical_device_at_index(1, "physical_device_A").vk_physical_device.handle;
 
     // Query using old number from last call (3), but it should be 5
     physical_count = static_cast<uint32_t>(driver.physical_devices.size());
@@ -1078,7 +1078,7 @@ TEST(EnumeratePhysicalDevices, MultipleAddRemoves) {
     ASSERT_EQ(physical_count, returned_physical_count);
 
     // Delete last two physical devices (A, B, 0, 2)
-    driver.physical_devices.pop_back();
+    driver.physical_devices.erase(phys_dev_handle_3);
 
     // Query using old number from last call (5), but it should be 4
     physical_count = static_cast<uint32_t>(driver.physical_devices.size());
@@ -1091,7 +1091,7 @@ TEST(EnumeratePhysicalDevices, MultipleAddRemoves) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &returned_physical_count, physical_dev_handles[5].data()));
 
     // Insert a new physical device (A, B, C, 0, 2)
-    driver.physical_devices.insert(driver.physical_devices.begin() + 2, "physical_device_C");
+    auto phys_dev_handle_c = driver.add_physical_device_at_index(2, "physical_device_C").vk_physical_device.handle;
 
     // Query using old number from last call (4), but it should be 5
     physical_count = static_cast<uint32_t>(driver.physical_devices.size());
@@ -1351,7 +1351,7 @@ TEST(CreateDevice, ConsecutiveCreate) {
     auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
 
     for (uint32_t i = 0; i < 100; i++) {
-        driver.physical_devices.emplace_back("physical_device_0");
+        driver.add_physical_device("physical_device_0");
     }
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
@@ -1368,7 +1368,7 @@ TEST(CreateDevice, ConsecutiveCreateWithoutDestruction) {
     auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
 
     for (uint32_t i = 0; i < 100; i++) {
-        driver.physical_devices.emplace_back("physical_device_0");
+        driver.add_physical_device("physical_device_0");
     }
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
@@ -1686,14 +1686,16 @@ TEST(EnumeratePhysicalDeviceGroups, OneCall) {
                        .add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
 
     // ICD contains 3 devices in two groups
+    std::array<PhysicalDevice*, 3> phys_devices;
     for (size_t i = 0; i < 3; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
+        auto& test_physical_device = driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
+        test_physical_device.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+        test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
+        phys_devices[i] = &test_physical_device;
     }
-    driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
-    driver.physical_device_groups.back().use_physical_device(driver.physical_devices[1]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[2]);
+    driver.physical_device_groups.emplace_back(phys_devices[0]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[1]);
+    driver.physical_device_groups.emplace_back(phys_devices[2]);
     const uint32_t max_physical_device_count = 3;
 
     // Core function
@@ -1820,14 +1822,16 @@ TEST(EnumeratePhysicalDeviceGroups, TwoCall) {
                        .add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
 
     // ICD contains 3 devices in two groups
+    std::array<PhysicalDevice*, 3> phys_devices;
     for (size_t i = 0; i < 3; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
+        auto& test_physical_device = driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
+        test_physical_device.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+        test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
+        phys_devices[i] = &test_physical_device;
     }
-    driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
-    driver.physical_device_groups.back().use_physical_device(driver.physical_devices[1]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[2]);
+    driver.physical_device_groups.emplace_back(phys_devices[0]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[1]);
+    driver.physical_device_groups.emplace_back(phys_devices[2]);
     const uint32_t max_physical_device_count = 3;
 
     // Core function
@@ -1937,14 +1941,16 @@ TEST(EnumeratePhysicalDeviceGroups, TwoCallIncomplete) {
                        .add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
 
     // ICD contains 3 devices in two groups
+    std::array<PhysicalDevice*, 3> phys_devices;
     for (size_t i = 0; i < 3; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
+        auto& test_physical_device = driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
+        test_physical_device.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+        test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
+        phys_devices[i] = &test_physical_device;
     }
-    driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
-    driver.physical_device_groups.back().use_physical_device(driver.physical_devices[1]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[2]);
+    driver.physical_device_groups.emplace_back(phys_devices[0]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[1]);
+    driver.physical_device_groups.emplace_back(phys_devices[2]);
 
     // Core function
     {
@@ -2038,19 +2044,19 @@ TEST(EnumeratePhysicalDeviceGroups, TestCoreVersusExtensionSameReturns) {
                        .add_instance_extension({VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME});
 
     // Generate the devices
+    std::array<PhysicalDevice*, 6> phys_devices;
     for (size_t i = 0; i < 6; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
+        auto& test_physical_device = driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
+        test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
+        phys_devices[i] = &test_physical_device;
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[1]);
-    driver.physical_device_groups.back()
-        .use_physical_device(driver.physical_devices[2])
-        .use_physical_device(driver.physical_devices[3]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[4]);
-    driver.physical_device_groups.back().use_physical_device(driver.physical_devices[5]);
+    driver.physical_device_groups.emplace_back(phys_devices[0]);
+    driver.physical_device_groups.emplace_back(phys_devices[1]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
+    driver.physical_device_groups.emplace_back(phys_devices[4]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[5]);
 
     uint32_t expected_counts[3] = {1, 3, 2};
     uint32_t core_group_count = 0;
@@ -2126,19 +2132,19 @@ TEST(EnumeratePhysicalDeviceGroups, CallThriceAddGroupInBetween) {
                        .set_icd_api_version(VK_API_VERSION_1_1);
 
     // Generate the devices
+    std::array<PhysicalDevice*, 7> phys_devices;
     for (size_t i = 0; i < 7; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
+        auto& test_physical_device = driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
+        test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
+        phys_devices[i] = &test_physical_device;
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[1]);
-    driver.physical_device_groups.back()
-        .use_physical_device(driver.physical_devices[2])
-        .use_physical_device(driver.physical_devices[3]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[4]);
-    driver.physical_device_groups.back().use_physical_device(driver.physical_devices[5]);
+    driver.physical_device_groups.emplace_back(phys_devices[0]);
+    driver.physical_device_groups.emplace_back(phys_devices[1]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
+    driver.physical_device_groups.emplace_back(phys_devices[4]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[5]);
 
     uint32_t before_expected_counts[3] = {1, 3, 2};
     uint32_t after_expected_counts[4] = {1, 3, 1, 2};
@@ -2161,7 +2167,7 @@ TEST(EnumeratePhysicalDeviceGroups, CallThriceAddGroupInBetween) {
     }
 
     // Insert new group after first two
-    driver.physical_device_groups.insert(driver.physical_device_groups.begin() + 2, driver.physical_devices[6]);
+    driver.physical_device_groups.insert(driver.physical_device_groups.begin() + 2, phys_devices[6]);
 
     std::vector<VkPhysicalDeviceGroupProperties> group_props_after{};
     group_props_after.resize(before_group_count,
@@ -2221,20 +2227,20 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceRemoveGroupInBetween) {
                        .set_icd_api_version(VK_API_VERSION_1_1);
 
     // Generate the devices
+    std::array<PhysicalDevice*, 7> phys_devices;
     for (size_t i = 0; i < 7; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
+        auto& test_physical_device = driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
+        test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
+        phys_devices[i] = &test_physical_device;
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[1]);
-    driver.physical_device_groups.back()
-        .use_physical_device(driver.physical_devices[2])
-        .use_physical_device(driver.physical_devices[3]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[4]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[5]);
-    driver.physical_device_groups.back().use_physical_device(driver.physical_devices[6]);
+    driver.physical_device_groups.emplace_back(phys_devices[0]);
+    driver.physical_device_groups.emplace_back(phys_devices[1]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
+    driver.physical_device_groups.emplace_back(phys_devices[4]);
+    driver.physical_device_groups.emplace_back(phys_devices[5]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[6]);
 
     uint32_t before_expected_counts[4] = {1, 3, 1, 2};
     uint32_t after_expected_counts[3] = {1, 3, 2};
@@ -2308,19 +2314,19 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceAddDeviceInBetween) {
                        .set_icd_api_version(VK_API_VERSION_1_1);
 
     // Generate the devices
+    std::array<PhysicalDevice*, 7> phys_devices;
     for (size_t i = 0; i < 7; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
+        auto& test_physical_device = driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
+        test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
+        phys_devices[i] = &test_physical_device;
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[1]);
-    driver.physical_device_groups.back()
-        .use_physical_device(driver.physical_devices[2])
-        .use_physical_device(driver.physical_devices[3]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[4]);
-    driver.physical_device_groups.back().use_physical_device(driver.physical_devices[5]);
+    driver.physical_device_groups.emplace_back(phys_devices[0]);
+    driver.physical_device_groups.emplace_back(phys_devices[1]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
+    driver.physical_device_groups.emplace_back(phys_devices[4]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[5]);
 
     uint32_t expected_group_count = 3;
     uint32_t before_expected_counts[3] = {1, 3, 2};
@@ -2342,7 +2348,7 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceAddDeviceInBetween) {
     }
 
     // Insert new device to 2nd group
-    driver.physical_device_groups[1].use_physical_device(driver.physical_devices[6]);
+    driver.physical_device_groups[1].use_physical_device(phys_devices[6]);
 
     std::vector<VkPhysicalDeviceGroupProperties> group_props_after{};
     group_props_after.resize(expected_group_count,
@@ -2394,19 +2400,19 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceRemoveDeviceInBetween) {
                        .set_icd_api_version(VK_API_VERSION_1_1);
 
     // Generate the devices
+    std::array<PhysicalDevice*, 6> phys_devices;
     for (size_t i = 0; i < 6; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
+        auto& test_physical_device = driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
+        test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
+        phys_devices[i] = &test_physical_device;
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[1]);
-    driver.physical_device_groups.back()
-        .use_physical_device(driver.physical_devices[2])
-        .use_physical_device(driver.physical_devices[3]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[4]);
-    driver.physical_device_groups.back().use_physical_device(driver.physical_devices[5]);
+    driver.physical_device_groups.emplace_back(phys_devices[0]);
+    driver.physical_device_groups.emplace_back(phys_devices[1]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
+    driver.physical_device_groups.emplace_back(phys_devices[4]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[5]);
 
     uint32_t before_expected_counts[3] = {1, 3, 2};
     uint32_t after_expected_counts[3] = {1, 2, 2};
@@ -2491,19 +2497,19 @@ TEST(EnumeratePhysicalDeviceGroups, MultipleAddRemoves) {
                        .set_icd_api_version(VK_API_VERSION_1_1);
 
     // Generate the devices
+    std::array<PhysicalDevice*, 9> phys_devices;
     for (size_t i = 0; i < 9; i++) {
-        driver.physical_devices.emplace_back(std::string("physical_device_") + std::to_string(i));
-        driver.physical_devices.back().properties.apiVersion = VK_API_VERSION_1_1;
+        auto& test_physical_device = driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
+        test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
+        phys_devices[i] = &test_physical_device;
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(driver.physical_devices[0]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[1]);
-    driver.physical_device_groups.back()
-        .use_physical_device(driver.physical_devices[2])
-        .use_physical_device(driver.physical_devices[3]);
-    driver.physical_device_groups.emplace_back(driver.physical_devices[4]);
-    driver.physical_device_groups.back().use_physical_device(driver.physical_devices[5]);
+    driver.physical_device_groups.emplace_back(phys_devices[0]);
+    driver.physical_device_groups.emplace_back(phys_devices[1]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
+    driver.physical_device_groups.emplace_back(phys_devices[4]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[5]);
 
     uint32_t before_expected_counts[3] = {1, 3, 2};
     uint32_t after_add_group_expected_counts[4] = {1, 3, 1, 2};
@@ -2530,7 +2536,7 @@ TEST(EnumeratePhysicalDeviceGroups, MultipleAddRemoves) {
     }
 
     // Insert new group after first two
-    driver.physical_device_groups.insert(driver.physical_device_groups.begin() + 2, driver.physical_devices[6]);
+    driver.physical_device_groups.insert(driver.physical_device_groups.begin() + 2, phys_devices[6]);
 
     // Should be: 4 Groups { { 0 }, { 1, 2, 3 }, { 6 }, { 4, 5 } }
     std::vector<VkPhysicalDeviceGroupProperties> group_props_after_add_group{};
@@ -2575,9 +2581,7 @@ TEST(EnumeratePhysicalDeviceGroups, MultipleAddRemoves) {
     }
 
     // Add two devices to last group
-    driver.physical_device_groups.back()
-        .use_physical_device(driver.physical_devices[7])
-        .use_physical_device(driver.physical_devices[8]);
+    driver.physical_device_groups.back().use_physical_device(phys_devices[7]).use_physical_device(phys_devices[8]);
 
     // Should be: 3 Groups { { 2, 3 }, { 6 }, { 4, 5, 7, 8 } }
     std::vector<VkPhysicalDeviceGroupProperties> group_props_after_add_device{};
@@ -2631,44 +2635,40 @@ TEST(EnumeratePhysicalDeviceGroups, FakePNext) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_1));
     auto& cur_icd_0 = env.get_test_icd(0);
     cur_icd_0.set_icd_api_version(VK_API_VERSION_1_1);
-    cur_icd_0.physical_devices.push_back({"pd0"});
-    cur_icd_0.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_0.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            888, 0xAAA001);
-    cur_icd_0.physical_devices.push_back({"pd1"});
-    cur_icd_0.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_0.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
-                            VK_API_VERSION_1_1, 888, 0xAAA002);
-    cur_icd_0.physical_devices.push_back({"pd2"});
-    cur_icd_0.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_0.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            888, 0xAAA003);
+    auto& test_physical_device_0 = cur_icd_0.add_and_get_physical_device({"pd0"});
+    test_physical_device_0.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_0.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA001);
+    auto& test_physical_device_1 = cur_icd_0.add_and_get_physical_device({"pd1"});
+    test_physical_device_1.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_1.properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA002);
+    auto& test_physical_device_2 = cur_icd_0.add_and_get_physical_device({"pd2"});
+    test_physical_device_2.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_2.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA003);
     cur_icd_0.physical_device_groups.push_back({});
-    cur_icd_0.physical_device_groups.back()
-        .use_physical_device(cur_icd_0.physical_devices[0])
-        .use_physical_device(cur_icd_0.physical_devices[2]);
-    cur_icd_0.physical_device_groups.push_back({cur_icd_0.physical_devices[1]});
+    cur_icd_0.physical_device_groups.back().use_physical_device(test_physical_device_0).use_physical_device(test_physical_device_2);
+    cur_icd_0.physical_device_groups.push_back({test_physical_device_1});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_1));
     auto& cur_icd_1 = env.get_test_icd(1);
     cur_icd_1.set_icd_api_version(VK_API_VERSION_1_1);
-    cur_icd_1.physical_devices.push_back({"pd4"});
-    cur_icd_1.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_1.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            75, 0xCCCC001);
-    cur_icd_1.physical_devices.push_back({"pd5"});
-    cur_icd_1.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_1.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            75, 0xCCCC002);
-    cur_icd_1.physical_devices.push_back({"pd6"});
-    cur_icd_1.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_1.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            75, 0xCCCC003);
+    auto& test_physical_device_4 = cur_icd_1.add_and_get_physical_device({"pd4"});
+    test_physical_device_4.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_4.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC001);
+    auto& test_physical_device_5 = cur_icd_1.add_and_get_physical_device({"pd5"});
+    test_physical_device_5.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_5.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC002);
+    auto& test_physical_device_6 = cur_icd_1.add_and_get_physical_device({"pd6"});
+    test_physical_device_6.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_6.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC003);
     cur_icd_1.physical_device_groups.push_back({});
-    cur_icd_1.physical_device_groups.back()
-        .use_physical_device(cur_icd_1.physical_devices[1])
-        .use_physical_device(cur_icd_1.physical_devices[2]);
-    cur_icd_1.physical_device_groups.push_back({cur_icd_1.physical_devices[0]});
+    cur_icd_1.physical_device_groups.back().use_physical_device(test_physical_device_5).use_physical_device(test_physical_device_6);
+    cur_icd_1.physical_device_groups.push_back({test_physical_device_4});
 
     InstWrapper inst(env.vulkan_functions);
     inst.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -2755,10 +2755,9 @@ TEST(ExtensionManual, ToolingProperties) {
     {  // core
         FrameworkEnvironment env{};
         env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, VK_API_VERSION_1_3))
-            .add_physical_device({})
             .set_supports_tooling_info_core(true)
             .add_tooling_property(icd_tool_props)
-            .physical_devices.back()
+            .add_and_get_physical_device({})
             .properties.apiVersion = VK_MAKE_API_VERSION(0, 1, 3, 0);
 
         InstWrapper inst{env.vulkan_functions};
@@ -2804,45 +2803,44 @@ TEST(SortedPhysicalDevices, DevicesSortEnabled10NoAppExt) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({"pd0"});
-    env.get_test_icd(0).physical_devices.back().set_pci_bus(7);
-    FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_1, 888, 0xAAA001);
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    env.get_test_icd(0).physical_devices.push_back({"pd1"});
-    env.get_test_icd(0).physical_devices.back().set_pci_bus(3);
-    FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
-                            VK_API_VERSION_1_1, 888, 0xAAA002);
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_0 = env.get_test_icd(0).add_and_get_physical_device({"pd0"});
+    test_physical_device_0.set_pci_bus(7);
+    FillInRandomDeviceProps(test_physical_device_0.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA001);
+    test_physical_device_0.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_1 = env.get_test_icd(0).add_and_get_physical_device({"pd1"});
+    test_physical_device_1.set_pci_bus(3);
+    FillInRandomDeviceProps(test_physical_device_1.properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA002);
+    test_physical_device_1.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
     env.get_test_icd(1).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(1).physical_devices.push_back({"pd2"});
-    env.get_test_icd(1).physical_devices.back().set_pci_bus(0);
-    FillInRandomDeviceProps(env.get_test_icd(1).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_0,
-                            1, 0xBBBB001);
-    env.get_test_icd(1).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_2 = env.get_test_icd(1).add_and_get_physical_device({"pd2"});
+    test_physical_device_2.set_pci_bus(0);
+    FillInRandomDeviceProps(test_physical_device_2.properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_0, 1, 0xBBBB001);
+    test_physical_device_2.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     env.get_test_icd(2).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(2).physical_devices.push_back({"pd3"});
-    env.get_test_icd(2).physical_devices.back().set_pci_bus(1);
-    FillInRandomDeviceProps(env.get_test_icd(2).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_1, 75, 0xCCCC001);
-    env.get_test_icd(2).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    env.get_test_icd(2).physical_devices.push_back({"pd4"});
-    env.get_test_icd(2).physical_devices.back().set_pci_bus(4);
-    FillInRandomDeviceProps(env.get_test_icd(2).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_0, 75, 0xCCCC002);
-    env.get_test_icd(2).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_3 = env.get_test_icd(2).add_and_get_physical_device({"pd3"});
+    test_physical_device_3.set_pci_bus(1);
+    FillInRandomDeviceProps(test_physical_device_3.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC001);
+    test_physical_device_3.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_4 = env.get_test_icd(2).add_and_get_physical_device({"pd4"});
+    test_physical_device_4.set_pci_bus(4);
+    FillInRandomDeviceProps(test_physical_device_4.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_0, 75,
+                            0xCCCC002);
+    test_physical_device_4.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     env.get_test_icd(3).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(3).physical_devices.push_back({"pd5"});
-    env.get_test_icd(3).physical_devices.back().set_pci_bus(0);
-    FillInRandomDeviceProps(env.get_test_icd(3).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU,
-                            VK_API_VERSION_1_1, 6940, 0xDDDD001);
-    env.get_test_icd(3).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_5 = env.get_test_icd(3).add_and_get_physical_device({"pd5"});
+    test_physical_device_5.set_pci_bus(0);
+    FillInRandomDeviceProps(test_physical_device_5.properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU, VK_API_VERSION_1_1, 6940,
+                            0xDDDD001);
+    test_physical_device_5.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     InstWrapper instance(env.vulkan_functions);
     instance.CheckCreate();
@@ -2912,45 +2910,44 @@ TEST(SortedPhysicalDevices, DevicesSortEnabled10AppExt) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({"pd0"});
-    env.get_test_icd(0).physical_devices.back().set_pci_bus(7);
-    FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_1, 888, 0xAAA001);
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    env.get_test_icd(0).physical_devices.push_back({"pd1"});
-    env.get_test_icd(0).physical_devices.back().set_pci_bus(3);
-    FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
-                            VK_API_VERSION_1_1, 888, 0xAAA002);
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_0 = env.get_test_icd(0).add_and_get_physical_device({"pd0"});
+    test_physical_device_0.set_pci_bus(7);
+    FillInRandomDeviceProps(test_physical_device_0.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA001);
+    test_physical_device_0.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_1 = env.get_test_icd(0).add_and_get_physical_device({"pd1"});
+    test_physical_device_1.set_pci_bus(3);
+    FillInRandomDeviceProps(test_physical_device_1.properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA002);
+    test_physical_device_1.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
     env.get_test_icd(1).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(1).physical_devices.push_back({"pd2"});
-    env.get_test_icd(1).physical_devices.back().set_pci_bus(0);
-    FillInRandomDeviceProps(env.get_test_icd(1).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_0,
-                            1, 0xBBBB001);
-    env.get_test_icd(1).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_2 = env.get_test_icd(1).add_and_get_physical_device({"pd2"});
+    test_physical_device_2.set_pci_bus(0);
+    FillInRandomDeviceProps(test_physical_device_2.properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_0, 1, 0xBBBB001);
+    test_physical_device_2.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     env.get_test_icd(2).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(2).physical_devices.push_back({"pd3"});
-    env.get_test_icd(2).physical_devices.back().set_pci_bus(1);
-    FillInRandomDeviceProps(env.get_test_icd(2).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_1, 75, 0xCCCC001);
-    env.get_test_icd(2).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    env.get_test_icd(2).physical_devices.push_back({"pd4"});
-    env.get_test_icd(2).physical_devices.back().set_pci_bus(4);
-    FillInRandomDeviceProps(env.get_test_icd(2).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_0, 75, 0xCCCC002);
-    env.get_test_icd(2).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_3 = env.get_test_icd(2).add_and_get_physical_device({"pd3"});
+    test_physical_device_3.set_pci_bus(1);
+    FillInRandomDeviceProps(test_physical_device_3.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC001);
+    test_physical_device_3.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_4 = env.get_test_icd(2).add_and_get_physical_device({"pd4"});
+    test_physical_device_4.set_pci_bus(4);
+    FillInRandomDeviceProps(test_physical_device_4.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_0, 75,
+                            0xCCCC002);
+    test_physical_device_4.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     env.get_test_icd(3).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(3).physical_devices.push_back({"pd5"});
-    env.get_test_icd(3).physical_devices.back().set_pci_bus(0);
-    FillInRandomDeviceProps(env.get_test_icd(3).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU,
-                            VK_API_VERSION_1_1, 6940, 0xDDDD001);
-    env.get_test_icd(3).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_5 = env.get_test_icd(3).add_and_get_physical_device({"pd5"});
+    test_physical_device_5.set_pci_bus(0);
+    FillInRandomDeviceProps(test_physical_device_5.properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU, VK_API_VERSION_1_1, 6940,
+                            0xDDDD001);
+    test_physical_device_5.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -3035,48 +3032,47 @@ TEST(SortedPhysicalDevices, DevicesSortEnabled11) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     env.get_test_icd(0).set_icd_api_version(VK_API_VERSION_1_1);
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({"pd0"});
-    env.get_test_icd(0).physical_devices.back().set_pci_bus(7);
-    FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_0, 888, 0xAAA001);
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    env.get_test_icd(0).physical_devices.push_back({"pd1"});
-    env.get_test_icd(0).physical_devices.back().set_pci_bus(3);
-    FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
-                            VK_API_VERSION_1_0, 888, 0xAAA002);
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_0 = env.get_test_icd(0).add_and_get_physical_device({"pd0"});
+    test_physical_device_0.set_pci_bus(7);
+    FillInRandomDeviceProps(test_physical_device_0.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_0, 888,
+                            0xAAA001);
+    test_physical_device_0.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_1 = env.get_test_icd(0).add_and_get_physical_device({"pd1"});
+    test_physical_device_1.set_pci_bus(3);
+    FillInRandomDeviceProps(test_physical_device_1.properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, VK_API_VERSION_1_0, 888,
+                            0xAAA002);
+    test_physical_device_1.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     env.get_test_icd(1).set_icd_api_version(VK_API_VERSION_1_1);
     env.get_test_icd(1).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(1).physical_devices.push_back({"pd2"});
-    env.get_test_icd(1).physical_devices.back().set_pci_bus(0);
-    FillInRandomDeviceProps(env.get_test_icd(1).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_0,
-                            1, 0xBBBB001);
-    env.get_test_icd(1).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_2 = env.get_test_icd(1).add_and_get_physical_device({"pd2"});
+    test_physical_device_2.set_pci_bus(0);
+    FillInRandomDeviceProps(test_physical_device_2.properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_0, 1, 0xBBBB001);
+    test_physical_device_2.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     env.get_test_icd(2).set_icd_api_version(VK_API_VERSION_1_1);
     env.get_test_icd(2).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(2).physical_devices.push_back({"pd3"});
-    env.get_test_icd(2).physical_devices.back().set_pci_bus(1);
-    FillInRandomDeviceProps(env.get_test_icd(2).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_1, 75, 0xCCCC001);
-    env.get_test_icd(2).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    env.get_test_icd(2).physical_devices.push_back({"pd4"});
-    env.get_test_icd(2).physical_devices.back().set_pci_bus(4);
-    FillInRandomDeviceProps(env.get_test_icd(2).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_1, 75, 0xCCCC002);
-    env.get_test_icd(2).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_3 = env.get_test_icd(2).add_and_get_physical_device({"pd3"});
+    test_physical_device_3.set_pci_bus(1);
+    FillInRandomDeviceProps(test_physical_device_3.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC001);
+    test_physical_device_3.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_4 = env.get_test_icd(2).add_and_get_physical_device({"pd4"});
+    test_physical_device_4.set_pci_bus(4);
+    FillInRandomDeviceProps(test_physical_device_4.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC002);
+    test_physical_device_4.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     env.get_test_icd(3).set_icd_api_version(VK_API_VERSION_1_1);
     env.get_test_icd(3).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(3).physical_devices.push_back({"pd5"});
-    env.get_test_icd(3).physical_devices.back().set_pci_bus(0);
-    FillInRandomDeviceProps(env.get_test_icd(3).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU,
-                            VK_API_VERSION_1_1, 6940, 0xDDDD001);
-    env.get_test_icd(3).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_5 = env.get_test_icd(3).add_and_get_physical_device({"pd5"});
+    test_physical_device_5.set_pci_bus(0);
+    FillInRandomDeviceProps(test_physical_device_5.properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU, VK_API_VERSION_1_1, 6940,
+                            0xDDDD001);
+    test_physical_device_5.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -3163,39 +3159,38 @@ TEST(SortedPhysicalDevices, DevicesSortedDisabled) {
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
     env.get_test_icd(0).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(0).physical_devices.push_back({"pd0"});
-    FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_0, 888, 0xAAA001);
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    env.get_test_icd(0).physical_devices.push_back({"pd1"});
-    FillInRandomDeviceProps(env.get_test_icd(0).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
-                            VK_API_VERSION_1_0, 888, 0xAAA002);
-    env.get_test_icd(0).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_0 = env.get_test_icd(0).add_and_get_physical_device({"pd0"});
+    FillInRandomDeviceProps(test_physical_device_0.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_0, 888,
+                            0xAAA001);
+    test_physical_device_0.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_1 = env.get_test_icd(0).add_and_get_physical_device({"pd1"});
+    FillInRandomDeviceProps(test_physical_device_1.properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, VK_API_VERSION_1_0, 888,
+                            0xAAA002);
+    test_physical_device_1.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
     env.get_test_icd(1).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(1).physical_devices.push_back({"pd2"});
-    FillInRandomDeviceProps(env.get_test_icd(1).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_0,
-                            1, 0xBBBB001);
-    env.get_test_icd(1).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_2 = env.get_test_icd(1).add_and_get_physical_device({"pd2"});
+    FillInRandomDeviceProps(test_physical_device_2.properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_0, 1, 0xBBBB001);
+    test_physical_device_2.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
     env.get_test_icd(2).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(2).physical_devices.push_back({"pd3"});
-    FillInRandomDeviceProps(env.get_test_icd(2).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_0, 75, 0xCCCC001);
-    env.get_test_icd(2).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    env.get_test_icd(2).physical_devices.push_back({"pd4"});
-    FillInRandomDeviceProps(env.get_test_icd(2).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-                            VK_API_VERSION_1_0, 75, 0xCCCC002);
-    env.get_test_icd(2).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_3 = env.get_test_icd(2).add_and_get_physical_device({"pd3"});
+    FillInRandomDeviceProps(test_physical_device_3.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_0, 75,
+                            0xCCCC001);
+    test_physical_device_3.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_4 = env.get_test_icd(2).add_and_get_physical_device({"pd4"});
+    FillInRandomDeviceProps(test_physical_device_4.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_0, 75,
+                            0xCCCC002);
+    test_physical_device_4.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_0));
     env.get_test_icd(3).add_instance_extension({VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME});
-    env.get_test_icd(3).physical_devices.push_back({"pd5"});
-    FillInRandomDeviceProps(env.get_test_icd(3).physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU,
-                            VK_API_VERSION_1_0, 6940, 0xDDDD001);
-    env.get_test_icd(3).physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    auto& test_physical_device_5 = env.get_test_icd(3).add_and_get_physical_device({"pd5"});
+    FillInRandomDeviceProps(test_physical_device_5.properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU, VK_API_VERSION_1_0, 6940,
+                            0xDDDD001);
+    test_physical_device_5.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
 
     InstWrapper instance(env.vulkan_functions);
     instance.create_info.add_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -3265,68 +3260,63 @@ TEST(SortedPhysicalDevices, DeviceGroupsSortedEnabled) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     auto& cur_icd_0 = env.get_test_icd(0);
     cur_icd_0.set_icd_api_version(VK_API_VERSION_1_1);
-    cur_icd_0.physical_devices.push_back({"pd0"});
-    cur_icd_0.physical_devices.back().set_pci_bus(7);
-    cur_icd_0.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_0.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            888, 0xAAA001);
-    cur_icd_0.physical_devices.push_back({"pd1"});
-    cur_icd_0.physical_devices.back().set_pci_bus(3);
-    cur_icd_0.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_0.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
-                            VK_API_VERSION_1_1, 888, 0xAAA002);
-    cur_icd_0.physical_devices.push_back({"pd2"});
-    cur_icd_0.physical_devices.back().set_pci_bus(6);
-    cur_icd_0.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_0.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            888, 0xAAA003);
+    auto& test_physical_device_0 = cur_icd_0.add_and_get_physical_device({"pd0"});
+    test_physical_device_0.set_pci_bus(7);
+    test_physical_device_0.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_0.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA001);
+    auto& test_physical_device_1 = cur_icd_0.add_and_get_physical_device({"pd1"});
+    test_physical_device_1.set_pci_bus(3);
+    test_physical_device_1.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_1.properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA002);
+    auto& test_physical_device_2 = cur_icd_0.add_and_get_physical_device({"pd2"});
+    test_physical_device_2.set_pci_bus(6);
+    test_physical_device_2.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_2.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA003);
     cur_icd_0.physical_device_groups.push_back({});
-    cur_icd_0.physical_device_groups.back()
-        .use_physical_device(cur_icd_0.physical_devices[0])
-        .use_physical_device(cur_icd_0.physical_devices[2]);
-    cur_icd_0.physical_device_groups.push_back({cur_icd_0.physical_devices[1]});
+    cur_icd_0.physical_device_groups.back().use_physical_device(test_physical_device_0).use_physical_device(test_physical_device_2);
+    cur_icd_0.physical_device_groups.push_back({test_physical_device_1});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     auto& cur_icd_1 = env.get_test_icd(1);
     cur_icd_1.set_icd_api_version(VK_API_VERSION_1_1);
-    cur_icd_1.physical_devices.push_back({"pd3"});
-    cur_icd_1.physical_devices.back().set_pci_bus(0);
-    cur_icd_1.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_1.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_1, 1,
-                            0xBBBB001);
+    auto& test_physical_device_3 = cur_icd_1.add_and_get_physical_device({"pd3"});
+    test_physical_device_3.set_pci_bus(0);
+    test_physical_device_3.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_3.properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_1, 1, 0xBBBB001);
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     auto& cur_icd_2 = env.get_test_icd(2);
     cur_icd_2.set_icd_api_version(VK_API_VERSION_1_1);
-    cur_icd_2.physical_devices.push_back({"pd4"});
-    cur_icd_2.physical_devices.back().set_pci_bus(1);
-    cur_icd_2.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_2.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            75, 0xCCCC001);
-    cur_icd_2.physical_devices.push_back({"pd5"});
-    cur_icd_2.physical_devices.back().set_pci_bus(4);
-    cur_icd_2.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_2.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            75, 0xCCCC002);
-    cur_icd_2.physical_devices.push_back({"pd6"});
-    cur_icd_2.physical_devices.back().set_pci_bus(2);
-    cur_icd_2.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_2.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            75, 0xCCCC003);
+    auto& test_physical_device_4 = cur_icd_2.add_and_get_physical_device({"pd4"});
+    test_physical_device_4.set_pci_bus(1);
+    test_physical_device_4.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_4.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC001);
+    auto& test_physical_device_5 = cur_icd_2.add_and_get_physical_device({"pd5"});
+    test_physical_device_5.set_pci_bus(4);
+    test_physical_device_5.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_5.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC002);
+    auto& test_physical_device_6 = cur_icd_2.add_and_get_physical_device({"pd6"});
+    test_physical_device_6.set_pci_bus(2);
+    test_physical_device_6.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_6.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC003);
     cur_icd_2.physical_device_groups.push_back({});
-    cur_icd_2.physical_device_groups.back()
-        .use_physical_device(cur_icd_2.physical_devices[1])
-        .use_physical_device(cur_icd_2.physical_devices[2]);
-    cur_icd_2.physical_device_groups.push_back({cur_icd_2.physical_devices[0]});
+    cur_icd_2.physical_device_groups.back().use_physical_device(test_physical_device_5).use_physical_device(test_physical_device_6);
+    cur_icd_2.physical_device_groups.push_back({test_physical_device_4});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     auto& cur_icd_3 = env.get_test_icd(3);
     cur_icd_3.set_icd_api_version(VK_API_VERSION_1_1);
-    cur_icd_3.physical_devices.push_back({"pd7"});
-    cur_icd_3.physical_devices.back().set_pci_bus(0);
-    cur_icd_3.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_3.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU, VK_API_VERSION_1_1,
-                            6940, 0xDDDD001);
+    auto& test_physical_device_7 = cur_icd_3.add_and_get_physical_device({"pd7"});
+    test_physical_device_7.set_pci_bus(0);
+    test_physical_device_7.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_7.properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU, VK_API_VERSION_1_1, 6940,
+                            0xDDDD001);
 
     InstWrapper inst(env.vulkan_functions);
     inst.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -3458,60 +3448,55 @@ TEST(SortedPhysicalDevices, DeviceGroupsSortedDisabled) {
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     auto& cur_icd_0 = env.get_test_icd(0);
     cur_icd_0.set_icd_api_version(VK_API_VERSION_1_1);
-    cur_icd_0.physical_devices.push_back({"pd0"});
-    cur_icd_0.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_0.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            888, 0xAAA001);
-    cur_icd_0.physical_devices.push_back({"pd1"});
-    cur_icd_0.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_0.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
-                            VK_API_VERSION_1_1, 888, 0xAAA002);
-    cur_icd_0.physical_devices.push_back({"pd2"});
-    cur_icd_0.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_0.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            888, 0xAAA003);
+    auto& test_physical_device_0 = cur_icd_0.add_and_get_physical_device({"pd0"});
+    test_physical_device_0.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_0.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA001);
+    auto& test_physical_device_1 = cur_icd_0.add_and_get_physical_device({"pd1"});
+    test_physical_device_1.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_1.properties, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA002);
+    auto& test_physical_device_2 = cur_icd_0.add_and_get_physical_device({"pd2"});
+    test_physical_device_2.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_2.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 888,
+                            0xAAA003);
     cur_icd_0.physical_device_groups.push_back({});
-    cur_icd_0.physical_device_groups.back()
-        .use_physical_device(cur_icd_0.physical_devices[0])
-        .use_physical_device(cur_icd_0.physical_devices[2]);
-    cur_icd_0.physical_device_groups.push_back({cur_icd_0.physical_devices[1]});
+    cur_icd_0.physical_device_groups.back().use_physical_device(test_physical_device_0).use_physical_device(test_physical_device_2);
+    cur_icd_0.physical_device_groups.push_back({test_physical_device_1});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     auto& cur_icd_1 = env.get_test_icd(1);
     cur_icd_1.set_icd_api_version(VK_API_VERSION_1_1);
-    cur_icd_1.physical_devices.push_back({"pd3"});
-    cur_icd_1.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_1.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_1, 1,
-                            0xBBBB001);
+    auto& test_physical_device_3 = cur_icd_1.add_and_get_physical_device({"pd3"});
+    test_physical_device_3.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_3.properties, VK_PHYSICAL_DEVICE_TYPE_CPU, VK_API_VERSION_1_1, 1, 0xBBBB001);
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     auto& cur_icd_2 = env.get_test_icd(2);
     cur_icd_2.set_icd_api_version(VK_API_VERSION_1_1);
-    cur_icd_2.physical_devices.push_back({"pd4"});
-    cur_icd_2.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_2.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            75, 0xCCCC001);
-    cur_icd_2.physical_devices.push_back({"pd5"});
-    cur_icd_2.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_2.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            75, 0xCCCC002);
-    cur_icd_2.physical_devices.push_back({"pd6"});
-    cur_icd_2.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_2.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1,
-                            75, 0xCCCC003);
+    auto& test_physical_device_4 = cur_icd_2.add_and_get_physical_device({"pd4"});
+    test_physical_device_4.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_4.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC001);
+    auto& test_physical_device_5 = cur_icd_2.add_and_get_physical_device({"pd5"});
+    test_physical_device_5.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_5.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC002);
+    auto& test_physical_device_6 = cur_icd_2.add_and_get_physical_device({"pd6"});
+    test_physical_device_6.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_6.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
+                            0xCCCC003);
     cur_icd_2.physical_device_groups.push_back({});
-    cur_icd_2.physical_device_groups.back()
-        .use_physical_device(cur_icd_2.physical_devices[1])
-        .use_physical_device(cur_icd_2.physical_devices[2]);
-    cur_icd_2.physical_device_groups.push_back({cur_icd_2.physical_devices[0]});
+    cur_icd_2.physical_device_groups.back().use_physical_device(test_physical_device_5).use_physical_device(test_physical_device_6);
+    cur_icd_2.physical_device_groups.push_back({test_physical_device_4});
 
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2, VK_API_VERSION_1_1));
     auto& cur_icd_3 = env.get_test_icd(3);
     cur_icd_3.set_icd_api_version(VK_API_VERSION_1_1);
-    cur_icd_3.physical_devices.push_back({"pd7"});
-    cur_icd_3.physical_devices.back().extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
-    FillInRandomDeviceProps(cur_icd_3.physical_devices.back().properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU, VK_API_VERSION_1_1,
-                            6940, 0xDDDD001);
+    auto& test_physical_device_7 = cur_icd_3.add_and_get_physical_device({"pd7"});
+    test_physical_device_7.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
+    FillInRandomDeviceProps(test_physical_device_7.properties, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU, VK_API_VERSION_1_1, 6940,
+                            0xDDDD001);
 
     InstWrapper inst(env.vulkan_functions);
     inst.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -3665,10 +3650,10 @@ TEST(PortabilityICDConfiguration, PortabilityAndRegularICD) {
     auto& driver0 = env.get_test_icd(0);
     auto& driver1 = env.get_test_icd(1);
 
-    driver0.physical_devices.emplace_back("physical_device_0");
+    driver0.add_and_get_physical_device("physical_device_0");
     driver0.max_icd_interface_version = 1;
 
-    driver1.physical_devices.emplace_back("portability_physical_device_1");
+    driver1.add_and_get_physical_device("portability_physical_device_1");
     driver1.max_icd_interface_version = 1;
     {  // enable portability extension and flag
         InstWrapper inst{env.vulkan_functions};
@@ -3746,10 +3731,10 @@ TEST(PortabilityICDConfiguration, PortabilityAndRegularICDCheckFlagsPassedIntoIC
     auto& driver0 = env.get_test_icd(0);
     auto& driver1 = env.get_test_icd(1);
 
-    driver0.physical_devices.emplace_back("physical_device_0");
+    driver0.add_and_get_physical_device("physical_device_0");
     driver0.max_icd_interface_version = 1;
 
-    driver1.physical_devices.emplace_back("portability_physical_device_1");
+    driver1.add_and_get_physical_device("portability_physical_device_1");
     driver1.add_instance_extension("VK_KHR_portability_enumeration");
     driver1.max_icd_interface_version = 1;
 
@@ -3909,10 +3894,11 @@ TEST(DuplicateRegistryEntries, Drivers) {
 TEST(LibraryLoading, SystemLocations) {
     FrameworkEnvironment env{};
 
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2).set_library_path_type(LibraryPathType::default_search_paths))
-                       .add_physical_device({});
+    auto& test_physical_device =
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2).set_library_path_type(LibraryPathType::default_search_paths))
+            .add_and_get_physical_device({});
     const char* fake_ext_name = "VK_FAKE_extension";
-    driver.physical_devices.back().add_extension(fake_ext_name);
+    test_physical_device.add_extension(fake_ext_name);
 
     const char* layer_name = "TestLayer";
     env.add_explicit_layer(
@@ -3996,11 +3982,11 @@ TEST(ManifestDiscovery, AppleBundles) {
     FrameworkEnvironment env{};
     env.setup_macos_bundle();
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA).set_discovery_type(ManifestDiscoveryType::macos_bundle));
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.at(0).properties.deviceID = 1337;
+    auto& test_physical_device_0 = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device_0.properties.deviceID = 1337;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
-    env.get_test_icd(1).physical_devices.push_back({});
-    env.get_test_icd(1).physical_devices.at(0).properties.deviceID = 9999;
+    auto& test_physical_device_1 = env.get_test_icd(1).add_and_get_physical_device({});
+    test_physical_device_1.properties.deviceID = 9999;
 
     InstWrapper inst{env.vulkan_functions};
     ASSERT_NO_FATAL_FAILURE(inst.CheckCreate());
@@ -4010,7 +3996,7 @@ TEST(ManifestDiscovery, AppleBundles) {
     // Verify that this is the 'right' GPU, aka the one from the bundle
     VkPhysicalDeviceProperties props{};
     inst->vkGetPhysicalDeviceProperties(physical_devices[0], &props);
-    ASSERT_EQ(env.get_test_icd(0).physical_devices.at(0).properties.deviceID, props.deviceID);
+    ASSERT_EQ(test_physical_device_0.properties.deviceID, props.deviceID);
 }
 
 // Add two drivers, one to the bundle and one using the driver env-var
@@ -4018,11 +4004,13 @@ TEST(ManifestDiscovery, AppleBundlesEnvVarActive) {
     FrameworkEnvironment env{};
     env.setup_macos_bundle();
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA).set_discovery_type(ManifestDiscoveryType::macos_bundle));
-    env.get_test_icd(0).physical_devices.push_back({});
-    env.get_test_icd(0).physical_devices.at(0).properties.deviceID = 1337;
+
+    auto& test_physical_device_0 = env.get_test_icd(0).add_and_get_physical_device({});
+    test_physical_device_0.properties.deviceID = 1337;
+
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA).set_discovery_type(ManifestDiscoveryType::env_var));
-    env.get_test_icd(1).physical_devices.push_back({});
-    env.get_test_icd(1).physical_devices.at(0).properties.deviceID = 9999;
+    auto& test_physical_device_1 = env.get_test_icd(1).add_and_get_physical_device({});
+    test_physical_device_1.properties.deviceID = 9999;
 
     InstWrapper inst{env.vulkan_functions};
     ASSERT_NO_FATAL_FAILURE(inst.CheckCreate());
@@ -4032,7 +4020,7 @@ TEST(ManifestDiscovery, AppleBundlesEnvVarActive) {
     // Verify that this is the 'right' GPU, aka the one from the env-var
     VkPhysicalDeviceProperties props{};
     inst->vkGetPhysicalDeviceProperties(physical_devices[0], &props);
-    ASSERT_EQ(env.get_test_icd(1).physical_devices.at(0).properties.deviceID, props.deviceID);
+    ASSERT_EQ(test_physical_device_1.properties.deviceID, props.deviceID);
 }
 #endif
 
@@ -4064,9 +4052,9 @@ TEST(LayerCreatesDevice, Basic) {
 TEST(LayerCreatesDevice, DifferentPhysicalDevice) {
     FrameworkEnvironment env{};
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
-    env.get_test_icd(0).physical_devices.emplace_back("Device0");
+    env.get_test_icd(0).add_and_get_physical_device("Device0");
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2));
-    env.get_test_icd(1).physical_devices.emplace_back("Device1");
+    env.get_test_icd(1).add_and_get_physical_device("Device1");
 
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("implicit_layer_name")
@@ -4242,14 +4230,13 @@ TEST(InvalidManifest, Layer) {
     inst.CheckCreate();
 }
 #if defined(WIN32)
-void add_dxgi_adapter(FrameworkEnvironment& env, std::filesystem::path const& name, LUID luid, uint32_t vendor_id) {
+VkPhysicalDevice add_dxgi_adapter(FrameworkEnvironment& env, std::filesystem::path const& name, LUID luid, uint32_t vendor_id) {
     auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_6).set_discovery_type(ManifestDiscoveryType::null_dir));
     driver.set_min_icd_interface_version(5);
     driver.set_max_icd_interface_version(6);
     driver.setup_WSI();
     driver.set_icd_api_version(VK_API_VERSION_1_1);
-    driver.physical_devices.emplace_back(name.string());
-    auto& pd0 = driver.physical_devices.back();
+    auto& pd0 = driver.add_and_get_physical_device(name.string());
     pd0.properties.apiVersion = VK_API_VERSION_1_1;
     driver.set_adapterLUID(luid);
 
@@ -4276,6 +4263,7 @@ void add_dxgi_adapter(FrameworkEnvironment& env, std::filesystem::path const& na
     } else {
         pAdapter->add_driver_manifest_path(env.get_icd_manifest_path(env.icds.size() - 1));
     }
+    return pd0.vk_physical_device.handle;
 }
 
 TEST(EnumerateAdapterPhysicalDevices, SameAdapterLUID_reordered) {
@@ -4288,7 +4276,7 @@ TEST(EnumerateAdapterPhysicalDevices, SameAdapterLUID_reordered) {
     // b) then in the reverse order to the drivers insertion into the test framework
     add_dxgi_adapter(env, "physical_device_2", LUID{10, 100}, 2);
     add_dxgi_adapter(env, "physical_device_1", LUID{20, 200}, 1);
-    add_dxgi_adapter(env, "physical_device_0", LUID{10, 100}, 2);
+    auto phys_dev_handle = add_dxgi_adapter(env, "physical_device_0", LUID{10, 100}, 2);
 
     {
         uint32_t returned_physical_count = 0;
@@ -4332,7 +4320,8 @@ TEST(EnumerateAdapterPhysicalDevices, SameAdapterLUID_reordered) {
     }
     // Set the first physical device that is enumerated to be a 'layered' driver so it should be swapped with the first physical
     // device
-    env.get_test_icd(2).physical_devices.back().layered_driver_underlying_api = VK_LAYERED_DRIVER_UNDERLYING_API_D3D12_MSFT;
+    env.get_test_icd(2).physical_devices.at(phys_dev_handle).layered_driver_underlying_api =
+        VK_LAYERED_DRIVER_UNDERLYING_API_D3D12_MSFT;
     {
         uint32_t returned_physical_count = 0;
         InstWrapper inst{env.vulkan_functions};
@@ -4384,12 +4373,13 @@ TEST(EnumerateAdapterPhysicalDevices, SameAdapterLUID_same_order) {
     // Physical devices are enumerated:
     // a) first in the order of LUIDs showing up in DXGIAdapter list
     // b) then in the reverse order to the drivers insertion into the test framework
-    add_dxgi_adapter(env, "physical_device_2", LUID{10, 100}, 2);
+    auto d3d12_physical_device = add_dxgi_adapter(env, "physical_device_2", LUID{10, 100}, 2);
     add_dxgi_adapter(env, "physical_device_1", LUID{20, 200}, 1);
     add_dxgi_adapter(env, "physical_device_0", LUID{10, 100}, 2);
 
-    // Set the last physical device that is enumerated last to be a 'layered'  physical device - no swapping should occur
-    env.get_test_icd(0).physical_devices.back().layered_driver_underlying_api = VK_LAYERED_DRIVER_UNDERLYING_API_D3D12_MSFT;
+    // Set the physical device that is enumerated last to be a 'layered'  physical device - no swapping should occur
+    env.get_test_icd(0).physical_devices.at(d3d12_physical_device).layered_driver_underlying_api =
+        VK_LAYERED_DRIVER_UNDERLYING_API_D3D12_MSFT;
 
     uint32_t returned_physical_count = 0;
     InstWrapper inst{env.vulkan_functions};

--- a/tests/loader_threading_tests.cpp
+++ b/tests/loader_threading_tests.cpp
@@ -88,7 +88,7 @@ TEST(Threading, InstanceCreateDestroyLoop) {
     uint32_t num_loops_try_get_instance_proc_addr = 5;
     uint32_t num_loops_try_get_device_proc_addr = 100;
 
-    driver.physical_devices.emplace_back("physical_device_0")
+    driver.add_and_get_physical_device("physical_device_0")
         .known_device_functions.push_back({"vkCmdBindPipeline", to_vkVoidFunction(test_vkCmdBindPipeline)});
 
     std::vector<std::thread> instance_creation_threads;
@@ -112,7 +112,7 @@ TEST(Threading, DeviceCreateDestroyLoop) {
     uint32_t num_loops_create_destroy_device = 1000;
     uint32_t num_loops_try_get_device_proc_addr = 5;
 
-    driver.physical_devices.emplace_back("physical_device_0").known_device_functions = {
+    driver.add_and_get_physical_device("physical_device_0").known_device_functions = {
         {"vkCmdBindPipeline", to_vkVoidFunction(test_vkCmdBindPipeline)},
         {"vkCmdBindDescriptorSets", to_vkVoidFunction(test_vkCmdBindDescriptorSets)},
         {"vkCmdBindVertexBuffers", to_vkVoidFunction(test_vkCmdBindVertexBuffers)},

--- a/tests/loader_unknown_ext_tests.cpp
+++ b/tests/loader_unknown_ext_tests.cpp
@@ -335,12 +335,13 @@ using layer_implementation_physical_device_functions = layer_implementation_func
 
 TEST(UnknownFunction, PhysicalDeviceFunction) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).add_physical_device({});
+    auto& test_physical_device =
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).add_and_get_physical_device({});
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
     std::vector<std::string> function_names;
     add_function_names(function_names, function_count);
 
-    fill_implementation_functions(driver.physical_devices.at(0).custom_physical_device_functions, function_names,
+    fill_implementation_functions(test_physical_device.custom_physical_device_functions, function_names,
                                   custom_physical_device_functions{}, function_count);
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
@@ -359,13 +360,15 @@ TEST(UnknownFunction, PhysicalDeviceFunctionMultipleDriverSupport) {
     add_function_names(function_names, function_count);
 
     // used to identify the GPUs
-    driver_0.physical_devices.emplace_back("physical_device_0").properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-    driver_1.physical_devices.emplace_back("physical_device_1").properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+    auto& test_physical_driver_0 = driver_0.add_and_get_physical_device("physical_device_0");
+    test_physical_driver_0.properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+    auto& test_physical_driver_1 = driver_1.add_and_get_physical_device("physical_device_1");
+    test_physical_driver_1.properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
 
     for (uint32_t i = 0; i < function_count / 10; i++) {
-        fill_implementation_functions(driver_0.physical_devices.at(0).custom_physical_device_functions, function_names,
+        fill_implementation_functions(test_physical_driver_0.custom_physical_device_functions, function_names,
                                       custom_physical_device_functions{}, 5, i * 10);
-        fill_implementation_functions(driver_1.physical_devices.at(0).custom_physical_device_functions, function_names,
+        fill_implementation_functions(test_physical_driver_1.custom_physical_device_functions, function_names,
                                       custom_physical_device_functions{}, 5, i * 10 + 5);
     }
     InstWrapper inst{env.vulkan_functions};
@@ -397,12 +400,14 @@ TEST(UnknownFunctionDeathTests, PhysicalDeviceFunctionErrorPath) {
     add_function_names(function_names, 1);
 
     // used to identify the GPUs
-    driver_0.physical_devices.emplace_back("physical_device_0").properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-    driver_1.physical_devices.emplace_back("physical_device_1").properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+    auto& test_physical_driver_0 = driver_0.add_and_get_physical_device("physical_device_0");
+    test_physical_driver_0.properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+    auto& test_physical_driver_1 = driver_1.add_and_get_physical_device("physical_device_1");
+    test_physical_driver_1.properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
     function_names.push_back(std::string("vkNotIntRealFuncTEST_0"));
 
     custom_physical_device_functions funcs{};
-    driver_0.physical_devices.at(0).custom_physical_device_functions.push_back(
+    test_physical_driver_0.custom_physical_device_functions.push_back(
         VulkanFunction{function_names.back(), to_vkVoidFunction(funcs.func_zero)});
 
     InstWrapper inst{env.vulkan_functions};
@@ -454,12 +459,14 @@ TEST(UnknownFunction, PhysicalDeviceFunctionMultipleDriverSupportWithImplicitLay
     add_function_names(function_names, function_count);
 
     // used to identify the GPUs
-    driver_0.physical_devices.emplace_back("physical_device_0").properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-    driver_1.physical_devices.emplace_back("physical_device_1").properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+    auto& test_physical_device_0 = driver_0.add_and_get_physical_device("physical_device_0");
+    test_physical_device_0.properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+    auto& test_physical_device_1 = driver_1.add_and_get_physical_device("physical_device_1");
+    test_physical_device_1.properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
     for (uint32_t i = 0; i < function_count / 10; i++) {
-        fill_implementation_functions(driver_0.physical_devices.at(0).custom_physical_device_functions, function_names,
+        fill_implementation_functions(test_physical_device_0.custom_physical_device_functions, function_names,
                                       custom_physical_device_functions{}, 5, i * 10);
-        fill_implementation_functions(driver_1.physical_devices.at(0).custom_physical_device_functions, function_names,
+        fill_implementation_functions(test_physical_device_1.custom_physical_device_functions, function_names,
                                       custom_physical_device_functions{}, 5, i * 10 + 5);
     }
 
@@ -515,11 +522,12 @@ TEST(UnknownFunction, PhysicalDeviceFunctionWithImplicitLayerInterception) {
 
 TEST(UnknownFunction, PhysicalDeviceFunctionDriverSupportWithImplicitLayerInterception) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).add_physical_device({});
+    auto& test_physical_device =
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).add_and_get_physical_device({});
     uint32_t function_count = 100;
     std::vector<std::string> function_names;
     add_function_names(function_names, function_count);
-    fill_implementation_functions(driver.physical_devices.at(0).custom_physical_device_functions, function_names,
+    fill_implementation_functions(test_physical_device.custom_physical_device_functions, function_names,
                                   layer_implementation_physical_device_functions{}, function_count);
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VK_LAYER_implicit_layer_unknown_function_intercept")
@@ -543,7 +551,7 @@ TEST(UnknownFunction, PhysicalDeviceFunctionWithMultipleImplicitLayersIntercepti
     std::vector<std::string> function_names;
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
     add_function_names(function_names, function_count);
-    driver.physical_devices.emplace_back("physical_device_0");
+    auto& test_physical_device = driver.add_and_get_physical_device("physical_device_0");
 
     env.add_implicit_layer(ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
                                                          .set_name("VK_LAYER_implicit_layer_unknown_function_intercept_0")
@@ -560,7 +568,7 @@ TEST(UnknownFunction, PhysicalDeviceFunctionWithMultipleImplicitLayersIntercepti
     auto& layer_1 = env.get_test_layer(1);
     layer_1.set_use_gipa_GetPhysicalDeviceProcAddr(false);
     for (uint32_t i = 0; i < function_count / 10; i++) {
-        fill_implementation_functions(driver.physical_devices.at(0).custom_physical_device_functions, function_names,
+        fill_implementation_functions(test_physical_device.custom_physical_device_functions, function_names,
                                       layer_implementation_physical_device_functions{}, 5, i * 10);
         fill_phys_dev_intercept_functions(layer_0, function_names, layer_intercept_physical_device_functions{}, 5, i * 10);
         fill_phys_dev_intercept_functions(layer_1, function_names, layer_intercept_physical_device_functions{}, 5, i * 10 + 5);
@@ -628,18 +636,18 @@ void unknown_function_test_impl(std::vector<TestConfig> const& flags) {
     using layer_intercept_functions_type = layer_intercept_functions<DispatchableHandleType>;
 
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).add_physical_device({});
+    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA));
+    auto& pd = driver.add_and_get_physical_device({});
     uint32_t function_count = MAX_NUM_UNKNOWN_EXTS;
 
     std::vector<std::string> function_names;
     add_function_names(function_names, function_count);
 
     if (has_flag(flags, TestConfig::add_layer_interception)) {
-        fill_implementation_functions(driver.physical_devices.back().known_device_functions, function_names,
-                                      layer_implementation_functions_type{}, function_count);
+        fill_implementation_functions(pd.known_device_functions, function_names, layer_implementation_functions_type{},
+                                      function_count);
     } else {
-        fill_implementation_functions(driver.physical_devices.back().known_device_functions, function_names,
-                                      custom_functions_type{}, function_count);
+        fill_implementation_functions(pd.known_device_functions, function_names, custom_functions_type{}, function_count);
     }
     TestLayer* layer_ptr = nullptr;
     if (has_flag(flags, TestConfig::add_layer_implementation) || has_flag(flags, TestConfig::add_layer_interception)) {
@@ -1089,8 +1097,7 @@ struct D {};
 
 TEST(UnknownFunction, PhysicalDeviceFunctionTwoLayerInterception) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).add_physical_device({});
-    PhysicalDevice& pd = driver.physical_devices.back();
+    PhysicalDevice& pd = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).add_and_get_physical_device({});
 
     UnknownFunction f{"vkFunc1"};
     Functions::three::physical_device::add_to_driver(f, pd);
@@ -1122,8 +1129,8 @@ TEST(UnknownFunction, PhysicalDeviceFunctionTwoLayerInterception) {
 
 TEST(UnknownFunction, ManyCombinations) {
     FrameworkEnvironment env{};
-    auto& driver = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).add_physical_device({});
-    PhysicalDevice& physical_device = driver.physical_devices.back();
+    PhysicalDevice& physical_device =
+        env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)).add_and_get_physical_device({});
     std::vector<UnknownFunction> unknown_funcs;
 
     unknown_funcs.emplace_back("vkZero_uint32_uint32_0");

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -127,7 +127,7 @@ TEST(WsiTests, GetPhysicalDeviceWin32PresentNoICDSupport) {
     cur_icd.set_min_icd_interface_version(5);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
-    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.add_and_get_physical_device("physical_device_0");
     cur_icd.enable_icd_wsi = false;
 
     InstWrapper inst{env.vulkan_functions};
@@ -154,7 +154,7 @@ TEST(WsiTests, GetPhysicalDeviceWin32PresentICDSupport) {
     cur_icd.set_min_icd_interface_version(5);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WIN32_SURFACE_EXTENSION_NAME});
-    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.add_and_get_physical_device("physical_device_0");
     cur_icd.enable_icd_wsi = true;
 
     InstWrapper inst{env.vulkan_functions};
@@ -181,8 +181,8 @@ TEST(WsiTests, Win32GetPhysicalDeviceSurfaceSupportKHR) {
         cur_icd.set_min_icd_interface_version(5);
         cur_icd.add_instance_extensions({first_ext, second_ext});
         std::string dev_name = "phys_dev_" + std::to_string(icd);
-        cur_icd.physical_devices.emplace_back(dev_name.c_str());
-        cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
+        cur_icd.add_and_get_physical_device(dev_name.c_str())
+            .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
         cur_icd.enable_icd_wsi = true;
     }
 
@@ -311,7 +311,7 @@ TEST(WsiTests, GetPhysicalDeviceXcbPresentNoICDSupport) {
     cur_icd.set_min_icd_interface_version(5);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
-    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.add_and_get_physical_device("physical_device_0");
     cur_icd.enable_icd_wsi = false;
 
     InstWrapper inst{env.vulkan_functions};
@@ -338,7 +338,7 @@ TEST(WsiTests, GetPhysicalDeviceXcbPresentICDSupport) {
     cur_icd.set_min_icd_interface_version(5);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XCB_SURFACE_EXTENSION_NAME});
-    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.add_and_get_physical_device("physical_device_0");
     cur_icd.enable_icd_wsi = true;
 
     InstWrapper inst{env.vulkan_functions};
@@ -365,8 +365,8 @@ TEST(WsiTests, XcbGetPhysicalDeviceSurfaceSupportKHR) {
         cur_icd.set_min_icd_interface_version(5);
         cur_icd.add_instance_extensions({first_ext, second_ext});
         std::string dev_name = "phys_dev_" + std::to_string(icd);
-        cur_icd.physical_devices.emplace_back(dev_name.c_str());
-        cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
+        cur_icd.add_and_get_physical_device(dev_name.c_str())
+            .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
         cur_icd.enable_icd_wsi = true;
     }
 
@@ -495,7 +495,7 @@ TEST(WsiTests, GetPhysicalDeviceXlibPresentNoICDSupport) {
     cur_icd.set_min_icd_interface_version(5);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
-    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.add_and_get_physical_device("physical_device_0");
     cur_icd.enable_icd_wsi = false;
 
     InstWrapper inst{env.vulkan_functions};
@@ -522,7 +522,7 @@ TEST(WsiTests, GetPhysicalDeviceXlibPresentICDSupport) {
     cur_icd.set_min_icd_interface_version(5);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_XLIB_SURFACE_EXTENSION_NAME});
-    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.add_and_get_physical_device("physical_device_0");
     cur_icd.enable_icd_wsi = true;
 
     InstWrapper inst{env.vulkan_functions};
@@ -549,8 +549,8 @@ TEST(WsiTests, XlibGetPhysicalDeviceSurfaceSupportKHR) {
         cur_icd.set_min_icd_interface_version(5);
         cur_icd.add_instance_extensions({first_ext, second_ext});
         std::string dev_name = "phys_dev_" + std::to_string(icd);
-        cur_icd.physical_devices.emplace_back(dev_name.c_str());
-        cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
+        cur_icd.add_and_get_physical_device(dev_name.c_str())
+            .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
         cur_icd.enable_icd_wsi = true;
     }
 
@@ -679,7 +679,7 @@ TEST(WsiTests, GetPhysicalDeviceWaylandPresentNoICDSupport) {
     cur_icd.set_min_icd_interface_version(5);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
-    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.add_and_get_physical_device("physical_device_0");
     cur_icd.enable_icd_wsi = false;
 
     InstWrapper inst{env.vulkan_functions};
@@ -706,7 +706,7 @@ TEST(WsiTests, GetPhysicalDeviceWaylandPresentICDSupport) {
     cur_icd.set_min_icd_interface_version(5);
     cur_icd.add_instance_extension({VK_KHR_SURFACE_EXTENSION_NAME});
     cur_icd.add_instance_extension({VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME});
-    cur_icd.physical_devices.emplace_back("physical_device_0");
+    cur_icd.add_and_get_physical_device("physical_device_0");
     cur_icd.enable_icd_wsi = true;
 
     InstWrapper inst{env.vulkan_functions};
@@ -733,8 +733,8 @@ TEST(WsiTests, WaylandGetPhysicalDeviceSurfaceSupportKHR) {
         cur_icd.set_min_icd_interface_version(5);
         cur_icd.add_instance_extensions({first_ext, second_ext});
         std::string dev_name = "phys_dev_" + std::to_string(icd);
-        cur_icd.physical_devices.emplace_back(dev_name.c_str());
-        cur_icd.physical_devices.back().add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
+        cur_icd.add_and_get_physical_device(dev_name.c_str())
+            .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true});
         cur_icd.enable_icd_wsi = true;
     }
 
@@ -925,15 +925,15 @@ TEST(WsiTests, EXTSurfaceMaintenance1) {
     VkSurfaceCapabilitiesKHR surface_caps{};
     surface_caps.maxImageExtent = VkExtent2D{300, 300};
     surface_caps.minImageExtent = VkExtent2D{100, 100};
-    env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
-        .setup_WSI()
-        .add_instance_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME)
-        .add_physical_device(PhysicalDevice{}
-                                 .add_extension("VK_KHR_swapchain")
-                                 .set_deviceName("no")
-                                 .set_surface_capabilities(surface_caps)
-                                 .add_surface_present_modes(present_modes)
-                                 .finish());
+    auto& test_physical_device_0 = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
+                                       .setup_WSI()
+                                       .add_instance_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME)
+                                       .add_and_get_physical_device(PhysicalDevice{}
+                                                                        .add_extension("VK_KHR_swapchain")
+                                                                        .set_deviceName("no")
+                                                                        .set_surface_capabilities(surface_caps)
+                                                                        .add_surface_present_modes(present_modes)
+                                                                        .finish());
     VkSurfacePresentScalingCapabilitiesEXT scaling_capabilities{};
     scaling_capabilities.supportedPresentScaling = VK_PRESENT_SCALING_ONE_TO_ONE_BIT_EXT;
     scaling_capabilities.supportedPresentGravityX = VK_PRESENT_SCALING_ASPECT_RATIO_STRETCH_BIT_EXT;
@@ -943,21 +943,22 @@ TEST(WsiTests, EXTSurfaceMaintenance1) {
     auto& icd2 = env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
                      .setup_WSI()
                      .add_instance_extension(VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME)
-                     .add_instance_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME)
-                     .add_physical_device(PhysicalDevice{}
-                                              .add_extension("VK_KHR_swapchain")
-                                              .set_deviceName("yes")
-                                              .set_surface_capabilities(surface_caps)
-                                              .add_surface_present_modes(present_modes)
-                                              .set_surface_present_scaling_capabilities(scaling_capabilities)
-                                              .finish());
+                     .add_instance_extension(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
+    auto& test_physical_device_1 =
+        icd2.add_and_get_physical_device(PhysicalDevice{}
+                                             .add_extension("VK_KHR_swapchain")
+                                             .set_deviceName("yes")
+                                             .set_surface_capabilities(surface_caps)
+                                             .add_surface_present_modes(present_modes)
+                                             .set_surface_present_scaling_capabilities(scaling_capabilities)
+                                             .finish());
     std::vector<std::vector<VkPresentModeKHR>> compatible_present_modes{
         {VK_PRESENT_MODE_FIFO_KHR, VK_PRESENT_MODE_FIFO_RELAXED_KHR},
         {VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_MAILBOX_KHR},
         {VK_PRESENT_MODE_MAILBOX_KHR, VK_PRESENT_MODE_IMMEDIATE_KHR},
         {VK_PRESENT_MODE_FIFO_RELAXED_KHR, VK_PRESENT_MODE_FIFO_KHR},
     };
-    icd2.physical_devices[0].surface_present_mode_compatibility = compatible_present_modes;
+    test_physical_device_1.surface_present_mode_compatibility = compatible_present_modes;
     env.add_icd(TestICDDetails(TEST_ICD_PATH_VERSION_2))
         .setup_WSI()
         .add_physical_device(PhysicalDevice{}


### PR DESCRIPTION
Requires extensive modifications to the tests since previously many tests accessed the physical device array directly.

The CreateDevice.ConsecutiveCreate test on linux-arm was taking +180s, with this PR only takes ~20s. 6x isn't a bad uplift (even if it is because of some naive test framework code being the culprit).