### PR TITLE
Require a compatible VulkanHeaders version in find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if(WIN32)
     set(BUILD_DLL_VERSIONINFO "" CACHE STRING "Set the version to be used in the loader.rc file. Default value is the currently generated header version")
 endif()
 
-find_package(VulkanHeaders CONFIG QUIET)
+find_package(VulkanHeaders ${CMAKE_PROJECT_VERSION} CONFIG QUIET)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Adding this field uses the generated version in `project()` to force CMake to check that the found VulkanHeaders package's version is the same or greater than the version of VulkanHeaders this project was generated with.