### PR TITLE
check realloc result before zeroing grown bytes in loader_realloc

### DIFF
--- a/loader/allocation.c
+++ b/loader/allocation.c
@@ -98,8 +98,9 @@ void *loader_realloc(const VkAllocationCallbacks *pAllocator, void *pMemory, siz
 #endif
     } else {
         pNewMem = realloc(pMemory, size);
-        // Clear out the newly allocated memory
-        if (size > orig_size) {
+        // Clear out the newly allocated memory. On failure realloc returns NULL and leaves the original block valid, so
+        // only write through pNewMem once we know it points at the resized allocation.
+        if (NULL != pNewMem && size > orig_size) {
             memset((uint8_t *)pNewMem + orig_size, 0, size - orig_size);
         }
     }


### PR DESCRIPTION
Was tracing the generic-list growth paths and stopped on loader_realloc.

1. on the default path we store realloc(pMemory, size) in pNewMem, then zero the grown tail with memset((uint8_t *)pNewMem + orig_size, 0, size - orig_size) whenever size > orig_size.
2. realloc hands back NULL on failure and leaves the original block untouched, so under OOM pNewMem is NULL and that memset writes through a null pointer at offset orig_size before we ever return.

The callers all check the returned pointer for NULL, so only the zero-fill inside loader_realloc touches it early. Guarded the memset on pNewMem so the tail is only cleared when realloc actually returned the resized block. Behaviour is unchanged on success.