### PR TITLE
fix: allocate additional_drivers with correct element type

### DIFF
--- a/loader/settings.c
+++ b/loader/settings.c
@@ -267,7 +267,7 @@ VkResult parse_additional_drivers(const struct loader_instance* inst, cJSON* set
     loader_settings->additional_driver_count = additional_driver_count;
 
     loader_settings->additional_drivers = loader_instance_heap_calloc(
-        inst, sizeof(loader_settings_layer_configuration) * additional_driver_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        inst, sizeof(loader_settings_driver_configuration) * additional_driver_count, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
     if (NULL == loader_settings->additional_drivers) {
         res = VK_ERROR_OUT_OF_HOST_MEMORY;
         goto out;


### PR DESCRIPTION
parse_additional_drivers at loader/settings.c:270 sizes the additional_drivers array with sizeof(loader_settings_layer_configuration), but its elements are loader_settings_driver_configuration. Use the matching type so the allocation size matches what's indexed and freed.