### PR TITLE
fix call DestroyInstance after loader_platform_close_library

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -735,7 +735,6 @@ out:
             loader_destroy_pointer_layer_list(ptr_instance, &ptr_instance->app_activated_layer_list);
 
             loader_delete_layer_list_and_properties(ptr_instance, &ptr_instance->instance_layer_list);
-            loader_clear_scanned_icd_list(ptr_instance, &ptr_instance->icd_tramp_list);
             loader_destroy_generic_list(ptr_instance, (struct loader_generic_list *)&ptr_instance->ext_list);
 
             // Free any icd_terms that were created.
@@ -755,6 +754,7 @@ out:
                 loader_icd_destroy(ptr_instance, icd_term, pAllocator);
             }
 
+            loader_clear_scanned_icd_list(ptr_instance, &ptr_instance->icd_tramp_list);
             free_string_list(ptr_instance, &ptr_instance->enabled_layer_names);
 
             loader_instance_heap_free(ptr_instance, ptr_instance);


### PR DESCRIPTION
Found that vkcts crash after "Get real path to layer & driver binaries : 77ccbe4f422ff89405272873c25bbb8ca88bd699" merged into vullan-loader.

The root cause of crash is icd.so lib has been closed before DestroyInstance called in loader free path when icd instance has been created and oom in layer.

eg. fpCreateInstance success but table->populate oom in wsi. TRY_LOG(fpCreateInstance(&modified_info, pAllocator, pInstance) , "Failed to create the instance");
TRY_LOG_CALL(table->populate(*pInstance, fpGetInstanceProcAddr, api_version));

So we need to defer close icd lib until DestroyInstance done.

Fix case: dEQP-VK.api.device_init.create_instance_device_ intentional_alloc_fail.basic