### PR TITLE
Add missing include in vk_layer_dispatch_table.h

### DIFF
--- a/loader/generated/vk_layer_dispatch_table.h
+++ b/loader/generated/vk_layer_dispatch_table.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <vulkan/vulkan.h>
+#include <vulkan/vk_layer.h>
 
 // Instance function pointer dispatch table
 typedef struct VkLayerInstanceDispatchTable_ {

--- a/scripts/generators/loader_extension_generator.py
+++ b/scripts/generators/loader_extension_generator.py
@@ -242,6 +242,7 @@ class LoaderExtensionGenerator(BaseGenerator):
         out.append('#pragma once\n')
         out.append('\n')
         out.append('#include <vulkan/vulkan.h>\n')
+        out.append('#include <vulkan/vk_layer.h>\n')
         out.append('\n')
         self.OutputLayerInstanceDispatchTable(out)
         self.OutputLayerDeviceDispatchTable(out)


### PR DESCRIPTION
After fixing a compilation error where PFN_GetPhysicalDeviceProcAddr was defined multiple times, the vk_layer_dispatch_table.h header lacks the required include that provided PFN_GetPhysicalDeviceProcAddr.