### PR TITLE
fix whole-wildcard and short prefix globs in determine_filter_type

### DIFF
--- a/loader/loader_environment.c
+++ b/loader/loader_environment.c
@@ -205,16 +205,18 @@ void determine_filter_type(const char *filter_string, enum loader_filter_string_
                 *filter_type = FILTER_STRING_SPECIAL;
                 *new_start = filter_string;
                 *new_length = filter_length;
+                return;
             } else {
                 star_begin = true;
             }
         }
         if ('*' == filter_string[filter_length - 1]) {
             // Not really valid, but just catch this case so if someone accidentally types "**" it will also mean everything
-            if (filter_length == 2) {
+            if (star_begin && filter_length == 2) {
                 *filter_type = FILTER_STRING_SPECIAL;
                 *new_start = filter_string;
                 *new_length = filter_length;
+                return;
             } else {
                 star_end = true;
             }

--- a/tests/loader_envvar_tests.cpp
+++ b/tests/loader_envvar_tests.cpp
@@ -714,6 +714,51 @@ TEST(EnvVarICDOverrideSetup, FilterSelectDriver) {
     ASSERT_FALSE(env.debug_log.find_prefix_then_postfix("CDE_ICD.json", "ignored because it was disabled by env var"));
 }
 
+// '**' is one of the three documented whole-wildcard forms, alongside '*' and '~all~', and a two character glob such as
+// "A*" is an ordinary prefix match. Both were classified as something else entirely and matched no manifest name at all.
+TEST(EnvVarICDOverrideSetup, FilterDriverDoubleStarAndShortPrefix) {
+    FrameworkEnvironment env{};
+    EnvVarWrapper filter_select_env_var{"VK_LOADER_DRIVERS_SELECT"};
+    EnvVarWrapper filter_disable_env_var{"VK_LOADER_DRIVERS_DISABLE"};
+
+    env.add_icd(TEST_ICD_PATH_VERSION_6, ManifestOptions{}.set_json_name("ABC_ICD.json"));
+    env.add_icd(TEST_ICD_PATH_VERSION_6, ManifestOptions{}.set_json_name("BCD_ICD.json"),
+                ManifestICD{}.set_api_version(VK_API_VERSION_1_2));
+
+    // '**' selects every driver, the same as '*' and '~all~' do.
+    filter_select_env_var.set_new_value("**");
+    {
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
+        inst.CheckCreate();
+        ASSERT_FALSE(env.debug_log.find_prefix_then_postfix("ABC_ICD.json", "ignored because not selected by env var"));
+        ASSERT_FALSE(env.debug_log.find_prefix_then_postfix("BCD_ICD.json", "ignored because not selected by env var"));
+    }
+
+    // A two character prefix glob matches on its single leading character.
+    env.debug_log.clear();
+    filter_select_env_var.set_new_value("A*");
+    {
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
+        inst.CheckCreate();
+        ASSERT_FALSE(env.debug_log.find_prefix_then_postfix("ABC_ICD.json", "ignored because not selected by env var"));
+        ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("BCD_ICD.json", "ignored because not selected by env var"));
+    }
+
+    // '**' on the disable filter drops every driver, leaving no usable ICD.
+    env.debug_log.clear();
+    filter_select_env_var.remove_value();
+    filter_disable_env_var.set_new_value("**");
+    {
+        InstWrapper inst{env.vulkan_functions};
+        FillDebugUtilsCreateDetails(inst.create_info, env.debug_log);
+        inst.CheckCreate(VK_ERROR_INCOMPATIBLE_DRIVER);
+        ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("ABC_ICD.json", "ignored because it was disabled by env var"));
+        ASSERT_TRUE(env.debug_log.find_prefix_then_postfix("BCD_ICD.json", "ignored because it was disabled by env var"));
+    }
+}
+
 // Exercise the driver select/disable filters against a manifest name that is much longer than VK_MAX_EXTENSION_NAME_SIZE
 // would have allowed when the matcher copied the name into a fixed-size buffer. The whole name has to be considered for
 // every filter type, not just the first 255 characters. See KhronosGroup/Vulkan-Loader#1913.


### PR DESCRIPTION
Setting the select filter to the whole-wildcard form leaves no usable driver:

    $ VK_LOADER_DRIVERS_SELECT='**' ./vulkaninfo
    [Vulkan Loader] WARNING | DRIVER: Driver "ABC_ICD.json" ignored because not selected by env var 'VK_LOADER_DRIVERS_SELECT'
    [Vulkan Loader] WARNING | DRIVER: Driver "BCD_ICD.json" ignored because not selected by env var 'VK_LOADER_DRIVERS_SELECT'
    vkCreateInstance: VK_ERROR_INCOMPATIBLE_DRIVER

Found this reading `determine_filter_type` for something unrelated. `**` is one of the three
whole-wildcard forms next to `*` and `~all~`, so it should have matched every name.

Both branches that classify a token as `FILTER_STRING_SPECIAL` assign the type and then fall
through into the star_begin/star_end classification below, which overwrites it. `**` comes out
as a suffix filter on `*`, and no manifest or layer name ends in a star. The `filter_length == 2`
test also never checked the leading character, so a two character glob like `A*` took that same
branch and ended up `FILTER_STRING_FULLNAME` on the literal `A*` rather than a prefix on `A`.

Worth noting the disable direction fails open: `VK_LOADER_LAYERS_DISABLE=**` sets neither
`disable_all` nor a filter that can match, so every layer stays enabled.

Returning once a token is classified special, and requiring the leading star for the two
character case, fixes both. Every other glob form classifies exactly as before.