### PR TITLE
terminate print_string_ptr output at the real end

### DIFF
--- a/loader/cJSON.c
+++ b/loader/cJSON.c
@@ -747,7 +747,10 @@ static cJSON_bool print_string_ptr(const unsigned char *const input, printbuffer
             }
         }
     }
-    output[output_length] = '\0';
+    // The loader-specific escaping above emits one byte where the standard form emits two, so the written
+    // length is shorter than output_length. Terminate at the actual end, otherwise the bytes between it and
+    // output_length (uninitialised when the caller buffer is not zeroed) get read back as part of the string.
+    *output_pointer = '\0';
 
     return true;
 }
@@ -983,7 +986,7 @@ loader_cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt, boo
     return (char *)p.buffer;
 }
 
-CJSON_PUBLIC(cJSON_bool)
+TEST_FUNCTION_EXPORT CJSON_PUBLIC(cJSON_bool)
 loader_cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format) {
     printbuffer p = {0, 0, 0, 0, 0, 0, 0};
 

--- a/loader/cJSON.c
+++ b/loader/cJSON.c
@@ -987,7 +987,7 @@ loader_cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt, boo
 }
 
 TEST_FUNCTION_EXPORT CJSON_PUBLIC(cJSON_bool)
-loader_cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format) {
+    loader_cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format) {
     printbuffer p = {0, 0, 0, 0, 0, 0, 0};
 
     if ((length < 0) || (buffer == NULL)) {

--- a/loader/cJSON.h
+++ b/loader/cJSON.h
@@ -176,7 +176,7 @@ loader_cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt, boo
 /* NOTE: cJSON is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you
  * actually need */
 TEST_FUNCTION_EXPORT CJSON_PUBLIC(cJSON_bool)
-loader_cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format);
+    loader_cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format);
 /* Delete a cJSON entity and all subentities. */
 TEST_FUNCTION_EXPORT CJSON_PUBLIC(void) loader_cJSON_Delete(cJSON *item);
 

--- a/loader/cJSON.h
+++ b/loader/cJSON.h
@@ -175,7 +175,7 @@ loader_cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt, boo
  * failure. */
 /* NOTE: cJSON is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you
  * actually need */
-CJSON_PUBLIC(cJSON_bool)
+TEST_FUNCTION_EXPORT CJSON_PUBLIC(cJSON_bool)
 loader_cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format);
 /* Delete a cJSON entity and all subentities. */
 TEST_FUNCTION_EXPORT CJSON_PUBLIC(void) loader_cJSON_Delete(cJSON *item);

--- a/tests/loader_fuzz_tests.cpp
+++ b/tests/loader_fuzz_tests.cpp
@@ -361,3 +361,31 @@ TEST(StringValidation, TruncatedMultiByteDoesNotReadPastTerminator) {
     std::vector<char> two_byte = {static_cast<char>(0xC2), static_cast<char>(0xA9), '\0'};
     EXPECT_EQ(vk_string_validate(MaxLoaderStringLength, two_byte.data()), VK_STRING_ERROR_NONE);
 }
+
+// The loader's fork of print_string_ptr strips the escaping backslash, so it writes fewer bytes than the
+// upstream escape budget it terminates at. It must terminate at the real end, otherwise the gap up to that
+// larger length is read back as part of the string. PrintPreallocated hands the result to a caller-owned
+// buffer that is not required to be zeroed, so any stale bytes in the gap leak out.
+TEST(JsonStringPrint, PrintPreallocatedTerminatesAtRealEnd) {
+    std::filesystem::path json_path = std::filesystem::temp_directory_path() / "loader_print_string_ptr_test.json";
+    {
+        std::ofstream f(json_path, std::ios::binary | std::ios::trunc);
+        // Top-level JSON string whose decoded value needs escaping: decodes to a b <LF> c d \ e f (8 bytes).
+        f << "\"ab\\ncd\\\\ef\"";
+    }
+
+    cJSON* json = NULL;
+    ASSERT_EQ(loader_get_json(NULL, json_path.string().c_str(), &json), VK_SUCCESS);
+    ASSERT_NE(json, nullptr);
+
+    // Caller owns the buffer and it need not be zeroed - poison it so a short-write shows up.
+    char buffer[64];
+    for (char& c : buffer) c = 'X';
+    ASSERT_TRUE(loader_cJSON_PrintPreallocated(json, buffer, static_cast<int>(sizeof(buffer)), false));
+
+    const char expected[] = {'a', 'b', '\n', 'c', 'd', '\\', 'e', 'f', '\0'};
+    EXPECT_STREQ(buffer, expected);
+
+    loader_cJSON_Delete(json);
+    std::filesystem::remove(json_path);
+}


### PR DESCRIPTION
loader_cJSON_PrintPreallocated into a poisoned 64-byte buffer, string value "ab\ncd\\ef":

    expected_len=8 printed_len=10
    bytes: 61 62 0a 63 64 5c 65 66 58 58

The trailing 58 58 are two stale 'X' bytes from the caller buffer that end up inside the returned string.

print_string_ptr is the loader's fork of the cJSON string serialiser. A post-release change (commented at the escape switch) drops the leading backslash, so each escaped character writes one byte where the upstream budget reserved two, and five rather than six for a control-char uXXXX form. output_length still holds the upstream budget, so the copy loop stops short of it, yet the terminator is written at output[output_length] instead of at the real end. Whatever sits in the gap is read back by the following strlen/update_offset.

I only noticed it because the default path hides it: the print buffer is calloc'd and loader_realloc zeroes its grown tail, so the gap reads as zeros and strlen stops early. Two cases break that. PrintPreallocated writes into a caller-owned buffer that the header explicitly says the caller owns and need not zero. And loader_cJSON_Print grows through loader_realloc, whose app-allocator (pfnReallocation) branch does not zero the grown bytes, so a custom VkAllocationCallbacks leaves the gap as uninitialised heap. The stale bytes are appended to manifest-derived strings such as library_path and the layer name.

Fix terminates at the actual end (output_pointer). The added test prints an escaped string into a poisoned preallocated buffer; it shows the stale bytes before the change and a correctly terminated string after.
