### PR TITLE
loader: Include limits.h for PATH_MAX

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -32,6 +32,7 @@
 
 #include <errno.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>


### PR DESCRIPTION
This fixes compiling against musl libc:

```
 loader/loader.c: In function 'normalize_pat':
 loader/loader.c:405:52: error: 'PATH_MAX' undeclared (first use in this function)
   405 |     char *path = loader_instance_heap_calloc(inst, PATH_MAX, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
       |                                                    ^~~~~~~~
```