### PR TITLE
clamp re-queried physical device count in setup_loader_term_phys_devs

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -6802,6 +6802,7 @@ VkResult setup_loader_term_phys_devs(struct loader_instance *inst) {
                 goto out;
             }
 
+            uint32_t allocated_count = icd_phys_dev_array[icd_idx].device_count;
             res = icd_term->dispatch.EnumeratePhysicalDevices(icd_term->instance, &(icd_phys_dev_array[icd_idx].device_count),
                                                               icd_phys_dev_array[icd_idx].physical_devices);
             if (VK_ERROR_OUT_OF_HOST_MEMORY == res) {
@@ -6818,6 +6819,9 @@ VkResult setup_loader_term_phys_devs(struct loader_instance *inst) {
                     icd_term->scanned_icd->lib_name, res);
                 icd_phys_dev_array[icd_idx].device_count = 0;
                 icd_phys_dev_array[icd_idx].physical_devices = 0;
+            } else if (icd_phys_dev_array[icd_idx].device_count > allocated_count) {
+                // The fill call sizes the array, but never read past what we actually allocated.
+                icd_phys_dev_array[icd_idx].device_count = allocated_count;
             }
         } else {
             loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0,


### PR DESCRIPTION
setup_loader_term_phys_devs, the per-ICD two-call enumeration:

    loader.c:6795  physical_devices = loader_stack_alloc(device_count * sizeof(VkPhysicalDevice));  // sizing query
    loader.c:6806  EnumeratePhysicalDevices(icd_instance, &device_count, physical_devices);          // fill query
    loader.c:6921  for (j = 0; j < device_count; ++j)
    loader.c:6922      check_and_add_to_new_phys_devs(..., physical_devices[j], ...);

Walking the two calls: device_count is the same in/out variable for both, and the size handed to loader_stack_alloc is never kept. A driver that reports a larger device_count on the fill call than on the sizing call leaves the consume loop reading past the end of the stack array, and those out-of-bounds VkPhysicalDevice handles feed straight into the wrapped device list.

terminator_EnumeratePhysicalDeviceGroups already clamps its re-queried group count this way; the base vkEnumeratePhysicalDevices path was the one still trusting the second count. Snapshot the count before the fill call and clamp device_count back down to it.