### PR TITLE
reject metal surface creation when extension not enabled

### DIFF
--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -1681,6 +1681,8 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateMetalSurfaceEXT(VkInstance insta
     if (!loader_inst->enabled_extensions.ext_metal_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
                    "VK_EXT_metal_surface extension not enabled. vkCreateMetalSurfaceEXT will not be executed.");
+        result = VK_ERROR_EXTENSION_NOT_PRESENT;
+        goto out;
     }
 
     // Next, if so, proceed with the implementation of this function:

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -835,6 +835,25 @@ TEST(WsiTests, ForgetEnableSurfaceExtensions) {
     ASSERT_EQ(VK_ERROR_EXTENSION_NOT_PRESENT, create_surface(inst, surface));
 }
 
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+// Calling the exported vkCreateMetalSurfaceEXT trampoline when VK_EXT_metal_surface was not enabled must be
+// rejected with VK_ERROR_EXTENSION_NOT_PRESENT, matching every other surface-creation terminator. The
+// terminator used to fall through and hand back a live surface with VK_SUCCESS.
+TEST(WsiTests, CreateMetalSurfaceWithoutEnablingExtension) {
+    FrameworkEnvironment env{};
+    env.add_icd(TEST_ICD_PATH_VERSION_2).setup_WSI().add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain"));
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.add_extension("VK_KHR_surface");
+    ASSERT_NO_FATAL_FAILURE(inst.CheckCreate());
+
+    VkMetalSurfaceCreateInfoEXT surf_create_info{VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT};
+    VkSurfaceKHR surface = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_ERROR_EXTENSION_NOT_PRESENT,
+              env.vulkan_functions.vkCreateMetalSurfaceEXT(inst, &surf_create_info, nullptr, &surface));
+}
+#endif  // VK_USE_PLATFORM_METAL_EXT
+
 TEST(WsiTests, SwapchainFunctional) {
     FrameworkEnvironment env{};
     env.add_icd(TEST_ICD_PATH_VERSION_2).setup_WSI().add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain"));


### PR DESCRIPTION
    loader_wsi_tests.cpp: Failure
    Expected equality of these values:
      VK_ERROR_EXTENSION_NOT_PRESENT
      vkCreateMetalSurfaceEXT(inst, &surf_create_info, nullptr, &surface)
        Which is: VK_SUCCESS

Went through each surface terminator's disabled-extension branch. terminator_CreateMetalSurfaceEXT logs the "extension not enabled" warning and then keeps going: it allocates the VkIcdSurface, copies the create_info and returns the handle with VK_SUCCESS. The other Create*Surface terminators refuse that branch, most returning VK_ERROR_EXTENSION_NOT_PRESENT. Metal is the only one that hands back a live surface for an extension the caller never enabled.

The vkGetInstanceProcAddr gate hides this on the usual resolution path, but the exported vkCreateMetalSurfaceEXT trampoline reaches the terminator directly, as does a layer calling down the chain. Fix sets the error and jumps to the shared cleanup so the behaviour matches the siblings. Added a regression test that drives the exported entrypoint on an instance that only enabled VK_KHR_surface.
