### PR TITLE
zero grown entries in loader_resize_generic_list

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1065,14 +1065,18 @@ VkResult loader_init_generic_list(const struct loader_instance *inst, struct loa
 }
 
 VkResult loader_resize_generic_list(const struct loader_instance *inst, struct loader_generic_list *list_info) {
-    void *new_ptr = loader_instance_heap_realloc(inst, list_info->list, list_info->capacity, list_info->capacity * 2,
-                                                 VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
+    size_t new_capacity = list_info->capacity * 2;
+    void *new_ptr =
+        loader_instance_heap_realloc(inst, list_info->list, list_info->capacity, new_capacity, VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);
     if (new_ptr == NULL) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "loader_resize_generic_list: Failed to allocate space for generic list");
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
+    // Consumers of the grown region expect unused entries to read as zero (eg a VK_NULL_HANDLE surface). An app supplied
+    // pfnReallocation is not required to zero the newly grown bytes, so do it here rather than relying on the allocator.
+    memset((uint8_t *)new_ptr + list_info->capacity, 0, new_capacity - list_info->capacity);
     list_info->list = new_ptr;
-    list_info->capacity = list_info->capacity * 2;
+    list_info->capacity = new_capacity;
     return VK_SUCCESS;
 }
 


### PR DESCRIPTION
Tracing how the loader's internal object lists get their zero-fill guarantee across the two allocator paths.

`loader_calloc` zeroes on both paths:

    // allocation.c, app-allocator branch
    pMemory = pAllocator->pfnAllocation(...);
    if (pMemory) memset(pMemory, 0, size);

`loader_realloc` only zeroes the grown tail on the default branch:

    // allocation.c, default branch
    pNewMem = realloc(pMemory, size);
    if (NULL != pNewMem && size > orig_size)
        memset((uint8_t *)pNewMem + orig_size, 0, size - orig_size);
    // the pfnReallocation branch has no matching memset

`loader_resize_generic_list` doubles a list and then trusts the new half to read as zero. That holds with the default allocator. It does not hold when the app supplies a `VkAllocationCallbacks` with `pfnReallocation`, since the callback is not obliged to zero grown memory.

These lists are indexed sparsely. `icd_term->surface_list` grows past its initial 32 slots once more than 32 surfaces are live. `wsi_unwrap_icd_surface` then reads `surface_list.list[surface_index]` and treats a non-null value as an already-created ICD surface, so an uninitialised slot makes it skip lazy creation and hand a garbage handle to the driver. The debug messenger lists have the same shape.

`loader_get_next_available_entry` already zeroes its own grown half after the resize instead of trusting the allocator. This moves that guarantee into the resize helper so every list gets it. Valid-input behaviour is unchanged for the default allocator.