### PR TITLE
check driver result in surface caps 2EXT emulation

### DIFF
--- a/loader/extension_manual.c
+++ b/loader/extension_manual.c
@@ -122,6 +122,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2E
 
         VkSurfaceCapabilitiesKHR surface_caps;
         res = icd_term->dispatch.GetPhysicalDeviceSurfaceCapabilitiesKHR(phys_dev_term->phys_dev, surface, &surface_caps);
+        if (res != VK_SUCCESS) {
+            // The driver did not populate surface_caps, so don't copy it out to the caller.
+            return res;
+        }
         pSurfaceCapabilities->minImageCount = surface_caps.minImageCount;
         pSurfaceCapabilities->maxImageCount = surface_caps.maxImageCount;
         pSurfaceCapabilities->currentExtent = surface_caps.currentExtent;

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -1087,7 +1087,7 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(Vk
     if (nullptr != pSurfaceCapabilities) {
         *pSurfaceCapabilities = GetPhysDevice(physicalDevice).surface_capabilities;
     }
-    return VK_SUCCESS;
+    return GetPhysDevice(physicalDevice).surface_capabilities_result;
 }
 VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                          uint32_t* pSurfaceFormatCount,

--- a/tests/framework/icd/test_icd.h
+++ b/tests/framework/icd/test_icd.h
@@ -113,6 +113,7 @@ struct PhysicalDevice {
     BUILDER_VECTOR(Extension, extensions, extension)
 
     BUILDER_VALUE(VkSurfaceCapabilitiesKHR, surface_capabilities)
+    BUILDER_VALUE_WITH_DEFAULT(VkResult, surface_capabilities_result, VK_SUCCESS)
     BUILDER_VECTOR(VkSurfaceFormatKHR, surface_formats, surface_format)
     BUILDER_VECTOR(VkPresentModeKHR, surface_present_modes, surface_present_mode)
     BUILDER_VALUE(VkSurfacePresentScalingCapabilitiesEXT, surface_present_scaling_capabilities)

--- a/tests/loader_wsi_tests.cpp
+++ b/tests/loader_wsi_tests.cpp
@@ -823,6 +823,46 @@ TEST(WsiTests, GoogleSurfaceslessQuery) {
 #endif
 }
 
+// When the ICD does not expose vkGetPhysicalDeviceSurfaceCapabilities2EXT the loader emulates it using the
+// KHR entrypoint. If that driver call fails it may leave the output untouched (per spec), so the loader must
+// not copy the emulation scratch struct back to the caller - doing so returned uninitialised loader stack to
+// the application. Model this with a driver whose vkGetPhysicalDeviceSurfaceCapabilitiesKHR returns an error;
+// the caller's struct must be left as-is.
+TEST(WsiTests, GetPhysicalDeviceSurfaceCapabilities2EXTEmulationDriverError) {
+    FrameworkEnvironment env{};
+    VkSurfaceCapabilitiesKHR driver_caps{};
+    driver_caps.minImageCount = 0xBADC0DE;
+    driver_caps.maxImageCount = 0xBADC0DE;
+    env.add_icd(TEST_ICD_PATH_VERSION_2)
+        .setup_WSI()
+        .add_instance_extension(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME)
+        .add_physical_device(PhysicalDevice{}
+                                 .add_extension("VK_KHR_swapchain")
+                                 .set_surface_capabilities(driver_caps)
+                                 .set_surface_capabilities_result(VK_ERROR_SURFACE_LOST_KHR));
+
+    InstWrapper inst{env.vulkan_functions};
+    inst.create_info.setup_WSI().add_extension(VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(inst.CheckCreate());
+
+    VkSurfaceKHR surface{};
+    ASSERT_EQ(VK_SUCCESS, create_surface(inst, surface));
+    WrappedHandle<VkSurfaceKHR, VkInstance, PFN_vkDestroySurfaceKHR> wrapped_surface{surface, inst.inst,
+                                                                                     env.vulkan_functions.vkDestroySurfaceKHR};
+
+    VkPhysicalDevice physical_device = inst.GetPhysDev();
+
+    PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT get_caps2ext = inst.load("vkGetPhysicalDeviceSurfaceCapabilities2EXT");
+    ASSERT_NE(get_caps2ext, nullptr);
+
+    VkSurfaceCapabilities2EXT caps2{};
+    caps2.sType = VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT;
+
+    ASSERT_EQ(VK_ERROR_SURFACE_LOST_KHR, get_caps2ext(physical_device, surface, &caps2));
+    ASSERT_EQ(0u, caps2.minImageCount);
+    ASSERT_EQ(0u, caps2.maxImageCount);
+}
+
 TEST(WsiTests, ForgetEnableSurfaceExtensions) {
     FrameworkEnvironment env{};
     env.add_icd(TEST_ICD_PATH_VERSION_2).setup_WSI().add_physical_device(PhysicalDevice{}.add_extension("VK_KHR_swapchain"));


### PR DESCRIPTION
Reviewing the WSI emulation terminators for how they handle a failing driver call. terminator_GetPhysicalDeviceSurfaceCapabilities2EXT was the odd one out.

    loader/extension_manual.c
        VkSurfaceCapabilitiesKHR surface_caps;              // uninitialised
        res = icd->GetPhysicalDeviceSurfaceCapabilitiesKHR(..., &surface_caps);
        pSurfaceCapabilities->minImageCount = surface_caps.minImageCount;   // res not checked

When an ICD does not expose vkGetPhysicalDeviceSurfaceCapabilities2EXT the loader emulates it through the KHR entrypoint into that stack local. res is captured but never inspected. On an error return the driver may leave the output untouched, so the field copies that follow hand uninitialised loader stack back to the application, and the error is then returned anyway.

Every other emulation terminator either writes straight into the caller struct or checks res before copying. Returning res before the copy keeps this one in line and stops fabricating output on failure.

Regression test drives a driver whose vkGetPhysicalDeviceSurfaceCapabilitiesKHR returns VK_ERROR_SURFACE_LOST_KHR. Before the change the caller VkSurfaceCapabilities2EXT comes back populated from the failed call; after, it is left untouched.