### PR TITLE
loader: Fix double free on Windows

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -476,6 +476,7 @@ VkResult normalize_path(const struct loader_instance *inst, char **passed_in_pat
         char *new_path = loader_instance_heap_realloc(inst, path, path_len, actual_len + 1, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
         if (NULL == new_path) {
             loader_instance_heap_free(inst, path);
+            path = NULL;
             res = VK_ERROR_OUT_OF_HOST_MEMORY;
             goto out;
         }


### PR DESCRIPTION
## Problem
If the path pointer is not null after loader_instance_heap_free(), it would be free twice and trigger crash on Windows.