### PR TITLE
index pd_details by matched device in settings device config apply

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7279,12 +7279,12 @@ VkResult loader_apply_settings_device_configurations(struct loader_instance *ins
                 if (pd_details[j].pd_supports_driver_properties) {
                     loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0,
                                "pPhysicalDevices array index %d is set to \"%s\" (%s, version %d) ", written_output_index,
-                               pd_details[j].properties.deviceName, pd_details[i].driver_properties.driverName,
-                               pd_details[i].properties.driverVersion);
+                               pd_details[j].properties.deviceName, pd_details[j].driver_properties.driverName,
+                               pd_details[j].properties.driverVersion);
                 } else {
                     loader_log(inst, VULKAN_LOADER_DEBUG_BIT, 0,
                                "pPhysicalDevices array index %d is set to \"%s\" (driver version %d) ", written_output_index,
-                               pd_details[j].properties.deviceName, pd_details[i].properties.driverVersion);
+                               pd_details[j].properties.deviceName, pd_details[j].properties.driverVersion);
                 }
                 pPhysicalDevices[written_output_index++] = (VkPhysicalDevice)inst->phys_devs_term[j];
                 pd_details[j].pd_was_added = true;


### PR DESCRIPTION
    pd_details: 1 element (phys_dev_count_term), 552 bytes
    i=1  &pd_details[i] lands past the end  ->  out-of-bounds read

pd_details in loader_apply_settings_device_configurations is sized by
inst->phys_dev_count_term, one entry per enumerated VkPhysicalDevice. The inner
loop walks the real devices with j and matches each settings-file
device_configuration (outer index i) against them.

Spotted while reading the device_configurations path. The two debug log lines in
the match block read pd_details[i] for driverName and driverVersion. i is the
outer index over inst->settings.device_configuration_count, which comes from
vk_loader_settings.json, not from the device array. The deviceName beside them
already uses pd_details[j], so j is the index that was meant.

A settings file may list more device_configurations than there are devices.
Duplicate one real device's deviceUUID/driverUUID/driverVersion across several
entries and every entry matches that same device. Once i passes
phys_dev_count_term the read walks off the end of the stack allocation.
driverVersion is read unconditionally as a vararg; the driverName %s read
follows when debug logging is on.

All three reads now use pd_details[j].