### PR TITLE
Create shared swapchains fixes

### DIFF
--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -2207,12 +2207,6 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateSharedSwapchainsKHR(VkDevice dev
                    "[VUID-vkCreateSharedSwapchainsKHR-device-parameter]");
         abort(); /* Intentionally fail so user can correct issue. */
     }
-    if (NULL != icd_term->surface_list.list) {
-        loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
-                   "vkCreateSharedSwapchainsKHR Terminator: No VkSurfaceKHR objects were created, indicating an application "
-                   "bug. Returning VK_SUCCESS. ");
-        return VK_SUCCESS;
-    }
     if (NULL == dev->loader_dispatch.extension_terminator_dispatch.CreateSharedSwapchainsKHR) {
         loader_log(NULL, VULKAN_LOADER_ERROR_BIT, 0,
                    "vkCreateSharedSwapchainsKHR Terminator: Driver's function pointer was NULL, returning VK_SUCCESS. Was the "

--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -294,7 +294,10 @@ TEST(GetDeviceProcAddr, SwapchainFuncsWithTerminator) {
         infos[1].sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
         infos[1].surface = surface2;
 
-        ASSERT_EQ(VK_SUCCESS, CreateSharedSwapchainsKHR(dev.dev, 2, infos.data(), nullptr, &swapchain));
+        std::array<VkSwapchainKHR, 2> swapchains{};
+        ASSERT_EQ(VK_SUCCESS, CreateSharedSwapchainsKHR(dev.dev, static_cast<uint32_t>(swapchains.size()), infos.data(), nullptr,
+                                                        swapchains.data()));
+        ASSERT_FALSE(log.find("vkCreateSharedSwapchainsKHR Terminator: No VkSurfaceKHR objects were created"));
     }
     env.vulkan_functions.vkDestroySurfaceKHR(inst.inst, surface, nullptr);
     env.vulkan_functions.vkDestroySurfaceKHR(inst.inst, surface2, nullptr);


### PR DESCRIPTION
There was a backwards check for ICD surfaces in vkCreateSharedSwapchainsKHR, causing it to always fail if it was called with surface handles that had been used before. The correct version of this check now lives in the helper function wsi_unwrap_icd_surface(), so remove this broken and redundant one.

While I was there, I noticed an overflow in vkCreateSharedSwapchainsKHR. The test was creating two swapchains and storing the result in a non-array result variable.