### PR TITLE
fix out-of-bounds read in vk_string_validate on truncated utf-8

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7487,7 +7487,7 @@ out:
     return res;
 }
 
-VkStringErrorFlags vk_string_validate(const int max_length, const char *utf8) {
+TEST_FUNCTION_EXPORT VkStringErrorFlags vk_string_validate(const int max_length, const char *utf8) {
     VkStringErrorFlags result = VK_STRING_ERROR_NONE;
     int num_char_bytes = 0;
     int i, j;
@@ -7519,6 +7519,12 @@ VkStringErrorFlags vk_string_validate(const int max_length, const char *utf8) {
             if (++i == max_length) {
                 result |= VK_STRING_ERROR_LENGTH;
                 break;
+            }
+            if (utf8[i] == 0) {
+                // The string terminated in the middle of a multi-byte character. Stop here so the
+                // continuation-byte scan doesn't read past the terminator.
+                result |= VK_STRING_ERROR_BAD_DATA;
+                return result;
             }
             if ((utf8[i] & UTF8_DATA_BYTE_MASK) != UTF8_DATA_BYTE_CODE) {
                 result |= VK_STRING_ERROR_BAD_DATA;

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -233,7 +233,7 @@ void unload_drivers_without_physical_devices(struct loader_instance *inst);
 VkResult loader_apply_settings_device_configurations(struct loader_instance *inst, uint32_t *pPhysicalDeviceCount,
                                                      VkPhysicalDevice *pPhysicalDevices);
 
-VkStringErrorFlags vk_string_validate(const int max_length, const char *char_array);
+TEST_FUNCTION_EXPORT VkStringErrorFlags vk_string_validate(const int max_length, const char *char_array);
 char *loader_get_next_path(char *path);
 VkResult add_if_manifest_file(const struct loader_instance *inst, const char *file_name, struct loader_string_list *out_files);
 VkResult prepend_if_manifest_file(const struct loader_instance *inst, const char *file_name, struct loader_string_list *out_files);

--- a/tests/loader_fuzz_tests.cpp
+++ b/tests/loader_fuzz_tests.cpp
@@ -28,6 +28,7 @@
 #include "framework/test_environment.h"
 
 #include <fstream>
+#include <vector>
 
 extern "C" {
 #include "loader.h"
@@ -340,4 +341,23 @@ TEST(BadJsonInput, ClusterFuzzTestCase_5123849246867456) {
 }
 TEST(BadJsonInput, ClusterFuzzTestCase_4626669072875520) {
     execute_setting_fuzzer("clusterfuzz-testcase-minimized-settings_fuzzer-4626669072875520");
+}
+
+// A string that ends in the middle of a multi-byte UTF-8 character must not make vk_string_validate read
+// past the terminator. Each buffer is sized to its exact contents so ASAN flags any over-read.
+TEST(StringValidation, TruncatedMultiByteDoesNotReadPastTerminator) {
+    // 2-, 3- and 4-byte lead bytes, each immediately followed by the terminator.
+    for (unsigned char lead : {0xC2u, 0xE2u, 0xF0u}) {
+        std::vector<char> truncated = {static_cast<char>(lead), '\0'};
+        EXPECT_EQ(vk_string_validate(MaxLoaderStringLength, truncated.data()), VK_STRING_ERROR_BAD_DATA);
+    }
+    // A lead byte with one valid continuation byte but still short of the required count.
+    std::vector<char> short_seq = {static_cast<char>(0xE2), static_cast<char>(0x82), '\0'};
+    EXPECT_EQ(vk_string_validate(MaxLoaderStringLength, short_seq.data()), VK_STRING_ERROR_BAD_DATA);
+
+    // Well-formed strings still validate cleanly.
+    std::vector<char> ascii = {'a', 'b', 'c', '\0'};
+    EXPECT_EQ(vk_string_validate(MaxLoaderStringLength, ascii.data()), VK_STRING_ERROR_NONE);
+    std::vector<char> two_byte = {static_cast<char>(0xC2), static_cast<char>(0xA9), '\0'};
+    EXPECT_EQ(vk_string_validate(MaxLoaderStringLength, two_byte.data()), VK_STRING_ERROR_NONE);
 }


### PR DESCRIPTION
Found while running the loaders layer/extension name validation under ASAN with malformed UTF-8.

1. on a multi-byte lead byte vk_string_validate sets num_char_bytes and then scans that many continuation bytes.
2. the inner scan stops at max_length but never at the strings null terminator.
3. a requested layer/extension name ending in a lone lead byte (eg 0xC2/0xE2/0xF0) makes it walk past the terminator, and the outer loop then resumes past it, so ASAN reports a heap read up to MaxLoaderStringLength (256) bytes past the buffer.
4. stop at a null seen inside a sequence, mark it bad data and return; added a regression test that trips the old read under ASAN.