### PR TITLE
heap overflow when appending oversized manifest paths

### DIFF
--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -130,8 +130,24 @@ bool windows_add_json_entry(const struct loader_instance *inst,
         return true;
     }
 
+    // The destination buffer must hold the existing contents plus the new value (json_size) and a null terminator.
+    // json_size is the size of an externally-supplied registry/adapter value and is not otherwise bounded, so size the
+    // buffer from the data length rather than assuming the initial *total_size is large enough.
+    size_t current_len = (NULL == *reg_data) ? 0 : strlen(*reg_data);
+    DWORD required_size = *total_size;
+    // Grow by doubling, stopping before required_size (a DWORD) would overflow.
+    while (current_len + json_size + 1 > required_size && required_size <= UINT32_MAX / 2) {
+        required_size *= 2;
+    }
+    if (current_len + json_size + 1 > required_size) {
+        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "windows_add_json_entry: Registry value for key %s is too large to store",
+                   json_path);
+        *result = VK_ERROR_OUT_OF_HOST_MEMORY;
+        return false;
+    }
+
     if (NULL == *reg_data) {
-        *reg_data = loader_instance_heap_alloc(inst, *total_size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+        *reg_data = loader_instance_heap_alloc(inst, required_size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
         if (NULL == *reg_data) {
             loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
                        "windows_add_json_entry: Failed to allocate space for registry data for key %s", json_path);
@@ -139,25 +155,27 @@ bool windows_add_json_entry(const struct loader_instance *inst,
             return false;
         }
         *reg_data[0] = '\0';
-    } else if (strlen(*reg_data) + json_size + 1 > *total_size) {
+        *total_size = required_size;
+    } else if (required_size > *total_size) {
         void *new_ptr =
-            loader_instance_heap_realloc(inst, *reg_data, *total_size, *total_size * 2, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+            loader_instance_heap_realloc(inst, *reg_data, *total_size, required_size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
         if (NULL == new_ptr) {
             loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                       "windows_add_json_entry: Failed to reallocate space for registry value of size %ld for key %s",
-                       *total_size * 2, json_path);
+                       "windows_add_json_entry: Failed to reallocate space for registry value of size %lu for key %s",
+                       required_size, json_path);
             *result = VK_ERROR_OUT_OF_HOST_MEMORY;
             return false;
         }
         *reg_data = new_ptr;
-        *total_size *= 2;
+        *total_size = required_size;
     }
 
     for (char *curr_filename = json_path; curr_filename[0] != '\0'; curr_filename += strlen(curr_filename) + 1) {
-        if (strlen(*reg_data) == 0) {
-            (void)snprintf(*reg_data, json_size + 1, "%s", curr_filename);
+        size_t cur_len = strlen(*reg_data);
+        if (cur_len == 0) {
+            (void)snprintf(*reg_data, *total_size, "%s", curr_filename);
         } else {
-            (void)snprintf(*reg_data + strlen(*reg_data), json_size + 2, "%c%s", PATH_SEPARATOR, curr_filename);
+            (void)snprintf(*reg_data + cur_len, *total_size - cur_len, "%c%s", PATH_SEPARATOR, curr_filename);
         }
         loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "%s: Located json file \"%s\" from PnP registry: %s", __FUNCTION__,
                    curr_filename, key_name);

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -4337,6 +4337,26 @@ TEST(DuplicateRegistryEntries, Drivers) {
                                    "\" from registry \"HKEY_LOCAL_MACHINE\\" VK_DRIVERS_INFO_REGISTRY_LOC
                                    "\" to the list due to duplication"));
 }
+
+// Regression test for a heap buffer overflow in windows_add_json_entry(). The buffer that aggregates manifest paths
+// discovered through the registry/D3DKMT enumeration starts at a fixed 4096 bytes, and the snprintf calls that append
+// to it were bounded by the source length instead of the destination's remaining capacity. As a result, a manifest
+// path longer than the buffer was written past the end of the allocation. This exercises that path with an oversized
+// value to ensure the destination buffer is grown to fit before writing.
+TEST(RegistryManifestParsing, OversizedD3DKMTDriverPathDoesNotOverflow) {
+    FrameworkEnvironment env{};
+
+    // Build a driver manifest path whose length exceeds the loader's initial 4096-byte registry buffer.
+    std::filesystem::path oversized_path = std::filesystem::path(std::string(5000, 'a')) / "test_icd.json";
+    ASSERT_GT(oversized_path.native().size(), 4096u);
+
+    env.platform_shim->add_d3dkmt_adapter(D3DKMT_Adapter{0, _LUID{10, 1000}}.add_driver_manifest_path(oversized_path));
+
+    // The path does not point at a real manifest, so no driver is found - but the loader must reach that conclusion
+    // without overflowing its internal buffer while enumerating the path.
+    InstWrapper inst{env.vulkan_functions};
+    inst.CheckCreate(VK_ERROR_INCOMPATIBLE_DRIVER);
+}
 #endif
 
 TEST(LibraryLoading, SystemLocations) {


### PR DESCRIPTION
## Summary

Fix a heap buffer overflow in `windows_add_json_entry()` when processing oversized manifest paths discovered through registry or D3DKMT enumeration.

## Root Cause

* The initial allocation path always used the existing buffer size, regardless of the incoming manifest path length.
* The growth path expanded the buffer by at most a single doubling, which could still leave the destination undersized for large values.
* Appended writes were bounded by the source length instead of the remaining destination capacity.

Together, these conditions could result in writes beyond the allocated buffer when handling oversized manifest paths.

## Changes

* Size the destination buffer based on the required length before writing.
* Grow the buffer until the incoming value fits.
* Return `VK_ERROR_OUT_OF_HOST_MEMORY` when the required size cannot be represented.
* Bound all writes using the destination buffer capacity.