### PR TITLE
use reserved index in debug messenger and report create rollback

### DIFF
--- a/loader/debug_utils.c
+++ b/loader/debug_utils.c
@@ -175,6 +175,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDebugUtilsMessengerEXT(VkInstanc
     VkResult res = VK_SUCCESS;
     VkLayerDbgFunctionNode *new_dbg_func_node = NULL;
     uint32_t next_index = 0;
+    bool index_reserved = false;
 
     uint32_t *pNextIndex = loader_instance_heap_alloc(inst, sizeof(uint32_t), VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
     if (NULL == pNextIndex) {
@@ -186,6 +187,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDebugUtilsMessengerEXT(VkInstanc
     if (res != VK_SUCCESS) {
         goto out;
     }
+    index_reserved = true;
 
     for (struct loader_icd_term *icd_term = inst->icd_terms; icd_term != NULL; icd_term = icd_term->next) {
         if (icd_term->debug_utils_messenger_list.list == NULL) {
@@ -245,11 +247,11 @@ out:
                 }
             }
         }
-        if (inst->debug_utils_messengers_list.list &&
-            inst->debug_utils_messengers_list.capacity > (*pNextIndex) * sizeof(struct loader_used_object_status)) {
-            inst->debug_utils_messengers_list.list[*pNextIndex].status = VK_FALSE;
+        if (index_reserved && inst->debug_utils_messengers_list.list &&
+            inst->debug_utils_messengers_list.capacity > next_index * sizeof(struct loader_used_object_status)) {
+            inst->debug_utils_messengers_list.list[next_index].status = VK_FALSE;
             if (NULL != pAllocator) {
-                inst->debug_utils_messengers_list.list[*pNextIndex].allocation_callbacks = *pAllocator;
+                inst->debug_utils_messengers_list.list[next_index].allocation_callbacks = *pAllocator;
             }
         }
         loader_free_with_instance_fallback(pAllocator, inst, new_dbg_func_node);
@@ -453,6 +455,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDebugReportCallbackEXT(VkInstanc
     VkResult res = VK_SUCCESS;
     VkLayerDbgFunctionNode *new_dbg_func_node = NULL;
     uint32_t next_index = 0;
+    bool index_reserved = false;
 
     uint32_t *pNextIndex = loader_instance_heap_alloc(inst, sizeof(uint32_t), VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
     if (NULL == pNextIndex) {
@@ -464,6 +467,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDebugReportCallbackEXT(VkInstanc
     if (res != VK_SUCCESS) {
         goto out;
     }
+    index_reserved = true;
 
     for (struct loader_icd_term *icd_term = inst->icd_terms; icd_term != NULL; icd_term = icd_term->next) {
         if (icd_term->debug_report_callback_list.list == NULL) {
@@ -523,11 +527,11 @@ out:
                 }
             }
         }
-        if (inst->debug_report_callbacks_list.list &&
-            inst->debug_report_callbacks_list.capacity > (*pNextIndex) * sizeof(struct loader_used_object_status)) {
-            inst->debug_report_callbacks_list.list[*pNextIndex].status = VK_FALSE;
+        if (index_reserved && inst->debug_report_callbacks_list.list &&
+            inst->debug_report_callbacks_list.capacity > next_index * sizeof(struct loader_used_object_status)) {
+            inst->debug_report_callbacks_list.list[next_index].status = VK_FALSE;
             if (NULL != pAllocator) {
-                inst->debug_report_callbacks_list.list[*pNextIndex].allocation_callbacks = *pAllocator;
+                inst->debug_report_callbacks_list.list[next_index].allocation_callbacks = *pAllocator;
             }
         }
         loader_free_with_instance_fallback(pAllocator, inst, new_dbg_func_node);


### PR DESCRIPTION
terminator_CreateDebugUtilsMessengerEXT, the rollback at out::

    179  uint32_t *pNextIndex = loader_instance_heap_alloc(...);   // malloc, uninitialised
    232  *pNextIndex = next_index;                                 // only on success
    250  ...messengers_list.list[*pNextIndex].status = VK_FALSE;   // read on the error path

*pNextIndex is set once, at the tail of the success path, but the error
rollback reads it. A failure before that point (a driver returning an
error from CreateDebugUtilsMessengerEXT, or the new_dbg_func_node
allocation failing) leaves it holding whatever malloc returned. If the
pNextIndex allocation itself failed while the instance already owns a
messenger, pNextIndex is NULL and the short-circuit dereferences it. On
32-bit the index * sizeof in the capacity check can also wrap the write
out of the list.

The destroy loop just above already uses the reserved local next_index.
Release the slot the same way, and only when one was reserved.
terminator_CreateDebugReportCallbackEXT had the same rollback.
