### PR TITLE
clamp re-queried extension count in enumeration helpers

### DIFF
--- a/loader/extension_manual.c
+++ b/loader/extension_manual.c
@@ -366,12 +366,14 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceToolPropertiesEXT(VkP
         goto out;
     }
 
+    uint32_t allocated_count = ext_count;
     enumerate_res = icd_term->dispatch.EnumerateDeviceExtensionProperties(phys_dev_term->phys_dev, NULL, &ext_count, ext_props);
     if (enumerate_res != VK_SUCCESS) {
         goto out;
     }
 
-    for (uint32_t i = 0; i < ext_count; i++) {
+    // The count returned by the second call sizes the array, but never read past what we actually allocated.
+    for (uint32_t i = 0; i < ext_count && i < allocated_count; i++) {
         if (strncmp(ext_props[i].extensionName, VK_EXT_TOOLING_INFO_EXTENSION_NAME, VK_MAX_EXTENSION_NAME_SIZE) == 0) {
             tooling_info_supported = true;
             break;

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1002,6 +1002,7 @@ VkResult loader_add_instance_extensions(const struct loader_instance *inst,
     }
     memset(ext_props, 0, count * sizeof(VkExtensionProperties));
 
+    uint32_t allocated_count = count;
     res = fp_get_props(NULL, &count, ext_props);
     if (res != VK_SUCCESS) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "loader_add_instance_extensions: Error getting Instance extensions from %s",
@@ -1009,7 +1010,8 @@ VkResult loader_add_instance_extensions(const struct loader_instance *inst,
         goto out;
     }
 
-    for (i = 0; i < count; i++) {
+    // The count returned by the second call sizes the array, but never read past what we actually allocated.
+    for (i = 0; i < count && i < allocated_count; i++) {
         bool ext_unsupported = wsi_unsupported_instance_extension(&ext_props[i]);
         if (!ext_unsupported) {
             res = loader_add_to_ext_list(inst, ext_list, 1, &ext_props[i]);
@@ -1045,11 +1047,13 @@ VkResult loader_add_device_extensions(const struct loader_instance *inst,
                        lib_name);
             return VK_ERROR_OUT_OF_HOST_MEMORY;
         }
+        uint32_t allocated_count = count;
         res = fpEnumerateDeviceExtensionProperties(physical_device, NULL, &count, ext_props);
         if (res != VK_SUCCESS) {
             return res;
         }
-        for (i = 0; i < count; i++) {
+        // The count returned by the second call sizes the array, but never read past what we actually allocated.
+        for (i = 0; i < count && i < allocated_count; i++) {
             res = loader_add_to_ext_list(inst, ext_list, 1, &ext_props[i]);
             if (res != VK_SUCCESS) {
                 return res;
@@ -7167,12 +7171,14 @@ VkResult check_physical_device_extensions_for_driver_properties_extension(struct
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
 
+    uint32_t allocated_count = extension_count;
     res = phys_dev_term->this_icd_term->dispatch.EnumerateDeviceExtensionProperties(phys_dev_term->phys_dev, NULL, &extension_count,
                                                                                     extension_data);
     if (res != VK_SUCCESS) {
         return VK_SUCCESS;
     }
-    for (uint32_t j = 0; j < extension_count; j++) {
+    // The count returned by the second call sizes the array, but never read past what we actually allocated.
+    for (uint32_t j = 0; j < extension_count && j < allocated_count; j++) {
         if (!strcmp(extension_data[j].extensionName, VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME)) {
             *supports_driver_properties = true;
             return VK_SUCCESS;

--- a/loader/loader_linux.c
+++ b/loader/loader_linux.c
@@ -279,9 +279,11 @@ VkResult linux_read_sorted_physical_devices(struct loader_instance *inst, uint32
                         res = VK_ERROR_OUT_OF_HOST_MEMORY;
                         goto out;
                     }
+                    uint32_t allocated_count = ext_count;
                     icd_term->dispatch.EnumerateDeviceExtensionProperties(sorted_device_info[index].physical_device, NULL,
                                                                           &ext_count, ext_props);
-                    for (uint32_t ext = 0; ext < ext_count; ++ext) {
+                    // The count returned by the second call sizes the array, but never read past what we actually allocated.
+                    for (uint32_t ext = 0; ext < ext_count && ext < allocated_count; ++ext) {
                         if (!strcmp(ext_props[ext].extensionName, VK_EXT_PCI_BUS_INFO_EXTENSION_NAME)) {
                             sorted_device_info[index].has_pci_bus_info = true;
                             break;
@@ -381,9 +383,11 @@ VkResult linux_sort_physical_device_groups(struct loader_instance *inst, uint32_
                     if (NULL == ext_props) {
                         return VK_ERROR_OUT_OF_HOST_MEMORY;
                     }
+                    uint32_t allocated_count = ext_count;
                     icd_term->dispatch.EnumerateDeviceExtensionProperties(
                         sorted_group_term[group].internal_device_info[gpu].physical_device, NULL, &ext_count, ext_props);
-                    for (uint32_t ext = 0; ext < ext_count; ++ext) {
+                    // The count returned by the second call sizes the array, but never read past what we actually allocated.
+                    for (uint32_t ext = 0; ext < ext_count && ext < allocated_count; ++ext) {
                         if (!strcmp(ext_props[ext].extensionName, VK_EXT_PCI_BUS_INFO_EXTENSION_NAME)) {
                             sorted_group_term[group].internal_device_info[gpu].has_pci_bus_info = true;
                             break;


### PR DESCRIPTION
Tracing the device extension enumeration helpers for the misbehaving-driver case the recent *2KHR clamps covered, the same shape turns up in the plain enumeration paths that fill a loader-internal scratch array.

1. each site queries the ICD for an extension count, sizes a scratch array to it, then calls the Enumerate*ExtensionProperties entrypoint again with that array.
2. the loop over the scratch array is bounded by the count the second call writes back, not by the count the array was sized for.
3. a driver that returns a larger count on the second call walks the loop past the allocation, reading out of bounds of the loader own buffer.

Clamped each loop to the snapshotted allocated count, same idea as the emulation terminators. Six sites: loader_add_instance_extensions, loader_add_device_extensions and check_physical_device_extensions_for_driver_properties_extension in loader.c, terminator_GetPhysicalDeviceToolPropertiesEXT in extension_manual.c, and the two PCI-bus checks in loader_linux.c.