### PR TITLE
Make layer manifest paths in settings file end in ".json"

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -246,6 +246,9 @@ loader_api_version loader_combine_version(uint32_t major, uint32_t minor, uint32
 // Helper macros for determining if a version is valid or not
 bool loader_check_version_meets_required(loader_api_version required, loader_api_version version);
 
+// Helper that returns true if the string passed in path ends in .json
+bool is_json(const char *path, size_t len);
+
 VkResult loader_filter_enumerated_physical_device(const struct loader_instance *inst,
                                                   const struct loader_envvar_id_filter *device_id_filter,
                                                   const struct loader_envvar_id_filter *vendor_id_filter,

--- a/loader/settings.c
+++ b/loader/settings.c
@@ -985,6 +985,10 @@ TEST_FUNCTION_EXPORT VkResult get_settings_layers(const struct loader_instance* 
             continue;
         }
 
+        if (!is_json(layer_config->path, strlen(layer_config->path))) {
+            continue;
+        }
+
         cJSON* json = NULL;
         VkResult local_res = loader_get_json(inst, layer_config->path, &json);
         if (VK_ERROR_OUT_OF_HOST_MEMORY == local_res) {

--- a/tests/loader_settings_tests.cpp
+++ b/tests/loader_settings_tests.cpp
@@ -2385,8 +2385,10 @@ TEST(SettingsFile, StderrLogFilters) {
                                          .set_name(explicit_layer_name)
                                          .set_path(env.get_shimmed_layer_manifest_path())
                                          .set_control("on"))
-            .add_layer_configuration(
-                LoaderSettingsLayerConfiguration{}.set_name("VK_LAYER_missing").set_path("/road/to/nowhere").set_control("on"))));
+            .add_layer_configuration(LoaderSettingsLayerConfiguration{}
+                                         .set_name("VK_LAYER_missing")
+                                         .set_path("/road/to/nowhere.json")
+                                         .set_control("on"))));
 
     std::string expected_output_verbose;
     expected_output_verbose += "[Vulkan Loader] DEBUG:          Layer Configurations count = 2\n";
@@ -2397,7 +2399,7 @@ TEST(SettingsFile, StderrLogFilters) {
     expected_output_verbose += "[Vulkan Loader] DEBUG:          Control: on\n";
     expected_output_verbose += "[Vulkan Loader] DEBUG:          ---- Layer Configuration [1] ----\n";
     expected_output_verbose += "[Vulkan Loader] DEBUG:          Name: VK_LAYER_missing\n";
-    expected_output_verbose += "[Vulkan Loader] DEBUG:          Path: /road/to/nowhere\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Path: /road/to/nowhere.json\n";
     expected_output_verbose += "[Vulkan Loader] DEBUG:          Layer Type: Explicit\n";
     expected_output_verbose += "[Vulkan Loader] DEBUG:          Control: on\n";
     expected_output_verbose += "[Vulkan Loader] DEBUG:          ---------------------------------\n";
@@ -2409,7 +2411,7 @@ TEST(SettingsFile, StderrLogFilters) {
                                           " does not conform to naming standard (Policy #LLP_LAYER_3)\n";
 
     std::string expected_output_error =
-        "[Vulkan Loader] ERROR:          loader_get_json: Failed to open JSON file /road/to/nowhere\n";
+        "[Vulkan Loader] ERROR:          loader_get_json: Failed to open JSON file /road/to/nowhere.json\n";
 
     env.loader_settings.app_specific_settings.at(0).stderr_log = {"all"};
     env.update_loader_settings(env.loader_settings);
@@ -2663,8 +2665,10 @@ TEST(SettingsFile, NoStderr_log_but_VK_LOADER_DEBUG) {
                                          .set_name(explicit_layer_name)
                                          .set_path(env.get_shimmed_layer_manifest_path())
                                          .set_control("auto"))
-            .add_layer_configuration(
-                LoaderSettingsLayerConfiguration{}.set_name("VK_LAYER_missing").set_path("/road/to/nowhere").set_control("auto")));
+            .add_layer_configuration(LoaderSettingsLayerConfiguration{}
+                                         .set_name("VK_LAYER_missing")
+                                         .set_path("/road/to/nowhere.json")
+                                         .set_control("auto")));
     env.loader_settings.app_specific_settings.at(0).stderr_log = {};
     env.update_loader_settings(env.loader_settings);
 
@@ -2677,7 +2681,7 @@ TEST(SettingsFile, NoStderr_log_but_VK_LOADER_DEBUG) {
     expected_output_verbose += "[Vulkan Loader] DEBUG:          Control: auto\n";
     expected_output_verbose += "[Vulkan Loader] DEBUG:          ---- Layer Configuration [1] ----\n";
     expected_output_verbose += "[Vulkan Loader] DEBUG:          Name: VK_LAYER_missing\n";
-    expected_output_verbose += "[Vulkan Loader] DEBUG:          Path: /road/to/nowhere\n";
+    expected_output_verbose += "[Vulkan Loader] DEBUG:          Path: /road/to/nowhere.json\n";
     expected_output_verbose += "[Vulkan Loader] DEBUG:          Layer Type: Explicit\n";
     expected_output_verbose += "[Vulkan Loader] DEBUG:          Control: auto\n";
     expected_output_verbose += "[Vulkan Loader] DEBUG:          ---------------------------------\n";
@@ -2689,7 +2693,7 @@ TEST(SettingsFile, NoStderr_log_but_VK_LOADER_DEBUG) {
         "[Vulkan Loader] WARNING:        Layer name Regular_TestLayer1 does not conform to naming standard (Policy #LLP_LAYER_3)\n";
 
     std::string expected_output_error =
-        "[Vulkan Loader] ERROR:          loader_get_json: Failed to open JSON file /road/to/nowhere\n";
+        "[Vulkan Loader] ERROR:          loader_get_json: Failed to open JSON file /road/to/nowhere.json\n";
 
     env.platform_shim->clear_logs();
     {


### PR DESCRIPTION
Otherwise the loader will try to load any valid file pointed to by the path.