### PR TITLE
clamp re-queried counts in terminator_EnumeratePhysicalDeviceGroups

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7806,6 +7806,12 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumeratePhysicalDeviceGroups(
             if (NULL == fpEnumeratePhysicalDeviceGroups) {
                 icd_term->dispatch.EnumeratePhysicalDevices(icd_term->instance, &count_this_time, NULL);
 
+                // The driver can report more devices on this query than it did during the counting pass above. The local arrays
+                // were sized to total_count, so never let this ICD write past the space still reserved for it.
+                if (count_this_time > total_count - cur_icd_group_count) {
+                    count_this_time = total_count - cur_icd_group_count;
+                }
+
                 VkPhysicalDevice *phys_dev_array = loader_stack_alloc(sizeof(VkPhysicalDevice) * count_this_time);
                 if (NULL == phys_dev_array) {
                     loader_log(
@@ -7841,6 +7847,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumeratePhysicalDeviceGroups(
                                "\'EnumeratePhysicalDeviceGroups\' to ICD %s to get group count.",
                                icd_term->scanned_icd->lib_name);
                     goto out;
+                }
+                // Same guard as the plain-device path: the re-queried count can exceed the space sized during the counting pass.
+                if (count_this_time > total_count - cur_icd_group_count) {
+                    count_this_time = total_count - cur_icd_group_count;
                 }
                 if (cur_icd_group_count + count_this_time < *pPhysicalDeviceGroupCount) {
                     // The total amount is still less than the amount of physical device group data passed in


### PR DESCRIPTION
Tracing the device-group terminator while chasing a stack-smash report:

    loader.c:7829  for (indiv_gpu = 0; indiv_gpu < count_this_time; ++indiv_gpu)
                       local_phys_dev_groups[indiv_gpu + cur_icd_group_count] = ...

`local_phys_dev_groups` is sized to `total_count`, which is summed in the first pass that asks each ICD for its group count. The fill pass then re-queries every ICD into `count_this_time` (`EnumeratePhysicalDevices` on the no-device-group path, `EnumeratePhysicalDeviceGroups` otherwise, both with a NULL property pointer) and indexes the array by that value. The re-queried count is never bounded to the space left in the array.

So a driver that reports more devices on the second query than it did on the first walks off the end of the stack array. Both fill branches re-query, so both can overrun. Same count-drift behaviour the *2KHR emulators already guard against, here on the two-pass group path.

Clamp `count_this_time` to the remaining reserved space (`total_count - cur_icd_group_count`) right after each re-query. No change for a well-behaved driver where the two passes agree; the existing device-group tests stay green.