### PR TITLE
log driverUUID instead of deviceUUID for missing device config

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7285,7 +7285,7 @@ VkResult loader_apply_settings_device_configurations(struct loader_instance *ins
             char device_uuid_str[UUID_STR_LEN] = {0};
             loader_log_generate_uuid_string(current_deviceUUID, device_uuid_str);
             char driver_uuid_str[UUID_STR_LEN] = {0};
-            loader_log_generate_uuid_string(current_deviceUUID, driver_uuid_str);
+            loader_log_generate_uuid_string(current_driverUUID, driver_uuid_str);
 
             // Log that this configuration was missing.
             if (inst->settings.device_configurations[i].deviceName[0] != '\0' &&


### PR DESCRIPTION
Spotted while reading the settings device-configuration matcher. When a device_configuration from vk_loader_settings.json matches no enumerated device, the loader warns about the missing config:

    ... Missing VkPhysicalDevice with deviceName: "...", deviceUUID: 0102...-..., driverName: "...", driverUUID: 0102...-..., driverVersion: ...

The driverUUID it prints is actually the deviceUUID. driver_uuid_str is generated from current_deviceUUID, the same source as device_uuid_str on the line above. current_driverUUID is set just before (and used in the memcmp that does the matching) but never reaches the log. settings.c logs the deviceUUID/driverUUID pair correctly, which is what made the mismatch stand out.

Only the driverUUID diagnostic is wrong here; the matching itself is unaffected.