### PR TITLE
break cyclic meta-layer recursion in loader_add_meta_layer

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1465,6 +1465,21 @@ VkResult loader_add_meta_layer(const struct loader_instance *inst, const struct 
     VkResult result = VK_SUCCESS;
     bool found_all_component_layers = true;
 
+    // A meta-layer whose component chain loops back to itself would recurse here until the stack overflows.
+    // verify_all_meta_layers rejects such cycles for layers found through normal discovery, but layers pulled
+    // in from the settings file skip that check, so break the recursion on the second entry to the same layer.
+    if (prop->is_being_expanded) {
+        loader_log(inst, VULKAN_LOADER_WARN_BIT | VULKAN_LOADER_LAYER_BIT, 0,
+                   "loader_add_meta_layer: Meta-layer %s recursively references itself through its component layers. Skipping the "
+                   "recursive reference.",
+                   prop->info.layerName);
+        if (NULL != out_found_all_component_layers) {
+            *out_found_all_component_layers = false;
+        }
+        return VK_SUCCESS;
+    }
+    prop->is_being_expanded = true;
+
     // We need to add all the individual component layers
     loader_api_version meta_layer_api_version = loader_make_version(prop->info.specVersion);
     for (uint32_t comp_layer = 0; comp_layer < prop->component_layer_names.count; comp_layer++) {
@@ -1518,6 +1533,8 @@ VkResult loader_add_meta_layer(const struct loader_instance *inst, const struct 
             found_all_component_layers = false;
         }
     }
+
+    prop->is_being_expanded = false;
 
     // Add this layer to the overall target list (not the expanded one)
     if (found_all_component_layers) {

--- a/loader/loader_common.h
+++ b/loader/loader_common.h
@@ -198,6 +198,8 @@ struct loader_layer_properties {
     struct loader_string_list override_paths;
     bool is_override;
     bool keep;
+    // Set while this meta-layer is being expanded, used to break cyclic component references.
+    bool is_being_expanded;
     struct loader_string_list blacklist_layer_names;
     struct loader_string_list app_key_paths;
 };

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -3603,3 +3603,49 @@ TEST(SettingsFile, DeviceConfigurationPreservesLayerEnumeration) {
     auto layer_props = env.GetLayerProperties(1);
     EXPECT_TRUE(string_eq(layer_props.at(0).layerName, layer_name));
 }
+
+// A meta-layer whose component chain loops back to itself is normally rejected by
+// verify_all_meta_layers, but layers pulled in from the settings file skip that pass. Without a
+// recursion guard in loader_add_meta_layer this cyclic reference recurses until the stack overflows.
+TEST(SettingsFile, CyclicMetaLayerComponentDoesNotRecurse) {
+    FrameworkEnvironment env{};
+    env.add_icd(TEST_ICD_PATH_VERSION_2).add_physical_device({});
+
+    const char* meta_a = "VK_LAYER_meta_A";
+    const char* meta_b = "VK_LAYER_meta_B";
+    env.add_implicit_layer(
+        ManifestOptions{}.set_json_name("meta_a.json"),
+        ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(ManifestLayer::LayerDescription{}
+                                                                         .set_name(meta_a)
+                                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                                                         .add_component_layer(meta_b)
+                                                                         .set_disable_environment("DISABLE_A")));
+    env.add_implicit_layer(
+        ManifestOptions{}.set_json_name("meta_b.json"),
+        ManifestLayer{}.set_file_format_version({1, 2, 0}).add_layer(ManifestLayer::LayerDescription{}
+                                                                         .set_name(meta_b)
+                                                                         .set_api_version(VK_MAKE_API_VERSION(0, 1, 1, 0))
+                                                                         .add_component_layer(meta_a)
+                                                                         .set_disable_environment("DISABLE_B")));
+
+    std::filesystem::path folder = env.get_folder(ManifestLocation::implicit_layer).location();
+    env.update_loader_settings(env.loader_settings.set_file_format_version({1, 0, 0}).add_app_specific_setting(
+        AppSpecificSettings{}
+            .add_stderr_log_filter("all")
+            .add_layer_configuration(LoaderSettingsLayerConfiguration{}
+                                         .set_name(meta_a)
+                                         .set_path(folder / "meta_a.json")
+                                         .set_control("on")
+                                         .set_treat_as_implicit_manifest(true))
+            .add_layer_configuration(LoaderSettingsLayerConfiguration{}
+                                         .set_name(meta_b)
+                                         .set_path(folder / "meta_b.json")
+                                         .set_control("on")
+                                         .set_treat_as_implicit_manifest(true))));
+
+    InstWrapper inst{env.vulkan_functions};
+    FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
+    // Before the recursion guard this call never returned - it recursed until the stack overflowed.
+    inst.CheckCreate();
+    ASSERT_TRUE(env.debug_log.find("recursively references itself through its component layers"));
+}


### PR DESCRIPTION
Found while fuzzing the loader settings file with malformed layer manifests.

    ==ERROR: AddressSanitizer: stack-overflow
        #3 loader_add_meta_layer     loader.c:1493
        #5 loader_add_meta_layer     loader.c:1493
        #6 loader_add_implicit_layer loader.c:1454
        #7 loader_add_meta_layer     loader.c:1493
        ...

Two meta-layers whose `component_layers` list each other recurse `loader_add_meta_layer` -> `loader_add_implicit_layer` -> `loader_add_meta_layer` and never stop. The stack runs out inside `vkCreateInstance`.

`verify_all_meta_layers` already catches these cycles and drops the offending layers, but it only runs over layers found through normal discovery. Layers named in `vk_loader_settings.json` arrive through `get_settings_layers` and never reach that pass, so the cycle is still live once expansion starts. b56f871 took the recursion out of `loader_find_layer_name_in_meta_layer` for the same reason; this sibling was missed.

The guard is a per-layer `is_being_expanded` flag, set on entry to `loader_add_meta_layer` and cleared once its components are walked. Re-entering a layer already on the expansion stack logs a warning and returns rather than recursing. A well-formed meta-layer that pulls in another meta-layer still expands exactly as before.

Added `SettingsFile.CyclicMetaLayerComponentDoesNotRecurse`, which points two settings meta-layers at each other. It overflows the stack under ASan without the guard and passes with it.
