### PR TITLE
Check that VulkanHeaders_VERSION exists before use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if(WIN32)
 endif()
 
 find_package(VulkanHeaders ${PROJECT_VERSION} CONFIG QUIET)
-if (${VulkanHeaders_VERSION} VERSION_GREATER ${PROJECT_VERSION})
+if (DEFINED ${VulkanHeaders_VERSION} AND ${VulkanHeaders_VERSION} VERSION_GREATER ${PROJECT_VERSION})
     message(WARNING "The Vulkan Headers version ${VulkanHeaders_VERSION} is newer than the expected version ${PROJECT_VERSION} used by the Vulkan-Loader. May cause issues.")
 endif()
 


### PR DESCRIPTION
When a project uses add_subdirectory to add the Vulkan-Headers, the lack of install causes VulkanHeaders_VERSION to not be defined. Since there is no easy way to get the version, simply disable the check if that variable isn't defined.