### PR TITLE
Cast to unsigned char before tolower in env var parsing

### DIFF
--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -264,7 +264,7 @@ VkResult parse_generic_filter_environment_var(const struct loader_instance *inst
     }
 
     for (uint32_t iii = 0; iii < env_var_len; ++iii) {
-        parsing_string[iii] = (char)tolower(env_var_value[iii]);
+        parsing_string[iii] = (char)tolower((unsigned char)env_var_value[iii]);
     }
     parsing_string[env_var_len] = '\0';
 
@@ -324,7 +324,7 @@ VkResult parse_layers_disable_filter_environment_var(const struct loader_instanc
     }
 
     for (uint32_t iii = 0; iii < env_var_len; ++iii) {
-        parsing_string[iii] = (char)tolower(env_var_value[iii]);
+        parsing_string[iii] = (char)tolower((unsigned char)env_var_value[iii]);
     }
     parsing_string[env_var_len] = '\0';
 
@@ -401,7 +401,7 @@ bool check_name_matches_filter_environment_var(const char *name, const struct lo
     }
     char lower_name[VK_MAX_EXTENSION_NAME_SIZE];
     for (uint32_t iii = 0; iii < name_len; ++iii) {
-        lower_name[iii] = (char)tolower(name[iii]);
+        lower_name[iii] = (char)tolower((unsigned char)name[iii]);
     }
     lower_name[name_len] = '\0';
     for (uint32_t filt = 0; filt < filter_struct->count; ++filt) {
@@ -583,7 +583,7 @@ void parse_id_filter_environment_var(const struct loader_instance *inst, const c
     // Allocate a separate string since scan_for_next_comma modifies the original string
     parsing_string = loader_stack_alloc(env_var_len + 1);
     for (uint32_t iii = 0; iii < env_var_len; ++iii) {
-        parsing_string[iii] = (char)tolower(env_var_value[iii]);
+        parsing_string[iii] = (char)tolower((unsigned char)env_var_value[iii]);
     }
     parsing_string[env_var_len] = '\0';
 


### PR DESCRIPTION
Reading through the layer filter parsing I noticed the lowercase loops hand a plain char straight to tolower:

    tolower() called with int argument = -30 (byte 0xe2)

env_var_value and name are char*, so on a signed-char target any byte >= 0x80 (a UTF-8 lead byte in a layer name, or in VK_LOADER_LAYERS_ENABLE / VK_LOADER_LAYERS_DISABLE / VK_LOADER_LAYERS_ALLOW / the device id filters) sign-extends to a negative int. That is undefined for tolower, whose argument has to be representable as unsigned char or be EOF.

Cast to unsigned char first. Same defect at all four sites in loader_environment.c, fixed identically.