### PR TITLE
Check for nullptr in loader_unwrap_physical_device

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -36,6 +36,9 @@
 LOADER_PLATFORM_THREAD_ONCE_EXTERN_DEFINITION(once_init)
 
 static inline VkPhysicalDevice loader_unwrap_physical_device(VkPhysicalDevice physicalDevice) {
+    if (VK_NULL_HANDLE == physicalDevice) {
+        return VK_NULL_HANDLE;
+    }
     struct loader_physical_device_tramp *phys_dev = (struct loader_physical_device_tramp *)physicalDevice;
     if (PHYS_TRAMP_MAGIC_NUMBER != phys_dev->magic) {
         return VK_NULL_HANDLE;


### PR DESCRIPTION
Makes sure nullptr's are checked before dereferencing it to check if the magic value is correct.