### PR TITLE
Use string lists for manifest search paths

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -284,6 +284,16 @@ VkResult loader_init_library_list(struct loader_layer_list *instance_layers, loa
     return VK_SUCCESS;
 }
 
+bool is_string_in_string_list(struct loader_string_list *string_list, const char *str) {
+    // Remove duplicate paths, or it would result in duplicate extensions, duplicate devices, etc.
+    for (size_t i = 0; i < string_list->count; i++) {
+        if (strcmp(string_list->list[i], str) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 VkResult loader_copy_to_new_str(const struct loader_instance *inst, const char *source_str, char **dest_str) {
     assert(source_str && dest_str);
     size_t str_len = strlen(source_str) + 1;
@@ -338,6 +348,16 @@ VkResult append_str_to_string_list(const struct loader_instance *inst, struct lo
     return VK_SUCCESS;
 }
 
+VkResult append_str_to_string_list_if_unique(const struct loader_instance *inst, struct loader_string_list *string_list,
+                                             char *str) {
+    if (is_string_in_string_list(string_list, str)) {
+        // Since this string is a duplicate and this function takes ownership, we need to free it.
+        loader_instance_heap_free(inst, str);
+        return VK_SUCCESS;
+    }
+    return append_str_to_string_list(inst, string_list, str);
+}
+
 VkResult prepend_str_to_string_list(const struct loader_instance *inst, struct loader_string_list *string_list, char *str) {
     assert(string_list && str);
     VkResult res = increase_str_capacity_by_at_least_one(inst, string_list);
@@ -362,6 +382,14 @@ VkResult copy_str_to_string_list(const struct loader_instance *inst, struct load
     loader_strncpy(new_str, str_len + 1, str, str_len);
     new_str[str_len] = '\0';
     return append_str_to_string_list(inst, string_list, new_str);
+}
+
+VkResult copy_str_to_string_list_if_unique(const struct loader_instance *inst, struct loader_string_list *string_list,
+                                           const char *str, size_t str_len) {
+    if (is_string_in_string_list(string_list, str)) {
+        return VK_SUCCESS;
+    }
+    return copy_str_to_string_list(inst, string_list, str, str_len);
 }
 
 VkResult copy_str_to_start_of_string_list(const struct loader_instance *inst, struct loader_string_list *string_list,
@@ -3258,30 +3286,11 @@ out:
     return result;
 }
 
-size_t determine_data_file_path_size(const char *cur_path, size_t relative_path_size) {
-    size_t path_size = 0;
-
-    if (NULL != cur_path) {
-        // For each folder in cur_path, (detected by finding additional
-        // path separators in the string) we need to add the relative path on
-        // the end.  Plus, leave an additional two slots on the end to add an
-        // additional directory slash and path separator if needed
-        path_size += strlen(cur_path) + relative_path_size + 2;
-        for (const char *x = cur_path; *x; ++x) {
-            if (*x == PATH_SEPARATOR) {
-                path_size += relative_path_size + 2;
-            }
-        }
-    }
-
-    return path_size;
-}
-
-void copy_data_file_info(const char *cur_path, const char *relative_path, size_t relative_path_size, char **output_path) {
+VkResult copy_data_file_info(const struct loader_instance *inst, const char *cur_path, const char *relative_path,
+                             size_t relative_path_size, struct loader_string_list *search_paths) {
     if (NULL != cur_path) {
         uint32_t start = 0;
         uint32_t stop = 0;
-        char *cur_write = *output_path;
 
         while (cur_path[start] != '\0') {
             while (cur_path[start] == PATH_SEPARATOR && cur_path[start] != '\0') {
@@ -3293,29 +3302,41 @@ void copy_data_file_info(const char *cur_path, const char *relative_path, size_t
             }
             const size_t s = stop - start;
             if (s) {
-                memcpy(cur_write, &cur_path[start], s);
-                cur_write += s;
+                // space enough for base path, relative path, path separator, and null terminator
+                size_t new_str_len = s + relative_path_size + 2;
+
+                char *new_str = loader_instance_heap_calloc(inst, new_str_len, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+                if (NULL == new_str) {
+                    return VK_ERROR_OUT_OF_HOST_MEMORY;
+                }
+                memcpy(new_str, &cur_path[start], s);
+                new_str[s] = '\0';
 
                 // If this is a specific JSON file, just add it and don't add any
                 // relative path or directory symbol to it.
-                if (!is_json(cur_write - s, s)) {
+                if (!is_json(new_str, s)) {
                     // Add the relative directory if present.
                     if (relative_path_size > 0) {
+                        char *rel_start = new_str + s;
+
                         // If last symbol written was not a directory symbol, add it.
-                        if (*(cur_write - 1) != DIRECTORY_SYMBOL) {
-                            *cur_write++ = DIRECTORY_SYMBOL;
+                        if (*(rel_start - 1) != DIRECTORY_SYMBOL) {
+                            *rel_start++ = DIRECTORY_SYMBOL;
                         }
-                        memcpy(cur_write, relative_path, relative_path_size);
-                        cur_write += relative_path_size;
+                        memcpy(rel_start, relative_path, relative_path_size);
+                        rel_start[relative_path_size] = '\0';
                     }
                 }
 
-                *cur_write++ = PATH_SEPARATOR;
+                VkResult res = append_str_to_string_list_if_unique(inst, search_paths, new_str);
+                if (VK_SUCCESS != res) {
+                    return res;
+                }
                 start = stop;
             }
         }
-        *output_path = cur_write;
     }
+    return VK_SUCCESS;
 }
 
 // If the file found is a manifest file name, add it to the end of out_files manifest list.
@@ -3348,77 +3369,47 @@ VkResult prepend_if_manifest_file(const struct loader_instance *inst, const char
     return copy_str_to_start_of_string_list(inst, out_files, file_name, name_len);
 }
 
-// Add any files found in the search_path.  If any path in the search path points to a specific JSON, attempt to
-// only open that one JSON.  Otherwise, if the path is a folder, search the folder for JSON files.
-VkResult add_data_files(const struct loader_instance *inst, char *search_path, struct loader_string_list *out_files) {
+// Iterate all strings in search_paths and add any files found.  If any path in the search path points to a specific JSON, attempt
+// to only open that one JSON.  Otherwise, if the path is a folder, search the folder for JSON files.
+VkResult add_data_files(const struct loader_instance *inst, struct loader_string_list *search_paths,
+                        struct loader_string_list *out_files) {
     VkResult vk_result = VK_SUCCESS;
     char full_path[2048];
 #if !defined(_WIN32)
     char temp_path[2048];
 #endif
 
-    // Now, parse the paths
-    char *next_file = search_path;
-    while (NULL != next_file && *next_file != '\0') {
-        char *name = NULL;
-        char *cur_file = next_file;
-        next_file = loader_get_next_path(cur_file);
+    for (size_t i = 0; i < search_paths->count; i++) {
+        // Now, parse the paths
+        char *next_file = search_paths->list[i];
+        while (NULL != next_file && *next_file != '\0') {
+            char *name = NULL;
+            char *cur_file = next_file;
+            next_file = loader_get_next_path(cur_file);
 
-        // Is this a JSON file, then try to open it.
-        size_t len = strlen(cur_file);
-        if (is_json(cur_file, len)) {
+            // Is this a JSON file, then try to open it.
+            size_t len = strlen(cur_file);
+            if (is_json(cur_file, len)) {
 #if defined(_WIN32)
-            name = cur_file;
+                name = cur_file;
 #elif COMMON_UNIX_PLATFORMS
-            // Only Linux has relative paths, make a copy of location so it isn't modified
-            size_t str_len;
-            if (NULL != next_file) {
-                str_len = next_file - cur_file + 1;
-            } else {
-                str_len = strlen(cur_file) + 1;
-            }
-            if (str_len > sizeof(temp_path)) {
-                loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "add_data_files: Path to %s too long", cur_file);
-                continue;
-            }
-            strncpy(temp_path, cur_file, str_len);
-            name = temp_path;
+                // Only Linux has relative paths, make a copy of location so it isn't modified
+                size_t str_len;
+                if (NULL != next_file) {
+                    str_len = next_file - cur_file + 1;
+                } else {
+                    str_len = strlen(cur_file) + 1;
+                }
+                if (str_len > sizeof(temp_path)) {
+                    loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0, "add_data_files: Path to %s too long", cur_file);
+                    continue;
+                }
+                strncpy(temp_path, cur_file, str_len);
+                name = temp_path;
 #else
 #warning add_data_files must define relative path copy for this platform
 #endif
-            loader_get_fullpath(cur_file, name, sizeof(full_path), full_path);
-            name = full_path;
-
-            VkResult local_res;
-            local_res = add_if_manifest_file(inst, name, out_files);
-
-            // Incomplete means this was not a valid data file.
-            if (local_res == VK_INCOMPLETE) {
-                continue;
-            } else if (local_res != VK_SUCCESS) {
-                vk_result = local_res;
-                break;
-            }
-        } else {  // Otherwise, treat it as a directory
-            DIR *dir_stream = loader_opendir(inst, cur_file);
-            if (NULL == dir_stream) {
-                continue;
-            }
-            while (1) {
-                errno = 0;
-                struct dirent *dir_entry = readdir(dir_stream);
-#if !defined(WIN32)  // Windows doesn't use readdir, don't check errors on functions which aren't called
-                if (errno != 0) {
-                    loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "readdir failed with %d: %s", errno, strerror(errno));
-                    break;
-                }
-#endif
-                if (NULL == dir_entry) {
-                    break;
-                }
-
-                name = &(dir_entry->d_name[0]);
-                loader_get_fullpath(name, cur_file, sizeof(full_path), full_path);
+                loader_get_fullpath(cur_file, name, sizeof(full_path), full_path);
                 name = full_path;
 
                 VkResult local_res;
@@ -3431,10 +3422,43 @@ VkResult add_data_files(const struct loader_instance *inst, char *search_path, s
                     vk_result = local_res;
                     break;
                 }
-            }
-            loader_closedir(inst, dir_stream);
-            if (vk_result != VK_SUCCESS) {
-                goto out;
+            } else {  // Otherwise, treat it as a directory
+                DIR *dir_stream = loader_opendir(inst, cur_file);
+                if (NULL == dir_stream) {
+                    continue;
+                }
+                while (1) {
+                    errno = 0;
+                    struct dirent *dir_entry = readdir(dir_stream);
+#if !defined(WIN32)  // Windows doesn't use readdir, don't check errors on functions which aren't called
+                    if (errno != 0) {
+                        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "readdir failed with %d: %s", errno, strerror(errno));
+                        break;
+                    }
+#endif
+                    if (NULL == dir_entry) {
+                        break;
+                    }
+
+                    name = &(dir_entry->d_name[0]);
+                    loader_get_fullpath(name, cur_file, sizeof(full_path), full_path);
+                    name = full_path;
+
+                    VkResult local_res;
+                    local_res = add_if_manifest_file(inst, name, out_files);
+
+                    // Incomplete means this was not a valid data file.
+                    if (local_res == VK_INCOMPLETE) {
+                        continue;
+                    } else if (local_res != VK_SUCCESS) {
+                        vk_result = local_res;
+                        break;
+                    }
+                }
+                loader_closedir(inst, dir_stream);
+                if (vk_result != VK_SUCCESS) {
+                    goto out;
+                }
             }
         }
     }
@@ -3447,17 +3471,20 @@ out:
 // Look for data files in the provided paths, but first check the environment override to determine if we should use that
 // instead.
 VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enum loader_data_files_type manifest_type,
-                                         const char *path_override, bool *override_active, struct loader_string_list *out_files) {
+                                         const struct loader_string_list *path_overrides, bool *override_active,
+                                         struct loader_string_list *out_files) {
     VkResult vk_result = VK_SUCCESS;
     char *override_env = NULL;
-    const char *override_path = NULL;
     char *additional_env = NULL;
-    size_t search_path_size = 0;
-    char *search_path = NULL;
-    char *cur_path_ptr = NULL;
+    struct loader_string_list search_paths = {0};
+
 #if COMMON_UNIX_PLATFORMS
     const char *relative_location = NULL;  // Only used on unix platforms
     size_t rel_size = 0;                   // unused in windows, dont declare so no compiler warnings are generated
+#endif
+
+#if defined(__APPLE__)
+    char *bundle_path = NULL;
 #endif
 
 #if defined(_WIN32)
@@ -3570,95 +3597,64 @@ VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enu
     }
 
     // Log a message when VK_LAYER_PATH is set but the override layer paths take priority
-    if (manifest_type == LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER && NULL != override_env && NULL != path_override) {
+    if (manifest_type == LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER &&
+        (NULL != override_env || (NULL != path_overrides && path_overrides->count > 0))) {
         loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_LAYER_BIT, 0,
                    "Ignoring VK_LAYER_PATH. The Override layer is active and has override paths set, which takes priority. "
                    "VK_LAYER_PATH is set to %s",
                    override_env);
     }
 
-    if (path_override != NULL) {
-        override_path = path_override;
+    // Add the remaining paths to the list
+    if (NULL != path_overrides && path_overrides->count > 0) {
+        // Log a message when VK_LAYER_PATH is set but the override layer paths take priority
+        if (manifest_type == LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER) {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_LAYER_BIT, 0,
+                       "Ignoring VK_LAYER_PATH. The Override layer is active and has override paths set, which takes priority. "
+                       "VK_LAYER_PATH is:");
+        }
+        for (size_t i = 0; i < path_overrides->count; i++) {
+            if (NULL != path_overrides->list[i]) {
+                if (manifest_type == LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER) {
+                    loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_LAYER_BIT, 0, "%s", path_overrides->list[i]);
+                }
+                vk_result = copy_data_file_info(inst, path_overrides->list[i], NULL, 0, &search_paths);
+                if (vk_result == VK_ERROR_OUT_OF_HOST_MEMORY) {
+                    goto out;
+                }
+            }
+        }
     } else if (override_env != NULL) {
-        override_path = override_env;
-    }
-
-    // Add two by default for NULL terminator and one path separator on end (just in case)
-    search_path_size = 2;
-
-    // If there's an override, use that (and the local folder if required) and nothing else
-    if (NULL != override_path) {
-        // Local folder and null terminator
-        search_path_size += strlen(override_path) + 2;
-    } else {
-        // Add the size of any additional search paths defined in the additive environment variable
-        if (NULL != additional_env) {
-            search_path_size += determine_data_file_path_size(additional_env, 0) + 2;
-#if defined(_WIN32)
+        // Log a message when VK_LAYER_PATH is set but the override layer paths take priority
+        if (manifest_type == LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER) {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_LAYER_BIT, 0,
+                       "Ignoring VK_LAYER_PATH. The Override layer is active and has override paths set, which takes priority. "
+                       "VK_LAYER_PATH is set to %s",
+                       override_env);
         }
-        if (NULL != package_path) {
-            search_path_size += determine_data_file_path_size(package_path, 0) + 2;
-        }
-        if (search_path_size == 2) {
+
+        vk_result = copy_data_file_info(inst, override_env, NULL, 0, &search_paths);
+        if (vk_result == VK_ERROR_OUT_OF_HOST_MEMORY) {
             goto out;
         }
-#elif COMMON_UNIX_PLATFORMS
-        }
-
-        // Add the general search folders (with the appropriate relative folder added)
-        rel_size = strlen(relative_location);
-        if (rel_size > 0) {
-#if defined(__APPLE__)
-            search_path_size += MAXPATHLEN;
-#endif
-            // Only add the home folders if defined
-            if (NULL != home_config_dir) {
-                search_path_size += determine_data_file_path_size(home_config_dir, rel_size);
-            }
-            search_path_size += determine_data_file_path_size(xdg_config_dirs, rel_size);
-            search_path_size += determine_data_file_path_size(SYSCONFDIR, rel_size);
-#if defined(EXTRASYSCONFDIR)
-            search_path_size += determine_data_file_path_size(EXTRASYSCONFDIR, rel_size);
-#endif
-            // Only add the home folders if defined
-            if (NULL != home_data_dir) {
-                search_path_size += determine_data_file_path_size(home_data_dir, rel_size);
-            }
-            search_path_size += determine_data_file_path_size(xdg_data_dirs, rel_size);
-        }
-#else
-#warning read_data_files_in_search_paths unsupported platform
-#endif
-    }
-
-    // Allocate the required space
-    search_path = loader_instance_heap_calloc(inst, search_path_size, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-    if (NULL == search_path) {
-        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "read_data_files_in_search_paths: Failed to allocate space for search path of length %d",
-                   (uint32_t)search_path_size);
-        vk_result = VK_ERROR_OUT_OF_HOST_MEMORY;
-        goto out;
-    }
-
-    cur_path_ptr = search_path;
-
-    // Add the remaining paths to the list
-    if (NULL != override_path) {
-        size_t override_path_len = strlen(override_path);
-        loader_strncpy(cur_path_ptr, search_path_size, override_path, override_path_len);
-        cur_path_ptr += override_path_len;
     } else {
         // Add any additional search paths defined in the additive environment variable
         if (NULL != additional_env) {
-            copy_data_file_info(additional_env, NULL, 0, &cur_path_ptr);
+            vk_result = copy_data_file_info(inst, additional_env, NULL, 0, &search_paths);
+            if (vk_result == VK_ERROR_OUT_OF_HOST_MEMORY) {
+                goto out;
+            }
         }
 
 #if defined(_WIN32)
         if (NULL != package_path) {
-            copy_data_file_info(package_path, NULL, 0, &cur_path_ptr);
+            vk_result = copy_data_file_info(inst, package_path, NULL, 0, &search_paths);
+            if (vk_result == VK_ERROR_OUT_OF_HOST_MEMORY) {
+                goto out;
+            }
         }
 #elif COMMON_UNIX_PLATFORMS
+        rel_size = strlen(relative_location);
         if (rel_size > 0) {
 #if defined(__APPLE__)
             // Add the bundle's Resources dir to the beginning of the search path.
@@ -3669,12 +3665,49 @@ VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enu
             if (NULL != main_bundle) {
                 CFURLRef ref = CFBundleCopyResourcesDirectoryURL(main_bundle);
                 if (NULL != ref) {
-                    if (CFURLGetFileSystemRepresentation(ref, TRUE, (UInt8 *)cur_path_ptr, search_path_size)) {
-                        cur_path_ptr += strlen(cur_path_ptr);
-                        *cur_path_ptr++ = DIRECTORY_SYMBOL;
-                        memcpy(cur_path_ptr, relative_location, rel_size);
-                        cur_path_ptr += rel_size;
-                        *cur_path_ptr++ = PATH_SEPARATOR;
+                    // Allocate large scratch buffer to hold the bundles path, the relative location inside the bundle, plus a path
+                    // separator and null terminator. Since we are using a while loop, initialize length with half the intended size
+                    size_t bundle_path_len = (MAXPATHLEN + rel_size + 2) / 2;
+                    bool bundle_query_success = false;
+                    uint32_t retry_count = 0;
+                    while (!bundle_query_success && retry_count < 4) {
+                        void *new_bundle_path = loader_instance_heap_realloc(
+                            inst, bundle_path, bundle_path_len, bundle_path_len * 2, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
+                        if (NULL == new_bundle_path) {
+                            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+                                       "read_data_files_in_search_paths: Failed to allocate space for bundle path of length %d",
+                                       (uint32_t)bundle_path_len * 2);
+                            vk_result = VK_ERROR_OUT_OF_HOST_MEMORY;
+                            goto out;
+                        }
+                        bundle_path = new_bundle_path;
+                        bundle_path_len = bundle_path_len * 2;
+                        memset(bundle_path, 0, bundle_path_len);
+                        bundle_query_success = CFURLGetFileSystemRepresentation(ref, TRUE, (UInt8 *)bundle_path, bundle_path_len);
+                        retry_count++;
+                    }
+
+                    if (bundle_query_success) {
+                        size_t cur_bundle_len = strlen(bundle_path);
+
+                        if (cur_bundle_len + rel_size + 2 > bundle_path_len) {
+                            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
+                                       "read_data_files_in_search_paths: bundle_path %s of size %d does not have enough space to "
+                                       "append relative_path",
+                                       bundle_path, (uint32_t)bundle_path_len);
+                            vk_result = VK_ERROR_INITIALIZATION_FAILED;
+                            goto out;
+                        }
+                        bundle_path[cur_bundle_len] = DIRECTORY_SYMBOL;
+                        cur_bundle_len++;
+                        memcpy(bundle_path + cur_bundle_len, relative_location, rel_size);
+                        cur_bundle_len += rel_size;
+                        bundle_path[cur_bundle_len] = '\0';
+
+                        vk_result = copy_data_file_info(inst, bundle_path, NULL, 0, &search_paths);
+                        if (vk_result == VK_ERROR_OUT_OF_HOST_MEMORY) {
+                            goto out;
+                        }
                     }
                     CFRelease(ref);
                 }
@@ -3683,93 +3716,62 @@ VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enu
 
             // Only add the home folders if not NULL
             if (NULL != home_config_dir) {
-                copy_data_file_info(home_config_dir, relative_location, rel_size, &cur_path_ptr);
+                vk_result = copy_data_file_info(inst, home_config_dir, relative_location, rel_size, &search_paths);
+                if (VK_SUCCESS != vk_result) {
+                    goto out;
+                }
             }
-            copy_data_file_info(xdg_config_dirs, relative_location, rel_size, &cur_path_ptr);
-            copy_data_file_info(SYSCONFDIR, relative_location, rel_size, &cur_path_ptr);
+            vk_result = copy_data_file_info(inst, xdg_config_dirs, relative_location, rel_size, &search_paths);
+            if (VK_SUCCESS != vk_result) {
+                goto out;
+            }
+            vk_result = copy_data_file_info(inst, SYSCONFDIR, relative_location, rel_size, &search_paths);
+            if (VK_SUCCESS != vk_result) {
+                goto out;
+            }
 #if defined(EXTRASYSCONFDIR)
-            copy_data_file_info(EXTRASYSCONFDIR, relative_location, rel_size, &cur_path_ptr);
+            vk_result = copy_data_file_info(inst, EXTRASYSCONFDIR, relative_location, rel_size, &search_paths);
+            if (VK_SUCCESS != vk_result) {
+                goto out;
+            }
 #endif
 
             // Only add the home folders if not NULL
             if (NULL != home_data_dir) {
-                copy_data_file_info(home_data_dir, relative_location, rel_size, &cur_path_ptr);
+                vk_result = copy_data_file_info(inst, home_data_dir, relative_location, rel_size, &search_paths);
+                if (VK_SUCCESS != vk_result) {
+                    goto out;
+                }
             }
-            copy_data_file_info(xdg_data_dirs, relative_location, rel_size, &cur_path_ptr);
+            vk_result = copy_data_file_info(inst, xdg_data_dirs, relative_location, rel_size, &search_paths);
+            if (VK_SUCCESS != vk_result) {
+                goto out;
+            }
         }
-
-        // Remove the last path separator
-        --cur_path_ptr;
-
-        assert(cur_path_ptr - search_path < (ptrdiff_t)search_path_size);
-        *cur_path_ptr = '\0';
 #else
 #warning read_data_files_in_search_paths unsupported platform
 #endif
     }
 
-    // Remove duplicate paths, or it would result in duplicate extensions, duplicate devices, etc.
-    // This uses minimal memory, but is O(N^2) on the number of paths. Expect only a few paths.
-    char path_sep_str[2] = {PATH_SEPARATOR, '\0'};
-    size_t search_path_updated_size = strlen(search_path);
-    for (size_t first = 0; first < search_path_updated_size;) {
-        // If this is an empty path, erase it
-        if (search_path[first] == PATH_SEPARATOR) {
-            memmove(&search_path[first], &search_path[first + 1], search_path_updated_size - first + 1);
-            search_path_updated_size -= 1;
-            continue;
-        }
-
-        size_t first_end = first + 1;
-        first_end += strcspn(&search_path[first_end], path_sep_str);
-        for (size_t second = first_end + 1; second < search_path_updated_size;) {
-            size_t second_end = second + 1;
-            second_end += strcspn(&search_path[second_end], path_sep_str);
-            if (first_end - first == second_end - second &&
-                !strncmp(&search_path[first], &search_path[second], second_end - second)) {
-                // Found duplicate. Include PATH_SEPARATOR in second_end, then erase it from search_path.
-                if (search_path[second_end] == PATH_SEPARATOR) {
-                    second_end++;
-                }
-                memmove(&search_path[second], &search_path[second_end], search_path_updated_size - second_end + 1);
-                search_path_updated_size -= second_end - second;
-            } else {
-                second = second_end + 1;
-            }
-        }
-        first = first_end + 1;
-    }
-    search_path_size = search_path_updated_size;
-
     // Print out the paths being searched if debugging is enabled
     uint32_t log_flags = 0;
-    if (search_path_size > 0) {
-        char *tmp_search_path = loader_instance_heap_alloc(inst, search_path_size + 1, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-        if (NULL != tmp_search_path) {
-            loader_strncpy(tmp_search_path, search_path_size + 1, search_path, search_path_size);
-            tmp_search_path[search_path_size] = '\0';
-            if (manifest_type == LOADER_DATA_FILE_MANIFEST_DRIVER) {
-                log_flags = VULKAN_LOADER_DRIVER_BIT;
-                loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "Searching for driver manifest files");
-            } else {
-                log_flags = VULKAN_LOADER_LAYER_BIT;
-                loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "Searching for %s layer manifest files",
-                           manifest_type == LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER ? "explicit" : "implicit");
-            }
-            loader_log(inst, log_flags, 0, "   In following locations:");
-            char *cur_file;
-            char *next_file = tmp_search_path;
-            while (NULL != next_file && *next_file != '\0') {
-                cur_file = next_file;
-                next_file = loader_get_next_path(cur_file);
-                loader_log(inst, log_flags, 0, "      %s", cur_file);
-            }
-            loader_instance_heap_free(inst, tmp_search_path);
-        }
+
+    if (manifest_type == LOADER_DATA_FILE_MANIFEST_DRIVER) {
+        log_flags = VULKAN_LOADER_DRIVER_BIT;
+        loader_log(inst, VULKAN_LOADER_DRIVER_BIT, 0, "Searching for driver manifest files");
+    } else {
+        log_flags = VULKAN_LOADER_LAYER_BIT;
+        loader_log(inst, VULKAN_LOADER_LAYER_BIT, 0, "Searching for %s layer manifest files",
+                   manifest_type == LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER ? "explicit" : "implicit");
+    }
+    loader_log(inst, log_flags, 0, "   In following locations:");
+
+    for (size_t i = 0; i < search_paths.count; i++) {
+        loader_log(inst, log_flags, 0, "      %s", search_paths.list[i]);
     }
 
     // Now, parse the paths and add any manifest files found in them.
-    vk_result = add_data_files(inst, search_path, out_files);
+    vk_result = add_data_files(inst, &search_paths, out_files);
 
     if (log_flags != 0 && out_files->count > 0) {
         loader_log(inst, log_flags, 0, "   Found the following files:");
@@ -3780,7 +3782,7 @@ VkResult read_data_files_in_search_paths(const struct loader_instance *inst, enu
         loader_log(inst, log_flags, 0, "   Found no files");
     }
 
-    if (NULL != override_path) {
+    if ((NULL != path_overrides && path_overrides->count > 0) || NULL != override_env) {
         *override_active = true;
     } else {
         *override_active = false;
@@ -3793,6 +3795,9 @@ out:
 #if defined(_WIN32)
     loader_instance_heap_free(inst, package_path);
 #elif COMMON_UNIX_PLATFORMS
+#if defined(__APPLE__)
+    loader_instance_heap_free(inst, bundle_path);
+#endif
     loader_free_getenv(xdg_config_home, inst);
     loader_free_getenv(xdg_config_dirs, inst);
     loader_free_getenv(xdg_data_home, inst);
@@ -3805,7 +3810,7 @@ out:
 #warning read_data_files_in_search_paths unsupported platform
 #endif
 
-    loader_instance_heap_free(inst, search_path);
+    free_string_list(inst, &search_paths);
 
     return vk_result;
 }
@@ -3834,14 +3839,14 @@ out:
 // Linux Layer| dirs     | dirs
 
 VkResult loader_get_data_files(const struct loader_instance *inst, enum loader_data_files_type manifest_type,
-                               const char *path_override, struct loader_string_list *out_files) {
+                               const struct loader_string_list *path_overrides, struct loader_string_list *out_files) {
     VkResult res = VK_SUCCESS;
     bool override_active = false;
 
     // Free and init the out_files information so there's no false data left from uninitialized variables.
     free_string_list(inst, out_files);
 
-    res = read_data_files_in_search_paths(inst, manifest_type, path_override, &override_active, out_files);
+    res = read_data_files_in_search_paths(inst, manifest_type, path_overrides, &override_active, out_files);
     if (VK_SUCCESS != res) {
         goto out;
     }
@@ -4193,12 +4198,12 @@ out:
 // into instance_layers
 // Manifest type must be either implicit or explicit
 VkResult loader_parse_instance_layers(struct loader_instance *inst, enum loader_data_files_type manifest_type,
-                                      const char *path_override, struct loader_layer_list *instance_layers) {
+                                      const struct loader_string_list *path_overrides, struct loader_layer_list *instance_layers) {
     assert(manifest_type == LOADER_DATA_FILE_MANIFEST_IMPLICIT_LAYER || manifest_type == LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER);
     VkResult res = VK_SUCCESS;
     struct loader_string_list manifest_files = {0};
 
-    res = loader_get_data_files(inst, manifest_type, path_override, &manifest_files);
+    res = loader_get_data_files(inst, manifest_type, path_overrides, &manifest_files);
     if (VK_SUCCESS != res) {
         goto out;
     }
@@ -4238,31 +4243,16 @@ out:
 // Given a loader_layer_properties struct that is a valid override layer, concatenate the properties override paths and put them
 // into the output parameter override_paths
 VkResult get_override_layer_override_paths(struct loader_instance *inst, struct loader_layer_properties *prop,
-                                           char **override_paths) {
+                                           struct loader_string_list *override_paths) {
     if (prop->override_paths.count > 0) {
-        char *cur_write_ptr = NULL;
-        size_t override_path_size = 0;
         for (uint32_t j = 0; j < prop->override_paths.count; j++) {
-            override_path_size += determine_data_file_path_size(prop->override_paths.list[j], 0);
+            VkResult result = copy_data_file_info(inst, prop->override_paths.list[j], NULL, 0, override_paths);
+            if (VK_SUCCESS != result) {
+                return result;
+            }
+            loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0, "Override layer has override path %s",
+                       prop->override_paths.list[j]);
         }
-        *override_paths = loader_instance_heap_alloc(inst, override_path_size, VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-        if (*override_paths == NULL) {
-            return VK_ERROR_OUT_OF_HOST_MEMORY;
-        }
-        cur_write_ptr = &(*override_paths)[0];
-        for (uint32_t j = 0; j < prop->override_paths.count; j++) {
-            copy_data_file_info(prop->override_paths.list[j], NULL, 0, &cur_write_ptr);
-        }
-
-        // Subtract one from cur_write_ptr only if something was written so we can set the null terminator
-        if (*override_paths < cur_write_ptr) {
-            --cur_write_ptr;
-            assert(cur_write_ptr - (*override_paths) < (ptrdiff_t)override_path_size);
-        }
-        // Remove the last path separator
-        *cur_write_ptr = '\0';
-        loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0, "Override layer has override paths set to %s",
-                   *override_paths);
     }
     return VK_SUCCESS;
 }
@@ -4294,7 +4284,7 @@ VkResult loader_scan_for_layers(struct loader_instance *inst, struct loader_laye
     struct loader_layer_list settings_layers = {0};
     struct loader_layer_list regular_instance_layers = {0};
     bool override_layer_valid = false;
-    char *override_paths = NULL;
+    struct loader_string_list override_paths = {0};
 
     bool should_search_for_other_layers = true;
     res = get_settings_layers(inst, &settings_layers, &should_search_for_other_layers);
@@ -4331,7 +4321,7 @@ VkResult loader_scan_for_layers(struct loader_instance *inst, struct loader_laye
     }
 
     // Get a list of manifest files for explicit layers
-    res = loader_parse_instance_layers(inst, LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER, override_paths, &regular_instance_layers);
+    res = loader_parse_instance_layers(inst, LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER, &override_paths, &regular_instance_layers);
     if (VK_SUCCESS != res) {
         goto out;
     }
@@ -4367,7 +4357,7 @@ out:
     loader_delete_layer_list_and_properties(inst, &settings_layers);
     loader_delete_layer_list_and_properties(inst, &regular_instance_layers);
 
-    loader_instance_heap_free(inst, override_paths);
+    free_string_list(inst, &override_paths);
     return res;
 }
 
@@ -4377,7 +4367,7 @@ VkResult loader_scan_for_implicit_layers(struct loader_instance *inst, struct lo
     struct loader_layer_list settings_layers = {0};
     struct loader_layer_list regular_instance_layers = {0};
     bool override_layer_valid = false;
-    char *override_paths = NULL;
+    struct loader_string_list override_paths = {0};
     bool implicit_metalayer_present = false;
 
     bool should_search_for_other_layers = true;
@@ -4433,7 +4423,7 @@ VkResult loader_scan_for_implicit_layers(struct loader_instance *inst, struct lo
     // in the override layer will be removed below in loader_remove_layers_in_blacklist().
     if (override_layer_valid || implicit_metalayer_present) {
         res =
-            loader_parse_instance_layers(inst, LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER, override_paths, &regular_instance_layers);
+            loader_parse_instance_layers(inst, LOADER_DATA_FILE_MANIFEST_EXPLICIT_LAYER, &override_paths, &regular_instance_layers);
         if (VK_SUCCESS != res) {
             goto out;
         }
@@ -4470,7 +4460,7 @@ out:
     loader_delete_layer_list_and_properties(inst, &settings_layers);
     loader_delete_layer_list_and_properties(inst, &regular_instance_layers);
 
-    loader_instance_heap_free(inst, override_paths);
+    free_string_list(inst, &override_paths);
     return res;
 }
 

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -110,6 +110,10 @@ VkResult create_string_list(const struct loader_instance *inst, uint32_t allocat
 // Resize if there isn't enough space, then add the string str to the end of the loader_string_list
 // This function takes ownership of the str passed in
 VkResult append_str_to_string_list(const struct loader_instance *inst, struct loader_string_list *string_list, char *str);
+// Checks that the string doesn't already exist in the list, resizes if there isn't enough space, adds the string str to the end of
+// the loader_string_list.
+// This function takes ownership of the str passed in
+VkResult append_str_to_string_list_if_unique(const struct loader_instance *inst, struct loader_string_list *string_list, char *str);
 // Resize if there isn't enough space, then add the string str to the start of the loader_string_list
 // This function takes ownership of the str passed in
 VkResult prepend_str_to_string_list(const struct loader_instance *inst, struct loader_string_list *string_list, char *str);
@@ -119,6 +123,13 @@ VkResult prepend_str_to_string_list(const struct loader_instance *inst, struct l
 // The str_len parameter does not include the null terminator
 VkResult copy_str_to_string_list(const struct loader_instance *inst, struct loader_string_list *string_list, const char *str,
                                  size_t str_len);
+// Checks that the string doesn't already exist in the list, then copies the string str to a new string and append it to
+// string_list, resizing string_list if there isn't enough space.
+// This function does not take ownership of the string, it merely copies it.
+// This function automatically appends a null terminator to the string being copied The str_len parameter does not
+// include the null terminator
+VkResult copy_str_to_string_list_if_unique(const struct loader_instance *inst, struct loader_string_list *string_list,
+                                           const char *str, size_t str_len);
 // Copy the string str to a new string and prepend it to string_list, resizing string_list if there isn't enough space.
 // This function does not take ownership of the string, it merely copies it.
 // This function automatically appends a null terminator to the string being copied
@@ -226,7 +237,8 @@ VkStringErrorFlags vk_string_validate(const int max_length, const char *char_arr
 char *loader_get_next_path(char *path);
 VkResult add_if_manifest_file(const struct loader_instance *inst, const char *file_name, struct loader_string_list *out_files);
 VkResult prepend_if_manifest_file(const struct loader_instance *inst, const char *file_name, struct loader_string_list *out_files);
-VkResult add_data_files(const struct loader_instance *inst, char *search_path, struct loader_string_list *out_files);
+VkResult add_data_files(const struct loader_instance *inst, struct loader_string_list *search_paths,
+                        struct loader_string_list *out_files);
 
 loader_api_version loader_make_version(uint32_t version);
 loader_api_version loader_combine_version(uint32_t major, uint32_t minor, uint32_t patch);

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -116,93 +116,45 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved) {
     return TRUE;
 }
 
-bool windows_add_json_entry(const struct loader_instance *inst,
-                            char **reg_data,    // list of JSON files
-                            PDWORD total_size,  // size of reg_data
-                            LPCSTR key_name,    // key name - used for debug prints - i.e. VulkanDriverName
-                            DWORD key_type,     // key data type
-                            LPSTR json_path,    // JSON string to add to the list reg_data
-                            DWORD json_size,    // size in bytes of json_path
-                            VkResult *result) {
-    // Check for and ignore duplicates.
-    if (*reg_data && strstr(*reg_data, json_path)) {
-        // Success. The json_path is already in the list.
-        return true;
-    }
-
-    // The destination buffer must hold the existing contents plus the new value (json_size) and a null terminator.
-    // json_size is the size of an externally-supplied registry/adapter value and is not otherwise bounded, so size the
-    // buffer from the data length rather than assuming the initial *total_size is large enough.
-    size_t current_len = (NULL == *reg_data) ? 0 : strlen(*reg_data);
-    DWORD required_size = *total_size;
-    // Grow by doubling, stopping before required_size (a DWORD) would overflow.
-    while (current_len + json_size + 1 > required_size && required_size <= UINT32_MAX / 2) {
-        required_size *= 2;
-    }
-    if (current_len + json_size + 1 > required_size) {
-        loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "windows_add_json_entry: Registry value for key %s is too large to store",
-                   json_path);
-        *result = VK_ERROR_OUT_OF_HOST_MEMORY;
-        return false;
-    }
-
-    if (NULL == *reg_data) {
-        *reg_data = loader_instance_heap_alloc(inst, required_size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-        if (NULL == *reg_data) {
-            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                       "windows_add_json_entry: Failed to allocate space for registry data for key %s", json_path);
-            *result = VK_ERROR_OUT_OF_HOST_MEMORY;
-            return false;
-        }
-        *reg_data[0] = '\0';
-        *total_size = required_size;
-    } else if (required_size > *total_size) {
-        void *new_ptr =
-            loader_instance_heap_realloc(inst, *reg_data, *total_size, required_size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-        if (NULL == new_ptr) {
-            loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,
-                       "windows_add_json_entry: Failed to reallocate space for registry value of size %lu for key %s",
-                       required_size, json_path);
-            *result = VK_ERROR_OUT_OF_HOST_MEMORY;
-            return false;
-        }
-        *reg_data = new_ptr;
-        *total_size = required_size;
-    }
-
+VkResult windows_add_json_entry(const struct loader_instance *inst, struct loader_string_list *search_paths,
+                                LPCSTR key_name,  // key name - used for debug prints - i.e. VulkanDriverName
+                                DWORD key_type,   // key data type
+                                LPSTR json_path,  // JSON string to add to the list reg_data
+                                DWORD json_size   // size in bytes of json_path
+) {
     for (char *curr_filename = json_path; curr_filename[0] != '\0'; curr_filename += strlen(curr_filename) + 1) {
-        size_t cur_len = strlen(*reg_data);
-        if (cur_len == 0) {
-            (void)snprintf(*reg_data, *total_size, "%s", curr_filename);
-        } else {
-            (void)snprintf(*reg_data + cur_len, *total_size - cur_len, "%c%s", PATH_SEPARATOR, curr_filename);
+        // Make sure we don't continue reading past the end of the buffer
+        if (curr_filename - json_path >= (long)json_size) {
+            break;
         }
-        loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "%s: Located json file \"%s\" from PnP registry: %s", __FUNCTION__,
-                   curr_filename, key_name);
 
+        VkResult res = copy_str_to_string_list_if_unique(inst, search_paths, curr_filename, strlen(curr_filename));
+
+        if (res == VK_SUCCESS) {
+            loader_log(inst, VULKAN_LOADER_INFO_BIT, 0, "%s: Located json file \"%s\" from PnP registry: %s", __FUNCTION__,
+                       curr_filename, key_name);
+        } else {
+            return res;
+        }
         if (key_type == REG_SZ) {
             break;
         }
     }
-    return true;
+    return VK_SUCCESS;
 }
 
-bool windows_get_device_registry_entry(const struct loader_instance *inst, char **reg_data, PDWORD total_size, DEVINST dev_id,
-                                       LPCSTR value_name, VkResult *result) {
+VkResult windows_get_device_registry_entry(const struct loader_instance *inst, struct loader_string_list *search_paths,
+                                           DEVINST dev_id, LPCSTR value_name) {
+    VkResult res = VK_SUCCESS;
     HKEY hkrKey = INVALID_HANDLE_VALUE;
     DWORD requiredSize, data_type;
     char *manifest_path = NULL;
-    bool found = false;
-
-    assert(reg_data != NULL && "windows_get_device_registry_entry: reg_data is a NULL pointer");
-    assert(total_size != NULL && "windows_get_device_registry_entry: total_size is a NULL pointer");
 
     CONFIGRET status = CM_Open_DevNode_Key(dev_id, KEY_QUERY_VALUE, 0, RegDisposition_OpenExisting, &hkrKey, CM_REGISTRY_SOFTWARE);
     if (status != CR_SUCCESS) {
         loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                    "windows_get_device_registry_entry: Failed to open registry key for DeviceID(%ld)", dev_id);
-        *result = VK_ERROR_INCOMPATIBLE_DRIVER;
-        return false;
+        return VK_ERROR_INCOMPATIBLE_DRIVER;
     }
 
     // query value
@@ -223,7 +175,7 @@ bool windows_get_device_registry_entry(const struct loader_instance *inst, char 
     if (manifest_path == NULL) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                    "windows_get_device_registry_entry: Failed to allocate space for DriverName.");
-        *result = VK_ERROR_OUT_OF_HOST_MEMORY;
+        res = VK_ERROR_OUT_OF_HOST_MEMORY;
         goto out;
     }
 
@@ -232,27 +184,27 @@ bool windows_get_device_registry_entry(const struct loader_instance *inst, char 
     if (ret != ERROR_SUCCESS) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                    "windows_get_device_registry_entry: DeviceID(%ld) Failed to obtain %s", dev_id, value_name);
-        *result = VK_ERROR_INCOMPATIBLE_DRIVER;
+        res = VK_ERROR_INCOMPATIBLE_DRIVER;
         goto out;
     }
 
     if (data_type != REG_SZ && data_type != REG_MULTI_SZ) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                    "windows_get_device_registry_entry: Invalid %s data type. Expected REG_SZ or REG_MULTI_SZ.", value_name);
-        *result = VK_ERROR_INCOMPATIBLE_DRIVER;
+        res = VK_ERROR_INCOMPATIBLE_DRIVER;
         goto out;
     }
 
-    found = windows_add_json_entry(inst, reg_data, total_size, value_name, data_type, manifest_path, requiredSize, result);
+    res = windows_add_json_entry(inst, search_paths, value_name, data_type, manifest_path, requiredSize);
 
 out:
     loader_instance_heap_free(inst, manifest_path);
     RegCloseKey(hkrKey);
-    return found;
+    return res;
 }
 
-VkResult windows_get_device_registry_files(const struct loader_instance *inst, uint32_t log_target_flag, char **reg_data,
-                                           PDWORD reg_data_size, LPCSTR value_name) {
+VkResult windows_get_device_registry_files(const struct loader_instance *inst, uint32_t log_target_flag,
+                                           struct loader_string_list *search_paths, LPCSTR value_name) {
     const wchar_t *softwareComponentGUID = L"{5c4c3332-344d-483c-8739-259e934c9cc8}";
     const wchar_t *displayGUID = L"{4d36e968-e325-11ce-bfc1-08002be10318}";
 #if defined(CM_GETIDLIST_FILTER_PRESENT)
@@ -271,9 +223,7 @@ VkResult windows_get_device_registry_files(const struct loader_instance *inst, u
     wchar_t *pDeviceNames = NULL;
     ULONG deviceNamesSize = 0;
     VkResult result = VK_SUCCESS;
-    bool found = false;
-
-    assert(reg_data != NULL && "windows_get_device_registry_files: reg_data is NULL");
+    uint32_t search_path_count_before = search_paths->count;
 
     // if after obtaining the DeviceNameSize, new device is added start over
     do {
@@ -315,10 +265,8 @@ VkResult windows_get_device_registry_files(const struct loader_instance *inst, u
             loader_log(inst, VULKAN_LOADER_INFO_BIT | log_target_flag, 0, "windows_get_device_registry_files: opening device %ls",
                        deviceName);
 
-            if (windows_get_device_registry_entry(inst, reg_data, reg_data_size, devID, value_name, &result)) {
-                found = true;
-                continue;
-            } else if (result == VK_ERROR_OUT_OF_HOST_MEMORY) {
+            result = windows_get_device_registry_entry(inst, search_paths, devID, value_name);
+            if (result == VK_ERROR_OUT_OF_HOST_MEMORY) {
                 break;
             }
 
@@ -351,9 +299,9 @@ VkResult windows_get_device_registry_files(const struct loader_instance *inst, u
                     continue;
                 }
 
-                if (windows_get_device_registry_entry(inst, reg_data, reg_data_size, childID, value_name, &result)) {
-                    found = true;
-                    break;  // check next-display-device
+                result = windows_get_device_registry_entry(inst, search_paths, childID, value_name);
+                if (result != VK_SUCCESS) {
+                    return result;
                 }
 
             } while (CM_Get_Sibling(&childID, childID, 0) == CR_SUCCESS);
@@ -362,7 +310,7 @@ VkResult windows_get_device_registry_files(const struct loader_instance *inst, u
         loader_instance_heap_free(inst, pDeviceNames);
     }
 
-    if (!found && result != VK_ERROR_OUT_OF_HOST_MEMORY) {
+    if (search_paths->count == search_path_count_before && result != VK_ERROR_OUT_OF_HOST_MEMORY) {
         loader_log(inst, log_target_flag, 0, "windows_get_device_registry_files: found no registry files");
         result = VK_ERROR_INCOMPATIBLE_DRIVER;
     }
@@ -370,8 +318,8 @@ VkResult windows_get_device_registry_files(const struct loader_instance *inst, u
     return result;
 }
 
-VkResult windows_get_registry_files(const struct loader_instance *inst, char *location, bool use_secondary_hive, char **reg_data,
-                                    PDWORD reg_data_size) {
+VkResult windows_get_registry_files(const struct loader_instance *inst, char *location, bool use_secondary_hive,
+                                    struct loader_string_list *search_paths) {
     // This list contains all of the allowed ICDs. This allows us to verify that a device is actually present from the vendor
     // specified. This does disallow other vendors, but any new driver should use the device-specific registries anyway.
     const struct {
@@ -425,12 +373,10 @@ VkResult windows_get_registry_files(const struct loader_instance *inst, char *lo
     DWORD value;
     DWORD value_size = sizeof(value);
     VkResult result = VK_SUCCESS;
-    bool found = false;
+    uint32_t search_path_count_before = search_paths->count;
     IDXGIFactory1 *dxgi_factory = NULL;
     bool is_driver = !strcmp(location, VK_DRIVERS_INFO_REGISTRY_LOC);
     uint32_t log_target_flag = is_driver ? VULKAN_LOADER_DRIVER_BIT : VULKAN_LOADER_LAYER_BIT;
-
-    assert(reg_data != NULL && "windows_get_registry_files: reg_data is a NULL pointer");
 
     if (is_driver) {
         HRESULT hres = fpCreateDXGIFactory1(&IID_IDXGIFactory1, (void **)&dxgi_factory);
@@ -452,32 +398,6 @@ VkResult windows_get_registry_files(const struct loader_instance *inst, char *lo
                  (rtn_value = RegEnumValue(key, idx++, name, &name_size, NULL, NULL, (LPBYTE)&value, &value_size)) == ERROR_SUCCESS;
                  name_size = sizeof(name), value_size = sizeof(value)) {
                 if (value_size == sizeof(value) && value == 0) {
-                    if (NULL == *reg_data) {
-                        *reg_data = loader_instance_heap_alloc(inst, *reg_data_size, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-                        if (NULL == *reg_data) {
-                            loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_target_flag, 0,
-                                       "windows_get_registry_files: Failed to allocate space for registry data for key %s", name);
-                            RegCloseKey(key);
-                            result = VK_ERROR_OUT_OF_HOST_MEMORY;
-                            goto out;
-                        }
-                        *reg_data[0] = '\0';
-                    } else if (strlen(*reg_data) + name_size + 1 > *reg_data_size) {
-                        void *new_ptr = loader_instance_heap_realloc(inst, *reg_data, *reg_data_size, *reg_data_size * 2,
-                                                                     VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
-                        if (NULL == new_ptr) {
-                            loader_log(
-                                inst, VULKAN_LOADER_ERROR_BIT | log_target_flag, 0,
-                                "windows_get_registry_files: Failed to reallocate space for registry value of size %ld for key %s",
-                                *reg_data_size * 2, name);
-                            RegCloseKey(key);
-                            result = VK_ERROR_OUT_OF_HOST_MEMORY;
-                            goto out;
-                        }
-                        *reg_data = new_ptr;
-                        *reg_data_size *= 2;
-                    }
-
                     // We've now found a json file. If this is an ICD, we still need to check if there is actually a device
                     // that matches this ICD
                     loader_log(inst, VULKAN_LOADER_INFO_BIT | log_target_flag, 0,
@@ -532,37 +452,9 @@ VkResult windows_get_registry_files(const struct loader_instance *inst, char *lo
                         }
                     }
 
-                    if (strlen(*reg_data) == 0) {
-                        // The list is emtpy. Add the first entry.
-                        (void)snprintf(*reg_data, name_size + 1, "%s", name);
-                        found = true;
-                    } else {
-                        // At this point the reg_data variable contains other JSON paths, likely from the PNP/device section
-                        // of the registry that we want to have precedence over this non-device specific section of the registry.
-                        // To make sure we avoid enumerating old JSON files/drivers that might be present in the non-device specific
-                        // area of the registry when a newer device specific JSON file is present, do a check before adding.
-                        // Find the file name, without path, of the JSON file found in the non-device specific registry location.
-                        // If the same JSON file name is already found in the list, don't add it again.
-                        bool foundDuplicate = false;
-                        char *pLastSlashName = strrchr(name, '\\');
-                        if (pLastSlashName != NULL) {
-                            char *foundMatch = strstr(*reg_data, pLastSlashName + 1);
-                            if (foundMatch != NULL) {
-                                foundDuplicate = true;
-                            }
-                        }
-                        // Only skip if we are adding a driver and a duplicate was found
-                        if (!is_driver || (is_driver && foundDuplicate == false)) {
-                            // Add the new entry to the list.
-                            (void)snprintf(*reg_data + strlen(*reg_data), name_size + 2, "%c%s", PATH_SEPARATOR, name);
-                            found = true;
-                        } else {
-                            loader_log(
-                                inst, VULKAN_LOADER_INFO_BIT | log_target_flag, 0,
-                                "Skipping adding of json file \"%s\" from registry \"%s\\%s\" to the list due to duplication", name,
-                                hive == DEFAULT_VK_REGISTRY_HIVE ? DEFAULT_VK_REGISTRY_HIVE_STR : SECONDARY_VK_REGISTRY_HIVE_STR,
-                                location);
-                        }
+                    result = copy_str_to_string_list_if_unique(inst, search_paths, name, name_size + 1);
+                    if (result != VK_SUCCESS) {
+                        goto out;
                     }
                 }
             }
@@ -578,7 +470,7 @@ VkResult windows_get_registry_files(const struct loader_instance *inst, char *lo
         }
     }
 
-    if (!found && result != VK_ERROR_OUT_OF_HOST_MEMORY) {
+    if (search_paths->count == search_path_count_before && result != VK_ERROR_OUT_OF_HOST_MEMORY) {
         loader_log(inst, log_target_flag, 0, "Found no registry files in %s\\%s",
                    (hive == DEFAULT_VK_REGISTRY_HIVE) ? DEFAULT_VK_REGISTRY_HIVE_STR : SECONDARY_VK_REGISTRY_HIVE_STR, location);
         result = VK_ERROR_INCOMPATIBLE_DRIVER;
@@ -593,7 +485,7 @@ out:
 }
 
 // Read manifest JSON files using the Windows driver interface
-VkResult windows_read_manifest_from_d3d_adapters(const struct loader_instance *inst, char **reg_data, PDWORD reg_data_size,
+VkResult windows_read_manifest_from_d3d_adapters(const struct loader_instance *inst, struct loader_string_list *search_paths,
                                                  const wchar_t *value_name) {
     VkResult result = VK_INCOMPLETE;
     LoaderEnumAdapters2 adapters = {.adapter_count = 0, .adapters = NULL};
@@ -702,9 +594,8 @@ VkResult windows_read_manifest_from_d3d_adapters(const struct loader_instance *i
             WideCharToMultiByte(CP_UTF8, 0, curr_path, -1, json_path, (int)json_path_size, NULL, NULL);
 
             // Add the string to the output list
-            result = VK_SUCCESS;
-            windows_add_json_entry(inst, reg_data, reg_data_size, (LPCTSTR)L"EnumAdapters", REG_SZ, json_path,
-                                   (DWORD)strlen(json_path) + 1, &result);
+            result = windows_add_json_entry(inst, search_paths, (LPCTSTR)L"EnumAdapters", REG_SZ, json_path,
+                                            (DWORD)strlen(json_path) + 1);
             if (result != VK_SUCCESS) {
                 goto out;
             }
@@ -729,7 +620,7 @@ VkResult windows_read_data_files_in_registry(const struct loader_instance *inst,
                                              bool warn_if_not_present, char *registry_location,
                                              struct loader_string_list *out_files) {
     VkResult vk_result = VK_SUCCESS;
-    char *search_path = NULL;
+    struct loader_string_list search_paths = {0};
     uint32_t log_target_flag = 0;
 
     if (data_file_type == LOADER_DATA_FILE_MANIFEST_DRIVER) {
@@ -744,25 +635,21 @@ VkResult windows_read_data_files_in_registry(const struct loader_instance *inst,
 
     // These calls look at the PNP/Device section of the registry.
     VkResult regHKR_result = VK_SUCCESS;
-    DWORD reg_size = 4096;
     if (!strncmp(registry_location, VK_DRIVERS_INFO_REGISTRY_LOC, sizeof(VK_DRIVERS_INFO_REGISTRY_LOC))) {
         // If we're looking for drivers we need to try enumerating adapters
-        regHKR_result = windows_read_manifest_from_d3d_adapters(inst, &search_path, &reg_size, LoaderPnpDriverRegistryWide());
+        regHKR_result = windows_read_manifest_from_d3d_adapters(inst, &search_paths, LoaderPnpDriverRegistryWide());
         if (regHKR_result == VK_INCOMPLETE) {
-            regHKR_result =
-                windows_get_device_registry_files(inst, log_target_flag, &search_path, &reg_size, LoaderPnpDriverRegistry());
+            regHKR_result = windows_get_device_registry_files(inst, log_target_flag, &search_paths, LoaderPnpDriverRegistry());
         }
     } else if (!strncmp(registry_location, VK_ELAYERS_INFO_REGISTRY_LOC, sizeof(VK_ELAYERS_INFO_REGISTRY_LOC))) {
-        regHKR_result = windows_read_manifest_from_d3d_adapters(inst, &search_path, &reg_size, LoaderPnpELayerRegistryWide());
+        regHKR_result = windows_read_manifest_from_d3d_adapters(inst, &search_paths, LoaderPnpELayerRegistryWide());
         if (regHKR_result == VK_INCOMPLETE) {
-            regHKR_result =
-                windows_get_device_registry_files(inst, log_target_flag, &search_path, &reg_size, LoaderPnpELayerRegistry());
+            regHKR_result = windows_get_device_registry_files(inst, log_target_flag, &search_paths, LoaderPnpELayerRegistry());
         }
     } else if (!strncmp(registry_location, VK_ILAYERS_INFO_REGISTRY_LOC, sizeof(VK_ILAYERS_INFO_REGISTRY_LOC))) {
-        regHKR_result = windows_read_manifest_from_d3d_adapters(inst, &search_path, &reg_size, LoaderPnpILayerRegistryWide());
+        regHKR_result = windows_read_manifest_from_d3d_adapters(inst, &search_paths, LoaderPnpILayerRegistryWide());
         if (regHKR_result == VK_INCOMPLETE) {
-            regHKR_result =
-                windows_get_device_registry_files(inst, log_target_flag, &search_path, &reg_size, LoaderPnpILayerRegistry());
+            regHKR_result = windows_get_device_registry_files(inst, log_target_flag, &search_paths, LoaderPnpILayerRegistry());
         }
     }
 
@@ -773,13 +660,13 @@ VkResult windows_read_data_files_in_registry(const struct loader_instance *inst,
 
     // This call looks into the Khronos non-device specific section of the registry for layer files.
     bool use_secondary_hive = (data_file_type != LOADER_DATA_FILE_MANIFEST_DRIVER) && (!is_high_integrity());
-    VkResult reg_result = windows_get_registry_files(inst, registry_location, use_secondary_hive, &search_path, &reg_size);
+    VkResult reg_result = windows_get_registry_files(inst, registry_location, use_secondary_hive, &search_paths);
     if (reg_result == VK_ERROR_OUT_OF_HOST_MEMORY) {
         vk_result = VK_ERROR_OUT_OF_HOST_MEMORY;
         goto out;
     }
 
-    if ((VK_SUCCESS != reg_result && VK_SUCCESS != regHKR_result) || NULL == search_path) {
+    if ((VK_SUCCESS != reg_result && VK_SUCCESS != regHKR_result) || search_paths.count == 0) {
         if (data_file_type == LOADER_DATA_FILE_MANIFEST_DRIVER) {
             loader_log(inst, VULKAN_LOADER_ERROR_BIT | log_target_flag, 0,
                        "windows_read_data_files_in_registry: Registry lookup failed to get ICD manifest files.  Possibly missing "
@@ -805,11 +692,11 @@ VkResult windows_read_data_files_in_registry(const struct loader_instance *inst,
     }
 
     // Now, parse the paths and add any manifest files found in them.
-    vk_result = add_data_files(inst, search_path, out_files);
+    vk_result = add_data_files(inst, &search_paths, out_files);
 
 out:
 
-    loader_instance_heap_free(inst, search_path);
+    free_string_list(inst, &search_paths);
 
     return vk_result;
 }

--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -998,7 +998,7 @@ VkResult windows_read_sorted_physical_devices(struct loader_instance *inst, uint
                 uint32_t old_size = icd_phys_devs_array_size * sizeof(struct loader_icd_physical_devices);
                 void *new_ptr = loader_instance_heap_realloc(inst, *icd_phys_devs_array, old_size, 2 * old_size,
                                                              VK_SYSTEM_ALLOCATION_SCOPE_COMMAND);
-                if (*icd_phys_devs_array == NULL) {
+                if (new_ptr == NULL) {
                     adapter->lpVtbl->Release(adapter);
                     res = VK_ERROR_OUT_OF_HOST_MEMORY;
                     goto out;

--- a/loader/loader_windows.h
+++ b/loader/loader_windows.h
@@ -43,22 +43,20 @@ void windows_initialization(void);
 // Append the JSON path data to the list and allocate/grow the list if it's not large enough.
 // Function returns true if filename was appended to reg_data list.
 // Caller should free reg_data.
-bool windows_add_json_entry(const struct loader_instance *inst,
-                            char **reg_data,    // list of JSON files
-                            PDWORD total_size,  // size of reg_data
-                            LPCSTR key_name,    // key name - used for debug prints - i.e. VulkanDriverName
-                            DWORD key_type,     // key data type
-                            LPSTR json_path,    // JSON string to add to the list reg_data
-                            DWORD json_size,    // size in bytes of json_path
-                            VkResult *result);
+VkResult windows_add_json_entry(const struct loader_instance *inst, struct loader_string_list *search_paths,
+                                LPCSTR key_name,  // key name - used for debug prints - i.e. VulkanDriverName
+                                DWORD key_type,   // key data type
+                                LPSTR json_path,  // JSON string to add to the list reg_data
+                                DWORD json_size   // size in bytes of json_path
+);
 
 // Find the list of registry files (names VulkanDriverName/VulkanDriverNameWow) in hkr.
 //
 // This function looks for filename in given device handle, filename is then added to return list
 // function return true if filename was appended to reg_data list
 // If error occurs result is updated with failure reason
-bool windows_get_device_registry_entry(const struct loader_instance *inst, char **reg_data, PDWORD total_size, DEVINST dev_id,
-                                       LPCSTR value_name, VkResult *result);
+VkResult windows_get_device_registry_entry(const struct loader_instance *inst, struct loader_string_list *search_paths,
+                                           DEVINST dev_id, LPCSTR value_name);
 
 // Find the list of registry files (names VulkanDriverName/VulkanDriverNameWow) in hkr .
 //
@@ -71,8 +69,8 @@ bool windows_get_device_registry_entry(const struct loader_instance *inst, char 
 //
 // *reg_data contains a string list of filenames as pointer.
 // When done using the returned string list, the caller should free the pointer.
-VkResult windows_get_device_registry_files(const struct loader_instance *inst, uint32_t log_target_flag, char **reg_data,
-                                           PDWORD reg_data_size, LPCSTR value_name);
+VkResult windows_get_device_registry_files(const struct loader_instance *inst, uint32_t log_target_flag,
+                                           struct loader_string_list *search_paths, LPCSTR value_name);
 
 // Find the list of registry files (names within a key) in key "location".
 //
@@ -87,11 +85,11 @@ VkResult windows_get_device_registry_files(const struct loader_instance *inst, u
 //
 // *reg_data contains a string list of filenames as pointer.
 // When done using the returned string list, the caller should free the pointer.
-VkResult windows_get_registry_files(const struct loader_instance *inst, char *location, bool use_secondary_hive, char **reg_data,
-                                    PDWORD reg_data_size);
+VkResult windows_get_registry_files(const struct loader_instance *inst, char *location, bool use_secondary_hive,
+                                    struct loader_string_list *search_paths);
 
 // Read manifest JSON files using the Windows driver interface
-VkResult windows_read_manifest_from_d3d_adapters(const struct loader_instance *inst, char **reg_data, PDWORD reg_data_size,
+VkResult windows_read_manifest_from_d3d_adapters(const struct loader_instance *inst, struct loader_string_list *search_paths,
                                                  const wchar_t *value_name);
 
 // Look for data files in the registry.

--- a/tests/loader_layer_tests.cpp
+++ b/tests/loader_layer_tests.cpp
@@ -1822,7 +1822,7 @@ TEST(OverrideMetaLayer, OverridePathsInteractionWithVK_LAYER_PATH) {
         std::string("Ignoring VK_LAYER_PATH. The Override layer is active and has override paths set, which takes priority. "
                     "VK_LAYER_PATH is set to ") +
         env.env_var_vk_layer_paths.value()));
-    ASSERT_TRUE(env.debug_log.find("Override layer has override paths set to " + meta_layer_path.string()));
+    ASSERT_TRUE(env.debug_log.find("Override layer has override path " + meta_layer_path.string()));
 
     env.layers.clear();
 }

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -4329,17 +4329,20 @@ TEST(DuplicateRegistryEntries, Drivers) {
     auto null_path = env.get_folder(ManifestLocation::null).location() / "test_icd_0.json";
     env.platform_shim->add_manifest_to_registry(ManifestCategory::icd, null_path);
 
-    env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::null_dir))
-        .add_physical_device("physical_device_0")
-        .set_adapterLUID(_LUID{10, 1000});
+    auto& real_driver =
+        env.add_icd(TEST_ICD_PATH_VERSION_2_EXPORT_ICD_GPDPA, ManifestOptions{}.set_discovery_type(ManifestDiscoveryType::null_dir))
+            .add_physical_device("physical_device_0")
+            .set_adapterLUID(_LUID{10, 1000});
     env.platform_shim->add_d3dkmt_adapter(D3DKMT_Adapter{0, _LUID{10, 1000}}.add_driver_manifest_path(env.get_icd_manifest_path()));
 
     InstWrapper inst{env.vulkan_functions};
     FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
     inst.CheckCreate();
-    ASSERT_TRUE(env.debug_log.find(std::string("Skipping adding of json file \"") + null_path.string() +
-                                   "\" from registry \"HKEY_LOCAL_MACHINE\\" VK_DRIVERS_INFO_REGISTRY_LOC
-                                   "\" to the list due to duplication"));
+    auto phys_devs = inst.GetPhysDevs(1);
+    ASSERT_EQ(phys_devs.size(), 1U);
+    ASSERT_TRUE(env.debug_log.find(std::string("Located json file \"") + env.get_icd_manifest_path().string() +
+                                   "\" from registry \"HKEY_LOCAL_MACHINE\\" VK_DRIVERS_INFO_REGISTRY_LOC));
+    ASSERT_TRUE(env.debug_log.find("Found no registry files in HKEY_LOCAL_MACHINE\\" VK_DRIVERS_INFO_REGISTRY_LOC));
 }
 
 // Regression test for a heap buffer overflow in windows_add_json_entry(). The buffer that aggregates manifest paths


### PR DESCRIPTION
Rather than try to combine all search paths into a single giant string, add each path to a list of strings, deduplicating as we go. This simplifies the logic to get all of the search paths by not needing to first sum up the lengths of all of the search paths in order to allocate a single large string, or having to reallocate the string if it isn't large enough.