### PR TITLE
loader: Use VULKAN_DIR macro in pathes

### DIFF
--- a/loader/settings.c
+++ b/loader/settings.c
@@ -487,13 +487,13 @@ VkResult get_unix_settings_path(const struct loader_instance* inst, char** setti
     }
 #endif
 
-    VkResult res = check_if_settings_path_exists(inst, xdg_config_home, "/vulkan/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
-                                                 settings_file_path);
+    VkResult res = check_if_settings_path_exists(
+        inst, xdg_config_home, "/" VULKAN_DIR "/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME, settings_file_path);
     if (res == VK_SUCCESS) {
         return res;
     }
 
-    res = check_if_settings_path_exists(inst, xdg_data_home, "/vulkan/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
+    res = check_if_settings_path_exists(inst, xdg_data_home, "/" VULKAN_DIR "/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
                                         settings_file_path);
     if (res == VK_SUCCESS) {
         return res;
@@ -503,41 +503,41 @@ VkResult get_unix_settings_path(const struct loader_instance* inst, char** setti
     char* home = loader_secure_getenv("HOME", inst);
     if (home != NULL) {
         if (NULL == xdg_config_home || '\0' == xdg_config_home[0]) {
-            res = check_if_settings_path_exists(inst, home, "/.config/vulkan/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
-                                                settings_file_path);
+            res = check_if_settings_path_exists(
+                inst, home, "/.config/" VULKAN_DIR "/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME, settings_file_path);
             if (res == VK_SUCCESS) {
                 return res;
             }
         }
         if (NULL == xdg_data_home || '\0' == xdg_data_home[0]) {
-            res = check_if_settings_path_exists(inst, home, "/.local/share/vulkan/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
-                                                settings_file_path);
+            res = check_if_settings_path_exists(
+                inst, home, "/.local/share/" VULKAN_DIR "/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME, settings_file_path);
             if (res == VK_SUCCESS) {
                 return res;
             }
         }
     }
 
-    res = check_if_settings_path_exists(inst, xdg_config_dirs, "/vulkan/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
+    res = check_if_settings_path_exists(inst, xdg_config_dirs, "/" VULKAN_DIR "/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
                                         settings_file_path);
     if (res == VK_SUCCESS) {
         return res;
     }
 
-    res = check_if_settings_path_exists(inst, SYSCONFDIR, "/vulkan/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
+    res = check_if_settings_path_exists(inst, SYSCONFDIR, "/" VULKAN_DIR "/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
                                         settings_file_path);
     if (res == VK_SUCCESS) {
         return res;
     }
 #if defined(EXTRASYSCONFDIR)
 
-    res = check_if_settings_path_exists(inst, EXTRASYSCONFDIR, "/vulkan/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
+    res = check_if_settings_path_exists(inst, EXTRASYSCONFDIR, "/" VULKAN_DIR "/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
                                         settings_file_path);
     if (res == VK_SUCCESS) {
         return res;
     }
 #endif
-    res = check_if_settings_path_exists(inst, xdg_data_dirs, "/vulkan/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
+    res = check_if_settings_path_exists(inst, xdg_data_dirs, "/" VULKAN_DIR "/loader_settings.d/" VK_LOADER_SETTINGS_FILENAME,
                                         settings_file_path);
     if (res == VK_SUCCESS) {
         return res;

--- a/tests/framework/util/test_defines.h
+++ b/tests/framework/util/test_defines.h
@@ -44,6 +44,8 @@
 #define TESTING_COMMON_UNIX_PLATFORMS 0
 #endif
 
+#define TESTING_VULKAN_DIR "vulkan/"
+
 #include FRAMEWORK_CONFIG_HEADER
 
 enum class ManifestCategory { implicit_layer, explicit_layer, icd, settings };

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -40,7 +40,7 @@ std::string get_settings_location_log_message([[maybe_unused]] FrameworkEnvironm
     return s + (env.get_folder(settings_location).location() / "vk_loader_settings.json").string();
 #elif TESTING_COMMON_UNIX_PLATFORMS
     return s + (use_secure ? env.secure_manifest_base_location : env.unsecure_manifest_base_location) +
-           "/vulkan/loader_settings.d/vk_loader_settings.json";
+           "/" TESTING_VULKAN_DIR "/loader_settings.d/vk_loader_settings.json";
 #endif
 }
 std::string get_unsecure_settings_location_log_message(FrameworkEnvironment const& env) {
@@ -54,7 +54,7 @@ std::string get_settings_not_in_use_log_message([[maybe_unused]] FrameworkEnviro
     return s + (env.get_folder(settings_location).location() / "vk_loader_settings.json").string();
 #elif TESTING_COMMON_UNIX_PLATFORMS
     return s + (use_secure ? env.secure_manifest_base_location : env.unsecure_manifest_base_location) +
-           "/vulkan/loader_settings.d/vk_loader_settings.json\" but did not contain any valid settings.";
+           "/" TESTING_VULKAN_DIR "/loader_settings.d/vk_loader_settings.json\" but did not contain any valid settings.";
 #endif
 }
 enum class LayerType {


### PR DESCRIPTION
Use VULKAN_DIR macro in pathes.
Also introduces TESTING_VULKAN_DIR macro in test framework.

It helps to handle the different implementations more clearly between APIs (e.g. Vulkan SC)