### PR TITLE
size string copies by str_len in copy_str_to_string_list

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -355,11 +355,11 @@ VkResult prepend_str_to_string_list(const struct loader_instance *inst, struct l
 VkResult copy_str_to_string_list(const struct loader_instance *inst, struct loader_string_list *string_list, const char *str,
                                  size_t str_len) {
     assert(string_list && str);
-    char *new_str = loader_instance_heap_calloc(inst, sizeof(char *) * str_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+    char *new_str = loader_instance_heap_calloc(inst, str_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
     if (NULL == new_str) {
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
-    loader_strncpy(new_str, sizeof(char *) * str_len + 1, str, str_len);
+    loader_strncpy(new_str, str_len + 1, str, str_len);
     new_str[str_len] = '\0';
     return append_str_to_string_list(inst, string_list, new_str);
 }
@@ -367,11 +367,11 @@ VkResult copy_str_to_string_list(const struct loader_instance *inst, struct load
 VkResult copy_str_to_start_of_string_list(const struct loader_instance *inst, struct loader_string_list *string_list,
                                           const char *str, size_t str_len) {
     assert(string_list && str);
-    char *new_str = loader_instance_heap_calloc(inst, sizeof(char *) * str_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+    char *new_str = loader_instance_heap_calloc(inst, str_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
     if (NULL == new_str) {
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
-    loader_strncpy(new_str, sizeof(char *) * str_len + 1, str, str_len);
+    loader_strncpy(new_str, str_len + 1, str, str_len);
     new_str[str_len] = '\0';
     return prepend_str_to_string_list(inst, string_list, new_str);
 }


### PR DESCRIPTION
copy_str_to_string_list / copy_str_to_start_of_string_list, sizing a 57-byte manifest path:

    sizeof(char *) * str_len + 1  ->  8 * 57 + 1 = 457 bytes to hold a 58-byte string

str_len is the length of one string, not a count of pointers. The sizeof(char *) factor belongs to create_string_list right above, which allocates the char* array, and got copied into these two char-buffer allocations. Every manifest path and enabled layer name copied through them lands in a buffer about eight times larger than needed. The loader_strncpy bound uses the same inflated size, so nothing overflows, it just over-allocates.

Spotted while reading the string-list helpers next to create_string_list. Size both buffers by str_len + 1 to match the element.