### PR TITLE
loader: Skip layer when interface negotiation fails

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5064,24 +5064,27 @@ VkResult loader_create_instance_chain(const VkInstanceCreateInfo *pCreateInfo, c
                     VkNegotiateLayerInterface interface_struct;
 
                     if (loader_get_layer_interface_version(negotiate_interface, &interface_struct)) {
-                        // Go ahead and set the properties version to the
-                        // correct value.
                         layer_prop->interface_version = interface_struct.loaderLayerInterfaceVersion;
 
-                        // If the interface is 2 or newer, we have access to the
-                        // new GetPhysicalDeviceProcAddr function, so grab it,
-                        // and the other necessary functions, from the
-                        // structure.
                         if (interface_struct.loaderLayerInterfaceVersion > 1) {
                             cur_gipa = interface_struct.pfnGetInstanceProcAddr;
                             cur_gdpa = interface_struct.pfnGetDeviceProcAddr;
                             cur_gpdpa = interface_struct.pfnGetPhysicalDeviceProcAddr;
                             if (cur_gipa != NULL) {
-                                // We've set the functions, so make sure we
-                                // don't do the unnecessary calls later.
                                 functions_in_interface = true;
                             }
                         }
+                    } else {
+                        // The layer explicitly failed interface negotiation (e.g. returned
+                        // VK_ERROR_INITIALIZATION_FAILED from vkNegotiateLoaderLayerInterfaceVersion).
+                        // Treat this the same as a layer whose library failed to load: skip it
+                        // entirely instead of silently falling back to the legacy
+                        // vkGetInstanceProcAddr path, which would incorrectly activate a layer
+                        // that told us it cannot be used.
+                        loader_log(inst, VULKAN_LOADER_ERROR_BIT | VULKAN_LOADER_LAYER_BIT, 0,
+                                   "loader_create_instance_chain: Layer \"%s\" failed interface negotiation, skipping",
+                                   layer_prop->info.layerName);
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
If a layer's vkNegotiateLoaderLayerInterfaceVersion call fails
(e.g. returns VK_ERROR_INITIALIZATION_FAILED), the loader was
silently falling back to the legacy vkGetInstanceProcAddr path
and still activating the layer, instead of treating the failure
as fatal for that layer.

Add the missing else branch so a failed negotiation is treated
the same as a layer whose library failed to load: log it and
skip the layer with continue, rather than adding it to the
instance chain.

Fixes #1708 