### PR TITLE
Fix typedef redefinition warnings

### DIFF
--- a/loader/cJSON.c
+++ b/loader/cJSON.c
@@ -58,8 +58,6 @@
 
 #include "cJSON.h"
 
-#include <vulkan/vulkan_core.h>
-
 #include "allocation.h"
 
 /* define our own boolean type */

--- a/loader/cJSON.h
+++ b/loader/cJSON.h
@@ -88,6 +88,8 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 #include <stddef.h>
 #include <stdbool.h>
 
+#include <vulkan/vulkan_core.h>
+
 #include "vk_loader_platform.h"
 
 /* cJSON Types: */
@@ -103,10 +105,6 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 
 #define cJSON_IsReference 256
 #define cJSON_StringIsConst 512
-
-/* loader type declarations for allocation hooks */
-typedef struct VkAllocationCallbacks VkAllocationCallbacks;
-struct loader_instance;
 
 /* The cJSON structure: */
 typedef struct cJSON {
@@ -129,7 +127,7 @@ typedef struct cJSON {
     /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
     char *string;
     /* pointer to the allocation callbacks to use */
-    const VkAllocationCallbacks *pAllocator;
+    const struct VkAllocationCallbacks *pAllocator;
 } cJSON;
 
 typedef int cJSON_bool;
@@ -150,18 +148,19 @@ typedef int cJSON_bool;
  * loader_cJSON_Delete) and loader_loader_cJSON_Print (with stdlib free, cJSON_Hooks.free_fn, or cJSON_free as appropriate). The
  * exception is cJSON_PrintPreallocated, where the caller has full responsibility of the buffer. */
 /* Supply a block of JSON, and this returns a cJSON object you can interrogate. */
-CJSON_PUBLIC(cJSON *) loader_cJSON_Parse(const VkAllocationCallbacks *pAllocator, const char *value, bool *out_of_memory);
+CJSON_PUBLIC(cJSON *) loader_cJSON_Parse(const struct VkAllocationCallbacks *pAllocator, const char *value, bool *out_of_memory);
 CJSON_PUBLIC(cJSON *)
-loader_cJSON_ParseWithLength(const VkAllocationCallbacks *pAllocator, const char *value, size_t buffer_length, bool *out_of_memory);
+loader_cJSON_ParseWithLength(const struct VkAllocationCallbacks *pAllocator, const char *value, size_t buffer_length,
+                             bool *out_of_memory);
 /* ParseWithOpts allows you to require (and check) that the JSON is null terminated, and to retrieve the pointer to the final byte
  * parsed. */
 /* If you supply a ptr in return_parse_end and parsing fails, then return_parse_end will contain a pointer to the error so will
  * match cJSON_GetErrorPtr(). */
 CJSON_PUBLIC(cJSON *)
-loader_cJSON_ParseWithOpts(const VkAllocationCallbacks *pAllocator, const char *value, const char **return_parse_end,
+loader_cJSON_ParseWithOpts(const struct VkAllocationCallbacks *pAllocator, const char *value, const char **return_parse_end,
                            cJSON_bool require_null_terminated, bool *out_of_memory);
 CJSON_PUBLIC(cJSON *)
-loader_cJSON_ParseWithLengthOpts(const VkAllocationCallbacks *pAllocator, const char *value, size_t buffer_length,
+loader_cJSON_ParseWithLengthOpts(const struct VkAllocationCallbacks *pAllocator, const char *value, size_t buffer_length,
                                  const char **return_parse_end, cJSON_bool require_null_terminated, bool *out_of_memory);
 
 /* Render a cJSON entity to text for transfer/storage. */

--- a/loader/generated/vk_layer_dispatch_table.h
+++ b/loader/generated/vk_layer_dispatch_table.h
@@ -30,10 +30,6 @@
 
 #include <vulkan/vulkan.h>
 
-#if !defined(PFN_GetPhysicalDeviceProcAddr)
-typedef PFN_vkVoidFunction (VKAPI_PTR *PFN_GetPhysicalDeviceProcAddr)(VkInstance instance, const char* pName);
-#endif
-
 // Instance function pointer dispatch table
 typedef struct VkLayerInstanceDispatchTable_ {
     // Manually add in GetPhysicalDeviceProcAddr entry

--- a/scripts/generators/loader_extension_generator.py
+++ b/scripts/generators/loader_extension_generator.py
@@ -243,9 +243,6 @@ class LoaderExtensionGenerator(BaseGenerator):
         out.append('\n')
         out.append('#include <vulkan/vulkan.h>\n')
         out.append('\n')
-        out.append('#if !defined(PFN_GetPhysicalDeviceProcAddr)\n')
-        out.append('typedef PFN_vkVoidFunction (VKAPI_PTR *PFN_GetPhysicalDeviceProcAddr)(VkInstance instance, const char* pName);\n')
-        out.append('#endif\n\n')
         self.OutputLayerInstanceDispatchTable(out)
         self.OutputLayerDeviceDispatchTable(out)
 


### PR DESCRIPTION
C99 does not support redefining typedefs and so the code should avoid doing that as necessary.

Also it turns out #if !defined(<typedef>) does not actually protect the inner value, since typedef does not operate on semantic constructs.