### PR TITLE
Refactor test framework to detect invalid handles and support multiple instances

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -67,10 +67,6 @@ static inline VkLayerInstanceDispatchTable *loader_get_instance_layer_dispatch(c
     return *((VkLayerInstanceDispatchTable **)obj);
 }
 
-static inline struct loader_instance_dispatch_table *loader_get_instance_dispatch(const void *obj) {
-    return *((struct loader_instance_dispatch_table **)obj);
-}
-
 static inline void loader_init_dispatch(void *obj, const void *data) {
 #if defined(DEBUG)
     assert(valid_loader_magic_value(obj) &&

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -144,13 +144,15 @@ void UpdatePhysicalDeviceDetails(VkInstance instance) {
     }
 }
 
-PhysicalDevice& GetPhysDevice(VkPhysicalDevice physicalDevice) {
-    if (icd.created_physical_device_details.count(physicalDevice) > 0) {
-        return icd.physical_devices.at(icd.created_physical_device_details.at(physicalDevice).index_physical_device);
+void check_valid_physical_device(VkPhysicalDevice physicalDevice) {
+    if (icd.created_physical_device_details.count(physicalDevice) == 0) {
+        abort();
     }
-    assert(false && "vkPhysicalDevice not found!");
-    return icd.physical_devices.at(
-        icd.created_physical_device_details.at(icd.created_physical_device_details.begin()->first).index_physical_device);
+}
+
+PhysicalDevice& GetPhysDevice(VkPhysicalDevice physicalDevice) {
+    check_valid_physical_device(physicalDevice);
+    return icd.physical_devices.at(icd.created_physical_device_details.at(physicalDevice).index_physical_device);
 }
 
 bool is_valid_surface(VkInstance instance, VkSurfaceKHR surface_to_check) {
@@ -168,6 +170,21 @@ void check_valid_instance(VkInstance instance) {
 void check_valid_instance_if_not_null(VkInstance instance) {
     if (instance == nullptr) return;
     if (icd.created_instance_details.count(instance) == 0) {
+        abort();
+    }
+}
+void check_valid_device(VkDevice device) {
+    if (icd.created_device_details.count(device) == 0) {
+        abort();
+    }
+}
+void check_valid_queue(VkQueue queue) {
+    if (icd.created_queues.count(queue) == 0) {
+        abort();
+    }
+}
+void check_valid_command_buffer(VkCommandBuffer commandBuffer) {
+    if (icd.created_command_buffers.count(commandBuffer) == 0) {
         abort();
     }
 }
@@ -528,6 +545,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroyDebugReportCallbackEXT(VkInstance insta
 // Debug utils & debug marker ext stubs
 VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectTagEXT(VkDevice dev, const VkDebugMarkerObjectTagInfoEXT* pTagInfo) {
     std::lock_guard lg(icd.mutex);
+    check_valid_device(dev);
     if (pTagInfo && pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pTagInfo->object);
         if (pd != icd.created_device_details.at(dev).physical_device_created_from) return VK_ERROR_DEVICE_LOST;
@@ -548,6 +566,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectTagEXT(VkDevice dev, c
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectNameEXT(VkDevice dev, const VkDebugMarkerObjectNameInfoEXT* pNameInfo) {
     std::lock_guard lg(icd.mutex);
+    check_valid_device(dev);
     if (pNameInfo && pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pNameInfo->object);
         if (pd != icd.created_device_details.at(dev).physical_device_created_from) return VK_ERROR_DEVICE_LOST;
@@ -566,12 +585,22 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectNameEXT(VkDevice dev, 
     }
     return VK_SUCCESS;
 }
-VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerBeginEXT(VkCommandBuffer, const VkDebugMarkerMarkerInfoEXT*) {}
-VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerEndEXT(VkCommandBuffer) {}
-VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerInsertEXT(VkCommandBuffer, const VkDebugMarkerMarkerInfoEXT*) {}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT*) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_command_buffer(commandBuffer);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_command_buffer(commandBuffer);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT*) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_command_buffer(commandBuffer);
+}
 
 VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectNameEXT(VkDevice dev, const VkDebugUtilsObjectNameInfoEXT* pNameInfo) {
     std::lock_guard lg(icd.mutex);
+    check_valid_device(dev);
     if (pNameInfo && pNameInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pNameInfo->objectHandle);
         if (pd != icd.created_device_details.at(dev).physical_device_created_from) return VK_ERROR_DEVICE_LOST;
@@ -592,6 +621,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectNameEXT(VkDevice dev, c
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectTagEXT(VkDevice dev, const VkDebugUtilsObjectTagInfoEXT* pTagInfo) {
     std::lock_guard lg(icd.mutex);
+    check_valid_device(dev);
     if (pTagInfo && pTagInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pTagInfo->objectHandle);
         if (pd != icd.created_device_details.at(dev).physical_device_created_from) return VK_ERROR_DEVICE_LOST;
@@ -610,12 +640,30 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectTagEXT(VkDevice dev, co
     }
     return VK_SUCCESS;
 }
-VKAPI_ATTR void VKAPI_CALL test_vkQueueBeginDebugUtilsLabelEXT(VkQueue, const VkDebugUtilsLabelEXT*) {}
-VKAPI_ATTR void VKAPI_CALL test_vkQueueEndDebugUtilsLabelEXT(VkQueue) {}
-VKAPI_ATTR void VKAPI_CALL test_vkQueueInsertDebugUtilsLabelEXT(VkQueue, const VkDebugUtilsLabelEXT*) {}
-VKAPI_ATTR void VKAPI_CALL test_vkCmdBeginDebugUtilsLabelEXT(VkCommandBuffer, const VkDebugUtilsLabelEXT*) {}
-VKAPI_ATTR void VKAPI_CALL test_vkCmdEndDebugUtilsLabelEXT(VkCommandBuffer) {}
-VKAPI_ATTR void VKAPI_CALL test_vkCmdInsertDebugUtilsLabelEXT(VkCommandBuffer, const VkDebugUtilsLabelEXT*) {}
+VKAPI_ATTR void VKAPI_CALL test_vkQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT*) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_queue(queue);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkQueueEndDebugUtilsLabelEXT(VkQueue queue) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_queue(queue);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkQueueInsertDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT*) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_queue(queue);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT*) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_command_buffer(commandBuffer);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_command_buffer(commandBuffer);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT*) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_command_buffer(commandBuffer);
+}
 
 //// Physical Device functions ////
 
@@ -651,11 +699,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevi
                                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
-    if (icd.created_physical_device_details.count(physicalDevice) == 0) {
-        return VK_ERROR_INITIALIZATION_FAILED;
-    }
-    auto& physical_device_info =
-        icd.physical_devices.at(icd.created_physical_device_details.at(physicalDevice).index_physical_device);
+
+    auto& physical_device_info = GetPhysDevice(physicalDevice);
 
     CreatedDeviceDetails new_device_details{};
     new_device_details.physical_device_created_from =
@@ -668,6 +713,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevi
     }
     for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; i++) {
         new_device_details.queue_handles.emplace_back();
+        icd.created_queues.insert(new_device_details.queue_handles.back().handle);
     }
     *pDevice = new_device_details.device.handle;
     icd.created_device_details.emplace(*pDevice, std::move(new_device_details));
@@ -678,10 +724,12 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevi
 VKAPI_ATTR void VKAPI_CALL test_vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
-
-    if (icd.created_device_details.count(device) == 0) {
-        // Loader shouldn't try to destroy devices not created from this ICD
-        abort();
+    check_valid_device(device);
+    for (const auto& queue : icd.created_device_details.at(device).queue_handles) {
+        icd.created_queues.erase(queue.handle);
+    }
+    for (const auto& command_buffer : icd.created_device_details.at(device).allocated_command_buffers) {
+        icd.created_command_buffers.erase(command_buffer.handle);
     }
     icd.created_device_details.erase(device);
 }
@@ -689,11 +737,9 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroyDevice(VkDevice device, const VkAllocat
 VKAPI_ATTR VkResult VKAPI_CALL generic_tool_props_function([[maybe_unused]] VkPhysicalDevice physicalDevice, uint32_t* pToolCount,
                                                            VkPhysicalDeviceToolPropertiesEXT* pToolProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (icd.tooling_properties.size() == 0) {
         return VK_SUCCESS;
-    }
-    if (icd.created_physical_device_details.count(physicalDevice) == 0) {
-        return VK_ERROR_INITIALIZATION_FAILED;
     }
     if (pToolProperties == nullptr && pToolCount != nullptr) {
         *pToolCount = static_cast<uint32_t>(icd.tooling_properties.size());
@@ -948,6 +994,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSwapchainKHR(VkDevice device, const 
                                                          const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
+    check_valid_device(device);
     // Validate that the surface came from this instance
     uint64_t surface_integer_value = from_nondispatch_handle(pCreateInfo->surface);
     auto& surface_handles =
@@ -960,11 +1007,11 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSwapchainKHR(VkDevice device, const 
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL test_vkGetSwapchainImagesKHR([[maybe_unused]] VkDevice device,
-                                                            [[maybe_unused]] VkSwapchainKHR swapchain,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkGetSwapchainImagesKHR(VkDevice device, [[maybe_unused]] VkSwapchainKHR swapchain,
                                                             uint32_t* pSwapchainImageCount, VkImage* pSwapchainImages) {
     std::vector<uint64_t> handles{123, 234, 345, 345, 456};
     std::lock_guard lg(icd.mutex);
+    check_valid_device(device);
     if (pSwapchainImages == nullptr) {
         if (pSwapchainImageCount) *pSwapchainImageCount = static_cast<uint32_t>(handles.size());
     } else if (pSwapchainImageCount) {
@@ -980,6 +1027,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroySwapchainKHR(VkDevice device, VkSwapcha
                                                       const VkAllocationCallbacks* pAllocator) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
+    check_valid_device(device);
     if (swapchain != VK_NULL_HANDLE) {
         uint64_t fake_swapchain_handle = from_nondispatch_handle(swapchain);
         auto& swapchain_handles = icd.created_device_details.at(device).swapchain_handles;
@@ -991,9 +1039,10 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroySwapchainKHR(VkDevice device, VkSwapcha
     }
 }
 // VK_KHR_swapchain with 1.1
-VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDeviceGroupSurfacePresentModesKHR([[maybe_unused]] VkDevice device,
-                                                                           [[maybe_unused]] VkSurfaceKHR surface,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDeviceGroupSurfacePresentModesKHR(VkDevice device, [[maybe_unused]] VkSurfaceKHR surface,
                                                                            VkDeviceGroupPresentModeFlagsKHR* pModes) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_device(device);
     if (!pModes) return VK_ERROR_INITIALIZATION_FAILED;
     if (!is_valid_surface(icd.created_device_details.at(device).instance_created_from, surface)) {
         abort();
@@ -1006,6 +1055,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDeviceGroupSurfacePresentModesKHR([[may
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
                                                                          VkSurfaceKHR surface, VkBool32* pSupported) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (surface != VK_NULL_HANDLE) {
         if (!is_valid_surface(icd.created_physical_device_details.at(physicalDevice).instance_created_from, surface)) {
             *pSupported = VK_FALSE;
@@ -1027,6 +1077,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceSupportKHR(VkPhysi
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                               VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (surface != VK_NULL_HANDLE) {
         if (!is_valid_surface(icd.created_physical_device_details.at(physicalDevice).instance_created_from, surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfaceCapabilitiesKHR query!");
@@ -1042,6 +1093,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceFormatsKHR(VkPhysi
                                                                          uint32_t* pSurfaceFormatCount,
                                                                          VkSurfaceFormatKHR* pSurfaceFormats) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (surface != VK_NULL_HANDLE) {
         if (!is_valid_surface(icd.created_physical_device_details.at(physicalDevice).instance_created_from, surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfaceFormatsKHR query!");
@@ -1060,6 +1112,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfacePresentModesKHR(Vk
                                                                               uint32_t* pPresentModeCount,
                                                                               VkPresentModeKHR* pPresentModes) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (surface != VK_NULL_HANDLE) {
         if (!is_valid_surface(icd.created_physical_device_details.at(physicalDevice).instance_created_from, surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfacePresentModesKHR query!");
@@ -1081,6 +1134,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfacePresentModes2EXT(V
                                                                                uint32_t* pPresentModeCount,
                                                                                VkPresentModeKHR* pPresentModes) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (pSurfaceInfo->surface != VK_NULL_HANDLE) {
         if (!is_valid_surface(icd.created_physical_device_details.at(physicalDevice).instance_created_from,
                               pSurfaceInfo->surface)) {
@@ -1103,6 +1157,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceDisplayPropertiesKHR(VkPh
                                                                             uint32_t* pPropertyCount,
                                                                             VkDisplayPropertiesKHR* pProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     FillCountPtr(GetPhysDevice(physicalDevice).display_properties, pPropertyCount, pProperties);
     return VK_SUCCESS;
 }
@@ -1110,6 +1165,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceDisplayPlanePropertiesKHR
                                                                                  uint32_t* pPropertyCount,
                                                                                  VkDisplayPlanePropertiesKHR* pProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     FillCountPtr(GetPhysDevice(physicalDevice).display_plane_properties, pPropertyCount, pProperties);
     return VK_SUCCESS;
 }
@@ -1117,6 +1173,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDisplayPlaneSupportedDisplaysKHR(VkPhys
                                                                           [[maybe_unused]] uint32_t planeIndex,
                                                                           uint32_t* pDisplayCount, VkDisplayKHR* pDisplays) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     FillCountPtr(GetPhysDevice(physicalDevice).displays, pDisplayCount, pDisplays);
     return VK_SUCCESS;
 }
@@ -1124,6 +1181,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDisplayModePropertiesKHR(VkPhysicalDevi
                                                                   [[maybe_unused]] VkDisplayKHR display, uint32_t* pPropertyCount,
                                                                   VkDisplayModePropertiesKHR* pProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     FillCountPtr(GetPhysDevice(physicalDevice).display_mode_properties, pPropertyCount, pProperties);
     return VK_SUCCESS;
 }
@@ -1131,6 +1189,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDisplayModeKHR(VkPhysicalDevice phys
                                                            [[maybe_unused]] const VkDisplayModeCreateInfoKHR* pCreateInfo,
                                                            const VkAllocationCallbacks* pAllocator, VkDisplayModeKHR* pMode) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     check_allocator_handle(pAllocator);
     if (nullptr != pMode) {
         *pMode = GetPhysDevice(physicalDevice).display_mode;
@@ -1142,6 +1201,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDisplayPlaneCapabilitiesKHR(VkPhysicalD
                                                                      [[maybe_unused]] uint32_t planeIndex,
                                                                      VkDisplayPlaneCapabilitiesKHR* pCapabilities) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pCapabilities) {
         *pCapabilities = GetPhysDevice(physicalDevice).display_plane_capabilities;
     }
@@ -1164,6 +1224,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceCapabilities2KHR(V
                                                                                const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
                                                                                VkSurfaceCapabilities2KHR* pSurfaceCapabilities) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pSurfaceInfo && nullptr != pSurfaceCapabilities) {
         if (IsInstanceExtensionSupported("VK_EXT_surface_maintenance1") &&
             IsInstanceExtensionEnabled(physicalDevice, "VK_EXT_surface_maintenance1")) {
@@ -1231,6 +1292,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhys
                                                                           uint32_t* pSurfaceFormatCount,
                                                                           VkSurfaceFormat2KHR* pSurfaceFormats) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pSurfaceFormatCount) {
         test_vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, pSurfaceInfo->surface, pSurfaceFormatCount, nullptr);
         if (nullptr != pSurfaceFormats) {
@@ -1250,6 +1312,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSharedSwapchainsKHR(VkDevice device,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 VkSwapchainKHR* pSwapchains) {
     std::lock_guard lg(icd.mutex);
+    check_valid_device(device);
     check_allocator_handle(pAllocator);
     for (uint32_t i = 0; i < swapchainCount; i++) {
         // Validate that the surface was created from this instance
@@ -1266,25 +1329,30 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSharedSwapchainsKHR(VkDevice device,
 }
 
 //// misc
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateCommandPool([[maybe_unused]] VkDevice device,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateCommandPool(VkDevice device,
                                                         [[maybe_unused]] const VkCommandPoolCreateInfo* pCreateInfo,
                                                         const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool) {
     check_allocator_handle(pAllocator);
+    std::lock_guard lg(icd.mutex);
+    check_valid_device(device);
     if (pCommandPool != nullptr) {
         pCommandPool = reinterpret_cast<VkCommandPool*>(0xdeadbeefdeadbeef);
     }
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR void VKAPI_CALL test_vkDestroyCommandPool(VkDevice, VkCommandPool, const VkAllocationCallbacks*) {
+VKAPI_ATTR void VKAPI_CALL test_vkDestroyCommandPool(VkDevice device, VkCommandPool, const VkAllocationCallbacks*) {
+    check_valid_device(device);
     // do nothing, leak memory for now
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                              VkCommandBuffer* pCommandBuffers) {
     std::lock_guard lg(icd.mutex);
+    check_valid_device(device);
     if (pAllocateInfo != nullptr && pCommandBuffers != nullptr) {
         for (size_t i = 0; i < pAllocateInfo->commandBufferCount; i++) {
             pCommandBuffers[i] = icd.created_device_details.at(device).allocated_command_buffers.emplace_back().handle;
+            icd.created_command_buffers.insert(pCommandBuffers[i]);
         }
     }
     return VK_SUCCESS;
@@ -1293,9 +1361,8 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkAllocateCommandBuffers(VkDevice device, co
 VKAPI_ATTR void VKAPI_CALL test_vkGetDeviceQueue(VkDevice device, [[maybe_unused]] uint32_t queueFamilyIndex, uint32_t queueIndex,
                                                  VkQueue* pQueue) {
     std::lock_guard lg(icd.mutex);
-    if (icd.created_device_details.count(device) > 0) {
-        *pQueue = icd.created_device_details.at(device).queue_handles.at(queueIndex).handle;
-    }
+    check_valid_device(device);
+    *pQueue = icd.created_device_details.at(device).queue_handles.at(queueIndex).handle;
 }
 
 // VK_EXT_acquire_drm_display
@@ -1304,6 +1371,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkAcquireDrmDisplayEXT(VkPhysicalDevice, int
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDrmDisplayEXT(VkPhysicalDevice physicalDevice, [[maybe_unused]] int32_t drmFd,
                                                        [[maybe_unused]] uint32_t connectorId, VkDisplayKHR* display) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != display && GetPhysDevice(physicalDevice).displays.size() > 0) {
         *display = GetPhysDevice(physicalDevice).displays[0];
     }
@@ -1314,6 +1382,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDrmDisplayEXT(VkPhysicalDevice physical
 // 1.0
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures* pFeatures) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pFeatures) {
         memcpy(pFeatures, &GetPhysDevice(physicalDevice).features, sizeof(VkPhysicalDeviceFeatures));
     }
@@ -1321,6 +1390,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceFeatures(VkPhysicalDevice phy
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
                                                               VkPhysicalDeviceProperties* pProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pProperties) {
         auto& phys_dev = GetPhysDevice(physicalDevice);
         memcpy(pProperties, &phys_dev.properties, sizeof(VkPhysicalDeviceProperties));
@@ -1333,6 +1403,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceProperties(VkPhysicalDevice p
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceMemoryProperties(VkPhysicalDevice physicalDevice,
                                                                     VkPhysicalDeviceMemoryProperties* pMemoryProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pMemoryProperties) {
         memcpy(pMemoryProperties, &GetPhysDevice(physicalDevice).memory_properties, sizeof(VkPhysicalDeviceMemoryProperties));
     }
@@ -1342,11 +1413,13 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceSparseImageFormatProperties(
     [[maybe_unused]] VkSampleCountFlagBits samples, [[maybe_unused]] VkImageUsageFlags usage, [[maybe_unused]] VkImageTiling tiling,
     uint32_t* pPropertyCount, VkSparseImageFormatProperties* pProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     FillCountPtr(GetPhysDevice(physicalDevice).sparse_image_format_properties, pPropertyCount, pProperties);
 }
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                     VkFormatProperties* pFormatProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pFormatProperties) {
         memcpy(pFormatProperties, &GetPhysDevice(physicalDevice).format_properties[static_cast<uint32_t>(format)],
                sizeof(VkFormatProperties));
@@ -1357,6 +1430,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceImageFormatProperties(
     [[maybe_unused]] VkImageTiling tiling, [[maybe_unused]] VkImageUsageFlags usage, [[maybe_unused]] VkImageCreateFlags flags,
     VkImageFormatProperties* pImageFormatProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pImageFormatProperties) {
         memcpy(pImageFormatProperties, &GetPhysDevice(physicalDevice).image_format_properties, sizeof(VkImageFormatProperties));
     }
@@ -1367,6 +1441,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceImageFormatProperties(
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice,
                                                              VkPhysicalDeviceFeatures2* pFeatures) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pFeatures) {
         test_vkGetPhysicalDeviceFeatures(physicalDevice, &pFeatures->features);
     }
@@ -1374,6 +1449,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceFeatures2(VkPhysicalDevice ph
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice,
                                                                VkPhysicalDeviceProperties2* pProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pProperties) {
         auto& phys_dev = GetPhysDevice(physicalDevice);
         test_vkGetPhysicalDeviceProperties(physicalDevice, &pProperties->properties);
@@ -1408,6 +1484,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceProperties2(VkPhysicalDevice 
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceMemoryProperties2(VkPhysicalDevice physicalDevice,
                                                                      VkPhysicalDeviceMemoryProperties2* pMemoryProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pMemoryProperties) {
         test_vkGetPhysicalDeviceMemoryProperties(physicalDevice, &pMemoryProperties->memoryProperties);
     }
@@ -1416,6 +1493,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceQueueFamilyProperties2(VkPhys
                                                                           uint32_t* pQueueFamilyPropertyCount,
                                                                           VkQueueFamilyProperties2* pQueueFamilyProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pQueueFamilyPropertyCount) {
         test_vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, pQueueFamilyPropertyCount, nullptr);
         if (nullptr != pQueueFamilyProperties) {
@@ -1433,6 +1511,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceSparseImageFormatProperties2(
     VkPhysicalDevice physicalDevice, const VkPhysicalDeviceSparseImageFormatInfo2* pFormatInfo, uint32_t* pPropertyCount,
     VkSparseImageFormatProperties2* pProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pPropertyCount) {
         test_vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, pFormatInfo->format, pFormatInfo->type,
                                                             pFormatInfo->samples, pFormatInfo->usage, pFormatInfo->tiling,
@@ -1451,6 +1530,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceSparseImageFormatProperties2(
 VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                      VkFormatProperties2* pFormatProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pFormatProperties) {
         test_vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &pFormatProperties->formatProperties);
     }
@@ -1459,6 +1539,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceImageFormatProperties2(
     VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
     VkImageFormatProperties2* pImageFormatProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pImageFormatInfo) {
         VkImageFormatProperties* ptr = nullptr;
         if (pImageFormatProperties) {
@@ -1474,6 +1555,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceExternalBufferProperties(
     VkPhysicalDevice physicalDevice, [[maybe_unused]] const VkPhysicalDeviceExternalBufferInfo* pExternalBufferInfo,
     VkExternalBufferProperties* pExternalBufferProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pExternalBufferProperties) {
         auto& phys_dev = GetPhysDevice(physicalDevice);
         memcpy(&pExternalBufferProperties->externalMemoryProperties, &phys_dev.external_memory_properties,
@@ -1484,6 +1566,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceExternalSemaphoreProperties(
     VkPhysicalDevice physicalDevice, [[maybe_unused]] const VkPhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo,
     VkExternalSemaphoreProperties* pExternalSemaphoreProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pExternalSemaphoreProperties) {
         auto& phys_dev = GetPhysDevice(physicalDevice);
         memcpy(pExternalSemaphoreProperties, &phys_dev.external_semaphore_properties, sizeof(VkExternalSemaphoreProperties));
@@ -1493,6 +1576,7 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceExternalFenceProperties(
     VkPhysicalDevice physicalDevice, [[maybe_unused]] const VkPhysicalDeviceExternalFenceInfo* pExternalFenceInfo,
     VkExternalFenceProperties* pExternalFenceProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
     if (nullptr != pExternalFenceProperties) {
         auto& phys_dev = GetPhysDevice(physicalDevice);
         memcpy(pExternalFenceProperties, &phys_dev.external_fence_properties, sizeof(VkExternalFenceProperties));
@@ -1500,24 +1584,43 @@ VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceExternalFenceProperties(
 }
 // Entry-points associated with the VK_KHR_performance_query extension
 VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
-    VkPhysicalDevice, uint32_t, uint32_t*, VkPerformanceCounterKHR*, VkPerformanceCounterDescriptionKHR*) {
+    VkPhysicalDevice physicalDevice, uint32_t, uint32_t*, VkPerformanceCounterKHR*, VkPerformanceCounterDescriptionKHR*) {
+    check_valid_physical_device(physicalDevice);
     return VK_SUCCESS;
 }
-VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(VkPhysicalDevice,
+VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(VkPhysicalDevice physicalDevice,
                                                                                         const VkQueryPoolPerformanceCreateInfoKHR*,
                                                                                         uint32_t*) {}
-VKAPI_ATTR VkResult VKAPI_CALL test_vkAcquireProfilingLockKHR(VkDevice, const VkAcquireProfilingLockInfoKHR*) { return VK_SUCCESS; }
-VKAPI_ATTR void VKAPI_CALL test_vkReleaseProfilingLockKHR(VkDevice) {}
-// Entry-points associated with the VK_EXT_sample_locations extension
-VKAPI_ATTR void VKAPI_CALL test_vkCmdSetSampleLocationsEXT(VkCommandBuffer, const VkSampleLocationsInfoEXT*) {}
-VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceMultisamplePropertiesEXT(VkPhysicalDevice, VkSampleCountFlagBits,
-                                                                            VkMultisamplePropertiesEXT*) {}
-// Entry-points associated with the VK_EXT_calibrated_timestamps extension
-VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(VkPhysicalDevice, uint32_t*, VkTimeDomainEXT*) {
+VKAPI_ATTR VkResult VKAPI_CALL test_vkAcquireProfilingLockKHR(VkDevice device, const VkAcquireProfilingLockInfoKHR*) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_device(device);
     return VK_SUCCESS;
 }
-VKAPI_ATTR VkResult VKAPI_CALL test_vkGetCalibratedTimestampsEXT(VkDevice, uint32_t, const VkCalibratedTimestampInfoEXT*, uint64_t*,
-                                                                 uint64_t*) {
+VKAPI_ATTR void VKAPI_CALL test_vkReleaseProfilingLockKHR(VkDevice device) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_device(device);
+}
+// Entry-points associated with the VK_EXT_sample_locations extension
+VKAPI_ATTR void VKAPI_CALL test_vkCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer, const VkSampleLocationsInfoEXT*) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_command_buffer(commandBuffer);
+}
+VKAPI_ATTR void VKAPI_CALL test_vkGetPhysicalDeviceMultisamplePropertiesEXT(VkPhysicalDevice physicalDevice, VkSampleCountFlagBits,
+                                                                            VkMultisamplePropertiesEXT*) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
+}
+// Entry-points associated with the VK_EXT_calibrated_timestamps extension
+VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(VkPhysicalDevice physicalDevice, uint32_t*,
+                                                                                   VkTimeDomainEXT*) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_physical_device(physicalDevice);
+    return VK_SUCCESS;
+}
+VKAPI_ATTR VkResult VKAPI_CALL test_vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t, const VkCalibratedTimestampInfoEXT*,
+                                                                 uint64_t*, uint64_t*) {
+    std::lock_guard lg(icd.mutex);
+    check_valid_device(device);
     return VK_SUCCESS;
 }
 
@@ -1973,6 +2076,7 @@ PFN_vkVoidFunction get_device_func(VkDevice device, const char* pName) {
 
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL test_vkGetInstanceProcAddr(VkInstance instance, const char* pName) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance_if_not_null(instance);
     return get_instance_func(instance, pName);
 }
 

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -1624,6 +1624,11 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetCalibratedTimestampsEXT(VkDevice device
     return VK_SUCCESS;
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL test_icd_internal_function(VkPhysicalDevice physicalDevice, uint32_t a, uint32_t b, float c) {
+    check_valid_physical_device(physicalDevice);
+    return VK_SUCCESS;
+}
+
 #if defined(WIN32)
 VKAPI_ATTR VkResult VKAPI_CALL test_vk_icdEnumerateAdapterPhysicalDevices(VkInstance instance, LUID adapterLUID,
                                                                           uint32_t* pPhysicalDeviceCount,
@@ -1955,7 +1960,9 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL get_physical_device_func(VkInstance ins
         if (string_eq(pName, "vkGetPhysicalDeviceToolPropertiesEXT"))
             return to_vkVoidFunction(test_vkGetPhysicalDeviceToolPropertiesEXT);
     }
-
+    if (icd.supports_internal_function && string_eq(pName, TEST_ICD_INTERNAL_FUNCTION_NAME_STRING)) {
+        return to_vkVoidFunction(test_icd_internal_function);
+    }
     for (auto const& [phys_dev_handle, phys_dev] : icd.created_physical_device_details) {
         if (phys_dev.instance_created_from != instance) {
             continue;

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -86,67 +86,90 @@ bool CheckLayer(std::vector<LayerDefinition>& layers, std::string layerName) {
     return false;
 }
 
+bool search_extension_list(std::vector<Extension> const& extension_list, const char* extension_name) {
+    return extension_list.end() !=
+           std::find_if(extension_list.begin(), extension_list.end(),
+                        [extension_name](Extension const& ext) { return string_eq(&ext.extensionName[0], extension_name); });
+}
+
 bool IsInstanceExtensionSupported(const char* extension_name) {
     std::lock_guard lg(icd.mutex);
-    return icd.instance_extensions.end() !=
-           std::find_if(icd.instance_extensions.begin(), icd.instance_extensions.end(),
-                        [extension_name](Extension const& ext) { return string_eq(&ext.extensionName[0], extension_name); });
+    return search_extension_list(icd.instance_extensions, extension_name);
 }
 
-bool IsInstanceExtensionEnabled(const char* extension_name) {
+bool IsInstanceExtensionEnabled(VkInstance instance, const char* extension_name) {
     std::lock_guard lg(icd.mutex);
-    return icd.enabled_instance_extensions.end() !=
-           std::find_if(icd.enabled_instance_extensions.begin(), icd.enabled_instance_extensions.end(),
-                        [extension_name](Extension const& ext) { return string_eq(&ext.extensionName[0], extension_name); });
+    return search_extension_list(icd.created_instance_details.at(instance).enabled_instance_extensions, extension_name);
 }
 
-bool IsPhysicalDeviceExtensionAvailable(const char* extension_name) {
-    for (auto const& [phys_dev_handle, phys_dev] : icd.physical_devices) {
-        if (phys_dev.extensions.end() !=
-            std::find_if(phys_dev.extensions.begin(), phys_dev.extensions.end(),
-                         [extension_name](Extension const& ext) { return ext.extensionName == extension_name; })) {
+bool IsInstanceExtensionEnabled(VkPhysicalDevice physical_device, const char* extension_name) {
+    std::lock_guard lg(icd.mutex);
+    return search_extension_list(
+        icd.created_instance_details.at(icd.created_physical_device_details.at(physical_device).instance_created_from)
+            .enabled_instance_extensions,
+        extension_name);
+}
+
+bool IsPhysicalDeviceExtensionAvailable(VkInstance instance, const char* extension_name) {
+    for (auto const& phys_dev : icd.physical_devices) {
+        if (search_extension_list(phys_dev.extensions, extension_name)) {
             return true;
         }
     }
     return false;
 }
 
-PhysicalDevice& GetPhysDevice(VkPhysicalDevice physicalDevice) {
-    if (icd.physical_devices.count(physicalDevice) > 0) {
-        return icd.physical_devices.at(physicalDevice);
-    }
-    assert(false && "vkPhysicalDevice not found!");
-    return icd.physical_devices.at(icd.physical_devices.begin()->first);
-}
-
-bool is_valid_surface(VkSurfaceKHR surface_to_check) {
-    uint64_t surf_handle = (uint64_t)(surface_to_check);
-    auto found = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), surf_handle);
-    return found != icd.surface_handles.end();
-}
-
-struct FindDevice {
-    bool found = false;
-    VkPhysicalDevice phys_dev = 0;
-    uint32_t dev_index = 0;
-};
-
-FindDevice lookup_device(VkDevice device) {
-    FindDevice fd{};
-    auto it = icd.device_to_physical_device_map.find(device);
-    if (it != icd.device_to_physical_device_map.end()) {
-        auto& phys_dev = icd.physical_devices.at(it->second);
-        fd.found = true;
-        fd.phys_dev = phys_dev.vk_physical_device.handle;
-        for (uint32_t d = 0; d < phys_dev.device_handles.size(); d++) {
-            if (phys_dev.device_handles.at(d) == device) {
-                fd.dev_index = d;
+// Iterate all PhysicalDevices to find those which have no associated VkPhysicalDevice for the given VkInstance
+// Add them if they are missing. This is to work around needing dispatchable handles associated with a VkInstance for each
+// PhysicalDevice.
+void UpdatePhysicalDeviceDetails(VkInstance instance) {
+    for (size_t i = 0; i < icd.physical_devices.size(); i++) {
+        VkPhysicalDevice matching_handle{};
+        for (auto& [vk_phys_dev, details] : icd.created_physical_device_details) {
+            if (details.instance_created_from == instance && details.index_physical_device == i) {
+                matching_handle = vk_phys_dev;
                 break;
             }
         }
-        return fd;
+        if (matching_handle != nullptr) {
+            icd.created_physical_device_details.at(matching_handle).index_physical_device = i;
+        } else {
+            CreatedPhysicalDeviceDetails new_physical_device{};
+            new_physical_device.index_physical_device = i;
+            new_physical_device.instance_created_from = instance;
+            icd.created_instance_details.at(instance).physical_devices.push_back(new_physical_device.vk_physical_device.handle);
+            icd.created_physical_device_details.emplace(new_physical_device.vk_physical_device.handle,
+                                                        std::move(new_physical_device));
+        }
     }
-    return fd;
+}
+
+PhysicalDevice& GetPhysDevice(VkPhysicalDevice physicalDevice) {
+    if (icd.created_physical_device_details.count(physicalDevice) > 0) {
+        return icd.physical_devices.at(icd.created_physical_device_details.at(physicalDevice).index_physical_device);
+    }
+    assert(false && "vkPhysicalDevice not found!");
+    return icd.physical_devices.at(
+        icd.created_physical_device_details.at(icd.created_physical_device_details.begin()->first).index_physical_device);
+}
+
+bool is_valid_surface(VkInstance instance, VkSurfaceKHR surface_to_check) {
+    uint64_t surf_handle = (uint64_t)(surface_to_check);
+    auto& surface_handles = icd.created_instance_details.at(instance).surface_handles;
+
+    auto found = std::find(surface_handles.begin(), surface_handles.end(), surf_handle);
+    return found != surface_handles.end();
+}
+void check_valid_instance(VkInstance instance) {
+    if (icd.created_instance_details.count(instance) == 0) {
+        abort();
+    }
+}
+void check_valid_instance_if_not_null(VkInstance instance) {
+    if (instance == nullptr) return;
+    if (icd.created_instance_details.count(instance) == 0) {
+        abort();
+    }
 }
 
 // typename T must have '.get()' function that returns a type U
@@ -258,54 +281,58 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo*
         }
     }
 
+    CreatedInstanceDetails new_instance_details{};
+
     // Add to the list of enabled extensions only those that the ICD actively supports
-    icd.enabled_instance_extensions.clear();
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         if (IsInstanceExtensionSupported(pCreateInfo->ppEnabledExtensionNames[i])) {
-            icd.enabled_instance_extensions.push_back({pCreateInfo->ppEnabledExtensionNames[i]});
+            new_instance_details.enabled_instance_extensions.push_back({pCreateInfo->ppEnabledExtensionNames[i]});
         }
     }
 
-    // VK_SUCCESS
-    *pInstance = icd.instance_handle.handle;
+    *pInstance = new_instance_details.instance.handle;
 
-    icd.passed_in_instance_create_flags = pCreateInfo->flags;
+    new_instance_details.passed_in_instance_create_flags = pCreateInfo->flags;
+
+    icd.created_instance_details.emplace(new_instance_details.instance.handle, std::move(new_instance_details));
+
+    UpdatePhysicalDeviceDetails(*pInstance);
 
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR void VKAPI_CALL test_vkDestroyInstance([[maybe_unused]] VkInstance instance, const VkAllocationCallbacks* pAllocator) {
+VKAPI_ATTR void VKAPI_CALL test_vkDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator) {
     std::lock_guard lg(icd.mutex);
-    icd.enabled_instance_extensions.clear();
+    check_valid_instance(instance);
     check_allocator_handle(pAllocator);
+    for (auto& phys_dev : icd.created_instance_details.at(instance).physical_devices) {
+        icd.created_physical_device_details.erase(phys_dev);
+    }
+
+    icd.created_instance_details.erase(instance);
 }
 
 // VK_SUCCESS,VK_INCOMPLETE
-VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDevices([[maybe_unused]] VkInstance instance, uint32_t* pPhysicalDeviceCount,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
                                                                VkPhysicalDevice* pPhysicalDevices) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (icd.enum_physical_devices_return_code != VK_SUCCESS) {
         return icd.enum_physical_devices_return_code;
     }
+
+    UpdatePhysicalDeviceDetails(instance);
+
     if (pPhysicalDevices == nullptr) {
-        *pPhysicalDeviceCount = static_cast<uint32_t>(icd.physical_devices.size());
+        *pPhysicalDeviceCount = static_cast<uint32_t>(icd.created_instance_details.at(instance).physical_devices.size());
     } else {
-        using SortPair = std::pair<size_t, VkPhysicalDevice>;
-        std::vector<SortPair> in_order_phys_dev;
-        for (auto const& [phys_dev_handle, phys_dev] : icd.physical_devices) {
-            in_order_phys_dev.push_back({phys_dev.iteration_order, phys_dev_handle});
-        }
-
-        std::sort(in_order_phys_dev.begin(), in_order_phys_dev.end(),
-                  [](SortPair const& a, SortPair const& b) { return a.first < b.first; });
-
         uint32_t handles_written = 0;
-        for (auto const& phys_dev : in_order_phys_dev) {
+        for (auto const& phys_dev : icd.created_instance_details.at(instance).physical_devices) {
             if (handles_written + 1 > *pPhysicalDeviceCount) {
                 *pPhysicalDeviceCount = handles_written;
                 return VK_INCOMPLETE;
             }
-            pPhysicalDevices[handles_written++] = phys_dev.second;
+            pPhysicalDevices[handles_written++] = phys_dev;
         }
         *pPhysicalDeviceCount = handles_written;
     }
@@ -313,11 +340,14 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDevices([[maybe_unused]] 
 }
 
 // VK_SUCCESS,VK_INCOMPLETE, VK_ERROR_INITIALIZATION_FAILED
-VKAPI_ATTR VkResult VKAPI_CALL
-test_vkEnumeratePhysicalDeviceGroups([[maybe_unused]] VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
-                                     VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties) {
+VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDeviceGroups(
+    VkInstance instance, uint32_t* pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
+    auto& created_instance = icd.created_instance_details.at(instance);
     VkResult result = VK_SUCCESS;
+
+    UpdatePhysicalDeviceDetails(instance);
 
     if (pPhysicalDeviceGroupProperties == nullptr) {
         if (0 == icd.physical_device_groups.size()) {
@@ -339,8 +369,8 @@ test_vkEnumeratePhysicalDeviceGroups([[maybe_unused]] VkInstance instance, uint3
 
         uint32_t group_count = 0;
         if (0 == icd.physical_device_groups.size()) {
-            group_count = static_cast<uint32_t>(icd.physical_devices.size());
-            for (size_t device_group = 0; device_group < icd.physical_devices.size(); device_group++) {
+            group_count = static_cast<uint32_t>(created_instance.physical_devices.size());
+            for (size_t device_group = 0; device_group < created_instance.physical_devices.size(); device_group++) {
                 if (device_group >= *pPhysicalDeviceGroupCount) {
                     group_count = *pPhysicalDeviceGroupCount;
                     result = VK_INCOMPLETE;
@@ -349,12 +379,9 @@ test_vkEnumeratePhysicalDeviceGroups([[maybe_unused]] VkInstance instance, uint3
 
                 pPhysicalDeviceGroupProperties[device_group].subsetAllocation = false;
                 pPhysicalDeviceGroupProperties[device_group].physicalDeviceCount = 1;
-                for (auto const& [phys_dev_handle, phys_dev] : icd.physical_devices) {
-                    if (phys_dev.iteration_order == device_group) {
-                        pPhysicalDeviceGroupProperties[device_group].physicalDevices[0] = phys_dev_handle;
-                        break;
-                    }
-                }
+                pPhysicalDeviceGroupProperties[device_group].physicalDevices[0] =
+                    created_instance.physical_devices.at(device_group);
+                // Clear out the unused handles
                 for (size_t i = 1; i < VK_MAX_DEVICE_GROUP_SIZE; i++) {
                     pPhysicalDeviceGroupProperties[device_group].physicalDevices[i] = {};
                 }
@@ -370,11 +397,12 @@ test_vkEnumeratePhysicalDeviceGroups([[maybe_unused]] VkInstance instance, uint3
                 pPhysicalDeviceGroupProperties[device_group].subsetAllocation =
                     icd.physical_device_groups[device_group].subset_allocation;
                 uint32_t handles_written = 0;
-                for (size_t i = 0; i < icd.physical_device_groups[device_group].physical_device_handles.size(); i++) {
+                for (size_t i = 0; i < icd.physical_device_groups[device_group].physical_device_indexes.size(); i++) {
                     handles_written++;
                     pPhysicalDeviceGroupProperties[device_group].physicalDevices[i] =
-                        icd.physical_device_groups[device_group].physical_device_handles[i]->vk_physical_device.handle;
+                        created_instance.physical_devices.at(icd.physical_device_groups[device_group].physical_device_indexes[i]);
                 }
+                // Clear out the unused handles
                 for (size_t i = handles_written; i < VK_MAX_DEVICE_GROUP_SIZE; i++) {
                     pPhysicalDeviceGroupProperties[device_group].physicalDevices[i] = {};
                 }
@@ -397,10 +425,11 @@ test_vkEnumeratePhysicalDeviceGroups([[maybe_unused]] VkInstance instance, uint3
     return result;
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDebugUtilsMessengerEXT(
-    [[maybe_unused]] VkInstance instance, [[maybe_unused]] const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator, VkDebugUtilsMessengerEXT* pMessenger) {
+VKAPI_ATTR VkResult VKAPI_CALL
+test_vkCreateDebugUtilsMessengerEXT(VkInstance instance, [[maybe_unused]] const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
+                                    const VkAllocationCallbacks* pAllocator, VkDebugUtilsMessengerEXT* pMessenger) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (nullptr != pMessenger) {
         uint8_t* new_handle_ptr = nullptr;
         if (pAllocator) {
@@ -410,7 +439,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDebugUtilsMessengerEXT(
             new_handle_ptr = new uint8_t;
         }
         uint64_t fake_msgr_handle = reinterpret_cast<uint64_t>(new_handle_ptr);
-        icd.messenger_handles.push_back(fake_msgr_handle);
+        icd.created_instance_details[instance].messenger_handles.push_back(fake_msgr_handle);
 #if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
     defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
         *pMessenger = reinterpret_cast<VkDebugUtilsMessengerEXT>(fake_msgr_handle);
@@ -421,16 +450,17 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDebugUtilsMessengerEXT(
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR void VKAPI_CALL test_vkDestroyDebugUtilsMessengerEXT([[maybe_unused]] VkInstance instance,
-                                                                VkDebugUtilsMessengerEXT messenger,
+VKAPI_ATTR void VKAPI_CALL test_vkDestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT messenger,
                                                                 const VkAllocationCallbacks* pAllocator) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (messenger != VK_NULL_HANDLE) {
         uint64_t fake_msgr_handle = (uint64_t)(messenger);
-        auto found_iter = std::find(icd.messenger_handles.begin(), icd.messenger_handles.end(), fake_msgr_handle);
-        if (found_iter != icd.messenger_handles.end()) {
+        auto& handles = icd.created_instance_details[instance].messenger_handles;
+        auto found_iter = std::find(handles.begin(), handles.end(), fake_msgr_handle);
+        if (found_iter != handles.end()) {
             // Remove it from the list
-            icd.messenger_handles.erase(found_iter);
+            handles.erase(found_iter);
             // Delete the handle
             if (pAllocator) {
                 pAllocator->pfnFree(pAllocator->pUserData, (uint8_t*)fake_msgr_handle);
@@ -446,10 +476,11 @@ VKAPI_ATTR void VKAPI_CALL test_vkDestroyDebugUtilsMessengerEXT([[maybe_unused]]
 
 // debug report create/destroy
 
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDebugReportCallbackEXT(
-    [[maybe_unused]] VkInstance instance, [[maybe_unused]] const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator, VkDebugReportCallbackEXT* pCallback) {
+VKAPI_ATTR VkResult VKAPI_CALL
+test_vkCreateDebugReportCallbackEXT(VkInstance instance, [[maybe_unused]] const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
+                                    const VkAllocationCallbacks* pAllocator, VkDebugReportCallbackEXT* pCallback) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (nullptr != pCallback) {
         uint8_t* new_handle_ptr = nullptr;
         if (pAllocator) {
@@ -459,7 +490,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDebugReportCallbackEXT(
             new_handle_ptr = new uint8_t;
         }
         uint64_t fake_msgr_handle = reinterpret_cast<uint64_t>(new_handle_ptr);
-        icd.callback_handles.push_back(fake_msgr_handle);
+        icd.created_instance_details[instance].callback_handles.push_back(fake_msgr_handle);
 #if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
     defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
         *pCallback = reinterpret_cast<VkDebugReportCallbackEXT>(fake_msgr_handle);
@@ -470,16 +501,17 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDebugReportCallbackEXT(
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR void VKAPI_CALL test_vkDestroyDebugReportCallbackEXT([[maybe_unused]] VkInstance instance,
-                                                                VkDebugReportCallbackEXT callback,
+VKAPI_ATTR void VKAPI_CALL test_vkDestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCallbackEXT callback,
                                                                 const VkAllocationCallbacks* pAllocator) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (callback != VK_NULL_HANDLE) {
         uint64_t fake_msgr_handle = (uint64_t)(callback);
-        auto found_iter = std::find(icd.callback_handles.begin(), icd.callback_handles.end(), fake_msgr_handle);
-        if (found_iter != icd.callback_handles.end()) {
+        auto& handles = icd.created_instance_details[instance].callback_handles;
+        auto found_iter = std::find(handles.begin(), handles.end(), fake_msgr_handle);
+        if (found_iter != handles.end()) {
             // Remove it from the list
-            icd.callback_handles.erase(found_iter);
+            handles.erase(found_iter);
             // Delete the handle
             if (pAllocator) {
                 pAllocator->pfnFree(pAllocator->pUserData, (uint8_t*)fake_msgr_handle);
@@ -498,13 +530,19 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectTagEXT(VkDevice dev, c
     std::lock_guard lg(icd.mutex);
     if (pTagInfo && pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pTagInfo->object);
-        if (pd != lookup_device(dev).phys_dev) return VK_ERROR_DEVICE_LOST;
+        if (pd != icd.created_device_details.at(dev).physical_device_created_from) return VK_ERROR_DEVICE_LOST;
     }
     if (pTagInfo && pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT) {
-        if (pTagInfo->object != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
+        if (!is_valid_surface(icd.created_device_details.at(dev).instance_created_from,
+                              (VkSurfaceKHR)(uintptr_t)pTagInfo->object)) {
+            return VK_ERROR_DEVICE_LOST;
+        }
     }
     if (pTagInfo && pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {
-        if (pTagInfo->object != (uint64_t)(uintptr_t)icd.instance_handle.handle) return VK_ERROR_DEVICE_LOST;
+        if (pTagInfo->object !=
+            (uint64_t)(uintptr_t)icd.created_instance_details.at(icd.created_device_details.at(dev).instance_created_from)
+                .instance.handle)
+            return VK_ERROR_DEVICE_LOST;
     }
     return VK_SUCCESS;
 }
@@ -512,13 +550,19 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkDebugMarkerSetObjectNameEXT(VkDevice dev, 
     std::lock_guard lg(icd.mutex);
     if (pNameInfo && pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pNameInfo->object);
-        if (pd != lookup_device(dev).phys_dev) return VK_ERROR_DEVICE_LOST;
+        if (pd != icd.created_device_details.at(dev).physical_device_created_from) return VK_ERROR_DEVICE_LOST;
     }
     if (pNameInfo && pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT) {
-        if (pNameInfo->object != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
+        if (!is_valid_surface(icd.created_device_details.at(dev).instance_created_from,
+                              (VkSurfaceKHR)(uintptr_t)pNameInfo->object)) {
+            return VK_ERROR_DEVICE_LOST;
+        }
     }
     if (pNameInfo && pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT) {
-        if (pNameInfo->object != (uint64_t)(uintptr_t)icd.instance_handle.handle) return VK_ERROR_DEVICE_LOST;
+        if (pNameInfo->object !=
+            (uint64_t)(uintptr_t)icd.created_instance_details.at(icd.created_device_details.at(dev).instance_created_from)
+                .instance.handle)
+            return VK_ERROR_DEVICE_LOST;
     }
     return VK_SUCCESS;
 }
@@ -530,13 +574,19 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectNameEXT(VkDevice dev, c
     std::lock_guard lg(icd.mutex);
     if (pNameInfo && pNameInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pNameInfo->objectHandle);
-        if (pd != lookup_device(dev).phys_dev) return VK_ERROR_DEVICE_LOST;
+        if (pd != icd.created_device_details.at(dev).physical_device_created_from) return VK_ERROR_DEVICE_LOST;
     }
     if (pNameInfo && pNameInfo->objectType == VK_OBJECT_TYPE_SURFACE_KHR) {
-        if (pNameInfo->objectHandle != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
+        if (!is_valid_surface(icd.created_device_details.at(dev).instance_created_from,
+                              (VkSurfaceKHR)(uintptr_t)pNameInfo->objectHandle)) {
+            return VK_ERROR_DEVICE_LOST;
+        }
     }
     if (pNameInfo && pNameInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {
-        if (pNameInfo->objectHandle != (uint64_t)(uintptr_t)icd.instance_handle.handle) return VK_ERROR_DEVICE_LOST;
+        if (pNameInfo->objectHandle !=
+            (uint64_t)(uintptr_t)icd.created_instance_details.at(icd.created_device_details.at(dev).instance_created_from)
+                .instance.handle)
+            return VK_ERROR_DEVICE_LOST;
     }
     return VK_SUCCESS;
 }
@@ -544,13 +594,19 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkSetDebugUtilsObjectTagEXT(VkDevice dev, co
     std::lock_guard lg(icd.mutex);
     if (pTagInfo && pTagInfo->objectType == VK_OBJECT_TYPE_PHYSICAL_DEVICE) {
         VkPhysicalDevice pd = (VkPhysicalDevice)(uintptr_t)(pTagInfo->objectHandle);
-        if (pd != lookup_device(dev).phys_dev) return VK_ERROR_DEVICE_LOST;
+        if (pd != icd.created_device_details.at(dev).physical_device_created_from) return VK_ERROR_DEVICE_LOST;
     }
     if (pTagInfo && pTagInfo->objectType == VK_OBJECT_TYPE_SURFACE_KHR) {
-        if (pTagInfo->objectHandle != icd.surface_handles.at(0)) return VK_ERROR_DEVICE_LOST;
+        if (!is_valid_surface(icd.created_device_details.at(dev).instance_created_from,
+                              (VkSurfaceKHR)(uintptr_t)pTagInfo->objectHandle)) {
+            return VK_ERROR_DEVICE_LOST;
+        }
     }
     if (pTagInfo && pTagInfo->objectType == VK_OBJECT_TYPE_INSTANCE) {
-        if (pTagInfo->objectHandle != (uint64_t)(uintptr_t)icd.instance_handle.handle) return VK_ERROR_DEVICE_LOST;
+        if (pTagInfo->objectHandle !=
+            (uint64_t)(uintptr_t)icd.created_instance_details.at(icd.created_device_details.at(dev).instance_created_from)
+                .instance.handle)
+            return VK_ERROR_DEVICE_LOST;
     }
     return VK_SUCCESS;
 }
@@ -595,33 +651,39 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDevice(VkPhysicalDevice physicalDevi
                                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
-    if (icd.physical_devices.count(physicalDevice) == 0) {
+    if (icd.created_physical_device_details.count(physicalDevice) == 0) {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
-    auto& found = icd.physical_devices.at(physicalDevice);
-    auto device_handle = DispatchableHandle<VkDevice>();
-    *pDevice = device_handle.handle;
-    found.device_handles.push_back(device_handle.handle);
-    found.device_create_infos.emplace_back(pCreateInfo);
-    for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; i++) {
-        found.queue_handles.emplace_back();
+    auto& physical_device_info =
+        icd.physical_devices.at(icd.created_physical_device_details.at(physicalDevice).index_physical_device);
+
+    CreatedDeviceDetails new_device_details{};
+    new_device_details.physical_device_created_from =
+        icd.created_physical_device_details.at(physicalDevice).vk_physical_device.handle;
+    new_device_details.instance_created_from = icd.created_physical_device_details.at(physicalDevice).instance_created_from;
+    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
+        if (search_extension_list(physical_device_info.extensions, pCreateInfo->ppEnabledExtensionNames[i])) {
+            new_device_details.enabled_device_extensions.push_back({pCreateInfo->ppEnabledExtensionNames[i]});
+        }
     }
-    icd.device_to_physical_device_map.emplace(device_handle.handle, physicalDevice);
-    icd.device_handles.emplace_back(std::move(device_handle));
+    for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; i++) {
+        new_device_details.queue_handles.emplace_back();
+    }
+    *pDevice = new_device_details.device.handle;
+    icd.created_device_details.emplace(*pDevice, std::move(new_device_details));
+
     return VK_SUCCESS;
 }
 
 VKAPI_ATTR void VKAPI_CALL test_vkDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
-    auto found = std::find(icd.device_handles.begin(), icd.device_handles.end(), device);
-    if (found != icd.device_handles.end()) icd.device_handles.erase(found);
-    auto fd = lookup_device(device);
-    if (!fd.found) return;
-    auto& phys_dev = icd.physical_devices.at(fd.phys_dev);
-    phys_dev.device_handles.erase(phys_dev.device_handles.begin() + fd.dev_index);
-    phys_dev.device_create_infos.erase(phys_dev.device_create_infos.begin() + fd.dev_index);
-    icd.device_to_physical_device_map.erase(device);
+
+    if (icd.created_device_details.count(device) == 0) {
+        // Loader shouldn't try to destroy devices not created from this ICD
+        abort();
+    }
+    icd.created_device_details.erase(device);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL generic_tool_props_function([[maybe_unused]] VkPhysicalDevice physicalDevice, uint32_t* pToolCount,
@@ -629,6 +691,9 @@ VKAPI_ATTR VkResult VKAPI_CALL generic_tool_props_function([[maybe_unused]] VkPh
     std::lock_guard lg(icd.mutex);
     if (icd.tooling_properties.size() == 0) {
         return VK_SUCCESS;
+    }
+    if (icd.created_physical_device_details.count(physicalDevice) == 0) {
+        return VK_ERROR_INITIALIZATION_FAILED;
     }
     if (pToolProperties == nullptr && pToolCount != nullptr) {
         *pToolCount = static_cast<uint32_t>(icd.tooling_properties.size());
@@ -691,19 +756,21 @@ void common_nondispatch_handle_creation(std::vector<uint64_t>& handles, HandleTy
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
                                                               const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     std::lock_guard lg(icd.mutex);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    check_valid_instance(instance);
+    common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     return VK_SUCCESS;
 }
 #endif
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWin32SurfaceKHR([[maybe_unused]] VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWin32SurfaceKHR(VkInstance instance,
                                                             [[maybe_unused]] const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
                                                             const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (IsInstanceExtensionSupported(VK_KHR_WIN32_SURFACE_EXTENSION_NAME)) {
-        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+        common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     }
     return VK_SUCCESS;
 }
@@ -712,13 +779,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceWin32PresentationSupportK
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWaylandSurfaceKHR([[maybe_unused]] VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateWaylandSurfaceKHR(VkInstance instance,
                                                               [[maybe_unused]] const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
                                                               const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (IsInstanceExtensionSupported(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME)) {
-        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+        common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     }
     return VK_SUCCESS;
 }
@@ -729,13 +797,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceWaylandPresentationSuppor
 }
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 #if defined(VK_USE_PLATFORM_XCB_KHR)
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXcbSurfaceKHR([[maybe_unused]] VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXcbSurfaceKHR(VkInstance instance,
                                                           [[maybe_unused]] const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (IsInstanceExtensionSupported(VK_KHR_XCB_SURFACE_EXTENSION_NAME)) {
-        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+        common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     }
     return VK_SUCCESS;
 }
@@ -747,13 +816,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceXcbPresentationSupportKHR
 #endif  // VK_USE_PLATFORM_XCB_KHR
 
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXlibSurfaceKHR([[maybe_unused]] VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateXlibSurfaceKHR(VkInstance instance,
                                                            [[maybe_unused]] const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
                                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (IsInstanceExtensionSupported(VK_KHR_XCB_SURFACE_EXTENSION_NAME)) {
-        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+        common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     }
     return VK_SUCCESS;
 }
@@ -764,12 +834,13 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceXlibPresentationSupportKH
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
 #if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDirectFBSurfaceEXT([[maybe_unused]] VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDirectFBSurfaceEXT(VkInstance instance,
                                                                [[maybe_unused]] const VkDirectFBSurfaceCreateInfoEXT* pCreateInfo,
                                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    check_valid_instance(instance);
+    common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     return VK_SUCCESS;
 }
 
@@ -780,56 +851,61 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceDirectFBPresentationSuppo
 #endif  // VK_USE_PLATFORM_DIRECTFB_EXT
 
 #if defined(VK_USE_PLATFORM_MACOS_MVK)
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMacOSSurfaceMVK([[maybe_unused]] VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMacOSSurfaceMVK(VkInstance instance,
                                                             [[maybe_unused]] const VkMacOSSurfaceCreateInfoMVK* pCreateInfo,
                                                             const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    check_valid_instance(instance);
+    common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     return VK_SUCCESS;
 }
 #endif  // VK_USE_PLATFORM_MACOS_MVK
 
 #if defined(VK_USE_PLATFORM_IOS_MVK)
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateIOSSurfaceMVK([[maybe_unused]] VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateIOSSurfaceMVK(VkInstance instance,
                                                           [[maybe_unused]] const VkIOSSurfaceCreateInfoMVK* pCreateInfo,
                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    check_valid_instance(instance);
+    common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     return VK_SUCCESS;
 }
 #endif  // VK_USE_PLATFORM_IOS_MVK
 
 #if defined(VK_USE_PLATFORM_GGP)
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateStreamDescriptorSurfaceGGP(
-    [[maybe_unused]] VkInstance instance, [[maybe_unused]] const VkStreamDescriptorSurfaceCreateInfoGGP* pCreateInfo,
+    VkInstance instance, [[maybe_unused]] const VkStreamDescriptorSurfaceCreateInfoGGP* pCreateInfo,
     const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    check_valid_instance(instance);
+    common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     return VK_SUCCESS;
 }
 #endif  // VK_USE_PLATFORM_GGP
 
 #if defined(VK_USE_PLATFORM_METAL_EXT)
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMetalSurfaceEXT([[maybe_unused]] VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateMetalSurfaceEXT(VkInstance instance,
                                                             [[maybe_unused]] const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
                                                             const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    check_valid_instance(instance);
+    common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     return VK_SUCCESS;
 }
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
 #if defined(VK_USE_PLATFORM_SCREEN_QNX)
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateScreenSurfaceQNX([[maybe_unused]] VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateScreenSurfaceQNX(VkInstance instance,
                                                              [[maybe_unused]] const VkScreenSurfaceCreateInfoQNX* pCreateInfo,
                                                              const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
-    common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+    check_valid_instance(instance);
+    common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     return VK_SUCCESS;
 }
 
@@ -839,38 +915,48 @@ VKAPI_ATTR VkBool32 VKAPI_CALL test_vkGetPhysicalDeviceScreenPresentationSupport
 }
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
 
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateHeadlessSurfaceEXT([[maybe_unused]] VkInstance instance,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateHeadlessSurfaceEXT(VkInstance instance,
                                                                [[maybe_unused]] const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
                                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (IsInstanceExtensionSupported(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME)) {
-        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+        common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     }
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR void VKAPI_CALL test_vkDestroySurfaceKHR([[maybe_unused]] VkInstance instance, VkSurfaceKHR surface,
+VKAPI_ATTR void VKAPI_CALL test_vkDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface,
                                                     const VkAllocationCallbacks* pAllocator) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (surface != VK_NULL_HANDLE) {
         uint64_t surf_handle = from_nondispatch_handle(surface);
-        auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), surf_handle);
-        if (found_iter != icd.surface_handles.end()) {
+        auto& surface_handles = icd.created_instance_details.at(instance).surface_handles;
+        auto found_iter = std::find(surface_handles.begin(), surface_handles.end(), surf_handle);
+        if (found_iter != surface_handles.end()) {
             // Remove it from the list
-            icd.surface_handles.erase(found_iter);
+            surface_handles.erase(found_iter);
         } else {
             assert(false && "Surface not found during destroy!");
         }
     }
 }
 // VK_KHR_swapchain
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSwapchainKHR([[maybe_unused]] VkDevice device,
-                                                         [[maybe_unused]] const VkSwapchainCreateInfoKHR* pCreateInfo,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                          const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
-    common_nondispatch_handle_creation(icd.swapchain_handles, pSwapchain);
+    // Validate that the surface came from this instance
+    uint64_t surface_integer_value = from_nondispatch_handle(pCreateInfo->surface);
+    auto& surface_handles =
+        icd.created_instance_details.at(icd.created_device_details.at(device).instance_created_from).surface_handles;
+    auto found_iter = std::find(surface_handles.begin(), surface_handles.end(), surface_integer_value);
+    if (found_iter == surface_handles.end()) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+    common_nondispatch_handle_creation(icd.created_device_details.at(device).swapchain_handles, pSwapchain);
     return VK_SUCCESS;
 }
 
@@ -890,16 +976,16 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetSwapchainImagesKHR([[maybe_unused]] VkD
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR void VKAPI_CALL test_vkDestroySwapchainKHR([[maybe_unused]] VkDevice device, VkSwapchainKHR swapchain,
+VKAPI_ATTR void VKAPI_CALL test_vkDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain,
                                                       const VkAllocationCallbacks* pAllocator) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
     if (swapchain != VK_NULL_HANDLE) {
         uint64_t fake_swapchain_handle = from_nondispatch_handle(swapchain);
-        auto found_iter = icd.swapchain_handles.erase(
-            std::remove(icd.swapchain_handles.begin(), icd.swapchain_handles.end(), fake_swapchain_handle),
-            icd.swapchain_handles.end());
-        if (!icd.swapchain_handles.empty() && found_iter == icd.swapchain_handles.end()) {
+        auto& swapchain_handles = icd.created_device_details.at(device).swapchain_handles;
+        auto found_iter = swapchain_handles.erase(
+            std::remove(swapchain_handles.begin(), swapchain_handles.end(), fake_swapchain_handle), swapchain_handles.end());
+        if (!swapchain_handles.empty() && found_iter == swapchain_handles.end()) {
             assert(false && "Swapchain not found during destroy!");
         }
     }
@@ -909,6 +995,9 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDeviceGroupSurfacePresentModesKHR([[may
                                                                            [[maybe_unused]] VkSurfaceKHR surface,
                                                                            VkDeviceGroupPresentModeFlagsKHR* pModes) {
     if (!pModes) return VK_ERROR_INITIALIZATION_FAILED;
+    if (!is_valid_surface(icd.created_device_details.at(device).instance_created_from, surface)) {
+        abort();
+    }
     *pModes = VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_MULTI_DEVICE_BIT_KHR;
     return VK_SUCCESS;
 }
@@ -918,14 +1007,16 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceSupportKHR(VkPhysi
                                                                          VkSurfaceKHR surface, VkBool32* pSupported) {
     std::lock_guard lg(icd.mutex);
     if (surface != VK_NULL_HANDLE) {
-        if (!is_valid_surface(surface)) {
+        if (!is_valid_surface(icd.created_physical_device_details.at(physicalDevice).instance_created_from, surface)) {
             *pSupported = VK_FALSE;
             return VK_SUCCESS;
         }
     }
     if (nullptr != pSupported) {
-        if (icd.physical_devices.count(physicalDevice) > 0) {
-            *pSupported = icd.physical_devices.at(physicalDevice).queue_family_properties.at(queueFamilyIndex).support_present;
+        if (icd.created_physical_device_details.count(physicalDevice) > 0) {
+            *pSupported = icd.physical_devices.at(icd.created_physical_device_details.at(physicalDevice).index_physical_device)
+                              .queue_family_properties.at(queueFamilyIndex)
+                              .support_present;
         } else {
             *pSupported = VK_FALSE;
             return VK_SUCCESS;
@@ -937,7 +1028,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(Vk
                                                                               VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
     std::lock_guard lg(icd.mutex);
     if (surface != VK_NULL_HANDLE) {
-        if (!is_valid_surface(surface)) {
+        if (!is_valid_surface(icd.created_physical_device_details.at(physicalDevice).instance_created_from, surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfaceCapabilitiesKHR query!");
             return VK_ERROR_UNKNOWN;
         }
@@ -952,12 +1043,12 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceFormatsKHR(VkPhysi
                                                                          VkSurfaceFormatKHR* pSurfaceFormats) {
     std::lock_guard lg(icd.mutex);
     if (surface != VK_NULL_HANDLE) {
-        if (!is_valid_surface(surface)) {
+        if (!is_valid_surface(icd.created_physical_device_details.at(physicalDevice).instance_created_from, surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfaceFormatsKHR query!");
             return VK_ERROR_UNKNOWN;
         }
     } else {
-        if (!IsInstanceExtensionEnabled(VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME)) {
+        if (!IsInstanceExtensionEnabled(physicalDevice, VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME)) {
             assert(false && "Surface is NULL but VK_GOOGLE_surfaceless_query was not enabled!");
             return VK_ERROR_UNKNOWN;
         }
@@ -970,12 +1061,12 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfacePresentModesKHR(Vk
                                                                               VkPresentModeKHR* pPresentModes) {
     std::lock_guard lg(icd.mutex);
     if (surface != VK_NULL_HANDLE) {
-        if (!is_valid_surface(surface)) {
+        if (!is_valid_surface(icd.created_physical_device_details.at(physicalDevice).instance_created_from, surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfacePresentModesKHR query!");
             return VK_ERROR_UNKNOWN;
         }
     } else {
-        if (!IsInstanceExtensionEnabled(VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME)) {
+        if (!IsInstanceExtensionEnabled(physicalDevice, VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME)) {
             assert(false && "Surface is NULL but VK_GOOGLE_surfaceless_query was not enabled!");
             return VK_ERROR_UNKNOWN;
         }
@@ -991,12 +1082,13 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfacePresentModes2EXT(V
                                                                                VkPresentModeKHR* pPresentModes) {
     std::lock_guard lg(icd.mutex);
     if (pSurfaceInfo->surface != VK_NULL_HANDLE) {
-        if (!is_valid_surface(pSurfaceInfo->surface)) {
+        if (!is_valid_surface(icd.created_physical_device_details.at(physicalDevice).instance_created_from,
+                              pSurfaceInfo->surface)) {
             assert(false && "Surface not found during GetPhysicalDeviceSurfacePresentModesKHR query!");
             return VK_ERROR_UNKNOWN;
         }
     } else {
-        if (!IsInstanceExtensionEnabled(VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME)) {
+        if (!IsInstanceExtensionEnabled(physicalDevice, VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME)) {
             assert(false && "Surface is NULL but VK_GOOGLE_surfaceless_query was not enabled!");
             return VK_ERROR_UNKNOWN;
         }
@@ -1055,13 +1147,14 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetDisplayPlaneCapabilitiesKHR(VkPhysicalD
     }
     return VK_SUCCESS;
 }
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateDisplayPlaneSurfaceKHR(
-    [[maybe_unused]] VkInstance instance, [[maybe_unused]] const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+VKAPI_ATTR VkResult VKAPI_CALL
+test_vkCreateDisplayPlaneSurfaceKHR(VkInstance instance, [[maybe_unused]] const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
+                                    const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
     check_allocator_handle(pAllocator);
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (IsInstanceExtensionSupported(VK_KHR_DISPLAY_EXTENSION_NAME)) {
-        common_nondispatch_handle_creation(icd.surface_handles, pSurface);
+        common_nondispatch_handle_creation(icd.created_instance_details.at(instance).surface_handles, pSurface);
     }
     return VK_SUCCESS;
 }
@@ -1073,7 +1166,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceCapabilities2KHR(V
     std::lock_guard lg(icd.mutex);
     if (nullptr != pSurfaceInfo && nullptr != pSurfaceCapabilities) {
         if (IsInstanceExtensionSupported("VK_EXT_surface_maintenance1") &&
-            IsInstanceExtensionEnabled("VK_EXT_surface_maintenance1")) {
+            IsInstanceExtensionEnabled(physicalDevice, "VK_EXT_surface_maintenance1")) {
             auto& phys_dev = GetPhysDevice(physicalDevice);
             void* pNext = pSurfaceCapabilities->pNext;
             while (pNext) {
@@ -1152,19 +1245,22 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhys
     return VK_SUCCESS;
 }
 // VK_KHR_display_swapchain
-VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSharedSwapchainsKHR([[maybe_unused]] VkDevice device, uint32_t swapchainCount,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,
                                                                 const VkSwapchainCreateInfoKHR* pCreateInfos,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 VkSwapchainKHR* pSwapchains) {
     std::lock_guard lg(icd.mutex);
     check_allocator_handle(pAllocator);
     for (uint32_t i = 0; i < swapchainCount; i++) {
+        // Validate that the surface was created from this instance
         uint64_t surface_integer_value = from_nondispatch_handle(pCreateInfos[i].surface);
-        auto found_iter = std::find(icd.surface_handles.begin(), icd.surface_handles.end(), surface_integer_value);
-        if (found_iter == icd.surface_handles.end()) {
+        auto& surface_handles =
+            icd.created_instance_details.at(icd.created_device_details.at(device).instance_created_from).surface_handles;
+        auto found_iter = std::find(surface_handles.begin(), surface_handles.end(), surface_integer_value);
+        if (found_iter == surface_handles.end()) {
             return VK_ERROR_INITIALIZATION_FAILED;
         }
-        common_nondispatch_handle_creation(icd.swapchain_handles, &pSwapchains[i]);
+        common_nondispatch_handle_creation(icd.created_device_details.at(device).swapchain_handles, &pSwapchains[i]);
     }
     return VK_SUCCESS;
 }
@@ -1183,25 +1279,22 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateCommandPool([[maybe_unused]] VkDevic
 VKAPI_ATTR void VKAPI_CALL test_vkDestroyCommandPool(VkDevice, VkCommandPool, const VkAllocationCallbacks*) {
     // do nothing, leak memory for now
 }
-VKAPI_ATTR VkResult VKAPI_CALL test_vkAllocateCommandBuffers([[maybe_unused]] VkDevice device,
-                                                             const VkCommandBufferAllocateInfo* pAllocateInfo,
+VKAPI_ATTR VkResult VKAPI_CALL test_vkAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                              VkCommandBuffer* pCommandBuffers) {
     std::lock_guard lg(icd.mutex);
     if (pAllocateInfo != nullptr && pCommandBuffers != nullptr) {
         for (size_t i = 0; i < pAllocateInfo->commandBufferCount; i++) {
-            icd.allocated_command_buffers.push_back({});
-            pCommandBuffers[i] = icd.allocated_command_buffers.back().handle;
+            pCommandBuffers[i] = icd.created_device_details.at(device).allocated_command_buffers.emplace_back().handle;
         }
     }
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR void VKAPI_CALL test_vkGetDeviceQueue([[maybe_unused]] VkDevice device, [[maybe_unused]] uint32_t queueFamilyIndex,
-                                                 uint32_t queueIndex, VkQueue* pQueue) {
+VKAPI_ATTR void VKAPI_CALL test_vkGetDeviceQueue(VkDevice device, [[maybe_unused]] uint32_t queueFamilyIndex, uint32_t queueIndex,
+                                                 VkQueue* pQueue) {
     std::lock_guard lg(icd.mutex);
-    auto fd = lookup_device(device);
-    if (fd.found) {
-        *pQueue = icd.physical_devices.at(fd.phys_dev).queue_handles[queueIndex].handle;
+    if (icd.created_device_details.count(device) > 0) {
+        *pQueue = icd.created_device_details.at(device).queue_handles.at(queueIndex).handle;
     }
 }
 
@@ -1433,6 +1526,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vk_icdEnumerateAdapterPhysicalDevices(VkInst
                                                                           uint32_t* pPhysicalDeviceCount,
                                                                           VkPhysicalDevice* pPhysicalDevices) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     if (icd.enum_adapter_physical_devices_return_code != VK_SUCCESS) {
         return icd.enum_adapter_physical_devices_return_code;
     }
@@ -1497,8 +1591,8 @@ PFN_vkVoidFunction get_instance_func_ver_1_1([[maybe_unused]] VkInstance instanc
     return nullptr;
 }
 
-PFN_vkVoidFunction get_physical_device_func_wsi([[maybe_unused]] VkInstance instance, const char* pName) {
-    if (IsInstanceExtensionEnabled("VK_KHR_surface")) {
+PFN_vkVoidFunction get_physical_device_func_wsi(VkInstance instance, const char* pName) {
+    if (IsInstanceExtensionEnabled(instance, "VK_KHR_surface")) {
         if (string_eq(pName, "vkGetPhysicalDeviceSurfaceSupportKHR"))
             return to_vkVoidFunction(test_vkGetPhysicalDeviceSurfaceSupportKHR);
         if (string_eq(pName, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR"))
@@ -1509,18 +1603,18 @@ PFN_vkVoidFunction get_physical_device_func_wsi([[maybe_unused]] VkInstance inst
             return to_vkVoidFunction(test_vkGetPhysicalDeviceSurfacePresentModesKHR);
     }
 #if defined(WIN32)
-    if (IsPhysicalDeviceExtensionAvailable("VK_EXT_full_screen_exclusive")) {
+    if (IsPhysicalDeviceExtensionAvailable(instance, "VK_EXT_full_screen_exclusive")) {
         if (string_eq(pName, "vkGetPhysicalDeviceSurfacePresentModes2EXT"))
             return to_vkVoidFunction(test_vkGetPhysicalDeviceSurfacePresentModes2EXT);
     }
 #endif
-    if (IsInstanceExtensionEnabled("VK_KHR_get_surface_capabilities2")) {
+    if (IsInstanceExtensionEnabled(instance, "VK_KHR_get_surface_capabilities2")) {
         if (string_eq(pName, "vkGetPhysicalDeviceSurfaceCapabilities2KHR"))
             return to_vkVoidFunction(test_vkGetPhysicalDeviceSurfaceCapabilities2KHR);
         if (string_eq(pName, "vkGetPhysicalDeviceSurfaceFormats2KHR"))
             return to_vkVoidFunction(test_vkGetPhysicalDeviceSurfaceFormats2KHR);
     }
-    if (IsInstanceExtensionEnabled("VK_KHR_display")) {
+    if (IsInstanceExtensionEnabled(instance, "VK_KHR_display")) {
         if (string_eq(pName, "vkGetPhysicalDeviceDisplayPropertiesKHR"))
             return to_vkVoidFunction(test_vkGetPhysicalDeviceDisplayPropertiesKHR);
         if (string_eq(pName, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR"))
@@ -1532,7 +1626,7 @@ PFN_vkVoidFunction get_physical_device_func_wsi([[maybe_unused]] VkInstance inst
         if (string_eq(pName, "vkGetDisplayPlaneCapabilitiesKHR")) return to_vkVoidFunction(test_vkGetDisplayPlaneCapabilitiesKHR);
         if (string_eq(pName, "vkCreateDisplayPlaneSurfaceKHR")) return to_vkVoidFunction(test_vkCreateDisplayPlaneSurfaceKHR);
     }
-    if (IsInstanceExtensionEnabled("VK_EXT_acquire_drm_display")) {
+    if (IsInstanceExtensionEnabled(instance, "VK_EXT_acquire_drm_display")) {
         if (string_eq(pName, "vkAcquireDrmDisplayEXT")) return to_vkVoidFunction(test_vkAcquireDrmDisplayEXT);
         if (string_eq(pName, "vkGetDrmDisplayEXT")) return to_vkVoidFunction(test_vkGetDrmDisplayEXT);
     }
@@ -1629,7 +1723,7 @@ PFN_vkVoidFunction get_instance_func_wsi(VkInstance instance, const char* pName)
             return to_vkVoidFunction(test_vkDestroySurfaceKHR);
         }
     }
-    if (IsInstanceExtensionEnabled(VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+    if (IsInstanceExtensionEnabled(instance, VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
         if (string_eq(pName, "vkCreateDebugUtilsMessengerEXT")) {
             return to_vkVoidFunction(test_vkCreateDebugUtilsMessengerEXT);
         }
@@ -1637,7 +1731,7 @@ PFN_vkVoidFunction get_instance_func_wsi(VkInstance instance, const char* pName)
             return to_vkVoidFunction(test_vkDestroyDebugUtilsMessengerEXT);
         }
     }
-    if (IsInstanceExtensionEnabled(VK_EXT_DEBUG_MARKER_EXTENSION_NAME)) {
+    if (IsInstanceExtensionEnabled(instance, VK_EXT_DEBUG_MARKER_EXTENSION_NAME)) {
         if (string_eq(pName, "vkCreateDebugReportCallbackEXT")) {
             return to_vkVoidFunction(test_vkCreateDebugReportCallbackEXT);
         }
@@ -1650,7 +1744,7 @@ PFN_vkVoidFunction get_instance_func_wsi(VkInstance instance, const char* pName)
     if (ret_phys_dev_wsi != nullptr) return ret_phys_dev_wsi;
     return nullptr;
 }
-VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL get_physical_device_func([[maybe_unused]] VkInstance instance, const char* pName) {
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL get_physical_device_func(VkInstance instance, const char* pName) {
     std::lock_guard lg(icd.mutex);
     if (string_eq(pName, "vkEnumerateDeviceLayerProperties")) return to_vkVoidFunction(test_vkEnumerateDeviceLayerProperties);
     if (string_eq(pName, "vkEnumerateDeviceExtensionProperties"))
@@ -1673,7 +1767,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL get_physical_device_func([[maybe_unused
     if (string_eq(pName, "vkGetPhysicalDeviceImageFormatProperties"))
         return icd.can_query_GetPhysicalDeviceFuncs ? to_vkVoidFunction(test_vkGetPhysicalDeviceImageFormatProperties) : nullptr;
 
-    if (IsInstanceExtensionEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
+    if (IsInstanceExtensionEnabled(instance, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
         if (string_eq(pName, "vkGetPhysicalDeviceFeatures2KHR")) return to_vkVoidFunction(test_vkGetPhysicalDeviceFeatures2);
         if (string_eq(pName, "vkGetPhysicalDeviceProperties2KHR")) return to_vkVoidFunction(test_vkGetPhysicalDeviceProperties2);
         if (string_eq(pName, "vkGetPhysicalDeviceFormatProperties2KHR"))
@@ -1691,22 +1785,22 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL get_physical_device_func([[maybe_unused
             return to_vkVoidFunction(test_vkGetPhysicalDeviceImageFormatProperties2);
         }
     }
-    if (IsInstanceExtensionEnabled(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME)) {
+    if (IsInstanceExtensionEnabled(instance, VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME)) {
         if (string_eq(pName, "vkGetPhysicalDeviceExternalBufferPropertiesKHR"))
             return to_vkVoidFunction(test_vkGetPhysicalDeviceExternalBufferProperties);
     }
-    if (IsInstanceExtensionEnabled(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME)) {
+    if (IsInstanceExtensionEnabled(instance, VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME)) {
         if (string_eq(pName, "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR"))
             return to_vkVoidFunction(test_vkGetPhysicalDeviceExternalSemaphoreProperties);
     }
-    if (IsInstanceExtensionEnabled(VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME)) {
+    if (IsInstanceExtensionEnabled(instance, VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME)) {
         if (string_eq(pName, "vkGetPhysicalDeviceExternalFencePropertiesKHR"))
             return to_vkVoidFunction(test_vkGetPhysicalDeviceExternalFenceProperties);
     }
 
     // The following physical device extensions only need 1 device to support them for the ICD to export
     // them
-    if (IsPhysicalDeviceExtensionAvailable(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME)) {
+    if (IsPhysicalDeviceExtensionAvailable(instance, VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME)) {
         if (string_eq(pName, "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR"))
             return to_vkVoidFunction(test_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR);
         if (string_eq(pName, "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR"))
@@ -1714,12 +1808,12 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL get_physical_device_func([[maybe_unused
         if (string_eq(pName, "vkAcquireProfilingLockKHR")) return to_vkVoidFunction(test_vkAcquireProfilingLockKHR);
         if (string_eq(pName, "vkReleaseProfilingLockKHR")) return to_vkVoidFunction(test_vkReleaseProfilingLockKHR);
     }
-    if (IsPhysicalDeviceExtensionAvailable(VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME)) {
+    if (IsPhysicalDeviceExtensionAvailable(instance, VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME)) {
         if (string_eq(pName, "vkCmdSetSampleLocationsEXT")) return to_vkVoidFunction(test_vkCmdSetSampleLocationsEXT);
         if (string_eq(pName, "vkGetPhysicalDeviceMultisamplePropertiesEXT"))
             return to_vkVoidFunction(test_vkGetPhysicalDeviceMultisamplePropertiesEXT);
     }
-    if (IsPhysicalDeviceExtensionAvailable(VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME)) {
+    if (IsPhysicalDeviceExtensionAvailable(instance, VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME)) {
         if (string_eq(pName, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT"))
             return to_vkVoidFunction(test_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT);
         if (string_eq(pName, "vkGetCalibratedTimestampsEXT")) return to_vkVoidFunction(test_vkGetCalibratedTimestampsEXT);
@@ -1759,8 +1853,11 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL get_physical_device_func([[maybe_unused
             return to_vkVoidFunction(test_vkGetPhysicalDeviceToolPropertiesEXT);
     }
 
-    for (auto const& [phys_dev_handle, phys_dev] : icd.physical_devices) {
-        for (auto& func : phys_dev.custom_physical_device_functions) {
+    for (auto const& [phys_dev_handle, phys_dev] : icd.created_physical_device_details) {
+        if (phys_dev.instance_created_from != instance) {
+            continue;
+        }
+        for (auto& func : icd.physical_devices.at(phys_dev.index_physical_device).custom_physical_device_functions) {
             if (func.name == pName) {
                 return to_vkVoidFunction(func.function);
             }
@@ -1773,7 +1870,7 @@ PFN_vkVoidFunction get_instance_func(VkInstance instance, const char* pName) {
     if (string_eq(pName, "vkDestroyInstance")) return to_vkVoidFunction(test_vkDestroyInstance);
     if (string_eq(pName, "vkEnumeratePhysicalDevices")) return to_vkVoidFunction(test_vkEnumeratePhysicalDevices);
 
-    if (IsInstanceExtensionEnabled(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME)) {
+    if (IsInstanceExtensionEnabled(instance, VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME)) {
         if (string_eq(pName, "vkEnumeratePhysicalDeviceGroupsKHR")) return to_vkVoidFunction(test_vkEnumeratePhysicalDeviceGroups);
     }
 
@@ -1795,25 +1892,19 @@ PFN_vkVoidFunction get_instance_func(VkInstance instance, const char* pName) {
     return nullptr;
 }
 
-bool should_check(std::vector<const char*>* exts, VkDevice device, const char* ext_name) {
+bool should_check(std::vector<Extension>* exts, VkDevice device, const char* ext_name) {
     if (exts == nullptr || device == VK_NULL_HANDLE) return true;  // always look if device is NULL
-    for (auto const& ext : *exts) {
-        if (string_eq(ext, ext_name)) {
-            return true;
-        }
-    }
-    return false;
+    return search_extension_list(*exts, ext_name);
 }
 
+// Implementation of the mock driver's vkGetDeviceProcAddr
+// This function is called by vkGetInstanceProcAddr with device == NULL
 PFN_vkVoidFunction get_device_func(VkDevice device, const char* pName) {
-    std::vector<const char*>* enabled_extensions = nullptr;
-    FindDevice found_device{};
+    std::vector<Extension>* enabled_extensions = nullptr;
     std::lock_guard lg(icd.mutex);
     if (device != nullptr) {
-        found_device = lookup_device(device);
-        if (!found_device.found) return NULL;
-        enabled_extensions =
-            &icd.physical_devices.at(found_device.phys_dev).device_create_infos.at(found_device.dev_index).enabled_extensions;
+        if (icd.created_device_details.count(device) == 0) return NULL;
+        enabled_extensions = &icd.created_device_details.at(device).enabled_device_extensions;
     }
 
     if (string_eq(pName, "vkCreateCommandPool")) return to_vkVoidFunction(test_vkCreateCommandPool);
@@ -1843,7 +1934,8 @@ PFN_vkVoidFunction get_device_func(VkDevice device, const char* pName) {
         if (string_eq(pName, "vkCmdDebugMarkerEndEXT")) return to_vkVoidFunction(test_vkCmdDebugMarkerEndEXT);
         if (string_eq(pName, "vkCmdDebugMarkerInsertEXT")) return to_vkVoidFunction(test_vkCmdDebugMarkerInsertEXT);
     }
-    if (IsInstanceExtensionEnabled("VK_EXT_debug_utils")) {
+    if (device == nullptr ||
+        IsInstanceExtensionEnabled(icd.created_device_details.at(device).instance_created_from, "VK_EXT_debug_utils")) {
         if (string_eq(pName, "vkSetDebugUtilsObjectNameEXT")) return to_vkVoidFunction(test_vkSetDebugUtilsObjectNameEXT);
         if (string_eq(pName, "vkSetDebugUtilsObjectTagEXT")) return to_vkVoidFunction(test_vkSetDebugUtilsObjectTagEXT);
         if (string_eq(pName, "vkQueueBeginDebugUtilsLabelEXT")) return to_vkVoidFunction(test_vkQueueBeginDebugUtilsLabelEXT);
@@ -1853,16 +1945,23 @@ PFN_vkVoidFunction get_device_func(VkDevice device, const char* pName) {
         if (string_eq(pName, "vkCmdEndDebugUtilsLabelEXT")) return to_vkVoidFunction(test_vkCmdEndDebugUtilsLabelEXT);
         if (string_eq(pName, "vkCmdInsertDebugUtilsLabelEXT")) return to_vkVoidFunction(test_vkCmdInsertDebugUtilsLabelEXT);
     }
-    if (found_device.found) {
+    if (icd.created_device_details.count(device) > 0) {
         // look for device functions setup from a test
-        for (const auto& function : icd.physical_devices.at(found_device.phys_dev).known_device_functions) {
+
+        for (const auto& function :
+             icd.physical_devices
+                 .at(icd.created_physical_device_details.at(icd.created_device_details.at(device).physical_device_created_from)
+                         .index_physical_device)
+                 .known_device_functions) {
             if (function.name == pName) {
                 return to_vkVoidFunction(function.function);
             }
         }
     } else {
-        for (const auto& [handle, phys_dev] : icd.physical_devices) {
-            for (const auto& function : phys_dev.known_device_functions) {
+        // Since this function is called inside of GIPA & GPDPA, the device handle can be NULL. So just iterate all devices to find
+        // the created devices
+        for (const auto& physical_device : icd.physical_devices) {
+            for (const auto& function : physical_device.known_device_functions) {
                 if (function.name == pName) {
                     return to_vkVoidFunction(function.function);
                 }
@@ -1932,6 +2031,7 @@ FRAMEWORK_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vk_icdNegotiateLoaderICDInterfac
 #if TEST_ICD_EXPORT_ICD_GPDPA && TEST_ICD_EXPORT_VERSION_7
 FRAMEWORK_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_icdGetPhysicalDeviceProcAddr(VkInstance instance, const char* pName) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance(instance);
     return get_physical_device_func(instance, pName);
 }
 #endif  // TEST_ICD_EXPORT_ICD_GPDPA
@@ -1939,12 +2039,14 @@ FRAMEWORK_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_icdGetPhysicalDevic
 #if TEST_ICD_EXPORT_ICD_GIPA
 FRAMEWORK_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_icdGetInstanceProcAddr(VkInstance instance, const char* pName) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance_if_not_null(instance);
     if (icd.called_vk_icd_gipa == CalledICDGIPA::not_called) icd.called_vk_icd_gipa = CalledICDGIPA::vk_icd_gipa;
     return base_get_instance_proc_addr(instance, pName);
 }
 #else   // !TEST_ICD_EXPORT_ICD_GIPA
 FRAMEWORK_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* pName) {
     std::lock_guard lg(icd.mutex);
+    check_valid_instance_if_not_null(instance);
     if (icd.called_vk_icd_gipa == CalledICDGIPA::not_called) icd.called_vk_icd_gipa = CalledICDGIPA::vk_gipa;
     return base_get_instance_proc_addr(instance, pName);
 }

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -33,6 +33,7 @@
 #include <mutex>
 #include <ostream>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "util/dispatchable_handle.h"
 #include "util/platform_wsi.h"
@@ -312,6 +313,8 @@ struct TestICD {
     std::unordered_map<VkInstance, CreatedInstanceDetails> created_instance_details;
     std::unordered_map<VkPhysicalDevice, CreatedPhysicalDeviceDetails> created_physical_device_details;
     std::unordered_map<VkDevice, CreatedDeviceDetails> created_device_details;
+    std::unordered_set<VkQueue> created_queues;
+    std::unordered_set<VkCommandBuffer> created_command_buffers;
 };
 
 using GetTestICDFunc = TestICD* (*)();

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <array>
+#include <algorithm>
 #include <filesystem>
 #include <mutex>
 #include <ostream>
@@ -89,7 +90,6 @@ struct PhysicalDevice {
     PhysicalDevice(std::string name) : deviceName(name) {}
     PhysicalDevice(const char* name) : deviceName(name) {}
 
-    DispatchableHandle<VkPhysicalDevice> vk_physical_device;
     BUILDER_VALUE(std::string, deviceName)
     BUILDER_VALUE(VulkanUUID, deviceUUID)
     BUILDER_VALUE(VulkanUUID, driverUUID)
@@ -132,15 +132,7 @@ struct PhysicalDevice {
         return *this;
     }
 
-    PhysicalDevice&& finish() { return std::move(*this); }
-
-    // Defines the order this physical device appears in vkEnumeratePhysicalDevices
-    uint32_t iteration_order = 0;
-
-    // Objects created from this physical device
-    std::vector<VkDevice> device_handles;
-    std::vector<DeviceCreateInfo> device_create_infos;
-    std::vector<DispatchableHandle<VkQueue>> queue_handles;
+    PhysicalDevice& finish() { return *this; }
 
     // Unknown physical device functions. Add a `VulkanFunction` to this list which will be searched in
     // vkGetInstanceProcAddr for custom_instance_functions and vk_icdGetPhysicalDeviceProcAddr for custom_physical_device_functions.
@@ -155,24 +147,57 @@ struct PhysicalDevice {
 
 struct PhysicalDeviceGroup {
     PhysicalDeviceGroup() {}
-    PhysicalDeviceGroup(PhysicalDevice const& physical_device) { physical_device_handles.push_back(&physical_device); }
-    PhysicalDeviceGroup(PhysicalDevice const* physical_device) { physical_device_handles.push_back(physical_device); }
-    PhysicalDeviceGroup(std::vector<PhysicalDevice*> const& physical_devices) {
-        physical_device_handles.insert(physical_device_handles.end(), physical_devices.begin(), physical_devices.end());
+    PhysicalDeviceGroup(size_t physical_device_index) { physical_device_indexes.push_back(physical_device_index); }
+    PhysicalDeviceGroup(std::vector<size_t> const& in_physical_device_indexes) {
+        physical_device_indexes.insert(physical_device_indexes.end(), in_physical_device_indexes.begin(),
+                                       in_physical_device_indexes.end());
     }
-    PhysicalDeviceGroup& use_physical_device(PhysicalDevice const* physical_device) {
-        physical_device_handles.push_back(physical_device);
+    PhysicalDeviceGroup& use_physical_device(size_t physical_device_index) {
+        physical_device_indexes.push_back(physical_device_index);
         return *this;
     }
-    PhysicalDeviceGroup& use_physical_device(PhysicalDevice const& physical_device) {
-        physical_device_handles.push_back(&physical_device);
+    PhysicalDeviceGroup& use_physical_devices(std::vector<size_t> const& in_physical_device_indexes) {
+        physical_device_indexes.insert(physical_device_indexes.begin(), in_physical_device_indexes.begin(),
+                                       in_physical_device_indexes.end());
         return *this;
     }
 
-    std::vector<PhysicalDevice const*> physical_device_handles;
+    std::vector<size_t> physical_device_indexes;
     VkBool32 subset_allocation = false;
 };
 
+struct CreatedDeviceDetails {
+    DispatchableHandle<VkDevice> device;
+    VkPhysicalDevice physical_device_created_from;
+    VkInstance instance_created_from;
+
+    std::vector<Extension> enabled_device_extensions;
+    std::vector<DispatchableHandle<VkQueue>> queue_handles;
+
+    std::vector<DispatchableHandle<VkCommandBuffer>> allocated_command_buffers;
+
+    std::vector<uint64_t> swapchain_handles;
+};
+
+struct CreatedPhysicalDeviceDetails {
+    DispatchableHandle<VkPhysicalDevice> vk_physical_device;
+    VkInstance instance_created_from{};
+
+    size_t index_physical_device{};  // index into the TestICD::physical_devices array this object represents
+};
+
+struct CreatedInstanceDetails {
+    DispatchableHandle<VkInstance> instance;
+    VkInstanceCreateFlags passed_in_instance_create_flags{};
+    std::vector<Extension> enabled_instance_extensions;
+
+    std::vector<uint64_t> surface_handles;
+    std::vector<uint64_t> messenger_handles;
+    std::vector<uint64_t> callback_handles;
+
+    // Store the handles here in order for EnumeratePhysicalDevices
+    std::vector<VkPhysicalDevice> physical_devices;
+};
 struct TestICD {
     std::recursive_mutex mutex;
     std::filesystem::path manifest_file_path;
@@ -208,42 +233,50 @@ struct TestICD {
     BUILDER_VALUE_WITH_DEFAULT(uint32_t, icd_api_version, VK_API_VERSION_1_0)
     BUILDER_VECTOR(LayerDefinition, instance_layers, instance_layer)
     BUILDER_VECTOR(Extension, instance_extensions, instance_extension)
-    std::vector<Extension> enabled_instance_extensions;
 
-    std::unordered_map<VkPhysicalDevice, PhysicalDevice> physical_devices;
-    TestICD& add_physical_device(PhysicalDevice&& physical_device) {
-        physical_device.iteration_order = physical_devices.size();
-        physical_devices.emplace(physical_device.vk_physical_device.handle, std::move(physical_device));
+    std::vector<PhysicalDevice> physical_devices;
+
+    TestICD& add_physical_device(PhysicalDevice const& physical_device) {
+        physical_devices.push_back(physical_device);
         return *this;
     }
 
-    PhysicalDevice& add_and_get_physical_device(PhysicalDevice&& physical_device) {
-        VkPhysicalDevice pd = physical_device.vk_physical_device.handle;
-        physical_device.iteration_order = physical_devices.size();
-        physical_devices.emplace(physical_device.vk_physical_device.handle, std::move(physical_device));
-        return physical_devices.at(pd);
+    PhysicalDevice& add_and_get_physical_device(PhysicalDevice const& physical_device) {
+        physical_devices.push_back(physical_device);
+        return physical_devices.back();
     }
 
-    PhysicalDevice& add_physical_device_at_index(size_t index, PhysicalDevice&& physical_device) {
-        VkPhysicalDevice pd = physical_device.vk_physical_device.handle;
-        physical_device.iteration_order = index;
-        for (auto& [handle, phys_dev] : physical_devices) {
-            if (phys_dev.iteration_order >= index) {
-                phys_dev.iteration_order++;
+    PhysicalDevice& add_physical_device_at_index(size_t index, PhysicalDevice const& physical_device) {
+        physical_devices.insert(physical_devices.begin() + index, physical_device);
+        return physical_devices.at(index);
+    }
+
+    void remove_physical_device(size_t index) {
+        // Remove all created physical devices which use this index.
+        // Because we are modifying the map as we iterate, we need to use iterators rather than range-for
+        for (auto iter = created_physical_device_details.begin(), end_iter = created_physical_device_details.end();
+             iter != end_iter;) {
+            if (iter->second.index_physical_device == index) {
+                // Clean up the instance's cache of physical devices
+                auto& ipd = created_instance_details.at(iter->second.instance_created_from).physical_devices;
+                ipd.erase(std::remove(ipd.begin(), ipd.end(), iter->second.vk_physical_device.handle), ipd.end());
+
+                iter = created_physical_device_details.erase(iter);
+            } else
+                ++iter;
+        }
+
+        physical_devices.erase(physical_devices.begin() + index);
+
+        // Update all other detail structs to refer to their intended PhysicalDevice (accounting for the removed index)
+        for (auto& [vk_physical_device, details] : created_physical_device_details) {
+            if (details.index_physical_device > index) {
+                details.index_physical_device--;
             }
         }
-        physical_devices.emplace(physical_device.vk_physical_device.handle, std::move(physical_device));
-        return physical_devices.at(pd);
     }
 
     BUILDER_VECTOR(PhysicalDeviceGroup, physical_device_groups, physical_device_group);
-
-    DispatchableHandle<VkInstance> instance_handle;
-    std::vector<DispatchableHandle<VkDevice>> device_handles;
-    std::vector<uint64_t> surface_handles;
-    std::vector<uint64_t> messenger_handles;
-    std::vector<uint64_t> callback_handles;
-    std::vector<uint64_t> swapchain_handles;
 
     BUILDER_VALUE_WITH_DEFAULT(bool, can_query_vkEnumerateInstanceVersion, true);
     BUILDER_VALUE_WITH_DEFAULT(bool, can_query_GetPhysicalDeviceFuncs, true);
@@ -260,9 +293,6 @@ struct TestICD {
     BUILDER_VALUE(bool, supports_tooling_info_core);
     // List of tooling properties that this driver 'supports'
     BUILDER_VECTOR(VkPhysicalDeviceToolPropertiesEXT, tooling_properties, tooling_property)
-    std::vector<DispatchableHandle<VkCommandBuffer>> allocated_command_buffers;
-
-    VkInstanceCreateFlags passed_in_instance_create_flags{};
 
     BUILDER_VALUE_WITH_DEFAULT(VkResult, enum_physical_devices_return_code, VK_SUCCESS);
     BUILDER_VALUE_WITH_DEFAULT(VkResult, enum_adapter_physical_devices_return_code, VK_SUCCESS);
@@ -274,13 +304,14 @@ struct TestICD {
         return info;
     }
 
-    // Speedup looking for physical devices by not having to iterate through the entire physical_device map to find a particular
-    // physical device
-    std::unordered_map<VkDevice, VkPhysicalDevice> device_to_physical_device_map;
-
 #if defined(WIN32)
     BUILDER_VALUE(LUID, adapterLUID)
 #endif  // defined(WIN32)
+
+    // Store all of the 'live' object details.
+    std::unordered_map<VkInstance, CreatedInstanceDetails> created_instance_details;
+    std::unordered_map<VkPhysicalDevice, CreatedPhysicalDeviceDetails> created_physical_device_details;
+    std::unordered_map<VkDevice, CreatedDeviceDetails> created_device_details;
 };
 
 using GetTestICDFunc = TestICD* (*)();

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -83,6 +83,8 @@ inline std::ostream& operator<<(std::ostream& os, const InterfaceVersionCheck& r
 
 using VulkanUUID = std::array<uint8_t, VK_UUID_SIZE>;
 
+using PFN_test_icd_internal_function = VKAPI_ATTR VkResult (VKAPI_CALL *)(VkPhysicalDevice physicalDevice, uint32_t a, uint32_t b, float c);
+#define TEST_ICD_INTERNAL_FUNCTION_NAME_STRING "TEST_ICD_INTERNAL_FUNCTION_NAME"
 // clang-format on
 
 // Move only type because it holds a DispatchableHandle<VkPhysicalDevice>
@@ -287,6 +289,9 @@ struct TestICD {
     // custom_physical_device_functions. To add unknown device functions, add it to the PhysicalDevice directly (in the
     // known_device_functions member)
     BUILDER_VECTOR(VulkanFunction, custom_instance_functions, custom_instance_function)
+
+    // When true, this ICD returns function pointers when TEST_ICD_INTERNAL_FUNCTION_NAME is queried.
+    BUILDER_VALUE(bool, supports_internal_function)
 
     // Must explicitely state support for the tooling info extension, that way we can control if vkGetInstanceProcAddr returns a
     // function pointer for vkGetPhysicalDeviceToolPropertiesEXT or vkGetPhysicalDeviceToolProperties (core version)

--- a/tests/framework/layer/test_layer.cpp
+++ b/tests/framework/layer/test_layer.cpp
@@ -528,14 +528,12 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDevices(VkInstance instan
             if (layer.add_phys_devs) {
                 // Insert a new device in the beginning, middle, and end
                 uint32_t middle = static_cast<uint32_t>(tmp_vector.size() / 2);
-                VkPhysicalDevice new_phys_dev = reinterpret_cast<VkPhysicalDevice>((size_t)(0xABCD0000));
-                layer.added_physical_devices.push_back(new_phys_dev);
+
+                VkPhysicalDevice new_phys_dev = layer.added_physical_devices.emplace_back().handle;
                 tmp_vector.insert(tmp_vector.begin(), new_phys_dev);
-                new_phys_dev = reinterpret_cast<VkPhysicalDevice>((size_t)(0xBADC0000));
-                layer.added_physical_devices.push_back(new_phys_dev);
+                new_phys_dev = layer.added_physical_devices.emplace_back().handle;
                 tmp_vector.insert(tmp_vector.begin() + middle, new_phys_dev);
-                new_phys_dev = reinterpret_cast<VkPhysicalDevice>((size_t)(0xDCBA0000));
-                layer.added_physical_devices.push_back(new_phys_dev);
+                new_phys_dev = layer.added_physical_devices.emplace_back().handle;
                 tmp_vector.push_back(new_phys_dev);
             }
 
@@ -644,7 +642,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumeratePhysicalDeviceGroups(
                 for (uint32_t dev = 0; dev < layer.added_physical_devices.size(); ++dev) {
                     VkPhysicalDeviceGroupProperties props{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES};
                     props.physicalDeviceCount = 1;
-                    props.physicalDevices[0] = layer.added_physical_devices[dev];
+                    props.physicalDevices[0] = layer.added_physical_devices[dev].handle;
                     tmp_vector.push_back(props);
                     layer.added_physical_device_groups.push_back(props);
                 }

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -35,6 +35,7 @@
 
 #include "loader/generated/vk_layer_dispatch_table.h"
 
+#include "util/dispatchable_handle.h"
 #include "util/functions.h"
 
 #include "layer_util.h"
@@ -140,12 +141,12 @@ struct TestLayer {
     BUILDER_VALUE(bool, add_phys_devs)
     BUILDER_VALUE(bool, remove_phys_devs)
     BUILDER_VALUE(bool, reorder_phys_devs)
-    BUILDER_VECTOR(VkPhysicalDevice, complete_physical_devices, complete_physical_device)
-    BUILDER_VECTOR(VkPhysicalDevice, removed_physical_devices, removed_physical_device)
-    BUILDER_VECTOR(VkPhysicalDevice, added_physical_devices, added_physical_device)
-    BUILDER_VECTOR(VkPhysicalDeviceGroupProperties, complete_physical_device_groups, complete_physical_device_group)
-    BUILDER_VECTOR(VkPhysicalDeviceGroupProperties, removed_physical_device_groups, removed_physical_device_group)
-    BUILDER_VECTOR(VkPhysicalDeviceGroupProperties, added_physical_device_groups, added_physical_device_group)
+    std::vector<VkPhysicalDevice> complete_physical_devices;
+    std::vector<VkPhysicalDevice> removed_physical_devices;
+    std::vector<DispatchableHandle<VkPhysicalDevice>> added_physical_devices;
+    std::vector<VkPhysicalDeviceGroupProperties> complete_physical_device_groups;
+    std::vector<VkPhysicalDeviceGroupProperties> removed_physical_device_groups;
+    std::vector<VkPhysicalDeviceGroupProperties> added_physical_device_groups;
 
     BUILDER_VECTOR(VulkanFunction, custom_physical_device_implementation_functions, custom_physical_device_implementation_function)
     BUILDER_VECTOR(VulkanFunction, custom_device_implementation_functions, custom_device_implementation_function)

--- a/tests/framework/layer/wrap_objects.cpp
+++ b/tests/framework/layer/wrap_objects.cpp
@@ -23,13 +23,10 @@
 #include <string>
 #include <algorithm>
 #include <assert.h>
-#include <unordered_map>
-#include <memory>
 #include <vector>
 
 #include "vulkan/vk_layer.h"
 #include "generated/vk_dispatch_table_helper.h"
-#include "loader/vk_loader_layer.h"
 
 // Export full support of instance extension VK_EXT_direct_mode_display extension
 #if !defined(TEST_LAYER_EXPORT_DIRECT_DISP)
@@ -104,7 +101,7 @@ struct saved_wrapped_handles_storage {
     std::vector<wrapped_debug_util_mess_obj *> debug_util_messengers;
 };
 
-saved_wrapped_handles_storage saved_wrapped_handles;
+static saved_wrapped_handles_storage saved_wrapped_handles;
 
 VkInstance unwrap_instance(const VkInstance instance, wrapped_inst_obj **inst) {
     *inst = reinterpret_cast<wrapped_inst_obj *>(instance);
@@ -159,7 +156,7 @@ const VkLayerProperties global_layer = {
     "LunarG Test Layer",
 };
 
-uint32_t loader_layer_if_version = CURRENT_LOADER_LAYER_INTERFACE_VERSION;
+static uint32_t loader_layer_if_version = CURRENT_LOADER_LAYER_INTERFACE_VERSION;
 
 VKAPI_ATTR VkResult VKAPI_CALL wrap_vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo,
                                                      const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) {
@@ -406,7 +403,7 @@ VKAPI_ATTR VkResult VKAPI_CALL wrap_vkEnumeratePhysicalDevices(VkInstance instan
             }
             phys_devs[i].obj = reinterpret_cast<void *>(pPhysicalDevices[i]);
             phys_devs[i].inst = inst;
-            pPhysicalDevices[i] = reinterpret_cast<VkPhysicalDevice>(&phys_devs[i]);
+            pPhysicalDevices[i] = reinterpret_cast<VkPhysicalDevice>(phys_devs + i);
         }
     }
     return result;

--- a/tests/framework/util/get_executable_path.cpp
+++ b/tests/framework/util/get_executable_path.cpp
@@ -51,7 +51,7 @@ std::string test_platform_executable_path() {
     buffer.resize(1024);
     pid_t pid = getpid();
     int ret = proc_pidpath(pid, &buffer[0], static_cast<uint32_t>(buffer.size()));
-    if (ret <= 0) return NULL;
+    if (ret <= 0) return "";
     buffer[ret] = '\0';
     buffer.resize(ret);
     return buffer;

--- a/tests/loader_alloc_callback_tests.cpp
+++ b/tests/loader_alloc_callback_tests.cpp
@@ -240,9 +240,8 @@ TEST(Allocation, EnumeratePhysicalDevices) {
 TEST(Allocation, InstanceAndDevice) {
     FrameworkEnvironment env{};
     env.add_icd(TEST_ICD_PATH_VERSION_2)
-        .add_physical_device(PhysicalDevice{"physical_device_0"}
-                                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false})
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{"physical_device_0"}.add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false}));
 
     MemoryTracker tracker;
     {
@@ -289,9 +288,8 @@ TEST(Allocation, InstanceAndDevice) {
 TEST(Allocation, InstanceButNotDevice) {
     FrameworkEnvironment env{};
     env.add_icd(TEST_ICD_PATH_VERSION_2)
-        .add_physical_device(PhysicalDevice{"physical_device_0"}
-                                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false})
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{"physical_device_0"}.add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false}));
 
     MemoryTracker tracker;
     {
@@ -338,9 +336,8 @@ TEST(Allocation, InstanceButNotDevice) {
 TEST(Allocation, DeviceButNotInstance) {
     FrameworkEnvironment env{};
     env.add_icd(TEST_ICD_PATH_VERSION_2)
-        .add_physical_device(PhysicalDevice{"physical_device_0"}
-                                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false})
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{"physical_device_0"}.add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false}));
 
     const char* layer_name = "VK_LAYER_implicit";
     env.add_implicit_layer({}, ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -633,12 +630,10 @@ TEST(Allocation, DriverEnvVarIntentionalAllocFail) {
 TEST(Allocation, CreateDeviceIntentionalAllocFail) {
     FrameworkEnvironment env{FrameworkSettings{}.set_log_filter("error,warn")};
     env.add_icd(TEST_ICD_PATH_VERSION_2)
-        .add_physical_device(PhysicalDevice{"physical_device_0"}
-                                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false})
-                                 .finish())
-        .add_physical_device(PhysicalDevice{"physical_device_1"}
-                                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false})
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{"physical_device_0"}.add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false}))
+        .add_physical_device(
+            PhysicalDevice{"physical_device_1"}.add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, false}));
 
     const char* layer_name = "VK_LAYER_implicit";
     env.add_implicit_layer({}, ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}

--- a/tests/loader_debug_ext_tests.cpp
+++ b/tests/loader_debug_ext_tests.cpp
@@ -1138,7 +1138,7 @@ TEST(DebugUtils, WrappingLayer) {
     FrameworkEnvironment env{};
     env.add_icd(TEST_ICD_PATH_VERSION_2)
         .set_min_icd_interface_version(5)
-        .add_physical_device(PhysicalDevice{}.add_extension(VK_EXT_DEBUG_MARKER_EXTENSION_NAME).finish())
+        .add_physical_device(PhysicalDevice{}.add_extension(VK_EXT_DEBUG_MARKER_EXTENSION_NAME))
         .add_instance_extension(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 
     const char* wrap_objects_name = "VK_LAYER_LUNARG_wrap_objects";

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -162,8 +162,10 @@ TEST(EnvVarICDOverrideSetup, TestOnlyDriverEnvVarInFolder) {
     ASSERT_EQ(inst1->vkEnumeratePhysicalDevices(inst1.inst, &phys_dev_count, phys_devs_array.data()), VK_SUCCESS);
     ASSERT_EQ(phys_dev_count, 1U);
 
+    // Make sure that the ICD's aren't double counted if the path appears multiple times
     for (uint32_t add = 0; add < 2; ++add) {
-        env.add_icd(TEST_ICD_PATH_EXPORT_NONE, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::env_var))
+        env.add_icd(TEST_ICD_PATH_EXPORT_NONE,
+                    ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::env_var).set_is_dir(true))
             .add_physical_device("pd" + std::to_string(add) + "0")
             .add_physical_device("pd" + std::to_string(add) + "1");
     }

--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -331,7 +331,7 @@ TEST(GetDeviceProcAddr, AppQueries11FunctionsWhileOnlyEnabling10) {
         env.add_icd(TEST_ICD_PATH_VERSION_2, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_1))
             .set_icd_api_version(VK_API_VERSION_1_1)
             .add_and_get_physical_device(
-                PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).add_extension(VK_KHR_MAINTENANCE_5_EXTENSION_NAME).finish());
+                PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).add_extension(VK_KHR_MAINTENANCE_5_EXTENSION_NAME));
 
     std::vector<const char*> functions = {"vkGetDeviceQueue2", "vkCmdDispatchBase", "vkCreateDescriptorUpdateTemplate"};
     for (const auto& f : functions) {
@@ -385,7 +385,7 @@ TEST(GetDeviceProcAddr, AppQueries12FunctionsWhileOnlyEnabling11) {
         env.add_icd(TEST_ICD_PATH_VERSION_2, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_2))
             .set_icd_api_version(VK_API_VERSION_1_2)
             .add_and_get_physical_device(
-                PhysicalDevice{}.set_api_version(VK_API_VERSION_1_2).add_extension(VK_KHR_MAINTENANCE_5_EXTENSION_NAME).finish());
+                PhysicalDevice{}.set_api_version(VK_API_VERSION_1_2).add_extension(VK_KHR_MAINTENANCE_5_EXTENSION_NAME));
     std::vector<const char*> functions = {"vkCmdDrawIndirectCount", "vkCmdNextSubpass2", "vkGetBufferDeviceAddress",
                                           "vkGetDeviceMemoryOpaqueCaptureAddress"};
     for (const auto& f : functions) {
@@ -442,7 +442,7 @@ TEST(GetDeviceProcAddr, AppQueries13FunctionsWhileOnlyEnabling12) {
         env.add_icd(TEST_ICD_PATH_VERSION_2, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_3))
             .set_icd_api_version(VK_API_VERSION_1_3)
             .add_and_get_physical_device(
-                PhysicalDevice{}.set_api_version(VK_API_VERSION_1_3).add_extension(VK_KHR_MAINTENANCE_5_EXTENSION_NAME).finish());
+                PhysicalDevice{}.set_api_version(VK_API_VERSION_1_3).add_extension(VK_KHR_MAINTENANCE_5_EXTENSION_NAME));
     std::vector<const char*> functions = {"vkCreatePrivateDataSlot", "vkGetDeviceBufferMemoryRequirements", "vkCmdWaitEvents2",
                                           "vkGetDeviceImageSparseMemoryRequirements"};
 

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -3508,7 +3508,7 @@ TEST(TestLayers, ExplicitlyEnableImplicitLayer) {
     uint32_t api_version = VK_API_VERSION_1_2;
     env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, {}, ManifestICD{}.set_api_version(api_version))
         .set_icd_api_version(api_version)
-        .add_physical_device(PhysicalDevice{}.set_api_version(api_version).finish());
+        .add_physical_device(PhysicalDevice{}.set_api_version(api_version));
 
     const char* regular_layer_name = "VK_LAYER_TestLayer1";
     env.add_implicit_layer({}, ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -3538,7 +3538,7 @@ TEST(TestLayers, NewerInstanceVersionThanImplicitLayer) {
     uint32_t api_version = VK_API_VERSION_1_2;
     env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, {}, ManifestICD{}.set_api_version(api_version))
         .set_icd_api_version(api_version)
-        .add_physical_device(PhysicalDevice{}.set_api_version(api_version).finish());
+        .add_physical_device(PhysicalDevice{}.set_api_version(api_version));
 
     const char* regular_layer_name = "VK_LAYER_TestLayer1";
     env.add_implicit_layer({}, ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -3578,7 +3578,7 @@ TEST(TestLayers, ImplicitLayerPre10APIVersion) {
     uint32_t api_version = VK_API_VERSION_1_2;
     env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, {}, ManifestICD{}.set_api_version(api_version))
         .set_icd_api_version(api_version)
-        .add_physical_device(PhysicalDevice{}.set_api_version(api_version).finish());
+        .add_physical_device(PhysicalDevice{}.set_api_version(api_version));
 
     const char* regular_layer_name = "VK_LAYER_TestLayer1";
     env.add_implicit_layer({}, ManifestLayer{}.add_layer(ManifestLayer::LayerDescription{}
@@ -3639,7 +3639,7 @@ TEST(TestLayers, InstEnvironEnableExplicitLayer) {
     uint32_t api_version = VK_API_VERSION_1_2;
     env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, {}, ManifestICD{}.set_api_version(api_version))
         .set_icd_api_version(api_version)
-        .add_physical_device(PhysicalDevice{}.set_api_version(api_version).finish());
+        .add_physical_device(PhysicalDevice{}.set_api_version(api_version));
 
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
     env.add_explicit_layer(
@@ -4639,7 +4639,7 @@ TEST(TestLayers, DoNotUseDeviceLayer) {
     FrameworkEnvironment env;
     env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_2))
         .set_icd_api_version(VK_API_VERSION_1_2)
-        .add_physical_device(PhysicalDevice{}.set_api_version(VK_API_VERSION_1_2).finish());
+        .add_physical_device(PhysicalDevice{}.set_api_version(VK_API_VERSION_1_2));
 
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
     env.add_explicit_layer(
@@ -4698,7 +4698,7 @@ TEST(TestLayers, InstanceAndDeviceLayer) {
     FrameworkEnvironment env;
     env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_2))
         .set_icd_api_version(VK_API_VERSION_1_2)
-        .add_physical_device(PhysicalDevice{}.set_api_version(VK_API_VERSION_1_2).finish());
+        .add_physical_device(PhysicalDevice{}.set_api_version(VK_API_VERSION_1_2));
 
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
     env.add_explicit_layer(
@@ -4734,7 +4734,7 @@ TEST(TestLayers, DeviceLayerNotPresent) {
     FrameworkEnvironment env;
     env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_2))
         .set_icd_api_version(VK_API_VERSION_1_2)
-        .add_physical_device(PhysicalDevice{}.set_api_version(VK_API_VERSION_1_2).finish());
+        .add_physical_device(PhysicalDevice{}.set_api_version(VK_API_VERSION_1_2));
     const char* explicit_layer_name = "VK_LAYER_LUNARG_wrap_objects";
 
     InstWrapper inst{env.vulkan_functions};

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -4775,9 +4775,8 @@ TEST(LayerPhysDeviceMod, AddPhysicalDevices) {
 #endif
             added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
+        cur_icd.physical_device_groups.emplace_back(0);
+        cur_icd.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2}));
     }
     const uint32_t icd_devices = 6;
 
@@ -4851,9 +4850,8 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDevices) {
 #endif
             added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
+        cur_icd.physical_device_groups.emplace_back(0);
+        cur_icd.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2}));
     }
     const uint32_t icd_devices = 6;
 
@@ -4900,9 +4898,8 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDevices) {
 #endif
             added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
+        cur_icd.physical_device_groups.emplace_back(0);
+        cur_icd.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2}));
     }
     const uint32_t icd_devices = 6;
 
@@ -4949,9 +4946,8 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDevices) {
 #endif
             added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
+        cur_icd.physical_device_groups.emplace_back(0);
+        cur_icd.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2}));
     }
     const uint32_t icd_devices = 6;
 
@@ -5024,9 +5020,8 @@ TEST(LayerPhysDeviceMod, AddPhysicalDeviceGroups) {
 #endif
             added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
+        cur_icd.physical_device_groups.emplace_back(0);
+        cur_icd.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2}));
     }
     const uint32_t icd_groups = 4;
 
@@ -5110,9 +5105,8 @@ TEST(LayerPhysDeviceMod, RemovePhysicalDeviceGroups) {
 #endif
             added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
+        cur_icd.physical_device_groups.emplace_back(0);
+        cur_icd.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2}));
     }
     const uint32_t icd_groups = 3;
 
@@ -5161,9 +5155,8 @@ TEST(LayerPhysDeviceMod, ReorderPhysicalDeviceGroups) {
 #endif
             added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[1]);
-        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[2]);
+        cur_icd.physical_device_groups.emplace_back(0);
+        cur_icd.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2}));
     }
     const uint32_t icd_groups = 4;
 
@@ -5212,9 +5205,8 @@ TEST(LayerPhysDeviceMod, AddRemoveAndReorderPhysicalDeviceGroups) {
 #endif
             added_phys_devs[dev] = &cur_icd.add_and_get_physical_device({}).set_properties(properties);
         }
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[0]);
-        cur_icd.physical_device_groups.back().use_physical_device(added_phys_devs[1]);
-        cur_icd.physical_device_groups.emplace_back(added_phys_devs[2]);
+        cur_icd.physical_device_groups.push_back(PhysicalDeviceGroup({0, 1}));
+        cur_icd.physical_device_groups.emplace_back(2);
     }
     const uint32_t icd_groups = 4;
 

--- a/tests/loader_phys_dev_inst_ext_tests.cpp
+++ b/tests/loader_phys_dev_inst_ext_tests.cpp
@@ -2582,7 +2582,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtBufPropsMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
+            for (auto const& cur_dev : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -2829,7 +2829,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtSemPropsMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
+            for (auto const& cur_dev : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -3075,7 +3075,7 @@ TEST(LoaderInstPhysDevExts, PhysDevExtFencePropsMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
+            for (auto const& cur_dev : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -3659,7 +3659,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPropsKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
+            for (auto const& cur_dev : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -3834,7 +3834,7 @@ TEST(LoaderInstPhysDevExts, PhysDevDispPlanePropsKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
+            for (auto const& cur_dev : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -4008,7 +4008,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneSupDispsKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
+            for (auto const& cur_dev : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -4181,7 +4181,7 @@ TEST(LoaderInstPhysDevExts, GetDispModePropsKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
+            for (auto const& cur_dev : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -4339,7 +4339,7 @@ TEST(LoaderInstPhysDevExts, GetDispModesKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
+            for (auto const& cur_dev : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -4511,7 +4511,7 @@ TEST(LoaderInstPhysDevExts, GetDispPlaneCapsKHRMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
+            for (auto const& cur_dev : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -5275,7 +5275,7 @@ TEST(LoaderInstPhysDevExts, AcquireDrmDisplayEXTMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
+            for (auto const& cur_dev : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&
@@ -5427,7 +5427,7 @@ TEST(LoaderInstPhysDevExts, GetDrmDisplayEXTMixed) {
         for (uint32_t icd = 0; icd < max_icd_count; ++icd) {
             auto& cur_icd = env.get_test_icd(icd);
             bool found = false;
-            for (auto const& [physical_device_handle, cur_dev] : cur_icd.physical_devices) {
+            for (auto const& cur_dev : cur_icd.physical_devices) {
                 // Find the ICD device matching the physical device we're looking at info for so we can compare the
                 // physical devices info with the returned info.
                 if (cur_dev.properties.apiVersion == pd_props.apiVersion && cur_dev.properties.deviceID == pd_props.deviceID &&

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -3170,7 +3170,7 @@ TEST(ExtensionManual, ToolingProperties) {
         env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA)
             .set_supports_tooling_info_ext(true)
             .add_tooling_property(icd_tool_props)
-            .add_physical_device(PhysicalDevice{}.add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME).finish());
+            .add_physical_device(PhysicalDevice{}.add_extension(VK_EXT_TOOLING_INFO_EXTENSION_NAME));
 
         InstWrapper inst{env.vulkan_functions};
         inst.CheckCreate();
@@ -4963,8 +4963,7 @@ void add_driver_for_unloading_testing(FrameworkEnvironment& env) {
         .setup_WSI()
         .add_physical_device(PhysicalDevice{}
                                  .add_extension("VK_KHR_swapchain")
-                                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true})
-                                 .finish());
+                                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true}));
 }
 
 void add_empty_driver_for_unloading_testing(FrameworkEnvironment& env) {

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -982,7 +982,7 @@ TEST(EnumeratePhysicalDevices, CallThriceRemoveInBetween) {
     ASSERT_EQ(physical_count, returned_physical_count);
 
     // Delete the 2nd physical device
-    driver.physical_devices.erase(std::next(driver.physical_devices.begin()));
+    driver.remove_physical_device(1);
 
     physical_count = static_cast<uint32_t>(driver.physical_devices.size());
     std::vector<VkPhysicalDevice> physical_device_handles_2 = std::vector<VkPhysicalDevice>(returned_physical_count);
@@ -1023,10 +1023,11 @@ TEST(EnumeratePhysicalDevices, CallThriceRemoveInBetween) {
 TEST(EnumeratePhysicalDevices, MultipleAddRemoves) {
     FrameworkEnvironment env{};
     auto& driver = env.add_icd(TEST_ICD_PATH_VERSION_2).set_min_icd_interface_version(5);
-    auto phys_dev_handle_0 = driver.add_and_get_physical_device("physical_device_0").vk_physical_device.handle;
-    auto phys_dev_handle_1 = driver.add_and_get_physical_device("physical_device_1").vk_physical_device.handle;
-    auto phys_dev_handle_2 = driver.add_and_get_physical_device("physical_device_2").vk_physical_device.handle;
-    auto phys_dev_handle_3 = driver.add_and_get_physical_device("physical_device_3").vk_physical_device.handle;
+    driver.add_physical_device("physical_device_0");
+    driver.add_physical_device("physical_device_1");
+
+    driver.add_physical_device("physical_device_2");
+    driver.add_physical_device("physical_device_3");
 
     std::array<std::vector<VkPhysicalDevice>, 8> physical_dev_handles;
 
@@ -1040,7 +1041,7 @@ TEST(EnumeratePhysicalDevices, MultipleAddRemoves) {
     ASSERT_EQ(physical_count, returned_physical_count);
 
     // Delete the 2nd physical device (0, 2, 3)
-    driver.physical_devices.erase(phys_dev_handle_1);
+    driver.remove_physical_device(1);
 
     // Query using old number from last call (4), but it should only return 3
     physical_count = static_cast<uint32_t>(driver.physical_devices.size());
@@ -1050,8 +1051,8 @@ TEST(EnumeratePhysicalDevices, MultipleAddRemoves) {
     physical_dev_handles[1].resize(returned_physical_count);
 
     // Add two new physical devices to the front (A, B, 0, 2, 3)
-    auto phys_dev_handle_a = driver.add_physical_device_at_index(0, "physical_device_B").vk_physical_device.handle;
-    auto phys_dev_handle_b = driver.add_physical_device_at_index(1, "physical_device_A").vk_physical_device.handle;
+    driver.add_physical_device_at_index(0, "physical_device_B");
+    driver.add_physical_device_at_index(1, "physical_device_A");
 
     // Query using old number from last call (3), but it should be 5
     physical_count = static_cast<uint32_t>(driver.physical_devices.size());
@@ -1067,7 +1068,7 @@ TEST(EnumeratePhysicalDevices, MultipleAddRemoves) {
     ASSERT_EQ(physical_count, returned_physical_count);
 
     // Delete last two physical devices (A, B, 0, 2)
-    driver.physical_devices.erase(phys_dev_handle_3);
+    driver.remove_physical_device(4);
 
     // Query using old number from last call (5), but it should be 4
     physical_count = static_cast<uint32_t>(driver.physical_devices.size());
@@ -1080,7 +1081,7 @@ TEST(EnumeratePhysicalDevices, MultipleAddRemoves) {
     ASSERT_EQ(VK_SUCCESS, inst->vkEnumeratePhysicalDevices(inst, &returned_physical_count, physical_dev_handles[5].data()));
 
     // Insert a new physical device (A, B, C, 0, 2)
-    auto phys_dev_handle_c = driver.add_physical_device_at_index(2, "physical_device_C").vk_physical_device.handle;
+    driver.add_physical_device_at_index(2, "physical_device_C");
 
     // Query using old number from last call (4), but it should be 5
     physical_count = static_cast<uint32_t>(driver.physical_devices.size());
@@ -1888,9 +1889,8 @@ TEST(EnumeratePhysicalDeviceGroups, OneCall) {
         test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
         phys_devices[i] = &test_physical_device;
     }
-    driver.physical_device_groups.emplace_back(phys_devices[0]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[1]);
-    driver.physical_device_groups.emplace_back(phys_devices[2]);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({0, 1}));
+    driver.physical_device_groups.emplace_back(2);
     const uint32_t max_physical_device_count = 3;
 
     // Core function
@@ -2024,9 +2024,8 @@ TEST(EnumeratePhysicalDeviceGroups, TwoCall) {
         test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
         phys_devices[i] = &test_physical_device;
     }
-    driver.physical_device_groups.emplace_back(phys_devices[0]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[1]);
-    driver.physical_device_groups.emplace_back(phys_devices[2]);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({0, 1}));
+    driver.physical_device_groups.emplace_back(2);
     const uint32_t max_physical_device_count = 3;
 
     // Core function
@@ -2143,9 +2142,8 @@ TEST(EnumeratePhysicalDeviceGroups, TwoCallIncomplete) {
         test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
         phys_devices[i] = &test_physical_device;
     }
-    driver.physical_device_groups.emplace_back(phys_devices[0]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[1]);
-    driver.physical_device_groups.emplace_back(phys_devices[2]);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({0, 1}));
+    driver.physical_device_groups.emplace_back(2);
 
     // Core function
     {
@@ -2247,11 +2245,9 @@ TEST(EnumeratePhysicalDeviceGroups, TestCoreVersusExtensionSameReturns) {
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(phys_devices[0]);
-    driver.physical_device_groups.emplace_back(phys_devices[1]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
-    driver.physical_device_groups.emplace_back(phys_devices[4]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[5]);
+    driver.physical_device_groups.emplace_back(0);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2, 3}));
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({4, 5}));
 
     uint32_t expected_counts[3] = {1, 3, 2};
     uint32_t core_group_count = 0;
@@ -2335,11 +2331,9 @@ TEST(EnumeratePhysicalDeviceGroups, CallThriceAddGroupInBetween) {
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(phys_devices[0]);
-    driver.physical_device_groups.emplace_back(phys_devices[1]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
-    driver.physical_device_groups.emplace_back(phys_devices[4]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[5]);
+    driver.physical_device_groups.emplace_back(0);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2, 3}));
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({4, 5}));
 
     uint32_t before_expected_counts[3] = {1, 3, 2};
     uint32_t after_expected_counts[4] = {1, 3, 1, 2};
@@ -2362,7 +2356,7 @@ TEST(EnumeratePhysicalDeviceGroups, CallThriceAddGroupInBetween) {
     }
 
     // Insert new group after first two
-    driver.physical_device_groups.insert(driver.physical_device_groups.begin() + 2, phys_devices[6]);
+    driver.physical_device_groups.insert(driver.physical_device_groups.begin() + 2, 6);
 
     std::vector<VkPhysicalDeviceGroupProperties> group_props_after{};
     group_props_after.resize(before_group_count,
@@ -2422,20 +2416,16 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceRemoveGroupInBetween) {
                        .set_icd_api_version(VK_API_VERSION_1_1);
 
     // Generate the devices
-    std::array<PhysicalDevice*, 7> phys_devices;
     for (size_t i = 0; i < 7; i++) {
         auto& test_physical_device = driver.add_and_get_physical_device(std::string("physical_device_") + std::to_string(i));
         test_physical_device.properties.apiVersion = VK_API_VERSION_1_1;
-        phys_devices[i] = &test_physical_device;
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(phys_devices[0]);
-    driver.physical_device_groups.emplace_back(phys_devices[1]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
-    driver.physical_device_groups.emplace_back(phys_devices[4]);
-    driver.physical_device_groups.emplace_back(phys_devices[5]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[6]);
+    driver.physical_device_groups.emplace_back(0);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2, 3}));
+    driver.physical_device_groups.emplace_back(4);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({5, 6}));
 
     uint32_t before_expected_counts[4] = {1, 3, 1, 2};
     uint32_t after_expected_counts[3] = {1, 3, 2};
@@ -2517,11 +2507,9 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceAddDeviceInBetween) {
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(phys_devices[0]);
-    driver.physical_device_groups.emplace_back(phys_devices[1]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
-    driver.physical_device_groups.emplace_back(phys_devices[4]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[5]);
+    driver.physical_device_groups.emplace_back(0);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2, 3}));
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({4, 5}));
 
     uint32_t expected_group_count = 3;
     uint32_t before_expected_counts[3] = {1, 3, 2};
@@ -2543,7 +2531,7 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceAddDeviceInBetween) {
     }
 
     // Insert new device to 2nd group
-    driver.physical_device_groups[1].use_physical_device(phys_devices[6]);
+    driver.physical_device_groups[1].use_physical_device(6);
 
     std::vector<VkPhysicalDeviceGroupProperties> group_props_after{};
     group_props_after.resize(expected_group_count,
@@ -2603,11 +2591,9 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceRemoveDeviceInBetween) {
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(phys_devices[0]);
-    driver.physical_device_groups.emplace_back(phys_devices[1]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
-    driver.physical_device_groups.emplace_back(phys_devices[4]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[5]);
+    driver.physical_device_groups.emplace_back(0);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2, 3}));
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({4, 5}));
 
     uint32_t before_expected_counts[3] = {1, 3, 2};
     uint32_t after_expected_counts[3] = {1, 2, 2};
@@ -2634,8 +2620,8 @@ TEST(EnumeratePhysicalDeviceGroups, CallTwiceRemoveDeviceInBetween) {
     }
 
     // Remove middle device in middle group
-    driver.physical_device_groups[1].physical_device_handles.erase(
-        driver.physical_device_groups[1].physical_device_handles.begin() + 1);
+    driver.physical_device_groups[1].physical_device_indexes.erase(
+        driver.physical_device_groups[1].physical_device_indexes.begin() + 1);
 
     std::vector<VkPhysicalDeviceGroupProperties> group_props_after{};
     group_props_after.resize(expected_group_count,
@@ -2700,11 +2686,9 @@ TEST(EnumeratePhysicalDeviceGroups, MultipleAddRemoves) {
     }
 
     // Generate the starting groups
-    driver.physical_device_groups.emplace_back(phys_devices[0]);
-    driver.physical_device_groups.emplace_back(phys_devices[1]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[2]).use_physical_device(phys_devices[3]);
-    driver.physical_device_groups.emplace_back(phys_devices[4]);
-    driver.physical_device_groups.back().use_physical_device(phys_devices[5]);
+    driver.physical_device_groups.emplace_back(0);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2, 3}));
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({4, 5}));
 
     uint32_t before_expected_counts[3] = {1, 3, 2};
     uint32_t after_add_group_expected_counts[4] = {1, 3, 1, 2};
@@ -2731,7 +2715,7 @@ TEST(EnumeratePhysicalDeviceGroups, MultipleAddRemoves) {
     }
 
     // Insert new group after first two
-    driver.physical_device_groups.insert(driver.physical_device_groups.begin() + 2, phys_devices[6]);
+    driver.physical_device_groups.insert(driver.physical_device_groups.begin() + 2, 6);
 
     // Should be: 4 Groups { { 0 }, { 1, 2, 3 }, { 6 }, { 4, 5 } }
     std::vector<VkPhysicalDeviceGroupProperties> group_props_after_add_group{};
@@ -2745,8 +2729,8 @@ TEST(EnumeratePhysicalDeviceGroups, MultipleAddRemoves) {
     }
 
     // Remove first device in 2nd group
-    driver.physical_device_groups[1].physical_device_handles.erase(
-        driver.physical_device_groups[1].physical_device_handles.begin());
+    driver.physical_device_groups[1].physical_device_indexes.erase(
+        driver.physical_device_groups[1].physical_device_indexes.begin());
 
     // Should be: 4 Groups { { 0 }, { 2, 3 }, { 6 }, { 4, 5 } }
     std::vector<VkPhysicalDeviceGroupProperties> group_props_after_remove_device{};
@@ -2776,7 +2760,7 @@ TEST(EnumeratePhysicalDeviceGroups, MultipleAddRemoves) {
     }
 
     // Add two devices to last group
-    driver.physical_device_groups.back().use_physical_device(phys_devices[7]).use_physical_device(phys_devices[8]);
+    driver.physical_device_groups.back().use_physical_devices({7, 8});
 
     // Should be: 3 Groups { { 2, 3 }, { 6 }, { 4, 5, 7, 8 } }
     std::vector<VkPhysicalDeviceGroupProperties> group_props_after_add_device{};
@@ -2842,9 +2826,8 @@ TEST(EnumeratePhysicalDeviceGroups, FakePNext) {
     test_physical_device_2.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
     FillInRandomDeviceProps(test_physical_device_2.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 888,
                             0xAAA003);
-    cur_icd_0.physical_device_groups.push_back({});
-    cur_icd_0.physical_device_groups.back().use_physical_device(test_physical_device_0).use_physical_device(test_physical_device_2);
-    cur_icd_0.physical_device_groups.push_back({test_physical_device_1});
+    cur_icd_0.physical_device_groups.push_back(PhysicalDeviceGroup({0, 2}));
+    cur_icd_0.physical_device_groups.push_back(1);
 
     env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_1));
     auto& cur_icd_1 = env.get_test_icd(1);
@@ -2861,9 +2844,8 @@ TEST(EnumeratePhysicalDeviceGroups, FakePNext) {
     test_physical_device_6.extensions.push_back({VK_EXT_PCI_BUS_INFO_EXTENSION_NAME, 0});
     FillInRandomDeviceProps(test_physical_device_6.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
                             0xCCCC003);
-    cur_icd_1.physical_device_groups.push_back({});
-    cur_icd_1.physical_device_groups.back().use_physical_device(test_physical_device_5).use_physical_device(test_physical_device_6);
-    cur_icd_1.physical_device_groups.push_back({test_physical_device_4});
+    cur_icd_1.physical_device_groups.push_back(PhysicalDeviceGroup({1, 2}));
+    cur_icd_1.physical_device_groups.push_back(0);
 
     InstWrapper inst(env.vulkan_functions);
     inst.create_info.set_api_version(VK_API_VERSION_1_1);
@@ -2921,8 +2903,7 @@ TEST(EnumeratePhysicalDeviceGroups, DeviceFiltering) {
     }
 
     for (size_t i = 0; i < 5; i++) {
-        driver.physical_device_groups.emplace_back(phys_devices[2 * i]);
-        driver.physical_device_groups.back().use_physical_device(phys_devices[2 * i + 1]);
+        driver.physical_device_groups.push_back(PhysicalDeviceGroup({2 * i, 2 * i + 1}));
     }
 
     InstWrapper inst{env.vulkan_functions};
@@ -3072,8 +3053,7 @@ TEST(EnumeratePhysicalDeviceGroups, DeviceFilteringByDriverId) {
     }
 
     for (size_t i = 0; i < 5; i++) {
-        driver.physical_device_groups.emplace_back(phys_devices[2 * i]);
-        driver.physical_device_groups.back().use_physical_device(phys_devices[2 * i + 1]);
+        driver.physical_device_groups.push_back(PhysicalDeviceGroup({2 * i, 2 * i + 1}));
     }
 
     InstWrapper inst{env.vulkan_functions};
@@ -3731,8 +3711,8 @@ TEST(SortedPhysicalDevices, DeviceGroupsSortedEnabled) {
     FillInRandomDeviceProps(test_physical_device_2.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 888,
                             0xAAA003);
     cur_icd_0.physical_device_groups.push_back({});
-    cur_icd_0.physical_device_groups.back().use_physical_device(test_physical_device_0).use_physical_device(test_physical_device_2);
-    cur_icd_0.physical_device_groups.push_back({test_physical_device_1});
+    cur_icd_0.physical_device_groups.back().use_physical_devices({0, 2});
+    cur_icd_0.physical_device_groups.push_back({1});
 
     env.add_icd(TEST_ICD_PATH_VERSION_2, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_1));
     auto& cur_icd_1 = env.get_test_icd(1);
@@ -3761,8 +3741,8 @@ TEST(SortedPhysicalDevices, DeviceGroupsSortedEnabled) {
     FillInRandomDeviceProps(test_physical_device_6.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
                             0xCCCC003);
     cur_icd_2.physical_device_groups.push_back({});
-    cur_icd_2.physical_device_groups.back().use_physical_device(test_physical_device_5).use_physical_device(test_physical_device_6);
-    cur_icd_2.physical_device_groups.push_back({test_physical_device_4});
+    cur_icd_2.physical_device_groups.back().use_physical_devices({1, 2});
+    cur_icd_2.physical_device_groups.push_back(0);
 
     env.add_icd(TEST_ICD_PATH_VERSION_2, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_1));
     auto& cur_icd_3 = env.get_test_icd(3);
@@ -3916,8 +3896,8 @@ TEST(SortedPhysicalDevices, DeviceGroupsSortedDisabled) {
     FillInRandomDeviceProps(test_physical_device_2.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 888,
                             0xAAA003);
     cur_icd_0.physical_device_groups.push_back({});
-    cur_icd_0.physical_device_groups.back().use_physical_device(test_physical_device_0).use_physical_device(test_physical_device_2);
-    cur_icd_0.physical_device_groups.push_back({test_physical_device_1});
+    cur_icd_0.physical_device_groups.back().use_physical_devices({0, 2});
+    cur_icd_0.physical_device_groups.push_back(1);
 
     env.add_icd(TEST_ICD_PATH_VERSION_2, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_1));
     auto& cur_icd_1 = env.get_test_icd(1);
@@ -3942,8 +3922,8 @@ TEST(SortedPhysicalDevices, DeviceGroupsSortedDisabled) {
     FillInRandomDeviceProps(test_physical_device_6.properties, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_API_VERSION_1_1, 75,
                             0xCCCC003);
     cur_icd_2.physical_device_groups.push_back({});
-    cur_icd_2.physical_device_groups.back().use_physical_device(test_physical_device_5).use_physical_device(test_physical_device_6);
-    cur_icd_2.physical_device_groups.push_back({test_physical_device_4});
+    cur_icd_2.physical_device_groups.back().use_physical_devices({1, 2});
+    cur_icd_2.physical_device_groups.push_back(0);
 
     env.add_icd(TEST_ICD_PATH_VERSION_2, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_1));
     auto& cur_icd_3 = env.get_test_icd(3);
@@ -4200,9 +4180,12 @@ TEST(PortabilityICDConfiguration, PortabilityAndRegularICDCheckFlagsPassedIntoIC
     inst.CheckCreate();
     ASSERT_FALSE(env.debug_log.find(portability_driver_warning));
 
-    ASSERT_EQ(static_cast<VkInstanceCreateFlags>(4), driver0.passed_in_instance_create_flags);
+    ASSERT_EQ(driver0.created_instance_details.size(), 1U);
+    ASSERT_EQ(static_cast<VkInstanceCreateFlags>(4),
+              driver0.created_instance_details.begin()->second.passed_in_instance_create_flags);
+    ASSERT_EQ(driver1.created_instance_details.size(), 1U);
     ASSERT_EQ(VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR | static_cast<VkInstanceCreateFlags>(4),
-              driver1.passed_in_instance_create_flags);
+              driver1.created_instance_details.begin()->second.passed_in_instance_create_flags);
 }
 
 TEST(PortabilityICDConfiguration, PortabilityAndRegularICDPreInstanceFunctions) {
@@ -4674,7 +4657,7 @@ TEST(InvalidManifest, Layer) {
     inst.CheckCreate();
 }
 #if defined(WIN32)
-VkPhysicalDevice add_dxgi_adapter(FrameworkEnvironment& env, std::filesystem::path const& name, LUID luid, uint32_t vendor_id) {
+void add_dxgi_adapter(FrameworkEnvironment& env, std::filesystem::path const& name, LUID luid, uint32_t vendor_id) {
     auto& driver = env.add_icd(TEST_ICD_PATH_VERSION_6, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::null_dir));
     driver.set_min_icd_interface_version(5);
     driver.set_max_icd_interface_version(6);
@@ -4707,7 +4690,6 @@ VkPhysicalDevice add_dxgi_adapter(FrameworkEnvironment& env, std::filesystem::pa
     } else {
         pAdapter->add_driver_manifest_path(env.get_icd_manifest_path(env.icds.size() - 1));
     }
-    return pd0.vk_physical_device.handle;
 }
 
 TEST(EnumerateAdapterPhysicalDevices, SameAdapterLUID_reordered) {
@@ -4720,7 +4702,7 @@ TEST(EnumerateAdapterPhysicalDevices, SameAdapterLUID_reordered) {
     // b) then in the reverse order to the drivers insertion into the test framework
     add_dxgi_adapter(env, "physical_device_2", LUID{10, 100}, 2);
     add_dxgi_adapter(env, "physical_device_1", LUID{20, 200}, 1);
-    auto phys_dev_handle = add_dxgi_adapter(env, "physical_device_0", LUID{10, 100}, 2);
+    add_dxgi_adapter(env, "physical_device_0", LUID{10, 100}, 2);
 
     {
         uint32_t returned_physical_count = 0;
@@ -4764,8 +4746,7 @@ TEST(EnumerateAdapterPhysicalDevices, SameAdapterLUID_reordered) {
     }
     // Set the first physical device that is enumerated to be a 'layered' driver so it should be swapped with the first physical
     // device
-    env.get_test_icd(2).physical_devices.at(phys_dev_handle).layered_driver_underlying_api =
-        VK_LAYERED_DRIVER_UNDERLYING_API_D3D12_MSFT;
+    env.get_test_icd(2).physical_devices.at(0).layered_driver_underlying_api = VK_LAYERED_DRIVER_UNDERLYING_API_D3D12_MSFT;
     {
         uint32_t returned_physical_count = 0;
         InstWrapper inst{env.vulkan_functions};
@@ -4817,13 +4798,12 @@ TEST(EnumerateAdapterPhysicalDevices, SameAdapterLUID_same_order) {
     // Physical devices are enumerated:
     // a) first in the order of LUIDs showing up in DXGIAdapter list
     // b) then in the reverse order to the drivers insertion into the test framework
-    auto d3d12_physical_device = add_dxgi_adapter(env, "physical_device_2", LUID{10, 100}, 2);
+    add_dxgi_adapter(env, "physical_device_2", LUID{10, 100}, 2);
     add_dxgi_adapter(env, "physical_device_1", LUID{20, 200}, 1);
     add_dxgi_adapter(env, "physical_device_0", LUID{10, 100}, 2);
 
     // Set the physical device that is enumerated last to be a 'layered'  physical device - no swapping should occur
-    env.get_test_icd(0).physical_devices.at(d3d12_physical_device).layered_driver_underlying_api =
-        VK_LAYERED_DRIVER_UNDERLYING_API_D3D12_MSFT;
+    env.get_test_icd(0).physical_devices.at(0).layered_driver_underlying_api = VK_LAYERED_DRIVER_UNDERLYING_API_D3D12_MSFT;
 
     uint32_t returned_physical_count = 0;
     InstWrapper inst{env.vulkan_functions};

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -2837,11 +2837,11 @@ TEST(SettingsFile, TooManyLayers) {
 
 TEST(SettingsFile, EnvVarsWorkTogether) {
     FrameworkEnvironment env{};
-    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device(PhysicalDevice{}.set_deviceName("regular").finish());
+    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device(PhysicalDevice{}.set_deviceName("regular"));
     env.add_icd(TEST_ICD_PATH_VERSION_2, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::env_var))
-        .add_physical_device(PhysicalDevice{}.set_deviceName("env_var").finish());
+        .add_physical_device(PhysicalDevice{}.set_deviceName("env_var"));
     env.add_icd(TEST_ICD_PATH_VERSION_2, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::add_env_var))
-        .add_physical_device(PhysicalDevice{}.set_deviceName("add_env_var").finish());
+        .add_physical_device(PhysicalDevice{}.set_deviceName("add_env_var"));
 
     const char* regular_explicit_layer = "VK_LAYER_regular_explicit_layer";
     env.add_explicit_layer(
@@ -3053,9 +3053,9 @@ TEST(SettingsFile, AdditionalDrivers) {
     FrameworkEnvironment env{FrameworkSettings{}.set_log_filter("")};
     const char* regular_driver_name = "regular";
     const char* settings_driver_name = "settings";
-    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device(PhysicalDevice{}.set_deviceName(regular_driver_name).finish());
+    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device(PhysicalDevice{}.set_deviceName(regular_driver_name));
     env.add_icd(TEST_ICD_PATH_VERSION_2, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::override_folder))
-        .add_physical_device(PhysicalDevice{}.set_deviceName(settings_driver_name).finish());
+        .add_physical_device(PhysicalDevice{}.set_deviceName(settings_driver_name));
 
     env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(
         AppSpecificSettings{}.add_stderr_log_filter("all").add_driver_configuration(
@@ -3077,9 +3077,9 @@ TEST(SettingsFile, ExclusiveAdditionalDrivers) {
     FrameworkEnvironment env{};
     const char* regular_driver_name = "regular";
     const char* settings_driver_name = "settings";
-    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device(PhysicalDevice{}.set_deviceName(regular_driver_name).finish());
+    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device(PhysicalDevice{}.set_deviceName(regular_driver_name));
     env.add_icd(TEST_ICD_PATH_VERSION_2, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::override_folder))
-        .add_physical_device(PhysicalDevice{}.set_deviceName(settings_driver_name).finish());
+        .add_physical_device(PhysicalDevice{}.set_deviceName(settings_driver_name));
 
     env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(
         AppSpecificSettings{}.set_additional_drivers_use_exclusively(true).add_driver_configuration(
@@ -3099,9 +3099,9 @@ TEST(SettingsFile, AdditionalDriversReplacesVK_LOADER_DRIVERS_SELECT) {
     FrameworkEnvironment env{};
     const char* regular_driver_name = "regular";
     const char* settings_driver_name = "settings";
-    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device(PhysicalDevice{}.set_deviceName(regular_driver_name).finish());
+    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device(PhysicalDevice{}.set_deviceName(regular_driver_name));
     env.add_icd(TEST_ICD_PATH_VERSION_2, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::override_folder))
-        .add_physical_device(PhysicalDevice{}.set_deviceName(settings_driver_name).finish());
+        .add_physical_device(PhysicalDevice{}.set_deviceName(settings_driver_name));
 
     env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(
         AppSpecificSettings{}.add_driver_configuration(LoaderSettingsDriverConfiguration{}.set_path(env.get_icd_manifest_path(1))));
@@ -3161,8 +3161,8 @@ TEST(SettingsFile, InvalidAdditionalDriversField) {
     const char* driver_name = "driver";
     const char* settings_driver_name = "settings_driver";
     env.add_icd(TEST_ICD_PATH_VERSION_2, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::override_folder))
-        .add_physical_device(PhysicalDevice{}.set_deviceName(settings_driver_name).finish());
-    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device(PhysicalDevice{}.set_deviceName(driver_name).finish());
+        .add_physical_device(PhysicalDevice{}.set_deviceName(settings_driver_name));
+    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device(PhysicalDevice{}.set_deviceName(driver_name));
 
     env.add_explicit_layer(
         ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::override_folder),
@@ -3216,8 +3216,7 @@ TEST(SettingsFile, DriverConfigurationsInSpecifiedOrder) {
         icd.add_physical_device(PhysicalDevice()
                                     .set_deviceName("PhysicalDevice_" + std::to_string(uuids.size() - 1 - i))
                                     .set_api_version(VK_API_VERSION_1_1)
-                                    .set_deviceUUID(uuids[uuids.size() - 1 - i])
-                                    .finish());
+                                    .set_deviceUUID(uuids[uuids.size() - 1 - i]));
     }
 
     env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(AppSpecificSettings{});
@@ -3254,8 +3253,7 @@ TEST(SettingsFile, OnlyOneDriverConfiguration) {
     auto& icd = env.add_icd(TEST_ICD_PATH_VERSION_2).set_icd_api_version(VK_API_VERSION_1_1);
     for (uint32_t i = 0; i < uuids.size(); i++) {
         // add the physical devices in reverse order of UUID's
-        icd.add_physical_device(
-            PhysicalDevice().set_api_version(VK_API_VERSION_1_1).set_deviceUUID(uuids[uuids.size() - 1 - i]).finish());
+        icd.add_physical_device(PhysicalDevice().set_api_version(VK_API_VERSION_1_1).set_deviceUUID(uuids[uuids.size() - 1 - i]));
     }
 
     env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(AppSpecificSettings{});
@@ -3295,7 +3293,7 @@ TEST(SettingsFile, MissingDriverConfiguration) {
     }
 
     auto& icd = env.add_icd(TEST_ICD_PATH_VERSION_2).set_icd_api_version(VK_API_VERSION_1_1);
-    icd.add_physical_device(PhysicalDevice().set_api_version(VK_API_VERSION_1_1).set_deviceUUID(uuids[1]).finish());
+    icd.add_physical_device(PhysicalDevice().set_api_version(VK_API_VERSION_1_1).set_deviceUUID(uuids[1]));
 
     env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(AppSpecificSettings{});
 
@@ -3320,8 +3318,7 @@ TEST(SettingsFile, DeviceConfigurationWithSameDriver) {
                                                             .set_api_version(VK_API_VERSION_1_2)
                                                             .set_deviceUUID(device_uuid)
                                                             .set_driverUUID(driver_uuid)
-                                                            .set_deviceName("foobar")
-                                                            .finish());
+                                                            .set_deviceName("foobar"));
     phys_dev_0.properties.driverVersion = 1000;
     std::string("Fake Driver XYZ").copy(phys_dev_0.driver_properties.driverName, VK_MAX_EXTENSION_NAME_SIZE);
 
@@ -3330,8 +3327,7 @@ TEST(SettingsFile, DeviceConfigurationWithSameDriver) {
                                                             .set_api_version(VK_API_VERSION_1_2)
                                                             .set_deviceUUID(device_uuid)
                                                             .set_driverUUID(driver_uuid)
-                                                            .set_deviceName("foobar")
-                                                            .finish());
+                                                            .set_deviceName("foobar"));
     phys_dev_1.properties.driverVersion = 30;
     std::string("Fake Driver XYZ, but differently named").copy(phys_dev_1.driver_properties.driverName, VK_MAX_EXTENSION_NAME_SIZE);
 
@@ -3373,15 +3369,13 @@ TEST(SettingsFile, DriverConfigurationIgnoresDriverEnvVars) {
         count++;
     }
 
-    env.add_icd(TEST_ICD_PATH_VERSION_2)
-        .add_physical_device(PhysicalDevice().set_deviceName("A").set_deviceUUID(uuids[0]).finish());
+    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device(PhysicalDevice().set_deviceName("A").set_deviceUUID(uuids[0]));
 
     auto& icd = env.add_icd(TEST_ICD_PATH_VERSION_2).set_icd_api_version(VK_API_VERSION_1_1);
-    icd.add_physical_device(
-        PhysicalDevice().set_api_version(VK_API_VERSION_1_1).set_deviceName("B").set_deviceUUID(uuids[1]).finish());
+    icd.add_physical_device(PhysicalDevice().set_api_version(VK_API_VERSION_1_1).set_deviceName("B").set_deviceUUID(uuids[1]));
 
     env.add_icd(TEST_ICD_PATH_VERSION_2, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::env_var))
-        .add_physical_device(PhysicalDevice().set_deviceName("C").set_deviceUUID(uuids[2]).finish());
+        .add_physical_device(PhysicalDevice().set_deviceName("C").set_deviceUUID(uuids[2]));
 
     env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(AppSpecificSettings{});
 
@@ -3418,19 +3412,15 @@ TEST(SettingsFile, DriverConfigurationsAndAdditionalDrivers) {
     }
 
     env.add_icd(TEST_ICD_PATH_VERSION_2, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::override_folder))
-        .add_physical_device(PhysicalDevice{}
-                                 .set_api_version(VK_API_VERSION_1_1)
-                                 .set_deviceName("additional_device")
-                                 .set_deviceUUID(uuids[0])
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).set_deviceName("additional_device").set_deviceUUID(uuids[0]));
 
     auto& icd = env.add_icd(TEST_ICD_PATH_VERSION_2)
                     .set_icd_api_version(VK_API_VERSION_1_1)
                     .add_physical_device(PhysicalDevice()
                                              .set_api_version(VK_API_VERSION_1_1)
                                              .set_deviceName("device_configuration_device")
-                                             .set_deviceUUID(uuids[1])
-                                             .finish());
+                                             .set_deviceUUID(uuids[1]));
     env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(AppSpecificSettings{});
     env.loader_settings.app_specific_settings.at(0).add_driver_configuration(
         LoaderSettingsDriverConfiguration().set_path(env.get_icd_manifest_path(0)));
@@ -3467,18 +3457,12 @@ TEST(SettingsFile, InvalidDriverConfigurations) {
     }
     env.add_icd(TEST_ICD_PATH_VERSION_2)
         .set_icd_api_version(VK_API_VERSION_1_1)
-        .add_physical_device(PhysicalDevice{}
-                                 .set_api_version(VK_API_VERSION_1_1)
-                                 .set_deviceName("regular_driver")
-                                 .set_deviceUUID(uuids[0])
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).set_deviceName("regular_driver").set_deviceUUID(uuids[0]));
 
     env.add_icd(TEST_ICD_PATH_VERSION_2, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::override_folder))
-        .add_physical_device(PhysicalDevice{}
-                                 .set_api_version(VK_API_VERSION_1_1)
-                                 .set_deviceName("additional_device")
-                                 .set_deviceUUID(uuids[2])
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).set_deviceName("additional_device").set_deviceUUID(uuids[2]));
 
     env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(
         AppSpecificSettings{}
@@ -3505,26 +3489,17 @@ TEST(SettingsFile, DeviceConfigurationReordersAdditionalDrivers) {
 
     env.add_icd(TEST_ICD_PATH_VERSION_2)
         .set_icd_api_version(VK_API_VERSION_1_1)
-        .add_physical_device(PhysicalDevice{}
-                                 .set_api_version(VK_API_VERSION_1_1)
-                                 .set_deviceName("regular_driverA")
-                                 .set_deviceUUID(uuids[0])
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).set_deviceName("regular_driverA").set_deviceUUID(uuids[0]));
     env.add_icd(TEST_ICD_PATH_VERSION_2)
         .set_icd_api_version(VK_API_VERSION_1_1)
-        .add_physical_device(PhysicalDevice{}
-                                 .set_api_version(VK_API_VERSION_1_1)
-                                 .set_deviceName("regular_driverB")
-                                 .set_deviceUUID(uuids[1])
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).set_deviceName("regular_driverB").set_deviceUUID(uuids[1]));
 
     env.add_icd(TEST_ICD_PATH_VERSION_2, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::override_folder))
         .set_icd_api_version(VK_API_VERSION_1_1)
-        .add_physical_device(PhysicalDevice{}
-                                 .set_api_version(VK_API_VERSION_1_1)
-                                 .set_deviceName("additional_device")
-                                 .set_deviceUUID(uuids[2])
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).set_deviceName("additional_device").set_deviceUUID(uuids[2]));
 
     env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(
         AppSpecificSettings{}
@@ -3574,26 +3549,17 @@ TEST(SettingsFile, DeviceConfigurationReordersExclusiveAdditionalDrivers) {
 
     env.add_icd(TEST_ICD_PATH_VERSION_2)
         .set_icd_api_version(VK_API_VERSION_1_1)
-        .add_physical_device(PhysicalDevice{}
-                                 .set_api_version(VK_API_VERSION_1_1)
-                                 .set_deviceName("regular_driverA")
-                                 .set_deviceUUID(uuids[0])
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).set_deviceName("regular_driverA").set_deviceUUID(uuids[0]));
     env.add_icd(TEST_ICD_PATH_VERSION_2)
         .set_icd_api_version(VK_API_VERSION_1_1)
-        .add_physical_device(PhysicalDevice{}
-                                 .set_api_version(VK_API_VERSION_1_1)
-                                 .set_deviceName("regular_driverB")
-                                 .set_deviceUUID(uuids[1])
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).set_deviceName("regular_driverB").set_deviceUUID(uuids[1]));
 
     env.add_icd(TEST_ICD_PATH_VERSION_2, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::override_folder))
         .set_icd_api_version(VK_API_VERSION_1_1)
-        .add_physical_device(PhysicalDevice{}
-                                 .set_api_version(VK_API_VERSION_1_1)
-                                 .set_deviceName("additional_device")
-                                 .set_deviceUUID(uuids[2])
-                                 .finish());
+        .add_physical_device(
+            PhysicalDevice{}.set_api_version(VK_API_VERSION_1_1).set_deviceName("additional_device").set_deviceUUID(uuids[2]));
 
     env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(
         AppSpecificSettings{}

--- a/tests/loader_unknown_ext_tests.cpp
+++ b/tests/loader_unknown_ext_tests.cpp
@@ -390,39 +390,34 @@ TEST(UnknownFunction, PhysicalDeviceFunctionMultipleDriverSupport) {
     }
 }
 
-// Add unknown functions to driver 0, and try to use them on driver 1.
+// Add unknown functions to driver 0, and try to use them on driver 1. Needs TestICD to implement the unknown function so that it
+// can validate the passed in VkPhysicalDevice
 TEST(UnknownFunctionDeathTests, PhysicalDeviceFunctionErrorPath) {
     FrameworkEnvironment env{};
     auto& driver_0 = env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA);
-    auto& driver_1 = env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA);
-    std::vector<std::string> function_names;
-    add_function_names(function_names, 1);
+    auto& driver_1 = env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA).set_supports_internal_function(true);
 
     // used to identify the GPUs
-    auto& test_physical_driver_0 = driver_0.add_and_get_physical_device("physical_device_0");
-    test_physical_driver_0.properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-    auto& test_physical_driver_1 = driver_1.add_and_get_physical_device("physical_device_1");
-    test_physical_driver_1.properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
-    function_names.push_back(std::string("vkNotIntRealFuncTEST_0"));
-
-    custom_physical_device_functions funcs{};
-    test_physical_driver_0.custom_physical_device_functions.push_back(
-        VulkanFunction{function_names.back(), to_vkVoidFunction(funcs.func_zero)});
+    driver_0.add_and_get_physical_device("physical_device_0").properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+    driver_1.add_and_get_physical_device("physical_device_1").properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
 
     InstWrapper inst{env.vulkan_functions};
     inst.CheckCreate();
 
     auto phys_devs = inst.GetPhysDevs(2);
-    VkPhysicalDevice phys_dev_to_use = phys_devs[1];
     VkPhysicalDeviceProperties props{};
-    env.vulkan_functions.vkGetPhysicalDeviceProperties(phys_devs[1], &props);
-    if (props.deviceType != VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU) phys_dev_to_use = phys_devs[0];
-    // use the wrong GPU to query the functions, should get 5 errors
+    env.vulkan_functions.vkGetPhysicalDeviceProperties(phys_devs[0], &props);
+    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU);
 
-    decltype(custom_physical_device_functions::func_zero)* returned_func_i =
-        env.vulkan_functions.load(inst.inst, function_names.at(0).c_str());
+    env.vulkan_functions.vkGetPhysicalDeviceProperties(phys_devs[1], &props);
+    ASSERT_EQ(props.deviceType, VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
+
+    // GPU that supports the unknown function is enumerated first (gpus are enumerated in reverse order)
+    PFN_test_icd_internal_function returned_func_i = env.vulkan_functions.load(inst.inst, TEST_ICD_INTERNAL_FUNCTION_NAME_STRING);
     ASSERT_NE(returned_func_i, nullptr);
-    ASSERT_DEATH(returned_func_i(phys_dev_to_use, 0), "Function vkNotIntRealFuncTEST_0 not supported for this physical device");
+    ASSERT_EQ(returned_func_i(phys_devs[0], 0, 1, 2.2f), VK_SUCCESS);
+    ASSERT_DEATH(returned_func_i(phys_devs[1], 0, 1, 2.2f),
+                 "Function " TEST_ICD_INTERNAL_FUNCTION_NAME_STRING " not supported for this physical device");
 }
 
 TEST(UnknownFunction, PhysicalDeviceFunctionWithImplicitLayerImplementation) {

--- a/tests/loader_version_tests.cpp
+++ b/tests/loader_version_tests.cpp
@@ -265,9 +265,9 @@ TEST(ICDInterfaceVersion2PlusEnumerateAdapterPhysicalDevices, VerifyGroupResults
     auto& test_physical_device_3 = driver.add_and_get_physical_device(physical_device_names[3]);
     auto& test_physical_device_4 = driver.add_and_get_physical_device(physical_device_names[4]);
 
-    driver.physical_device_groups.emplace_back(test_physical_device_0).use_physical_device(test_physical_device_1);
-    driver.physical_device_groups.emplace_back(test_physical_device_2);
-    driver.physical_device_groups.emplace_back(test_physical_device_3).use_physical_device(test_physical_device_4);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({0, 1}));
+    driver.physical_device_groups.emplace_back(2);
+    driver.physical_device_groups.push_back(PhysicalDeviceGroup({3, 4}));
 
     auto& known_driver = known_driver_list.at(2);  // which driver this test pretends to be
     DXGI_ADAPTER_DESC1 desc1{};
@@ -419,9 +419,9 @@ TEST(MultipleDriverConfig, DifferentICDsWithDevices) {
 
 TEST(MultipleDriverConfig, DifferentICDsWithDevicesAndGroups) {
     FrameworkEnvironment env{};
-    env.add_icd(TEST_ICD_PATH_EXPORT_ICD_GIPA);
-    env.add_icd(TEST_ICD_PATH_VERSION_2, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_1));
-    env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA);
+    TestICD& icd0 = env.add_icd(TEST_ICD_PATH_EXPORT_ICD_GIPA);
+    TestICD& icd1 = env.add_icd(TEST_ICD_PATH_VERSION_2, {}, ManifestICD{}.set_api_version(VK_API_VERSION_1_1));
+    TestICD& icd2 = env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA);
 
     // The loader has to be able to handle drivers that support device groups in combination
     // with drivers that don't support device groups.  When this is the case, the loader needs
@@ -430,27 +430,23 @@ TEST(MultipleDriverConfig, DifferentICDsWithDevicesAndGroups) {
     // device groups returned info.
 
     // ICD 0 :  No 1.1 support (so 1 device will become 1 group in loader)
-    TestICD& icd0 = env.get_test_icd(0);
-    icd0.add_and_get_physical_device("physical_device_0");
+    icd0.add_physical_device("physical_device_0");
     icd0.min_icd_interface_version = 5;
     icd0.max_icd_interface_version = 5;
     icd0.set_icd_api_version(VK_API_VERSION_1_0);
 
     // ICD 1 :  1.1 support (with 1 group with 2 devices)
-    TestICD& icd1 = env.get_test_icd(1);
     auto& pd1 = icd1.add_and_get_physical_device("physical_device_1").set_api_version(VK_API_VERSION_1_1);
     auto& pd2 = icd1.add_and_get_physical_device("physical_device_2").set_api_version(VK_API_VERSION_1_1);
-    icd1.physical_device_groups.emplace_back(pd1);
-    icd1.physical_device_groups.back().use_physical_device(pd2);
+    icd1.physical_device_groups.push_back(PhysicalDeviceGroup({0, 1}));
     icd1.min_icd_interface_version = 5;
     icd1.max_icd_interface_version = 5;
     icd1.set_icd_api_version(VK_API_VERSION_1_1);
 
     // ICD 2 :  No 1.1 support (so 3 devices will become 3 groups in loader)
-    TestICD& icd2 = env.get_test_icd(2);
-    icd2.add_and_get_physical_device("physical_device_3");
-    icd2.add_and_get_physical_device("physical_device_4");
-    icd2.add_and_get_physical_device("physical_device_5");
+    icd2.add_physical_device("physical_device_3");
+    icd2.add_physical_device("physical_device_4");
+    icd2.add_physical_device("physical_device_5");
     icd2.min_icd_interface_version = 5;
     icd2.max_icd_interface_version = 5;
     icd2.set_icd_api_version(VK_API_VERSION_1_0);

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -777,8 +777,7 @@ TEST(WsiTests, GoogleSurfaceslessQuery) {
                                  .add_extension("VK_EXT_full_screen_exclusive")
 #endif
                                  .add_surface_format(surface_format)
-                                 .add_surface_present_modes(present_modes)
-                                 .finish());
+                                 .add_surface_present_modes(present_modes));
 
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extension("VK_KHR_surface");
@@ -826,9 +825,7 @@ TEST(WsiTests, GoogleSurfaceslessQuery) {
 
 TEST(WsiTests, ForgetEnableSurfaceExtensions) {
     FrameworkEnvironment env{};
-    env.add_icd(TEST_ICD_PATH_VERSION_2)
-        .setup_WSI()
-        .add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain").finish());
+    env.add_icd(TEST_ICD_PATH_VERSION_2).setup_WSI().add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain"));
 
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.add_extension("VK_KHR_surface");
@@ -840,9 +837,7 @@ TEST(WsiTests, ForgetEnableSurfaceExtensions) {
 
 TEST(WsiTests, SwapchainFunctional) {
     FrameworkEnvironment env{};
-    env.add_icd(TEST_ICD_PATH_VERSION_2)
-        .setup_WSI()
-        .add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain").finish());
+    env.add_icd(TEST_ICD_PATH_VERSION_2).setup_WSI().add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain"));
 
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.setup_WSI();
@@ -932,8 +927,7 @@ TEST(WsiTests, EXTSurfaceMaintenance1) {
                                                                         .add_extension("VK_KHR_swapchain")
                                                                         .set_deviceName("no")
                                                                         .set_surface_capabilities(surface_caps)
-                                                                        .add_surface_present_modes(present_modes)
-                                                                        .finish());
+                                                                        .add_surface_present_modes(present_modes));
     VkSurfacePresentScalingCapabilitiesEXT scaling_capabilities{};
     scaling_capabilities.supportedPresentScaling = VK_PRESENT_SCALING_ONE_TO_ONE_BIT_EXT;
     scaling_capabilities.supportedPresentGravityX = VK_PRESENT_SCALING_ASPECT_RATIO_STRETCH_BIT_EXT;
@@ -950,8 +944,7 @@ TEST(WsiTests, EXTSurfaceMaintenance1) {
                                              .set_deviceName("yes")
                                              .set_surface_capabilities(surface_caps)
                                              .add_surface_present_modes(present_modes)
-                                             .set_surface_present_scaling_capabilities(scaling_capabilities)
-                                             .finish());
+                                             .set_surface_present_scaling_capabilities(scaling_capabilities));
     std::vector<std::vector<VkPresentModeKHR>> compatible_present_modes{
         {VK_PRESENT_MODE_FIFO_KHR, VK_PRESENT_MODE_FIFO_RELAXED_KHR},
         {VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_MAILBOX_KHR},
@@ -965,8 +958,7 @@ TEST(WsiTests, EXTSurfaceMaintenance1) {
                                  .add_extension("VK_KHR_swapchain")
                                  .set_deviceName("no")
                                  .set_surface_capabilities(surface_caps)
-                                 .add_surface_present_modes(present_modes)
-                                 .finish());
+                                 .add_surface_present_modes(present_modes));
 
     InstWrapper inst{env.vulkan_functions};
     inst.create_info.setup_WSI();
@@ -1050,15 +1042,13 @@ TEST(WsiTests, MultiPlatformGetPhysicalDeviceSurfaceSupportKHR) {
         .setup_WSI("VK_USE_PLATFORM_XCB_KHR")
         .add_physical_device(PhysicalDevice{}
                                  .set_deviceName(xcb_device_name)
-                                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true})
-                                 .finish());
+                                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true}));
     const char* wayland_device_name = "WAYLAND";
     env.add_icd(TEST_ICD_PATH_VERSION_2)
         .setup_WSI("VK_USE_PLATFORM_WAYLAND_KHR")
         .add_physical_device(PhysicalDevice{}
                                  .set_deviceName(wayland_device_name)
-                                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true})
-                                 .finish());
+                                 .add_queue_family_properties({{VK_QUEUE_GRAPHICS_BIT, 1, 0, {1, 1, 1}}, true}));
 
     {
         // Create instance with only XCB support


### PR DESCRIPTION
The test framework was originally written with some rather limiting assumptions, such as:

* Each driver could only have 1 instance created from it at a time.
* Physical Device handles were attached to a struct defining the properties/features/extensions of that physical device, and were re-used between different instances.
* Assuming the handles passed into the driver are correct and return whatever the mock values are, not checking if they correspond to the handle passed in.
* Test_layer's fake physical devices weren't dispatchable. 

These all proved to be a problem with the attempted rewrite to not wrap physical device handles. While that rewrite is not finalized, breaking out these changes makes sure that if the rewrite fails, then these useful changes aren't lost.