### PR TITLE
null-terminate device name copies in linux device sort

### DIFF
--- a/loader/loader_linux.c
+++ b/loader/loader_linux.c
@@ -262,7 +262,8 @@ VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32
 
             icd_term->dispatch.GetPhysicalDeviceProperties(sorted_device_info[index].physical_device, &dev_props);
             sorted_device_info[index].device_type = dev_props.deviceType;
-            strncpy(sorted_device_info[index].device_name, dev_props.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
+            strncpy(sorted_device_info[index].device_name, dev_props.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE - 1);
+            sorted_device_info[index].device_name[VK_MAX_PHYSICAL_DEVICE_NAME_SIZE - 1] = '\0';
             sorted_device_info[index].vendor_id = dev_props.vendorID;
             sorted_device_info[index].device_id = dev_props.deviceID;
 
@@ -365,7 +366,8 @@ VkResult linux_sort_physical_device_groups(struct loader_instance *inst, uint32_
                                                            &dev_props);
             sorted_group_term[group].internal_device_info[gpu].device_type = dev_props.deviceType;
             strncpy(sorted_group_term[group].internal_device_info[gpu].device_name, dev_props.deviceName,
-                    VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
+                    VK_MAX_PHYSICAL_DEVICE_NAME_SIZE - 1);
+            sorted_group_term[group].internal_device_info[gpu].device_name[VK_MAX_PHYSICAL_DEVICE_NAME_SIZE - 1] = '\0';
             sorted_group_term[group].internal_device_info[gpu].vendor_id = dev_props.vendorID;
             sorted_group_term[group].internal_device_info[gpu].device_id = dev_props.deviceID;
 


### PR DESCRIPTION
ASan, with a driver that fills all 256 bytes of deviceName and no terminator:

    READ of size 257 ... heap-buffer-overflow
    #0 printf_common
    #2 linux_read_sorted_physical_devices loader_linux.c

Was reading through the physical-device sort path. The loader copies the driver-reported deviceName into its own LinuxSortedDeviceInfo with strncpy bounded by the full VK_MAX_PHYSICAL_DEVICE_NAME_SIZE. strncpy leaves no terminator when the source occupies the whole field, so a driver that returns a 256-byte name produces an unterminated device_name. That field is then logged with %s, so the read runs off the end of the buffer, past the heap allocation for the last sorted entry.

We make our own copy here, so the termination has to be guaranteed on our side rather than trusted from the driver. The same copy is in linux_sort_physical_device_groups. Both now bound the copy to SIZE-1 and write the terminator, matching the strncpy plus explicit nul already used in loader_windows.c.