### PR TITLE
Update github actions CI to use macOS-14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,7 +274,7 @@ jobs:
     mac:
         # Mac is 10x expensive to run on GitHub machines, so only run if we know something else passed as well
         needs: windows_clang
-        runs-on: macos-13
+        runs-on: macos-14
         timeout-minutes: 30
         strategy:
             matrix:
@@ -305,7 +305,7 @@ jobs:
         # Mac is 10x expensive to run on GitHub machines, so only run if we know something else passed as well
         needs: windows_clang
         name: ${{ matrix.CMAKE_SYSTEM_NAME }}
-        runs-on: macos-13
+        runs-on: macos-14
         timeout-minutes: 30
         strategy:
             matrix:


### PR DESCRIPTION
macOS-13 is being removed from github actions.