### PR TITLE
loader: Propagate OOM from loader_add_to_ext_list in two call sites

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3018,7 +3018,8 @@ VkResult loader_read_layer_json(const struct loader_instance *inst, struct loade
             loader_instance_heap_free(inst, spec_version);
             bool ext_unsupported = wsi_unsupported_instance_extension(&ext_prop);
             if (!ext_unsupported) {
-                loader_add_to_ext_list(inst, &props.instance_extension_list, 1, &ext_prop);
+                result = loader_add_to_ext_list(inst, &props.instance_extension_list, 1, &ext_prop);
+                if (result == VK_ERROR_OUT_OF_HOST_MEMORY) goto out;
             }
         }
     }
@@ -7617,7 +7618,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateInstanceExtensionProperties(c
         }
         for (uint32_t i = 0; i < instance_layers.count; i++) {
             struct loader_extension_list *ext_list = &instance_layers.list[i].instance_extension_list;
-            loader_add_to_ext_list(NULL, &local_ext_list, ext_list->count, ext_list->list);
+            res = loader_add_to_ext_list(NULL, &local_ext_list, ext_list->count, ext_list->list);
+            if (VK_SUCCESS != res) {
+                goto out;
+            }
         }
 
         global_ext_list = &local_ext_list;


### PR DESCRIPTION
loader_add_to_ext_list() returns VkResult and documents that VK_ERROR_OUT_OF_HOST_MEMORY signals allocation failure, but two call sites discarded the return value entirely:

1. loader_read_layer_json() – when appending an instance extension from a layer's JSON manifest the OOM path silently drops the extension and continues.  The device-extension block directly below it correctly checks the analogous loader_add_to_dev_ext_list() return value; bring instance-extension parsing in line with it.

2. terminator_EnumerateInstanceExtensionProperties() – when merging implicit-layer extensions into the local list the return value was ignored.  On allocation failure the function continues with an incomplete list and returns VK_SUCCESS to the application, violating the Vulkan spec guarantee that a successful count query returns the full set of available extensions.

Capture the return value in both sites and propagate VK_ERROR_OUT_OF_HOST_MEMORY via the existing 'goto out' paths.

Fixes: silent OOM swallowing in loader_read_layer_json
Fixes: silent OOM swallowing in terminator_EnumerateInstanceExtensionProperties
Reviewed-by: (pending)