### PR TITLE
Remove duplicate driver workaround for macOS

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3354,8 +3354,7 @@ VkResult prepend_if_manifest_file(const struct loader_instance *inst, const char
 
 // Add any files found in the search_path.  If any path in the search path points to a specific JSON, attempt to
 // only open that one JSON.  Otherwise, if the path is a folder, search the folder for JSON files.
-VkResult add_data_files(const struct loader_instance *inst, char *search_path, struct loader_string_list *out_files,
-                        bool use_first_found_manifest) {
+VkResult add_data_files(const struct loader_instance *inst, char *search_path, struct loader_string_list *out_files) {
     VkResult vk_result = VK_SUCCESS;
     char full_path[2048];
 #if !defined(_WIN32)
@@ -3442,9 +3441,6 @@ VkResult add_data_files(const struct loader_instance *inst, char *search_path, s
                 goto out;
             }
         }
-        if (use_first_found_manifest && out_files->count > 0) {
-            break;
-        }
     }
 
 out:
@@ -3463,7 +3459,6 @@ VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enu
     size_t search_path_size = 0;
     char *search_path = NULL;
     char *cur_path_ptr = NULL;
-    bool use_first_found_manifest = false;
 #if COMMON_UNIX_PLATFORMS
     const char *relative_location = NULL;  // Only used on unix platforms
     size_t rel_size = 0;                   // unused in windows, dont declare so no compiler warnings are generated
@@ -3684,9 +3679,6 @@ VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enu
                         memcpy(cur_path_ptr, relative_location, rel_size);
                         cur_path_ptr += rel_size;
                         *cur_path_ptr++ = PATH_SEPARATOR;
-                        if (manifest_type == LOADER_DATA_FILE_MANIFEST_DRIVER) {
-                            use_first_found_manifest = true;
-                        }
                     }
                     CFRelease(ref);
                 }
@@ -3781,7 +3773,7 @@ VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enu
     }
 
     // Now, parse the paths and add any manifest files found in them.
-    vk_result = add_data_files(inst, search_path, out_files, use_first_found_manifest);
+    vk_result = add_data_files(inst, search_path, out_files);
 
     if (log_flags != 0 && out_files->count > 0) {
         loader_log(inst, log_flags, 0, "   Found the following files:");

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -228,8 +228,7 @@ VkStringErrorFlags vk_string_validate(const int max_length, const char *char_arr
 char *loader_get_next_path(char *path);
 VkResult add_if_manifest_file(const struct loader_instance *inst, const char *file_name, struct loader_string_list *out_files);
 VkResult prepend_if_manifest_file(const struct loader_instance *inst, const char *file_name, struct loader_string_list *out_files);
-VkResult add_data_files(const struct loader_instance *inst, char *search_path, struct loader_string_list *out_files,
-                        bool use_first_found_manifest);
+VkResult add_data_files(const struct loader_instance *inst, char *search_path, struct loader_string_list *out_files);
 
 loader_api_version loader_make_version(uint32_t version);
 loader_api_version loader_combine_version(uint32_t major, uint32_t minor, uint32_t patch);

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -788,7 +788,7 @@ VkResult windows_read_data_files_in_registry(const struct loader_instance *inst,
     }
 
     // Now, parse the paths and add any manifest files found in them.
-    vk_result = add_data_files(inst, search_path, out_files, false);
+    vk_result = add_data_files(inst, search_path, out_files);
 
 out:
 

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -4458,11 +4458,13 @@ TEST(ManifestDiscovery, AppleBundles) {
     InstWrapper inst{env.vulkan_functions};
     ASSERT_NO_FATAL_FAILURE(inst.CheckCreate());
     auto physical_devices = inst.GetPhysDevs();
-    ASSERT_EQ(1, physical_devices.size());
+    ASSERT_EQ(2, physical_devices.size());
 
-    // Verify that this is the 'right' GPU, aka the one from the bundle
+    // Should get both GPUs, in reverse order to driver enumeration (due to enumerating the last driver first)
     VkPhysicalDeviceProperties props{};
     inst->vkGetPhysicalDeviceProperties(physical_devices[0], &props);
+    ASSERT_EQ(test_physical_device_1.properties.deviceID, props.deviceID);
+    inst->vkGetPhysicalDeviceProperties(physical_devices[1], &props);
     ASSERT_EQ(test_physical_device_0.properties.deviceID, props.deviceID);
 }
 


### PR DESCRIPTION
On macOS, applications can bundle drivers with themselves. When they do this and also install the same driver to a global location, the loader will load 2 separate drivers which happen to be the same binary, causing the linker to emit warnings.

The fix was to simply only load one driver if the app was bundled. Because there was only one macOS driver available, this worked. Now that both KosmicKrisp and LavaPipe are available, this workaround is no longer appropriate. If apps bundle multiple drivers, they would be unable to use more than 1.