### PR TITLE
Remove duplicates from vkEnumerateInstanceLayerProperties

### DIFF
--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -174,7 +174,7 @@ TEST(EnumerateInstanceLayerProperties, UsageChecks) {
     env.add_icd(TEST_ICD_PATH_VERSION_2);
 
     const char* layer_name_1 = "TestLayer1";
-    const char* layer_name_2 = "TestLayer1";
+    const char* layer_name_2 = "TestLayer2";
 
     env.add_explicit_layer(
         {}, ManifestLayer{}.add_layer(


### PR DESCRIPTION
If multiple layers share the same name, the loader should remove them as the application cannot specify which of the duplicate layers should be loaded when vkCreateInstance is called. This mirrors the behavior of vkCreateInstance which removes duplicate layers before loading. By de-duplicating during vkEnumerateInstanceLayerProperties and vkEnumerateInstanceExtensionProperties, it prevents situations where the duplicate layers differed in available instance extensions and the extension would be reported as unavailable during vkCreateInstance because the layer chosen to load didn't have the extension.