### PR TITLE
release VK_INSTANCE_LAYERS in enable_correct_layers_from_settings

### DIFF
--- a/loader/settings.c
+++ b/loader/settings.c
@@ -1265,6 +1265,10 @@ VkResult enable_correct_layers_from_settings(const struct loader_instance* inst,
         }
     }
 out:
+    if (vk_instance_layers_env != NULL) {
+        loader_free_getenv(vk_instance_layers_env, inst);
+    }
+
     return res;
 }
 

--- a/tests/loader_alloc_callback_tests.cpp
+++ b/tests/loader_alloc_callback_tests.cpp
@@ -694,6 +694,36 @@ TEST(Allocation, CreateInstanceIntentionalAllocFailWithSettingsFilePresent) {
     }
 }
 
+// An active layer configuration in the settings file routes layer selection through
+// enable_correct_layers_from_settings, which reads VK_INSTANCE_LAYERS itself. On Windows loader_getenv
+// allocates through the application's allocator, so that read has to be released like the ones in
+// loader_enable_instance_layers and loader_validate_instance_extensions.
+TEST(Allocation, SettingsLayerConfigurationWithInstanceLayersEnvVar) {
+    FrameworkEnvironment env{FrameworkSettings{}.set_log_filter("error,warn")};
+    env.add_icd(TEST_ICD_PATH_VERSION_2);
+
+    const char* layer_name = "VK_LAYER_TestLayer";
+    env.add_explicit_layer(
+        {}, ManifestLayer{}.add_layer(
+                ManifestLayer::LayerDescription{}.set_name(layer_name).set_lib_path(TEST_LAYER_PATH_EXPORT_VERSION_2)));
+
+    env.update_loader_settings(
+        env.loader_settings.add_app_specific_setting(AppSpecificSettings{}.add_stderr_log_filter("all").add_layer_configuration(
+            LoaderSettingsLayerConfiguration{}
+                .set_name(layer_name)
+                .set_control("on")
+                .set_path(env.get_shimmed_layer_manifest_path(0)))));
+
+    EnvVarWrapper instance_layers_env_var{"VK_INSTANCE_LAYERS", layer_name};
+
+    MemoryTracker tracker{};
+    {
+        InstWrapper inst{env.vulkan_functions, tracker.get()};
+        ASSERT_NO_FATAL_FAILURE(inst.CheckCreate());
+    }
+    ASSERT_TRUE(tracker.empty());
+}
+
 // Test failure during vkCreateInstance & surface creation to make sure we don't leak memory if
 // one of the out-of-memory conditions trigger.
 TEST(Allocation, CreateSurfaceIntentionalAllocFailWithSettingsFilePresent) {


### PR DESCRIPTION
Was tracing `loader_getenv`/`loader_free_getenv` pairing through the settings-file layer path. One `vkCreateInstance` with `VK_INSTANCE_LAYERS` set:

    acquire enable_correct_layers_from_settings ENABLED_LAYERS_ENV=0x604000014023 (VK_LAYER_TestLayer)
    acquire enable_correct_layers_from_settings ENABLED_LAYERS_ENV=0x604000014023 (VK_LAYER_TestLayer)

Two acquires, no release. `settings.c:1163` reads the env var and the `out:` label just returns `res`. On Windows `loader_getenv` hands back a `loader_instance_heap_alloc` buffer, so that read is owned by the caller. On unix it is plain `getenv` and nothing is leaked, which is why this stayed quiet.

Two calls because this is the settings-file branch of layer selection, reached from both `loader_enable_instance_layers` and `loader_validate_instance_extensions`. Both of those already release their own `ENABLED_LAYERS_ENV` read at `loader.c:4758` and `loader.c:5732`. The callee was missed, so the string leaks once per call for as long as the process keeps creating instances.

Swept every `loader_getenv`/`loader_secure_getenv` site in the loader. This is the only unpaired one. `get_unix_settings_path` reads four XDG vars without releasing them but is unix-only, where the free is a no-op, so I left it alone.

The test asserts allocator balance for a settings file with an active layer configuration plus `VK_INSTANCE_LAYERS`. It only detects the leak on Windows, since that is the only platform where the read allocates.
