### PR TITLE
check khr_android_surface in terminator_CreateAndroidSurfaceKHR

### DIFF
--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -1368,9 +1368,9 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateAndroidSurfaceKHR(VkInstance ins
                                                                   const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
     // First, check to ensure the appropriate extension was enabled:
     struct loader_instance *loader_inst = loader_get_instance(instance);
-    if (!loader_inst->enabled_extensions.khr_display) {
+    if (!loader_inst->enabled_extensions.khr_android_surface) {
         loader_log(loader_inst, VULKAN_LOADER_ERROR_BIT, 0,
-                   "VK_KHR_display extension not enabled. vkCreateAndroidSurfaceKHR not executed!");
+                   "VK_KHR_android_surface extension not enabled. vkCreateAndroidSurfaceKHR not executed!");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 


### PR DESCRIPTION
Reading down the surface-creation terminators in wsi.c to check each one gates on its own extension, this line did not match:

    loader/wsi.c:1371:  if (!loader_inst->enabled_extensions.khr_display) {

terminator_CreateAndroidSurfaceKHR implements VK_KHR_android_surface but checks the khr_display flag. Every sibling terminator checks its own extension, and the vkGetInstanceProcAddr entry for vkCreateAndroidSurfaceKHR (wsi.c:3016) already gates on khr_android_surface.

Behaviour with the wrong flag: an instance that enables VK_KHR_android_surface but not VK_KHR_display has vkCreateAndroidSurfaceKHR rejected with VK_ERROR_EXTENSION_NOT_PRESENT, and one that enables VK_KHR_display without VK_KHR_android_surface can create an Android surface with the extension off.

Pointed the check and the log message at khr_android_surface.