### PR TITLE
loader: Change device ID missing value log from INFO to DEBUG(#1827)

### DIFF
--- a/loader/loader_windows.c
+++ b/loader/loader_windows.c
@@ -162,7 +162,7 @@ VkResult windows_get_device_registry_entry(const struct loader_instance *inst, s
 
     if (ret != ERROR_SUCCESS) {
         if (ret == ERROR_FILE_NOT_FOUND) {
-            loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
+            loader_log(inst, VULKAN_LOADER_DEBUG_BIT | VULKAN_LOADER_DRIVER_BIT, 0,
                        "windows_get_device_registry_entry: Device ID(%ld) Does not contain a value for \"%s\"", dev_id, value_name);
         } else {
             loader_log(inst, VULKAN_LOADER_INFO_BIT | VULKAN_LOADER_DRIVER_BIT, 0,


### PR DESCRIPTION
Changes the missing device ID log severity from INFO to DEBUG as requested in #1827 to reduce log spam.