### PR TITLE
loader: Match select/disable filters on full name

### DIFF
--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -275,14 +275,12 @@ VkResult parse_generic_filter_environment_var(const struct loader_instance *inst
         const char *actual_start;
         size_t actual_len;
         determine_filter_type(token, &cur_filter_type, &actual_start, &actual_len);
-        if (actual_len > VK_MAX_EXTENSION_NAME_SIZE) {
-            loader_strncpy(filter_struct->filters[filter_struct->count].value, VK_MAX_EXTENSION_NAME_SIZE, actual_start,
-                           VK_MAX_EXTENSION_NAME_SIZE);
-        } else {
-            loader_strncpy(filter_struct->filters[filter_struct->count].value, VK_MAX_EXTENSION_NAME_SIZE, actual_start,
-                           actual_len);
-        }
-        filter_struct->filters[filter_struct->count].length = actual_len;
+        // value holds at most VK_MAX_EXTENSION_NAME_SIZE - 1 chars plus the null terminator. Keep the stored length in sync
+        // with what actually fits so the matcher never walks past the buffer, and make sure it stays null terminated.
+        size_t stored_len = actual_len < VK_MAX_EXTENSION_NAME_SIZE - 1 ? actual_len : VK_MAX_EXTENSION_NAME_SIZE - 1;
+        loader_strncpy(filter_struct->filters[filter_struct->count].value, VK_MAX_EXTENSION_NAME_SIZE, actual_start, stored_len);
+        filter_struct->filters[filter_struct->count].value[stored_len] = '\0';
+        filter_struct->filters[filter_struct->count].length = stored_len;
         filter_struct->filters[filter_struct->count++].type = cur_filter_type;
         if (filter_struct->count >= MAX_ADDITIONAL_FILTERS) {
             break;
@@ -346,14 +344,13 @@ VkResult parse_layers_disable_filter_environment_var(const struct loader_instanc
                 disable_struct->disable_all_explicit = true;
             }
         } else {
-            if (actual_len > VK_MAX_EXTENSION_NAME_SIZE) {
-                loader_strncpy(disable_struct->additional_filters.filters[cur_count].value, VK_MAX_EXTENSION_NAME_SIZE,
-                               actual_start, VK_MAX_EXTENSION_NAME_SIZE);
-            } else {
-                loader_strncpy(disable_struct->additional_filters.filters[cur_count].value, VK_MAX_EXTENSION_NAME_SIZE,
-                               actual_start, actual_len);
-            }
-            disable_struct->additional_filters.filters[cur_count].length = actual_len;
+            // Keep the stored length in sync with what actually fits (value is VK_MAX_EXTENSION_NAME_SIZE bytes including
+            // the null terminator) so the matcher never reads past the buffer.
+            size_t stored_len = actual_len < VK_MAX_EXTENSION_NAME_SIZE - 1 ? actual_len : VK_MAX_EXTENSION_NAME_SIZE - 1;
+            loader_strncpy(disable_struct->additional_filters.filters[cur_count].value, VK_MAX_EXTENSION_NAME_SIZE, actual_start,
+                           stored_len);
+            disable_struct->additional_filters.filters[cur_count].value[stored_len] = '\0';
+            disable_struct->additional_filters.filters[cur_count].length = stored_len;
             disable_struct->additional_filters.filters[cur_count].type = cur_filter_type;
             disable_struct->additional_filters.count++;
             if (disable_struct->additional_filters.count >= MAX_ADDITIONAL_FILTERS) {
@@ -385,6 +382,18 @@ VkResult parse_layer_environment_var_filters(const struct loader_instance *inst,
     return res;
 }
 
+// Case-insensitive compare of `count` bytes of a name against a filter value. Filter values are already lowercased when
+// they get parsed (see parse_generic_filter_environment_var), so we only need to fold the name side as we go. The caller
+// guarantees both sides have at least `count` valid bytes.
+static bool name_segment_matches_filter_value(const char *name_segment, const char *lowercase_filter_value, size_t count) {
+    for (size_t iii = 0; iii < count; ++iii) {
+        if ((char)tolower((unsigned char)name_segment[iii]) != lowercase_filter_value[iii]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 // Check to see if the provided layer name matches any of the filter strings.
 // This will properly check against:
 //  - substrings "*string*"
@@ -394,54 +403,44 @@ VkResult parse_layer_environment_var_filters(const struct loader_instance *inst,
 bool check_name_matches_filter_environment_var(const char *name, const struct loader_envvar_filter *filter_struct) {
     bool ret_value = false;
     size_t name_len = strlen(name);
-    // name may be a manifest filename (from the driver select/disable filters) which, unlike layer names, is not capped to
-    // VK_MAX_EXTENSION_NAME_SIZE at parse time. Clamp so the lowercase copy stays inside lower_name.
-    if (name_len >= VK_MAX_EXTENSION_NAME_SIZE) {
-        name_len = VK_MAX_EXTENSION_NAME_SIZE - 1;
-    }
-    char lower_name[VK_MAX_EXTENSION_NAME_SIZE];
-    for (uint32_t iii = 0; iii < name_len; ++iii) {
-        lower_name[iii] = (char)tolower((unsigned char)name[iii]);
-    }
-    lower_name[name_len] = '\0';
+    // Compare each filter against `name` directly. name_segment_matches_filter_value does a case-insensitive compare
+    // (filter values are already lowercased at parse time), so there's no need to make a lowercased copy of name first
+    // and no limit on how long name can be.
     for (uint32_t filt = 0; filt < filter_struct->count; ++filt) {
-        // Check if the filter name is longer (this is with all special characters removed), and if it is
-        // continue since it can't match.
-        if (filter_struct->filters[filt].length > name_len) {
+        const struct loader_envvar_filter_value *filter = &filter_struct->filters[filt];
+        // The filter (with its wildcards stripped) is longer than the name, so it can't possibly match.
+        if (filter->length > name_len) {
             continue;
         }
-        switch (filter_struct->filters[filt].type) {
+        switch (filter->type) {
             case FILTER_STRING_SPECIAL:
-                if (!strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_1, filter_struct->filters[filt].value) ||
-                    !strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_2, filter_struct->filters[filt].value) ||
-                    !strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_3, filter_struct->filters[filt].value)) {
+                if (!strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_1, filter->value) ||
+                    !strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_2, filter->value) ||
+                    !strcmp(VK_LOADER_DISABLE_ALL_LAYERS_VAR_3, filter->value)) {
                     ret_value = true;
                 }
                 break;
 
             case FILTER_STRING_SUBSTRING:
-                if (NULL != strstr(lower_name, filter_struct->filters[filt].value)) {
-                    ret_value = true;
+                // Slide the filter along the name looking for a match, stopping as soon as one is found.
+                for (size_t start = 0; start + filter->length <= name_len; ++start) {
+                    if (name_segment_matches_filter_value(name + start, filter->value, filter->length)) {
+                        ret_value = true;
+                        break;
+                    }
                 }
                 break;
 
             case FILTER_STRING_SUFFIX:
-                if (0 == strncmp(lower_name + name_len - filter_struct->filters[filt].length, filter_struct->filters[filt].value,
-                                 filter_struct->filters[filt].length)) {
-                    ret_value = true;
-                }
+                ret_value = name_segment_matches_filter_value(name + name_len - filter->length, filter->value, filter->length);
                 break;
 
             case FILTER_STRING_PREFIX:
-                if (0 == strncmp(lower_name, filter_struct->filters[filt].value, filter_struct->filters[filt].length)) {
-                    ret_value = true;
-                }
+                ret_value = name_segment_matches_filter_value(name, filter->value, filter->length);
                 break;
 
             case FILTER_STRING_FULLNAME:
-                if (0 == strncmp(lower_name, filter_struct->filters[filt].value, name_len)) {
-                    ret_value = true;
-                }
+                ret_value = (name_len == filter->length) && name_segment_matches_filter_value(name, filter->value, filter->length);
                 break;
         }
         if (ret_value) {

--- a/loader/loader_json.c
+++ b/loader/loader_json.c
@@ -57,6 +57,18 @@ static VkResult loader_read_entire_file(const struct loader_instance *inst, cons
         if (MultiByteToWideChar(CP_UTF8, 0, filename, -1, filename_utf16, filename_utf16_size) == filename_utf16_size) {
             file_handle =
                 CreateFileW(filename_utf16, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+            // A path at or beyond MAX_PATH won't open unless we opt into long paths with the "\\?\" prefix, so retry with it.
+            if (INVALID_HANDLE_VALUE == file_handle && filename_utf16_size >= MAX_PATH) {
+                int prefixed_utf16_size = filename_utf16_size + 4;  // room for the leading "\\?\"
+                wchar_t *prefixed_utf16 = (wchar_t *)loader_stack_alloc(prefixed_utf16_size * sizeof(wchar_t));
+                prefixed_utf16[0] = L'\\';
+                prefixed_utf16[1] = L'\\';
+                prefixed_utf16[2] = L'?';
+                prefixed_utf16[3] = L'\\';
+                memcpy(prefixed_utf16 + 4, filename_utf16, filename_utf16_size * sizeof(wchar_t));
+                file_handle =
+                    CreateFileW(prefixed_utf16, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+            }
         }
     }
     if (INVALID_HANDLE_VALUE == file_handle) {

--- a/tests/framework/util/folder_manager.cpp
+++ b/tests/framework/util/folder_manager.cpp
@@ -65,6 +65,13 @@ std::filesystem::path Folder::write_manifest(std::filesystem::path const& name, 
     std::filesystem::path out_path = (folder / name).lexically_normal();
     if (!::testing::internal::InDeathTestChild()) {
         auto file = std::ofstream(out_path, std::ios_base::trunc | std::ios_base::out);
+#if defined(_WIN32)
+        // If the manifest path is too long for Windows, retry with the \\?\ absolute-path prefix.
+        if (!file) {
+            std::wstring long_path = L"\\\\?\\" + std::filesystem::absolute(out_path).native();
+            file = std::ofstream(long_path.c_str(), std::ios_base::trunc | std::ios_base::out);
+        }
+#endif
         if (!file) {
             std::cerr << "Failed to create manifest " << name << " at " << out_path << "\n";
             return out_path;

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -712,6 +712,64 @@ TEST(EnvVarICDOverrideSetup, FilterSelectDriver) {
     ASSERT_FALSE(env.debug_log.find_prefix_then_postfix("CDE_ICD.json", "ignored because it was disabled by env var"));
 }
 
+// Exercise the driver select/disable filters against a manifest name that is much longer than VK_MAX_EXTENSION_NAME_SIZE
+// would have allowed when the matcher copied the name into a fixed-size buffer. The whole name has to be considered for
+// every filter type, not just the first 255 characters. See KhronosGroup/Vulkan-Loader#1913.
+TEST(EnvVarICDOverrideSetup, FilterDriverLongManifestName) {
+    FrameworkEnvironment env{};
+    EnvVarWrapper filter_select_env_var{"VK_LOADER_DRIVERS_SELECT"};
+    EnvVarWrapper filter_disable_env_var{"VK_LOADER_DRIVERS_DISABLE"};
+
+    // Filesystems cap a single filename at NAME_MAX (255 on the platforms the tests run on), so use the longest practical
+    // name. The distinguishing part lives at the very end so any matcher that stops early gets it wrong.
+    const std::string long_name = "long_driver_" + std::string(220, 'a') + "_unique_ICD.json";
+    ASSERT_LT(long_name.size(), static_cast<size_t>(255));
+    env.add_icd(TEST_ICD_PATH_VERSION_6, ManifestOptions{}.set_json_name(long_name));
+
+    // A suffix filter that only matches via characters past the old 255 limit should still select the driver.
+    filter_select_env_var.set_new_value("*_unique_ICD.json");
+    {
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
+        inst.CheckCreate();
+        ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("Found ICD manifest file", long_name.c_str()));
+        ASSERT_FALSE(env.debug_log.find_prefix_then_postfix(long_name.c_str(), "ignored because not selected by env var"));
+    }
+
+    // A substring filter spanning the tail of the name should match as well.
+    env.debug_log.clear();
+    filter_select_env_var.set_new_value("*a_unique*");
+    {
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
+        inst.CheckCreate();
+        ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("Found ICD manifest file", long_name.c_str()));
+        ASSERT_FALSE(env.debug_log.find_prefix_then_postfix(long_name.c_str(), "ignored because not selected by env var"));
+    }
+
+    // The full long name matched exactly must select the driver.
+    env.debug_log.clear();
+    filter_select_env_var.set_new_value(long_name);
+    {
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
+        inst.CheckCreate();
+        ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("Found ICD manifest file", long_name.c_str()));
+        ASSERT_FALSE(env.debug_log.find_prefix_then_postfix(long_name.c_str(), "ignored because not selected by env var"));
+    }
+
+    // A disable filter keyed off the tail must drop the driver, leaving no usable ICD.
+    env.debug_log.clear();
+    filter_select_env_var.remove_value();
+    filter_disable_env_var.set_new_value("*_unique_ICD.json");
+    {
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
+        inst.CheckCreate(VK_ERROR_INCOMPATIBLE_DRIVER);
+        ASSERT_TRUE(env.debug_log.find_prefix_then_postfix(long_name.c_str(), "ignored because it was disabled by env var"));
+    }
+}
+
 // Test that the driver filter disable disables driver manifest files that match the filter
 TEST(EnvVarICDOverrideSetup, FilterDisableDriver) {
     FrameworkEnvironment env{};


### PR DESCRIPTION
Fixes #1913.

`check_name_matches_filter_environment_var` copied the name being matched into a fixed `VK_MAX_EXTENSION_NAME_SIZE` buffer and clamped it to the first 255 characters before matching. The driver select/disable filters match against the manifest filename, so a name longer than that got matched on a truncated copy. This is a follow-up to the earlier clamp that was added to stop that copy from overflowing.

Instead of copying, match against the name in place. Filter values are already lowercased when they get parsed, so a small helper folds the name side as it compares. No copy, no length cap, works for any length.

I also made the two filter parsers store a length that matches what actually fits in the `value` buffer and keep it null terminated, so the matcher can never read past it. `loader_strncpy` is plain `strncpy`, so a >= 256 char filter used to leave `value` unterminated with `length` set past the buffer.

Added a test that runs the driver select/disable filters against a long manifest name across suffix, substring, and full-name matches. Heads up: a single filename is capped at NAME_MAX (255 on the platforms the tests run on), so the test uses the longest practical name rather than going past 255. The matcher itself no longer has the cap.

All 577 regression tests pass locally.