### PR TITLE
Revert "Sort PhysicalDevices to match ICD's ordering"

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1768,14 +1768,9 @@ struct loader_icd_term *loader_icd_add(struct loader_instance *ptr_inst, const s
     icd_term->scanned_icd = scanned_icd;
     icd_term->this_instance = ptr_inst;
 
-    // Append to the list
-    struct loader_icd_term *prev = ptr_inst->icd_terms;
-    if (prev == NULL) {
-        ptr_inst->icd_terms = icd_term;
-    } else {
-        while (prev->next) prev = prev->next;
-        prev->next = icd_term;
-    }
+    // Prepend to the list
+    icd_term->next = ptr_inst->icd_terms;
+    ptr_inst->icd_terms = icd_term;
     ptr_inst->icd_terms_count++;
 
     return icd_term;

--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -188,8 +188,8 @@ TEST(GetProcAddr, Verify10FunctionsFailToLoadWithSingleDriver) {
 
 TEST(GetProcAddr, Verify10FunctionsLoadWithMultipleDrivers) {
     FrameworkEnvironment env{};
-    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device({}).set_can_query_GetPhysicalDeviceFuncs(false);
     env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device({});
+    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device({}).set_can_query_GetPhysicalDeviceFuncs(false);
 
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -3658,31 +3658,31 @@ TEST(SortedPhysicalDevices, DevicesSortedDisabled) {
     ASSERT_EQ(VK_SUCCESS, instance->vkEnumeratePhysicalDevices(instance, &device_count, physical_devices.data()));
     ASSERT_EQ(device_count, max_phys_devs);
 
-    // make sure the order is what we started with
+    // make sure the order is what we started with - but its a bit wonky due to the loader reading physical devices "backwards"
     VkPhysicalDeviceProperties props{};
     instance->vkGetPhysicalDeviceProperties(physical_devices[0], &props);
-    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
-    ASSERT_STREQ(props.deviceName, "pd0");
+    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU);
+    ASSERT_STREQ(props.deviceName, "pd5");
 
     instance->vkGetPhysicalDeviceProperties(physical_devices[1], &props);
-    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU);
-    ASSERT_STREQ(props.deviceName, "pd1");
-
-    instance->vkGetPhysicalDeviceProperties(physical_devices[2], &props);
-    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_CPU);
-    ASSERT_STREQ(props.deviceName, "pd2");
-
-    instance->vkGetPhysicalDeviceProperties(physical_devices[3], &props);
     ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
     ASSERT_STREQ(props.deviceName, "pd3");
 
-    instance->vkGetPhysicalDeviceProperties(physical_devices[4], &props);
+    instance->vkGetPhysicalDeviceProperties(physical_devices[2], &props);
     ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
     ASSERT_STREQ(props.deviceName, "pd4");
 
+    instance->vkGetPhysicalDeviceProperties(physical_devices[3], &props);
+    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_CPU);
+    ASSERT_STREQ(props.deviceName, "pd2");
+
+    instance->vkGetPhysicalDeviceProperties(physical_devices[4], &props);
+    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
+    ASSERT_STREQ(props.deviceName, "pd0");
+
     instance->vkGetPhysicalDeviceProperties(physical_devices[5], &props);
-    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU);
-    ASSERT_STREQ(props.deviceName, "pd5");
+    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU);
+    ASSERT_STREQ(props.deviceName, "pd1");
 
     // Make sure if we call enumerate again, the information is the same
     std::array<VkPhysicalDevice, max_phys_devs> physical_devices_again;
@@ -3974,40 +3974,39 @@ TEST(SortedPhysicalDevices, DeviceGroupsSortedDisabled) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDeviceGroups(inst, &group_count, physical_device_groups.data()));
     ASSERT_EQ(group_count, max_phys_dev_groups);
 
-    // make sure the order is what we started with
+    // make sure the order is what we started with - but its a bit wonky due to the loader reading physical devices "backwards"
     VkPhysicalDeviceProperties props{};
-
     inst->vkGetPhysicalDeviceProperties(physical_devices[0], &props);
-    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
-    ASSERT_STREQ(props.deviceName, "pd0");
+    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU);
+    ASSERT_STREQ(props.deviceName, "pd7");
 
     inst->vkGetPhysicalDeviceProperties(physical_devices[1], &props);
-    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU);
-    ASSERT_STREQ(props.deviceName, "pd1");
-
-    inst->vkGetPhysicalDeviceProperties(physical_devices[2], &props);
-    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
-    ASSERT_STREQ(props.deviceName, "pd2");
-
-    inst->vkGetPhysicalDeviceProperties(physical_devices[3], &props);
-    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_CPU);
-    ASSERT_STREQ(props.deviceName, "pd3");
-
-    inst->vkGetPhysicalDeviceProperties(physical_devices[4], &props);
     ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
     ASSERT_STREQ(props.deviceName, "pd4");
 
-    inst->vkGetPhysicalDeviceProperties(physical_devices[5], &props);
+    inst->vkGetPhysicalDeviceProperties(physical_devices[2], &props);
     ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
     ASSERT_STREQ(props.deviceName, "pd5");
 
-    inst->vkGetPhysicalDeviceProperties(physical_devices[6], &props);
+    inst->vkGetPhysicalDeviceProperties(physical_devices[3], &props);
     ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
     ASSERT_STREQ(props.deviceName, "pd6");
 
+    inst->vkGetPhysicalDeviceProperties(physical_devices[4], &props);
+    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_CPU);
+    ASSERT_STREQ(props.deviceName, "pd3");
+
+    inst->vkGetPhysicalDeviceProperties(physical_devices[5], &props);
+    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
+    ASSERT_STREQ(props.deviceName, "pd0");
+
+    inst->vkGetPhysicalDeviceProperties(physical_devices[6], &props);
+    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU);
+    ASSERT_STREQ(props.deviceName, "pd1");
+
     inst->vkGetPhysicalDeviceProperties(physical_devices[7], &props);
-    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU);
-    ASSERT_STREQ(props.deviceName, "pd7");
+    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
+    ASSERT_STREQ(props.deviceName, "pd2");
 
     // Make sure if we call enumerate again, the information is the same
     std::array<VkPhysicalDeviceGroupProperties, max_phys_dev_groups> physical_device_groups_again{};
@@ -4447,9 +4446,9 @@ TEST(ManifestDiscovery, AppleBundles) {
     // Should get both GPUs, in reverse order to driver enumeration (due to enumerating the last driver first)
     VkPhysicalDeviceProperties props{};
     inst->vkGetPhysicalDeviceProperties(physical_devices[0], &props);
-    ASSERT_EQ(test_physical_device_0.properties.deviceID, props.deviceID);
-    inst->vkGetPhysicalDeviceProperties(physical_devices[1], &props);
     ASSERT_EQ(test_physical_device_1.properties.deviceID, props.deviceID);
+    inst->vkGetPhysicalDeviceProperties(physical_devices[1], &props);
+    ASSERT_EQ(test_physical_device_0.properties.deviceID, props.deviceID);
 }
 
 // Add two drivers, one to the bundle and one using the driver env-var
@@ -4718,10 +4717,10 @@ TEST(EnumerateAdapterPhysicalDevices, SameAdapterLUID_reordered) {
 
     // Physical devices are enumerated:
     // a) first in the order of LUIDs showing up in DXGIAdapter list
-    // b) then in the order to the drivers insertion into the test framework
-    auto phys_dev_handle = add_dxgi_adapter(env, "physical_device_0", LUID{10, 100}, 2);
-    add_dxgi_adapter(env, "physical_device_1", LUID{20, 200}, 1);
+    // b) then in the reverse order to the drivers insertion into the test framework
     add_dxgi_adapter(env, "physical_device_2", LUID{10, 100}, 2);
+    add_dxgi_adapter(env, "physical_device_1", LUID{20, 200}, 1);
+    auto phys_dev_handle = add_dxgi_adapter(env, "physical_device_0", LUID{10, 100}, 2);
 
     {
         uint32_t returned_physical_count = 0;
@@ -4765,7 +4764,7 @@ TEST(EnumerateAdapterPhysicalDevices, SameAdapterLUID_reordered) {
     }
     // Set the first physical device that is enumerated to be a 'layered' driver so it should be swapped with the first physical
     // device
-    env.get_test_icd(0).physical_devices.at(phys_dev_handle).layered_driver_underlying_api =
+    env.get_test_icd(2).physical_devices.at(phys_dev_handle).layered_driver_underlying_api =
         VK_LAYERED_DRIVER_UNDERLYING_API_D3D12_MSFT;
     {
         uint32_t returned_physical_count = 0;

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -3069,8 +3069,8 @@ TEST(SettingsFile, AdditionalDrivers) {
     VkPhysicalDeviceProperties props1{}, props2{};
     inst.functions->vkGetPhysicalDeviceProperties(pds.at(0), &props1);
     inst.functions->vkGetPhysicalDeviceProperties(pds.at(1), &props2);
-    ASSERT_TRUE(string_eq(props1.deviceName, settings_driver_name));
-    ASSERT_TRUE(string_eq(props2.deviceName, regular_driver_name));
+    ASSERT_TRUE(string_eq(props1.deviceName, regular_driver_name));
+    ASSERT_TRUE(string_eq(props2.deviceName, settings_driver_name));
 }
 // settings file provided drivers replacing system found drivers
 TEST(SettingsFile, ExclusiveAdditionalDrivers) {

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -991,23 +991,25 @@ void CheckDirectDriverLoading(FrameworkEnvironment& env, std::vector<DriverInfo>
     auto phys_devs = inst.GetPhysDevs();
     ASSERT_EQ(phys_devs.size(), expected_driver_count);
 
+    // We have to iterate through the driver lists backwards because the loader *prepends* icd's, so the last found ICD is found
+    // first in the driver list
     uint32_t driver_index = 0;
-    if (!direct_drivers.empty()) {
-        for (size_t i = 0; i < direct_drivers.size(); i++) {
-            if (direct_drivers.at(i).expect_to_find) {
-                VkPhysicalDeviceProperties props{};
-                inst.functions->vkGetPhysicalDeviceProperties(phys_devs.at(driver_index), &props);
-                ASSERT_EQ(props.driverVersion, direct_drivers.at(i).driver_version);
-                driver_index++;
-            }
-        }
-    }
     if (!normal_drivers.empty()) {
-        for (size_t i = 0; i < normal_drivers.size(); i++) {
+        for (int i = normal_drivers.size() - 1; i >= 0; i--) {
             if (!exclusive && normal_drivers.at(i).expect_to_find) {
                 VkPhysicalDeviceProperties props{};
                 inst.functions->vkGetPhysicalDeviceProperties(phys_devs.at(driver_index), &props);
                 ASSERT_EQ(props.driverVersion, normal_drivers.at(i).driver_version);
+                driver_index++;
+            }
+        }
+    }
+    if (!direct_drivers.empty()) {
+        for (int i = direct_drivers.size() - 1; i >= 0; i--) {
+            if (direct_drivers.at(i).expect_to_find) {
+                VkPhysicalDeviceProperties props{};
+                inst.functions->vkGetPhysicalDeviceProperties(phys_devs.at(driver_index), &props);
+                ASSERT_EQ(props.driverVersion, direct_drivers.at(i).driver_version);
                 driver_index++;
             }
         }

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -994,24 +994,20 @@ void CheckDirectDriverLoading(FrameworkEnvironment& env, std::vector<DriverInfo>
     // We have to iterate through the driver lists backwards because the loader *prepends* icd's, so the last found ICD is found
     // first in the driver list
     uint32_t driver_index = 0;
-    if (!normal_drivers.empty()) {
-        for (int i = normal_drivers.size() - 1; i >= 0; i--) {
-            if (!exclusive && normal_drivers.at(i).expect_to_find) {
-                VkPhysicalDeviceProperties props{};
-                inst.functions->vkGetPhysicalDeviceProperties(phys_devs.at(driver_index), &props);
-                ASSERT_EQ(props.driverVersion, normal_drivers.at(i).driver_version);
-                driver_index++;
-            }
+    for (size_t i = normal_drivers.size() - 1; i == 0; i--) {
+        if (normal_drivers.at(i).expect_to_find) {
+            VkPhysicalDeviceProperties props{};
+            inst.functions->vkGetPhysicalDeviceProperties(phys_devs.at(driver_index), &props);
+            ASSERT_EQ(props.driverVersion, normal_drivers.at(i).driver_version);
+            driver_index++;
         }
     }
-    if (!direct_drivers.empty()) {
-        for (int i = direct_drivers.size() - 1; i >= 0; i--) {
-            if (direct_drivers.at(i).expect_to_find) {
-                VkPhysicalDeviceProperties props{};
-                inst.functions->vkGetPhysicalDeviceProperties(phys_devs.at(driver_index), &props);
-                ASSERT_EQ(props.driverVersion, direct_drivers.at(i).driver_version);
-                driver_index++;
-            }
+    for (size_t i = direct_drivers.size() - 1; i == 0; i--) {
+        if (direct_drivers.at(i).expect_to_find) {
+            VkPhysicalDeviceProperties props{};
+            inst.functions->vkGetPhysicalDeviceProperties(phys_devs.at(driver_index), &props);
+            ASSERT_EQ(props.driverVersion, direct_drivers.at(i).driver_version);
+            driver_index++;
         }
     }
 }

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -1067,9 +1067,9 @@ TEST(WsiTests, MultiPlatformGetPhysicalDeviceSurfaceSupportKHR) {
         inst.CheckCreate();
 
         auto phys_devs = inst.GetPhysDevs();
-        // Physical devices are enumerated in order to the ICD order
-        VkPhysicalDevice xcb_physical_device = phys_devs[0];
-        VkPhysicalDevice wayland_physical_device = phys_devs[1];
+        // Physical devices are enumerated in reverse order to the ICD order
+        VkPhysicalDevice xcb_physical_device = phys_devs[1];
+        VkPhysicalDevice wayland_physical_device = phys_devs[0];
         VkPhysicalDeviceProperties props0{};
         inst->vkGetPhysicalDeviceProperties(wayland_physical_device, &props0);
         ASSERT_TRUE(string_eq(props0.deviceName, wayland_device_name));
@@ -1113,9 +1113,9 @@ TEST(WsiTests, MultiPlatformGetPhysicalDeviceSurfaceSupportKHR) {
         inst.CheckCreate();
 
         auto phys_devs = inst.GetPhysDevs();
-        // Physical devices are enumerated in ICD discovery order
-        VkPhysicalDevice xcb_physical_device = phys_devs[0];
-        VkPhysicalDevice wayland_physical_device = phys_devs[1];
+        // Physical devices are enumerated in reverse order to the ICD order
+        VkPhysicalDevice xcb_physical_device = phys_devs[1];
+        VkPhysicalDevice wayland_physical_device = phys_devs[0];
         VkPhysicalDeviceProperties props0{};
         inst->vkGetPhysicalDeviceProperties(wayland_physical_device, &props0);
         ASSERT_TRUE(string_eq(props0.deviceName, wayland_device_name));


### PR DESCRIPTION
Reverts KhronosGroup/Vulkan-Loader#1744

The change breaks angle tests which fail to find the correct physical device. An example failure error is:

```
[ RUN      ] TraceTest.supertuxkart
WARN: vulkan_icd.cpp:388 (ChoosePhysicalDevice): Preferred device ICD not found. Using default physicalDevice instead.
GL_RENDERER: ANGLE (Mesa, Vulkan 1.3.255 (llvmpipe (LLVM 15.0.7 256 bits) (0x00000000)), llvmpipe-0.0.1)
GL_VERSION: OpenGL ES 3.1 (ANGLE 2.1.27044 git hash: 2c07b13173f8)
running test name: "TracePerf", backend: "_vulkan", story: "supertuxkart"
Test Trials: 1
../../src/tests/perf_tests/ANGLEPerfTest.h:131: Failure
Failed
Failing test because of unexpected error:
vk_renderer.cpp:1033 (DebugUtilsMessenger): [ SYNC-HAZARD-WRITE-AFTER-WRITE ] vkCmdWaitEvents(): WRITE_AFTER_WRITE hazard detected. vkCmdWaitEvents performs image layout transition on the VkImage 0xe490000000e49, which was previously written by vkCmdEndRenderPass. 
```