### PR TITLE
loader: Log VkInstanceCreateInfo for debugging

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -500,7 +500,11 @@ static void loader_log_instance_create_info(const struct loader_instance *inst, 
                "vkCreateInstance: Requested %u instance layer(s):", pCreateInfo->enabledLayerCount);
     if (pCreateInfo->ppEnabledLayerNames) {
         for (uint32_t i = 0; i < pCreateInfo->enabledLayerCount; ++i) {
-            loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "   %s", pCreateInfo->ppEnabledLayerNames[i]);
+            if (pCreateInfo->ppEnabledLayerNames[i]) {
+                loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "   %s", pCreateInfo->ppEnabledLayerNames[i]);
+            } else {
+                loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "   <NULL>");
+            }
         }
     }
 
@@ -508,7 +512,11 @@ static void loader_log_instance_create_info(const struct loader_instance *inst, 
                "vkCreateInstance: Requested %u instance extension(s):", pCreateInfo->enabledExtensionCount);
     if (pCreateInfo->ppEnabledExtensionNames) {
         for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; ++i) {
-            loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "   %s", pCreateInfo->ppEnabledExtensionNames[i]);
+            if (pCreateInfo->ppEnabledExtensionNames[i]) {
+                loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "   %s", pCreateInfo->ppEnabledExtensionNames[i]);
+            } else {
+                loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "   <NULL>");
+            }
         }
     }
 }

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -478,6 +478,41 @@ void loader_remove_instance_only_debug_funcs(struct loader_instance *ptr_instanc
     }
 }
 
+// Dump the app's VkInstanceCreateInfo under VK_LOADER_DEBUG (names, versions, requested layers/extensions). Handy
+// for debugging instance setup and matching driver workarounds to a specific app.
+static void loader_log_instance_create_info(const struct loader_instance *inst, const VkInstanceCreateInfo *pCreateInfo) {
+    const VkApplicationInfo *app_info = pCreateInfo->pApplicationInfo;
+    const char *app_name = (app_info && app_info->pApplicationName) ? app_info->pApplicationName : "";
+    const char *engine_name = (app_info && app_info->pEngineName) ? app_info->pEngineName : "";
+    uint32_t app_version = app_info ? app_info->applicationVersion : 0;
+    uint32_t engine_version = app_info ? app_info->engineVersion : 0;
+    uint32_t api_version = app_info ? app_info->apiVersion : 0;
+
+    loader_log(inst, VULKAN_LOADER_INFO_BIT, 0,
+               "vkCreateInstance: applicationName: \"%s\", applicationVersion: %u, engineName: \"%s\", engineVersion: %u, "
+               "apiVersion: %u.%u.%u",
+               app_name, app_version, engine_name, engine_version, VK_API_VERSION_MAJOR(api_version),
+               VK_API_VERSION_MINOR(api_version), VK_API_VERSION_PATCH(api_version));
+
+    // Guard the name arrays: this runs before the loader validates pCreateInfo, so the count may be non-zero with a null
+    // array (see the null-pointer tests).
+    loader_log(inst, VULKAN_LOADER_INFO_BIT, 0,
+               "vkCreateInstance: Requested %u instance layer(s):", pCreateInfo->enabledLayerCount);
+    if (pCreateInfo->ppEnabledLayerNames) {
+        for (uint32_t i = 0; i < pCreateInfo->enabledLayerCount; ++i) {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "   %s", pCreateInfo->ppEnabledLayerNames[i]);
+        }
+    }
+
+    loader_log(inst, VULKAN_LOADER_INFO_BIT, 0,
+               "vkCreateInstance: Requested %u instance extension(s):", pCreateInfo->enabledExtensionCount);
+    if (pCreateInfo->ppEnabledExtensionNames) {
+        for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; ++i) {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "   %s", pCreateInfo->ppEnabledExtensionNames[i]);
+        }
+    }
+}
+
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo,
                                                               const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) {
     struct loader_instance *ptr_instance = NULL;
@@ -542,6 +577,8 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
         // Failure of setting up one or more of the callback.
         goto out;
     }
+
+    loader_log_instance_create_info(ptr_instance, pCreateInfo);
 
     VkResult settings_file_res = get_loader_settings(ptr_instance, &ptr_instance->settings);
     if (settings_file_res == VK_ERROR_OUT_OF_HOST_MEMORY) {

--- a/tests/loader_debug_ext_tests.cpp
+++ b/tests/loader_debug_ext_tests.cpp
@@ -154,7 +154,7 @@ TEST_F(CreateDestroyInstanceReport, WarnInCreateIgnored) {
     expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
     expected_flag = VK_DEBUG_REPORT_WARNING_BIT_EXT;
 
-    VkApplicationInfo app_info;
+    VkApplicationInfo app_info{};
     app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
     VkInstance inst = VK_NULL_HANDLE;
     ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_ERROR_BIT_EXT, &inst, &app_info));
@@ -170,7 +170,7 @@ TEST_F(CreateDestroyInstanceReport, WarnInCreate) {
     expected_object_type = VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
     expected_flag = VK_DEBUG_REPORT_WARNING_BIT_EXT;
 
-    VkApplicationInfo app_info;
+    VkApplicationInfo app_info{};
     app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
     VkInstance inst = VK_NULL_HANDLE;
     ASSERT_EQ(VK_SUCCESS, CreateReportInstance(VK_DEBUG_REPORT_WARNING_BIT_EXT, &inst, &app_info));
@@ -498,7 +498,7 @@ TEST_F(CreateDestroyInstanceMessenger, WarnInCreateIgnored) {
     expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
     expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
 
-    VkApplicationInfo app_info;
+    VkApplicationInfo app_info{};
     app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
 
     VkInstance inst = VK_NULL_HANDLE;
@@ -516,7 +516,7 @@ TEST_F(CreateDestroyInstanceMessenger, WarnInCreate) {
     expected_message_flags = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
     expected_severity_flags = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
 
-    VkApplicationInfo app_info;
+    VkApplicationInfo app_info{};
     app_info.apiVersion = VK_MAKE_API_VERSION(1, 1, 0, 0);
 
     VkInstance inst = VK_NULL_HANDLE;

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -142,6 +142,27 @@ TEST(CreateInstance, ApiVersionBelow1_0) {
                        "greater than or equal to the value of VK_API_VERSION_1_0 [VUID-VkApplicationInfo-apiVersion]"));
 }
 
+// The loader should log the application's VkInstanceCreateInfo so it shows up under VK_LOADER_DEBUG. See #1819.
+TEST(CreateInstance, LogsInstanceCreateInfo) {
+    FrameworkEnvironment env{};
+    env.add_icd(TEST_ICD_PATH_VERSION_2);
+
+    DebugUtilsLogger debug_log{VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT};
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.set_app_name("MyTestApp")
+        .set_app_version(42)
+        .set_engine_name("MyTestEngine")
+        .set_engine_version(7)
+        .set_api_version(1, 2, 0);
+    FillDebugUtilsCreateDetails(inst.create_info, debug_log);
+    inst.CheckCreate();
+
+    ASSERT_TRUE(debug_log.find("applicationName: \"MyTestApp\", applicationVersion: 42"));
+    ASSERT_TRUE(debug_log.find("engineName: \"MyTestEngine\", engineVersion: 7, apiVersion: 1.2.0"));
+    // FillDebugUtilsCreateDetails enables VK_EXT_debug_utils, so it should appear in the requested-extensions dump.
+    ASSERT_TRUE(debug_log.find("VK_EXT_debug_utils"));
+}
+
 TEST(CreateInstance, ConsecutiveCreate) {
     FrameworkEnvironment env{};
     env.add_icd(TEST_ICD_PATH_VERSION_2);


### PR DESCRIPTION
Closes #1819.

vkCreateInstance now logs the application's VkApplicationInfo (app and engine name/version, apiVersion) plus the requested instance layers and extensions at info level, so they show up under VK_LOADER_DEBUG. Useful for debugging instance setup and for matching driver workarounds to a specific app.

Example:
```
vkCreateInstance: applicationName: "MyApp", applicationVersion: 42, engineName: "MyEngine", engineVersion: 7, apiVersion: 1.2.0
vkCreateInstance: Requested 1 instance layer(s):
   VK_LAYER_KHRONOS_validation
vkCreateInstance: Requested 1 instance extension(s):
   VK_EXT_debug_utils
```

Added a regression test covering the dump.