### PR TITLE
Enable additional security mitigations on binaries produced by MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,12 @@ if(CMAKE_C_COMPILER_ID MATCHES "MSVC" OR (CMAKE_C_COMPILER_ID STREQUAL "Clang" A
         target_link_options(loader_common_options INTERFACE "LINKER:/cetcompat")
     endif()
 
+    # Enable EH Continuation Metadata for 64-bit architectures
+    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+        target_compile_options(loader_common_options INTERFACE $<$<COMPILE_LANGUAGE::CXX,C>:/guard:ehcont>)
+        target_link_options(loader_common_options INTERFACE "LINKER:/guard:ehcont")
+    endif()
+
     # Prevent <windows.h> from polluting the code. guards against things like MIN and MAX
     target_compile_definitions(loader_common_options INTERFACE WIN32_LEAN_AND_MEAN)
 


### PR DESCRIPTION
This PR enables `/cetcompat` and `/guard:ehcont` mitigations for all compatible targets (x86/x64 for CET and x64/ARM64 for EHCont). More information on these mitigations can be found in [Microsoft's blog post](https://techcommunity.microsoft.com/blog/windowsosplatform/developer-guidance-for-hardware-enforced-stack-protection/2163340).

The resulting x86 and x64 binaries and tests were executed on a CET-compatible platform (AMD Ryzen 7950X) and loaded into a CET-enabled Vulkan application to verify compatibility. The ARM64 build of `vulkan-1.dll` was also tested successfully in a Vulkan application on a Snapdragon X Elite system.