### PR TITLE
fix off-by-one write in loader_platform_executable_path

### DIFF
--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -307,6 +307,9 @@ static inline char *loader_platform_executable_path(char *buffer, size_t size) {
     ssize_t count = readlink("/proc/self/exe", buffer, size);
     if (count == -1) return NULL;
     if (count == 0) return NULL;
+    // readlink does not append a null terminator and returns up to size bytes, so a target of size or more
+    // would leave no room for the terminator and buffer[count] would write past the end.
+    if ((size_t)count >= size) return NULL;
     buffer[count] = '\0';
     return buffer;
 }


### PR DESCRIPTION
ASAN on a minimal harness of the Linux readlink branch (buffer sized to the caller's 1024):

    WRITE of size 1 at 0x619000000980 thread T0
        #0 loader_platform_executable_path
    0x619000000980 is located 0 bytes after 1024-byte region [...980)

readlink() never appends a terminator and returns up to `size` bytes. When /proc/self/exe resolves to a path of 1024 bytes or more it returns exactly 1024, and `buffer[count] = '\0'` then writes one byte past `current_process_path[1024]`, the stack array `get_loader_settings` hands in.

Found this while diffing the exe-path helpers against each other. The QNX branch already bails on `rdsize == size`, and the comment above this function promises a NULL return for over-long paths, but the readlink branch never enforced either. Bail out when count reaches size so the terminator always has room, which also makes the code match its documented behaviour.
