### PR TITLE
Update codeql in github actions to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,11 +50,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@b9e0990d219a03df7633c93f6f005a8fecbcab22 # v5.0.1
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
     #     If you wish to specify custom queries, you can do so here or in a config file.
@@ -69,7 +69,7 @@ jobs:
     # If this step fails, then you should remove it and run the build manually
     - name: Autobuild
       if: matrix.language == 'python'
-      uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      uses: github/codeql-action/autobuild@v4
 
     - uses: actions/setup-python@v6
       if: matrix.language == 'cpp'
@@ -93,6 +93,6 @@ jobs:
       run: cmake --build build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Uses just v4 rather than explicitly listing the hash. This is an attempt at working around dependabot not creating a single PR to update the version hashes in codeql.yml.