### PR TITLE
Implement unknown function support for ARM64EC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,6 +297,49 @@ jobs:
             - run: cmake --install build --prefix build/install --config ${{matrix.config}}
             - run: ctest --parallel --output-on-failure -C ${{matrix.config}} --test-dir build/
 
+  windows_arm64x:
+        # Native Windows on Arm: Tests building a genuine arm64x binary and validates that an x64 test suite passes
+        # windows is 2x expensive to run on GitHub machines, so only run if we know something else simple passed as well
+        # needs: windows_arm
+        runs-on: windows-11-arm
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v5
+              with:
+                python-version: '3.x'
+            - run: python scripts/update_deps.py --arch arm64 --api vulkan --dir external --clean-build --clean-install
+            - run: |
+                cmake -S. -B build_arm64x `
+                -A arm64 `
+                -D BUILD_AS_ARM64X=ARM64 `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D BUILD_WERROR=ON `
+                -C external/helper.cmake
+            - run: cmake --build build_arm64x/ --config Release
+            - run: |
+                cmake -S. -B build_arm64xec `
+                -A arm64ec `
+                -D BUILD_AS_ARM64X=ARM64EC `
+                -D BUILD_TESTS=ON `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D BUILD_WERROR=ON `
+                -C external/helper.cmake
+            - run: cmake --build build_arm64xec/ --config Release
+            - run: cmake --install build_arm64xec --prefix build/install --config Release
+            - run: ctest --parallel --output-on-failure -C Release --test-dir build_arm64xec/
+            - run: |
+                cmake -S. -B build_x64 `
+                -A x64 `
+                -D BUILD_TESTS=ON `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D BUILD_WERROR=ON `
+                -C external/helper.cmake
+            - run: cmake --build build_x64/ --config Release
+            - run: ctest --parallel --output-on-failure -C Release --test-dir build_x64/
+              env:
+                VK_LOADER_TEST_LOADER_PATH: ${{ github.workspace }}/build_arm64xec/loader/Release/vulkan-1.dll
+
     # Test both clang and clang-cl (Chromium project uses clang-cl)
     windows_clang:
       # windows is 2x expensive to run on GitHub machines, so only run if we know something else simple passed as well

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,7 +297,7 @@ jobs:
             - run: cmake --install build --prefix build/install --config ${{matrix.config}}
             - run: ctest --parallel --output-on-failure -C ${{matrix.config}} --test-dir build/
 
-  windows_arm64x:
+    windows_arm64x:
         # Native Windows on Arm: Tests building a genuine arm64x binary and validates that an x64 test suite passes
         # windows is 2x expensive to run on GitHub machines, so only run if we know something else simple passed as well
         # needs: windows_arm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,6 +271,32 @@ jobs:
             - run: cmake --build build/ --config Release
             - run: ctest --parallel --output-on-failure -C Release -E UnknownFunction --test-dir build/
 
+    windows_arm:
+        # Native Windows on Arm: covers the arm64 and arm64ec MARMASM paths the x64 runners can't.
+        # windows is 2x expensive to run on GitHub machines, so only run if we know something else simple passed as well
+        needs: linux-no-asm
+        runs-on: windows-11-arm
+        timeout-minutes: 30
+        strategy:
+            matrix:
+                arch: [ arm64, arm64ec ]
+                config: [ Debug, Release ]
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v5
+              with:
+                python-version: '3.x'
+            - run: |
+                cmake -S. -B build `
+                -D BUILD_TESTS=ON `
+                -D UPDATE_DEPS=ON `
+                -D CMAKE_BUILD_TYPE=${{matrix.config}} `
+                -A ${{ matrix.arch }} `
+                -D BUILD_WERROR=ON
+            - run: cmake --build build/ --config ${{matrix.config}}
+            - run: cmake --install build --prefix build/install --config ${{matrix.config}}
+            - run: ctest --parallel --output-on-failure -C ${{matrix.config}} --test-dir build/
+
     # Test both clang and clang-cl (Chromium project uses clang-cl)
     windows_clang:
       # windows is 2x expensive to run on GitHub machines, so only run if we know something else simple passed as well

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,15 @@ target_link_libraries(loader_common_options INTERFACE platform_wsi)
 # Enable beta Vulkan extensions
 target_compile_definitions(loader_common_options INTERFACE VK_ENABLE_BETA_EXTENSIONS)
 
-string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" SYSTEM_PROCESSOR)
+# Use the target architecture when it is known. Visual Studio generators set CMAKE_GENERATOR_PLATFORM from the -A option
+# (e.g. arm64, arm64ec), which is what we need to pick the right assembler when the host and target differ (such as
+# building arm64/arm64ec on an x64 host). Other generators (Ninja, Makefiles, non-Windows) leave it empty, so fall back
+# to the host processor there.
+if (CMAKE_GENERATOR_PLATFORM)
+    string(TOLOWER "${CMAKE_GENERATOR_PLATFORM}" SYSTEM_PROCESSOR)
+else()
+    string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" SYSTEM_PROCESSOR)
+endif()
 
 option(BUILD_WERROR "Enable warnings as errors")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,3 +324,47 @@ if (BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)
 endif()
+
+
+# Building Arm64X binaries requires 2 builds. One for the arm64 code, and the other for the x64.
+# Source https://learn.microsoft.com/en-us/windows/arm/arm64x-build#building-an-arm64x-dll-with-cmake
+if(DEFINED BUILD_AS_ARM64X)
+ 	set(ARM64X_TARGETS vulkan)
+
+    # directory where the link.rsp file generated during arm64 build will be stored
+    set(arm64ReproDir "${CMAKE_CURRENT_SOURCE_DIR}/repros")
+
+    # This function reads in the content of the rsp file outputted from arm64 build for a target. Then passes the arm64 libs, objs and def file to the linker using /machine:arm64x to combine them with the arm64ec counterparts and create an arm64x binary.
+
+    function(set_arm64_dependencies n)
+        set(REPRO_FILE "${arm64ReproDir}/${n}.rsp")
+        file(STRINGS "${REPRO_FILE}" ARM64_OBJS REGEX obj\"$)
+        file(STRINGS "${REPRO_FILE}" ARM64_DEF REGEX def\"$)
+        file(STRINGS "${REPRO_FILE}" ARM64_LIBS REGEX lib\"$)
+        string(REPLACE "\"" ";" ARM64_OBJS "${ARM64_OBJS}")
+        string(REPLACE "\"" ";" ARM64_LIBS "${ARM64_LIBS}")
+        string(REPLACE "\"" ";" ARM64_DEF "${ARM64_DEF}")
+        string(REPLACE "/def:" "/defArm64Native:" ARM64_DEF "${ARM64_DEF}")
+
+        target_sources(${n} PRIVATE ${ARM64_OBJS})
+        target_link_options(${n} PRIVATE /machine:arm64x "${ARM64_DEF}" "${ARM64_LIBS}")
+    endfunction()
+
+    # During the arm64 build, create link.rsp files that containes the absolute path to the inputs passed to the linker (objs, def files, libs).
+
+    if("${BUILD_AS_ARM64X}" STREQUAL "ARM64")
+        add_custom_target(mkdirs ALL COMMAND cmd /c (if not exist \"${arm64ReproDir}/\" mkdir \"${arm64ReproDir}\" ))
+        foreach (n ${ARM64X_TARGETS})
+            add_dependencies(${n} mkdirs)
+            # tell the linker to produce this special rsp file that has absolute paths to its inputs
+            target_link_options(${n} PRIVATE "/LINKREPROFULLPATHRSP:${arm64ReproDir}/${n}.rsp")
+        endforeach()
+
+    # During the ARM64EC build, modify the link step appropriately to produce an arm64x binary
+    elseif("${BUILD_AS_ARM64X}" STREQUAL "ARM64EC")
+        foreach (n ${ARM64X_TARGETS})
+            set_arm64_dependencies(${n})
+        endforeach()
+    endif()
+endif()
+

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -139,8 +139,24 @@ if(WIN32 AND NOT USE_GAS)
             if(CMAKE_VERSION VERSION_LESS "3.26.0")
                 set(ASM_FAILURE_MSG ${ARMASM_CMAKE_FAILURE_MSG})
             else()
+                # CMake's MARMASM detection regex only matches "ARM64", so for arm64ec it
+                # picks the 32-bit armasm, and even on arm64 it leaves the compiler as a bare
+                # name that the check below can't run without the dev tools on PATH. Resolve
+                # armasm64 (next to the C compiler) and use its full path. Drop this once
+                # CMake's detection learns about ARM64EC.
+                if(SYSTEM_PROCESSOR MATCHES "arm64")
+                    get_filename_component(MARMASM_TOOLCHAIN_DIR "${CMAKE_C_COMPILER}" DIRECTORY)
+                    find_program(MARMASM_ARMASM64 NAMES armasm64 HINTS "${MARMASM_TOOLCHAIN_DIR}")
+                endif()
+                if(MARMASM_ARMASM64)
+                    set(CMAKE_ASM_MARMASM_COMPILER "${MARMASM_ARMASM64}")
+                endif()
                 enable_language(ASM_MARMASM)
                 set(LOADER_ASM_DIALECT "MARMASM")
+                if(MARMASM_ARMASM64)
+                    # enable_language resets the compiler to a bare name; re-assert the full path.
+                    set(CMAKE_ASM_MARMASM_COMPILER "${MARMASM_ARMASM64}")
+                endif()
             endif()
         else()
             enable_language(ASM_MASM)

--- a/loader/asm_offset.c
+++ b/loader/asm_offset.c
@@ -137,7 +137,7 @@ int main(int argc, char **argv) {
         }
     } else if (assembler == MARMASM) {
         fprintf(file, "    AREA    loader_structs_details, DATA,READONLY\n");
-#if defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
         fprintf(file, "AARCH_64 EQU 1\n");
 #else
         fprintf(file, "AARCH_64 EQU 0\n");

--- a/loader/unknown_ext_chain_marmasm.asm
+++ b/loader/unknown_ext_chain_marmasm.asm
@@ -25,9 +25,119 @@
 ; jump to the next function in the call chain
 
 
+#if defined(_ARM64EC_)
+; arm64ec needs the SDK macros, which ksarm64.h gates on _M_ARM64EC. MARMASM
+; doesn't set that, so derive it from the _ARM64EC_ it does set.
+#define _M_ARM64EC 1
+#include "ksarm64.h"
+#endif
+
     GET gen_defines.asm
 
     EXTERN loader_log_asm_function_not_supported
+
+#if defined(_ARM64EC_)
+
+; arm64ec apps can reach these through emulated x64, so each trampoline is an
+; adjustor thunk: an entry thunk for x64 callers (jumps via __os_arm64x_x64_jump)
+; and a body for arm64ec callers (checks the target with __os_arm64x_check_icall).
+; Entry thunk goes first, and the body must be non-COMDAT, or the SDK's
+; __AddEntryThunkPointer won't wire the two together.
+
+    IMPORT __os_arm64x_check_icall
+    IMPORT __os_arm64x_x64_jump
+
+    MACRO
+    PhysDevExtTramp $num
+    ARM64EC_CUSTOM_ENTRY_THUNK A64NAME(vkPhysDevExtTramp$num)
+    ldr     x9, [x0]                                                 ; Load the loader_instance_dispatch_table* into x9
+    ldr     x9, [x9, (PHYS_DEV_OFFSET_INST_DISPATCH + (PTR_SIZE * $num))] ; Load the address to branch to out of the dispatch table
+    ldr     x0, [x0, PHYS_DEV_OFFSET_PHYS_DEV_TRAMP]                 ; Load the unwrapped VkPhysicalDevice into x0
+    adrp    xip0, __os_arm64x_x64_jump
+    ldr     xip0, [xip0, __os_arm64x_x64_jump]
+    br      xip0                                                     ; jump to the target
+    LEAF_END
+    NESTED_ENTRY A64NAME(vkPhysDevExtTramp$num)
+    PROLOG_SAVE_REG_PAIR fp, lr, #-16!
+    ldr     x9, [x0]                                                 ; Load the loader_instance_dispatch_table* into x9
+    ldr     x11, [x9, (PHYS_DEV_OFFSET_INST_DISPATCH + (PTR_SIZE * $num))] ; Load the address to branch to out of the dispatch table
+    ldr     x0, [x0, PHYS_DEV_OFFSET_PHYS_DEV_TRAMP]                 ; Load the unwrapped VkPhysicalDevice into x0
+    adrp    xip0, __os_arm64x_check_icall
+    ldr     xip0, [xip0, __os_arm64x_check_icall]
+    blr     xip0                                                     ; check the target arch
+    EPILOG_RESTORE_REG_PAIR fp, lr, #16!
+    EPILOG_END              br x11                                   ; Branch to the next member of the dispatch chain
+    NESTED_END
+    MEND
+
+    MACRO
+$label    PhysDevExtTermin $num
+    ARM64EC_CUSTOM_ENTRY_THUNK A64NAME(vkPhysDevExtTermin$num)
+    ldr     x9, [x0, ICD_TERM_OFFSET_PHYS_DEV_TERM]             ; Load the loader_icd_term* in x9
+    ldr     x10, [x9, (DISPATCH_OFFSET_ICD_TERM + (PTR_SIZE * $num))] ; Load the address of the next function in the dispatch chain
+    cbz     x10, terminEntryError$num                           ; Go to the error section if the next function in the chain is NULL
+    ldr     x0, [x0, PHYS_DEV_OFFSET_PHYS_DEV_TERM]             ; Unwrap the VkPhysicalDevice in x0
+    mov     x9, x10                                             ; jump helper wants the target in x9
+    adrp    xip0, __os_arm64x_x64_jump
+    ldr     xip0, [xip0, __os_arm64x_x64_jump]
+    br      xip0                                                ; jump to the target
+terminEntryError$num
+    mov     x10, (FUNCTION_OFFSET_INSTANCE + (CHAR_PTR_SIZE * $num)) ; Offset of the function name string in the instance
+    ldr     x11, [x9, INSTANCE_OFFSET_ICD_TERM]   ; Load the instance pointer
+    mov     x0, x11                               ; Vulkan instance pointer (first arg)
+    mov     x1, VULKAN_LOADER_ERROR_BIT           ; The error logging bit (second arg)
+    mov     x2, #0                                ; Zero (third arg)
+    ldr     x3, [x11, x10]                        ; The function name (fourth arg)
+    bl      loader_log_asm_function_not_supported ; Log the error message before we crash
+    mov     x0, #0
+    br      x0                                    ; Crash intentionally by jumping to address zero
+    LEAF_END
+    NESTED_ENTRY A64NAME(vkPhysDevExtTermin$num)
+    PROLOG_SAVE_REG_PAIR fp, lr, #-16!
+    ldr     x9, [x0, ICD_TERM_OFFSET_PHYS_DEV_TERM]             ; Load the loader_icd_term* in x9
+    ldr     x11, [x9, (DISPATCH_OFFSET_ICD_TERM + (PTR_SIZE * $num))] ; Load the address of the next function in the dispatch chain
+    cbz     x11, terminError$num                                ; Go to the error section if the next function in the chain is NULL
+    ldr     x0, [x0, PHYS_DEV_OFFSET_PHYS_DEV_TERM]             ; Unwrap the VkPhysicalDevice in x0
+    adrp    xip0, __os_arm64x_check_icall
+    ldr     xip0, [xip0, __os_arm64x_check_icall]
+    blr     xip0                                                ; check the target arch
+    EPILOG_RESTORE_REG_PAIR fp, lr, #16!
+    EPILOG_END              br x11                               ; Jump to the next function in the chain
+terminError$num
+    mov     x10, (FUNCTION_OFFSET_INSTANCE + (CHAR_PTR_SIZE * $num)) ; Offset of the function name string in the instance
+    ldr     x11, [x9, INSTANCE_OFFSET_ICD_TERM]   ; Load the instance pointer
+    mov     x0, x11                               ; Vulkan instance pointer (first arg)
+    mov     x1, VULKAN_LOADER_ERROR_BIT           ; The error logging bit (second arg)
+    mov     x2, #0                                ; Zero (third arg)
+    ldr     x3, [x11, x10]                        ; The function name (fourth arg)
+    bl      loader_log_asm_function_not_supported ; Log the error message before we crash
+    mov     x0, #0
+    br      x0                                    ; Crash intentionally by jumping to address zero
+    NESTED_END
+    MEND
+
+    MACRO
+    DevExtTramp $num
+    ARM64EC_CUSTOM_ENTRY_THUNK A64NAME(vkdev_ext$num)
+    ldr     x9, [x0]                                              ; Load the loader_instance_dispatch_table* into x9
+    ldr     x9, [x9, (EXT_OFFSET_DEVICE_DISPATCH + (PTR_SIZE * $num))] ; Load the function address
+    adrp    xip0, __os_arm64x_x64_jump
+    ldr     xip0, [xip0, __os_arm64x_x64_jump]
+    br      xip0                                                  ; jump to the target
+    LEAF_END
+    NESTED_ENTRY A64NAME(vkdev_ext$num)
+    PROLOG_SAVE_REG_PAIR fp, lr, #-16!
+    ldr     x9, [x0]                                              ; Load the loader_instance_dispatch_table* into x9
+    ldr     x11, [x9, (EXT_OFFSET_DEVICE_DISPATCH + (PTR_SIZE * $num))] ; Load the function address
+    adrp    xip0, __os_arm64x_check_icall
+    ldr     xip0, [xip0, __os_arm64x_check_icall]
+    blr     xip0                                                  ; check the target arch
+    EPILOG_RESTORE_REG_PAIR fp, lr, #16!
+    EPILOG_END              br x11
+    NESTED_END
+    MEND
+
+#else
 
     IF AARCH_64==1
 
@@ -134,11 +244,18 @@ vkdev_ext$num FUNCTION
 
     ENDIF
 
+#endif
+
     AREA terminator_string_data, DATA, READONLY
 
 termin_error_string DCB "Function %s not supported for this physical device", 0
 
+#if defined(_ARM64EC_)
+; the entry-thunk pointer wants 16-byte aligned functions, so set .text alignment here
+    AREA |.text|, CODE, READONLY, ALIGN=4
+#else
     AREA UnknownFunctionImpl, CODE, READONLY
+#endif
 
     PhysDevExtTramp 0
     PhysDevExtTramp 1

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -515,6 +515,8 @@ class GoodRepo(object):
                 cmake_cmd.append('x64')
             elif self._args.arch == 'arm64':
                 cmake_cmd.append('arm64')
+            elif self._args.arch == 'arm64ec':
+                cmake_cmd.append('arm64ec')
             elif self._args.arch == 'arm':
                 cmake_cmd.append('arm')
             else:
@@ -693,7 +695,7 @@ def main():
     parser.add_argument(
         '--arch',
         dest='arch',
-        choices=['32', '64', 'x86', 'x64', 'win32', 'win64', 'arm', 'arm64'],
+        choices=['32', '64', 'x86', 'x64', 'win32', 'win64', 'arm', 'arm64', 'arm64ec'],
         type=str.lower,
         help="Set build files architecture (Visual Studio Generator Only)",
         default='64')

--- a/tests/loader_get_proc_addr_tests.cpp
+++ b/tests/loader_get_proc_addr_tests.cpp
@@ -27,6 +27,62 @@
 
 #include "test_environment.h"
 
+// On arm64x the loader has two views of each entry point. An x64 caller (an arm64ec build, or a plain
+// x64 process emulated on an Arm64 host) gets an export's x64 fast-forward-sequence thunk back from
+// GetProcAddress, while the loader resolves its own name to the native arm64ec function. Same command,
+// different address, and the spec doesn't require them to match, so in that case compare behavior
+// instead of raw pointer identity. Everywhere else the pointers are expected to be identical.
+static bool proc_addr_identity_expected() {
+#if defined(_M_ARM64EC)
+    return false;
+#elif defined(_WIN32)
+    USHORT process_machine = 0, native_machine = 0;
+    if (IsWow64Process2(GetCurrentProcess(), &process_machine, &native_machine)) {
+        // On an Arm64 host vulkan-1.dll may be arm64x, in which case an x64 (emulated) or arm64ec
+        // caller gets a fast-forward-sequence thunk that differs from the loader's native pointer.
+        // Note x64-on-Arm64 is not classic WOW64, so process_machine is UNKNOWN there, not AMD64;
+        // key off the native machine instead.
+        return native_machine != IMAGE_FILE_MACHINE_ARM64;
+    }
+    return true;
+#else
+    return true;
+#endif
+}
+
+static void assert_gipa_equivalent(PFN_vkGetInstanceProcAddr from_loader, PFN_vkGetInstanceProcAddr from_query) {
+    if (proc_addr_identity_expected()) {
+        ASSERT_EQ(from_loader, from_query);
+        return;
+    }
+    ASSERT_NE(from_loader, nullptr);
+    ASSERT_NE(from_query, nullptr);
+    ASSERT_EQ(from_loader(nullptr, "vkThisCommandDoesNotExist"), nullptr);
+    ASSERT_EQ(from_query(nullptr, "vkThisCommandDoesNotExist"), nullptr);
+    PFN_vkVoidFunction create_from_loader = from_loader(nullptr, "vkCreateInstance");
+    PFN_vkVoidFunction create_from_query = from_query(nullptr, "vkCreateInstance");
+    ASSERT_NE(create_from_loader, nullptr);
+    ASSERT_EQ(create_from_loader, create_from_query);
+}
+
+static void assert_gdpa_equivalent(PFN_vkGetDeviceProcAddr from_loader, PFN_vkGetDeviceProcAddr from_query, VkDevice device) {
+    if (proc_addr_identity_expected()) {
+        (void)device;
+        ASSERT_EQ(from_loader, from_query);
+        return;
+    }
+    ASSERT_NE(from_loader, nullptr);
+    ASSERT_NE(from_query, nullptr);
+    if (device != VK_NULL_HANDLE) {
+        ASSERT_EQ(from_loader(device, "vkThisCommandDoesNotExist"), nullptr);
+        ASSERT_EQ(from_query(device, "vkThisCommandDoesNotExist"), nullptr);
+        PFN_vkVoidFunction destroy_from_loader = from_loader(device, "vkDestroyDevice");
+        PFN_vkVoidFunction destroy_from_query = from_query(device, "vkDestroyDevice");
+        ASSERT_NE(destroy_from_loader, nullptr);
+        ASSERT_EQ(destroy_from_loader, destroy_from_query);
+    }
+}
+
 // Verify that the various ways to get vkGetInstanceProcAddr return the same value
 TEST(GetProcAddr, VerifyGetInstanceProcAddr) {
     FrameworkEnvironment env{};
@@ -41,7 +97,7 @@ TEST(GetProcAddr, VerifyGetInstanceProcAddr) {
         PFN_vkGetInstanceProcAddr gipa_loader = env.vulkan_functions.vkGetInstanceProcAddr;
         PFN_vkGetInstanceProcAddr gipa_queried = reinterpret_cast<PFN_vkGetInstanceProcAddr>(
             env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetInstanceProcAddr"));
-        ASSERT_EQ(gipa_loader, gipa_queried);
+        assert_gipa_equivalent(gipa_loader, gipa_queried);
     }
 
     {
@@ -54,7 +110,7 @@ TEST(GetProcAddr, VerifyGetInstanceProcAddr) {
         PFN_vkGetInstanceProcAddr gipa_loader = env.vulkan_functions.vkGetInstanceProcAddr;
         PFN_vkGetInstanceProcAddr gipa_queried = reinterpret_cast<PFN_vkGetInstanceProcAddr>(
             env.vulkan_functions.vkGetInstanceProcAddr(inst.inst, "vkGetInstanceProcAddr"));
-        ASSERT_EQ(gipa_loader, gipa_queried);
+        assert_gipa_equivalent(gipa_loader, gipa_queried);
     }
 }
 
@@ -72,13 +128,13 @@ TEST(GetProcAddr, VerifyGetDeviceProcAddr) {
     //       that to what is returned by asking it what the various Vulkan get proc addr functions are.
     PFN_vkGetDeviceProcAddr gdpa_loader = env.vulkan_functions.vkGetDeviceProcAddr;
     PFN_vkGetDeviceProcAddr gdpa_inst_queried = inst.load("vkGetDeviceProcAddr");
-    ASSERT_EQ(gdpa_loader, gdpa_inst_queried);
+    assert_gdpa_equivalent(gdpa_loader, gdpa_inst_queried, VK_NULL_HANDLE);
 
     DeviceWrapper dev{inst};
     dev.CheckCreate(phys_dev);
 
     PFN_vkGetDeviceProcAddr gdpa_dev_queried = dev.load("vkGetDeviceProcAddr");
-    ASSERT_EQ(gdpa_loader, gdpa_dev_queried);
+    assert_gdpa_equivalent(gdpa_loader, gdpa_dev_queried, dev);
 }
 
 // Load the global function pointers with and without a NULL vkInstance handle.
@@ -164,7 +220,7 @@ TEST(GetProcAddr, GlobalFunctions) {
         handle_assert_null(CreateInstance);
 
         PFN_vkGetInstanceProcAddr GetInstanceProcAddr = inst.load("vkGetInstanceProcAddr");
-        handle_assert_equal(env.vulkan_functions.vkGetInstanceProcAddr, GetInstanceProcAddr);
+        assert_gipa_equivalent(env.vulkan_functions.vkGetInstanceProcAddr, GetInstanceProcAddr);
         ASSERT_EQ(GetInstanceProcAddr,
                   reinterpret_cast<PFN_vkGetInstanceProcAddr>(GetInstanceProcAddr(inst, "vkGetInstanceProcAddr")));
         ASSERT_EQ(GetInstanceProcAddr,


### PR DESCRIPTION
Fixes #1884.

The loader's unknown-function trampolines (the phys-dev and device extension chains) didn't have an ARM64EC path, so unknown entrypoints would fall over on Windows on Arm. This adds one.

What's here:
- **asm**: Each trampoline now gets an ARM64EC custom entry thunk ahead of a signature-less body. x64 callers enter through `__os_arm64x_x64_jump`, while ARM64EC callers come in through `__os_arm64x_check_icall`. The implementation uses the `ksarm64.h` helpers under `_ARM64EC_`.
- **build**: `SYSTEM_PROCESSOR` now comes from the generator platform, `update_deps.py` learns the arm64ec architecture, and `_M_ARM64EC` maps to the 64-bit assembly offsets. Also resolves `armasm64` by full path since CMake's MARMASM detection only recognizes plain `ARM64`.
- **tests**: On ARM64EC, `GetProcAddress` returns an x64 fast-forward-sequence stub, while the loader's internal `&fn` points at the native ARM64EC implementation. Both are valid entrypoints, but they aren't required to be bit-identical, so the proc-addr tests compare behavior rather than raw pointer identity on ARM64EC and remain strict everywhere else.
- **ci**: Adds a native Windows 11 Arm job covering ARM64 and ARM64EC in both Debug and Release configurations.

This ended up touching a little more than just the trampoline assembly. Getting ARM64EC support fully wired through required build-system updates, test fixes for the expected pointer-identity split, and CI coverage to keep it from regressing.