### PR TITLE
zero-init instance_layer_list in EnumerateInstanceLayerProperties

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -7656,7 +7656,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_pre_instance_EnumerateInstanceExtensio
 VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateInstanceLayerProperties(uint32_t *pPropertyCount,
                                                                            VkLayerProperties *pProperties) {
     VkResult result = VK_SUCCESS;
-    struct loader_layer_list instance_layer_list;
+    struct loader_layer_list instance_layer_list = {0};
     struct loader_envvar_all_filters layer_filters = {0};
 
     LOADER_PLATFORM_THREAD_ONCE(&once_init, loader_initialize);
@@ -7667,7 +7667,6 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateInstanceLayerProperties(uint3
     }
 
     // Get layer libraries
-    memset(&instance_layer_list, 0, sizeof(instance_layer_list));
     result = loader_scan_for_layers(NULL, &instance_layer_list, &layer_filters);
     if (VK_SUCCESS != result) {
         goto out;


### PR DESCRIPTION
Found this comparing the two instance-property terminators.

`terminator_EnumerateInstanceLayerProperties`, on the `parse_layer_environment_var_filters` error path:

    loader.c:7659  struct loader_layer_list instance_layer_list;   // uninitialised
    loader.c:7664  result = parse_layer_environment_var_filters(NULL, &layer_filters);
                   if (result != VK_SUCCESS) goto out;             // reaches cleanup before the memset

`parse_layer_environment_var_filters` returns `VK_ERROR_OUT_OF_HOST_MEMORY` when it cannot allocate the lowercased copy of `VK_LOADER_LAYERS_ENABLE` / `VK_LAYERS_DISABLE` / `VK_LOADER_LAYERS_ALLOW`. That copy is sized by the env var value and `inst` is NULL here, so it is a plain `calloc`. The `memset` that clears `instance_layer_list` sits after that call, so the early `goto out` reaches the `out:` cleanup with the struct still holding stack garbage. `loader_delete_layer_list_and_properties` then walks `count` entries, calling `loader_platform_close_library(list[i].lib_handle)` and freeing every string in each element, then frees `list`, all from indeterminate values.

The sibling `terminator_EnumerateInstanceExtensionProperties` memsets its list before the same call. This one had the order reversed. Zero-initialise at the declaration so the cleanup is a no-op when the parse fails.
