### PR TITLE
size sparse image format emulation array by its element type

### DIFF
--- a/loader/terminator.c
+++ b/loader/terminator.c
@@ -465,7 +465,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceSparseImageFormatProperti
         } else {
             // Allocate a temporary array for the output of the old function
             VkSparseImageFormatProperties *properties =
-                loader_stack_alloc(*pPropertyCount * sizeof(VkSparseImageMemoryRequirements));
+                loader_stack_alloc(*pPropertyCount * sizeof(VkSparseImageFormatProperties));
             if (properties == NULL) {
                 *pPropertyCount = 0;
                 loader_log(icd_term->this_instance, VULKAN_LOADER_ERROR_BIT, 0,

--- a/loader/terminator.c
+++ b/loader/terminator.c
@@ -464,8 +464,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceSparseImageFormatProperti
                 pFormatInfo->tiling, pPropertyCount, NULL);
         } else {
             // Allocate a temporary array for the output of the old function
-            VkSparseImageFormatProperties *properties =
-                loader_stack_alloc(*pPropertyCount * sizeof(VkSparseImageFormatProperties));
+            VkSparseImageFormatProperties *properties = loader_stack_alloc(*pPropertyCount * sizeof(VkSparseImageFormatProperties));
             if (properties == NULL) {
                 *pPropertyCount = 0;
                 loader_log(icd_term->this_instance, VULKAN_LOADER_ERROR_BIT, 0,


### PR DESCRIPTION
Reading the propertyCount emulation paths in terminator.c next to each other, the scratch-array allocations line up except one:

    GetPhysicalDeviceQueueFamilyProperties2:        *pQueueFamilyPropertyCount * sizeof(VkQueueFamilyProperties)
    GetPhysicalDeviceSparseImageFormatProperties2:  *pPropertyCount * sizeof(VkSparseImageMemoryRequirements)

Every path sizes its scratch array by the element type it later fills. The sparse one is the odd one out. `properties` is declared `VkSparseImageFormatProperties *`, the ICD writes `VkSparseImageFormatProperties` into it, and the copy loop reads it back with `memcpy(..., sizeof(VkSparseImageFormatProperties))`. Only the allocation counts in `VkSparseImageMemoryRequirements`, which belongs to the `vkGetImageSparseMemoryRequirements` family and is unrelated to this call.

It does not overrun, since that struct is the larger of the two (48 vs 20 bytes here), so the alloca is about 2.4x bigger than needed per element, scaled by the caller's pPropertyCount. The wrong type pairing is the real problem though: it reads like the buffer holds sparse memory requirements when it holds format properties.

Swept the other allocations in the tree, this is the only one whose sizeof type disagrees with its pointer. Sized it by VkSparseImageFormatProperties to match the buffer and the sibling paths.