### PR TITLE
Fix build when SDK is installed globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,10 @@ if (${VulkanHeaders_VERSION} VERSION_GREATER ${PROJECT_VERSION})
     message(WARNING "The Vulkan Headers version ${VulkanHeaders_VERSION} is newer than the expected version ${PROJECT_VERSION} used by the Vulkan-Loader. May cause issues.")
 endif()
 
+if (CMAKE_C_COMPILER_ID STREQUAL AppleClang AND TARGET Vulkan::Headers AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.25)
+    set_target_properties(Vulkan::Headers PROPERTIES SYSTEM OFF)
+endif()
+
 include(GNUInstallDirs)
 
 set(GIT_BRANCH_NAME "--unknown--")


### PR DESCRIPTION
Because of clang always adding /usr/local/include and CMake using -isystem by default in 3.25+, builds on MacOS could use system installed headers by mistake. Because this repo has code generated against a specific version of the Vulkan Headers, if the system installed headers are older (which is usually the case for developers of this repo) then the build fails.

Fix it by marking the Vulkan::Headers target as not a system target.