### PR TITLE
Limit parallelism to stop failing jobs in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -420,7 +420,7 @@ jobs:
               -D BUILD_WERROR=ON `
               -D BUILD_TESTS=ON `
               -G Ninja
-          - run: cmake --build build/
+          - run: cmake --build build/ --parallel 1
           - run: ctest --parallel --output-on-failure --test-dir build/
           - run: cmake --install build --prefix build/install
 
@@ -456,7 +456,7 @@ jobs:
               env:
                 # Prevents regression of KhronosGroup/Vulkan-Loader/issues/1332
                 LDFLAGS: -Wl,-fatal_warnings
-            - run: cmake --build build
+            - run: cmake --build build --parallel 1
             - run: cmake --install build --prefix /tmp
             - run: ctest --parallel --output-on-failure --test-dir build/
 
@@ -490,7 +490,7 @@ jobs:
               -G Ninja
             env:
               LDFLAGS: -Wl,-fatal_warnings
-          - run: cmake --build build
+          - run: cmake --build build --parallel 1
           - run: cmake --install build --prefix /tmp
           - name: Verify Universal Binary
             run: |
@@ -530,7 +530,7 @@ jobs:
                 -G Ninja
               env:
                 LDFLAGS: -Wl,-fatal_warnings
-            - run: cmake --build build --config Release
+            - run: cmake --build build --config Release --parallel 1
             - run: ctest --parallel --output-on-failure --build-config Release -E UnknownFunction --test-dir build/
             - run: cmake --install build --config Release --prefix /tmp
             - name: Verify Universal Binary


### PR DESCRIPTION
CMake 4.4.0 has a bug that causes builds to fail due to a race condition when building tests in parallel. CMake 4.4.1 fixes this, but while we wait for github to update the runners, disable the parallelism in the build for the time being.