### PR TITLE
clamp group physicalDeviceCount to VK_MAX_DEVICE_GROUP_SIZE

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7874,6 +7874,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumeratePhysicalDeviceGroups(
                     for (uint32_t group = 0; group < count_this_time; ++group) {
                         uint32_t cur_index = group + cur_icd_group_count;
                         local_phys_dev_groups[cur_index].group_props = pPhysicalDeviceGroupProperties[cur_index];
+                        // physicalDevices is a fixed VK_MAX_DEVICE_GROUP_SIZE array; don't trust a larger count from the ICD.
+                        if (local_phys_dev_groups[cur_index].group_props.physicalDeviceCount > VK_MAX_DEVICE_GROUP_SIZE) {
+                            local_phys_dev_groups[cur_index].group_props.physicalDeviceCount = VK_MAX_DEVICE_GROUP_SIZE;
+                        }
                         local_phys_dev_groups[cur_index].this_icd_term = icd_term;
                     }
                 } else {
@@ -7904,6 +7908,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumeratePhysicalDeviceGroups(
                     for (uint32_t group = 0; group < count_this_time; ++group) {
                         uint32_t cur_index = group + cur_icd_group_count;
                         local_phys_dev_groups[cur_index].group_props = tmp_group_props[group];
+                        // physicalDevices is a fixed VK_MAX_DEVICE_GROUP_SIZE array; don't trust a larger count from the ICD.
+                        if (local_phys_dev_groups[cur_index].group_props.physicalDeviceCount > VK_MAX_DEVICE_GROUP_SIZE) {
+                            local_phys_dev_groups[cur_index].group_props.physicalDeviceCount = VK_MAX_DEVICE_GROUP_SIZE;
+                        }
                         local_phys_dev_groups[cur_index].this_icd_term = icd_term;
                     }
                 }


### PR DESCRIPTION
Tracing how driver-reported counts flow into the device-group sort.

    out-of-bounds write, linux_sort_physical_device_groups (loader_linux.c:363):
        internal_device_info[gpu] = ...      gpu < group_props.physicalDeviceCount
        internal_device_info is [VK_MAX_DEVICE_GROUP_SIZE]   (32 entries)

`VkPhysicalDeviceGroupProperties::physicalDevices` is a fixed `[VK_MAX_DEVICE_GROUP_SIZE]` array, and `loader_physical_device_group_term` embeds a matching `internal_device_info[VK_MAX_DEVICE_GROUP_SIZE]`. terminator_EnumeratePhysicalDeviceGroups copies each group straight from the ICD into `local_phys_dev_groups[...].group_props` and trusts `physicalDeviceCount` unmodified.

An ICD that reports `physicalDeviceCount` greater than 32 then drives the consumers off the end of those fixed arrays: the Linux sort writes past `internal_device_info`, while the Windows sort and `setup_loader_tramp_phys_dev_groups` read past `physicalDevices`. The count from the first (group-count) query is already clamped, but the per-group device count never was.

Clamp it to `VK_MAX_DEVICE_GROUP_SIZE` at the two points where the group is copied in, so every downstream consumer sees a count that fits its array. The plain-device path already sets the count to 1.
