### PR TITLE
codegen: Don't hide import error message from Python

### DIFF
--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -27,6 +27,7 @@ import subprocess
 import shutil
 import sys
 import tempfile
+import traceback
 import datetime
 import re
 import common_codegen
@@ -56,9 +57,9 @@ def RunGenerators(api: str, registry: str, directory: str, styleFile: str, targe
     sys.path.insert(0, registry_headers_path)
     try:
         from reg import Registry
-    except:
-        print("ModuleNotFoundError: No module named 'reg'") # normal python error message
-        print(f'{registry_headers_path} is not pointing to the Vulkan-Headers registry directory.')
+    except ModuleNotFoundError as e:
+        traceback.print_exc()
+        print(f'Perhaps {registry_headers_path} is not pointing to the Vulkan-Headers registry directory.')
         print("Inside Vulkan-Headers there is a registry/reg.py file that is used.")
         sys.exit(1) # Return without call stack so easy to spot error
 


### PR DESCRIPTION
`from reg import Registry` could fail for reasons other than not having Vulkan-Headers' `registry/` directory on `sys.path`. For example, if the `pyparsing` module dependency isn't installed, then importing `reg` will also fail as a result.

Show Python's error message to the user so that they can correct any missing dependencies.