### PR TITLE
loader: Change incompatible driver warning to debug level

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -6023,7 +6023,8 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateInstance(const VkInstanceCreateI
             res = VK_ERROR_OUT_OF_HOST_MEMORY;
             goto out;
         } else if (VK_SUCCESS != icd_result) {
-            loader_log(ptr_instance, VULKAN_LOADER_WARN_BIT, 0,
+            VkFlags log_level = VK_ERROR_INCOMPATIBLE_DRIVER == icd_result ? VULKAN_LOADER_DEBUG_BIT : VULKAN_LOADER_WARN_BIT;
+            loader_log(ptr_instance, log_level, 0,
                        "terminator_CreateInstance: Received return code %i from call to vkCreateInstance in ICD %s. Skipping "
                        "this driver.",
                        icd_result, icd_term->scanned_icd->lib_name);


### PR DESCRIPTION
Some Linux distros (at least Fedora 44) ship Mesa's Dozen driver, even though it's not compatible as is on Linux.

So the loader would systematically warn about it, and Vulkan application users are confused by the message:

```
terminator_CreateInstance: Received return code -9 from call to vkCreateInstance in ICD /usr/lib64/libvulkan_dzn.so. Skipping this driver.
```

Some additional context:
- Godot PR silencing this warning at application level: https://github.com/godotengine/godot/pull/120393
  * That's sufficient for Godot, but I think it's a loader issue to warn about something users shouldn't worry about it, hence this suggestion.
- @airlied seemed to run into this too and changed the return code for Dozen from `VK_ERROR_INITIALIZATION_FAILED` to `VK_ERROR_INCOMPATIBLE_DRIVER` in Mesa: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/38611
  * I was hoping this would silence the warning but it seems it doesn't as of Mesa 26.0.8 in Fedora 44.
- I don't claim the change I propose is the best approach, either functionally or style wise. Feel free to suggest changes / make a different change, or outright reject if you don't think this should be changed. Some other options would be to use `VULKAN_LOADER_INFO_BIT` instead of `DEBUG` (Godot ignores both so that's good for me) and/or to write a custom message that's more intelligible now that `VK_ERROR_INCOMPATIBLE_DRIVER` is special-cased.
- I tested this change on top of `v1.4.341`, as that's the version of `vulkan-headers` I had packaged on Fedora 44, so it was more convenient. I expect it to work fine on `main` too.
- No AI was used in making this change or writing this description.