### PR TITLE
loader: fix memory leak from loader_scanned_icd_add

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2258,13 +2258,16 @@ VkResult loader_scanned_icd_add(const struct loader_instance *inst, struct loade
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "loader_scanned_icd_add: Out of memory can't add ICD %s", filename);
         goto out;
     }
-    icd_tramp_list->count++;
 
     // Uses OS calls to find the 'true' path to the binary, for more accurate logging later on.
     res = fixup_library_binary_path(inst, &(new_scanned_icd->lib_name), new_scanned_icd->handle, fp_get_proc_addr);
     if (res == VK_ERROR_OUT_OF_HOST_MEMORY) {
+        loader_instance_heap_free(inst, new_scanned_icd->lib_name);
         goto out;
     }
+
+    icd_tramp_list->count++;
+
 out:
     if (res != VK_SUCCESS) {
         if (NULL != handle) {


### PR DESCRIPTION
This shows up with the Vulkan CTS test `dEQP-VK.api.device_init.create_instance_device_intentional_alloc_fail.basic` and appears to be a regression from https://github.com/KhronosGroup/Vulkan-Loader/commit/77ccbe4f422ff89405272873c25bbb8ca88bd699