### PR TITLE
loader: Fix missing bounds check in parse_id_filter_environment_var

### DIFF
--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -586,6 +586,14 @@ void parse_id_filter_environment_var(const struct loader_instance *inst, const c
     char *context = NULL;
     char *token = thread_safe_strtok(parsing_string, ",", &context);
     while (NULL != token) {
+        if (filter_struct->count >= MAX_ADDITIONAL_FILTERS) {
+            loader_log(inst, VULKAN_LOADER_WARN_BIT, 0,
+                       "parse_id_filter_environment_var: Exceeded maximum number of filters (%d) for env var '%s'. "
+                       "Remaining entries will be ignored.",
+                       MAX_ADDITIONAL_FILTERS, env_var_name);
+            break;
+        }
+
         struct loader_envvar_id_filter_value *filter_value = &filter_struct->filters[filter_struct->count];
 
         char *pEnd;


### PR DESCRIPTION
Both parse_generic_filter_environment_var and
parse_layers_disable_filter_environment_var correctly guard against exceeding MAX_ADDITIONAL_FILTERS before writing into their fixed-size filter arrays. parse_id_filter_environment_var was the only filter parser that lacked this guard, meaning a sufficiently long comma- separated environment variable (e.g. VK_LOADER_DEBUG) could write beyond the end of loader_envvar_id_filter::filters[MAX_ADDITIONAL_FILTERS], overflowing the stack or adjacent heap memory.

Add the same count >= MAX_ADDITIONAL_FILTERS early-break that the other two parsers already use, and emit a WARN log entry so users know that entries beyond the limit are silently ignored.

Fixes: write past end of loader_envvar_id_filter::filters[]
Reported-by: code review
Reviewed-by: (pending)